### PR TITLE
Four MSH cards: a repeatable optional payment, per-object coloured pips, a re-evaluated base-P/T set, and one CR 302.6 gate

### DIFF
--- a/backlog/sets/marvel-super-heroes/cards.md
+++ b/backlog/sets/marvel-super-heroes/cards.md
@@ -3,7 +3,7 @@
 **Set Size:** 276 booster cards (collector numbers 1-276; basic lands 277-296 and showcase
 variants 297+ are excluded)
 **Release Date:** June 26, 2026
-**Implemented:** 262 / 276
+**Implemented:** 263 / 276
 - [x] Agent 13, Sharon Carter
 - [x] Agent Maria Hill
 - [x] Agent of Atlas
@@ -70,7 +70,7 @@ variants 297+ are excluded)
 - [ ] Leader, Super-Genius
 - [x] Loki, God of Mischief
 - [x] Mister Fantastic, Reed Richards
-- [ ] Ms. Marvel, Kamala Khan
+- [x] Ms. Marvel, Kamala Khan
 - [x] Multiversal Incursion
 - [ ] Namor the Sub-Mariner
 - [x] Pym Particles

--- a/backlog/sets/marvel-super-heroes/cards.md
+++ b/backlog/sets/marvel-super-heroes/cards.md
@@ -3,7 +3,7 @@
 **Set Size:** 276 booster cards (collector numbers 1-276; basic lands 277-296 and showcase
 variants 297+ are excluded)
 **Release Date:** June 26, 2026
-**Implemented:** 263 / 276
+**Implemented:** 264 / 276
 - [x] Agent 13, Sharon Carter
 - [x] Agent Maria Hill
 - [x] Agent of Atlas
@@ -72,7 +72,7 @@ variants 297+ are excluded)
 - [x] Mister Fantastic, Reed Richards
 - [x] Ms. Marvel, Kamala Khan
 - [x] Multiversal Incursion
-- [ ] Namor the Sub-Mariner
+- [x] Namor the Sub-Mariner
 - [x] Pym Particles
 - [x] Rewrite History
 - [x] Secret Invasion

--- a/backlog/sets/marvel-super-heroes/cards.md
+++ b/backlog/sets/marvel-super-heroes/cards.md
@@ -3,7 +3,7 @@
 **Set Size:** 276 booster cards (collector numbers 1-276; basic lands 277-296 and showcase
 variants 297+ are excluded)
 **Release Date:** June 26, 2026
-**Implemented:** 264 / 276
+**Implemented:** 265 / 276
 - [x] Agent 13, Sharon Carter
 - [x] Agent Maria Hill
 - [x] Agent of Atlas
@@ -190,7 +190,7 @@ variants 297+ are excluded)
 - [x] Rick Jones, Destined Sidekick
 - [x] Savage Land Dinosaur
 - [x] Serpent Specialist
-- [ ] Shang-Chi, Master of Kung Fu
+- [x] Shang-Chi, Master of Kung Fu
 - [x] She-Hulk, Jade Defender
 - [x] Super Strength
 - [x] The Thing, Ben Grimm

--- a/backlog/sets/marvel-super-heroes/cards.md
+++ b/backlog/sets/marvel-super-heroes/cards.md
@@ -3,7 +3,7 @@
 **Set Size:** 276 booster cards (collector numbers 1-276; basic lands 277-296 and showcase
 variants 297+ are excluded)
 **Release Date:** June 26, 2026
-**Implemented:** 265 / 276
+**Implemented:** 266 / 276
 - [x] Agent 13, Sharon Carter
 - [x] Agent Maria Hill
 - [x] Agent of Atlas
@@ -133,7 +133,7 @@ variants 297+ are excluded)
 - [x] Death to Our Enemies
 - [ ] Evil's Thrall
 - [x] Fin Fang Foom
-- [ ] Hawkeye, Master Marksman
+- [x] Hawkeye, Master Marksman
 - [x] Hawkeye, Young Avenger
 - [x] Hawkeye's Bow
 - [x] Hex Magic

--- a/backlog/sets/marvel-super-heroes/mechanics.md
+++ b/backlog/sets/marvel-super-heroes/mechanics.md
@@ -610,21 +610,32 @@ gate lands inside the "may" rather than around the whole composite.
 > end of turn, Ms. Marvel gains "**Ms. Marvel's base power is equal to the number of cards in your
 > hand.**"
 
-The granted clause is a **characteristic-defining ability**: base power must keep tracking hand size
-for the rest of the turn. `Effects.SetBasePower` is a one-shot resolution-time *set* —
-`SetBaseStatsEffect` documents its `power` as "evaluated at resolution time" and is deliberately
-distinct from the projector's `SetPowerToughnessDynamic`, which is "re-evaluated per affected entity
-at projection time". So her power froze at whatever the hand was when the trigger resolved.
-Reproduced: hand 8 → power 11 (8 base + Giant Growth's 3); after a draw, hand 9 → power still 11.
+Base power must keep tracking hand size for the rest of the turn. `Effects.SetBasePower` used to be a
+one-shot resolution-time *set* — `SetBaseStatsEffect` documented its `power` as "evaluated at
+resolution time" — so her power froze at whatever the hand was when the trigger resolved. Reproduced:
+hand 8 → power 11 (8 base + Giant Growth's 3); after a draw, hand 9 → power still 11.
 
-**Implemented then removed from this branch.** The right shape is
-`Effects.GrantStaticAbility(<power-only dynamic CDA>, EffectTarget.Self, Duration.EndOfTurn)` —
-`GrantStaticAbility` already exists, but there is no power-only dynamic CDA to hand it:
-`SetBasePowerToughnessDynamicStatic` (`mtg-sdk/.../scripting/StatsStaticAbilities.kt`) sets **both**
-stats from one `DynamicAmount`, which would clobber her printed toughness of 4. Needed: a
-`SetBasePowerDynamicStatic` mirroring the existing toughness-only `SetBaseToughnessForCreatureGroup`,
-plus its `StaticAbilityHandler` branch onto the projector's existing `SetPowerToughnessDynamic` path.
-Narrow and reusable — any "power is equal to X" grant wants it.
+**Fixed (u35).** `SetBaseStatsEffect` now takes `reevaluateContinuously`; when true the executor
+carries the `DynamicAmount` into the floating effect as a nullable-halves
+`SetPowerToughnessDynamic` modification, which the projector re-reads on every pass. The card is
+`Effects.SetBasePower(EffectTarget.Self, DynamicAmounts.cardsInYourHand(), Duration.EndOfTurn,
+reevaluateContinuously = true)`.
+
+Two corrections to the earlier triage, for anyone reading it as precedent:
+ - The granted clause is **not** a characteristic-defining ability. CR 604.3a requires the ability to
+   be printed on the card it affects (criterion 2) and to not be one the object grants to itself
+   (criterion 4); this one fails both. It is a plain layer 7b effect (CR 613.4b).
+ - `Effects.GrantStaticAbility(<power-only dynamic CDA>, …)` would **not** have worked *as
+   `GrantStaticAbility` is wired*. Grants made that way land in `GameState.grantedStaticAbilities`,
+   which is read at points of use (combat, cast permission, ability legality) and is deliberately
+   never fed into the layer projector — see the KDoc on `GrantedStaticAbility` — so a base-P/T static
+   handed out that way would have compiled and done nothing. A projected route for runtime-granted
+   statics does exist (`StaticAbilityHandler.lowerToContinuousEffectData`, used by
+   `BecomeArtifactExecutor` so The Irencrag's granted `ModifyStats(3,3)` reaches the layer system),
+   and routing a `GrantStaticAbility` variant through it would have worked and would generalise to
+   any quoted static ability. The flag on the existing layer-7b atom is the smaller change for this
+   card; the lowering route is the one to reach for if a card ever needs to hand out a whole quoted
+   static ability.
 
 Her other two lines are fine today: `NoMaximumHandSize` and
 `Triggers.youCastSpellTargeting(Creature.youControl())`.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1065,17 +1065,53 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   turn). Pass `Duration.WhileSourceTapped("…")` for the Antiquities "tap-locked" buffs (Ashnod's Battle
   Gear `+2/-2`, Tawnos's Weaponry `+1/+1`): the bonus persists for as long as the source artifact remains
   tapped and the one-way latch drops it when it untaps.
-- `SetBasePower(target, power: DynamicAmount, duration)` — set base power to a dynamic value (Layer 7b),
-  leaving toughness unchanged.
-- `SetBaseToughness(target, toughness: DynamicAmount, duration)` — toughness-only sibling of `SetBasePower`.
+- `SetBasePower(target, power: DynamicAmount, duration, reevaluateContinuously = false)` — set base power
+  to a dynamic value (Layer 7b), leaving toughness unchanged.
+- `SetBaseToughness(target, toughness: DynamicAmount, duration, reevaluateContinuously = false)` —
+  toughness-only sibling of `SetBasePower`.
 - `SetBasePowerAndToughness(power, toughness, target?, duration)` — set base power AND toughness (Layer 7b,
   set values), e.g. "Target creature has base power and toughness 5/5 until end of turn" (Dreadful as the
-  Storm). Two overloads: fixed `Int`s or `DynamicAmount`s.
+  Storm). Two overloads: fixed `Int`s, or `DynamicAmount`s (which also take `reevaluateContinuously`).
   - All three facades lower onto the one **`SetBaseStatsEffect(target, power: DynamicAmount?, toughness:
-    DynamicAmount?, duration)`** atom — `null` power or toughness leaves that stat unchanged, so the same
-    type covers power-only, toughness-only, and both. (Distinct from `ModifyStatsEffect`, a +N/+N
-    *modifier* in layer 7c, and from the `SetBasePowerToughness*Static` CDAs, which apply for as long as a
-    static ability is active rather than as a one-shot floating effect.)
+    DynamicAmount?, duration, reevaluateContinuously)`** atom — `null` power or toughness leaves that stat
+    unchanged, so the same type covers power-only, toughness-only, and both. (Distinct from
+    `ModifyStatsEffect`, a +N/+N *modifier* in layer 7c, and from the `SetBasePowerToughness*Static` CDAs,
+    which apply for as long as a static ability printed on a permanent is active rather than as a floating
+    effect with a duration.)
+  - **`reevaluateContinuously`** picks *when* the `DynamicAmount`s are read — the headline difference
+    between two real Magic templates on the same layer, though not the only one (three further limits
+    follow):
+    - `false` (default) — **snapshot**: evaluated once as the effect resolves and frozen for the duration.
+      "Change this creature's base power to target creature's power" keeps the number it saw.
+    - `true` — **re-evaluated**: the `DynamicAmount` travels into the floating effect (a nullable-halves
+      `SetPowerToughnessDynamic` modification) and is recomputed on every projection pass, so the stat
+      tracks the game state. This is what an effect handing out a *quoted static ability* needs —
+      **Ms. Marvel, Kamala Khan**'s "Until end of turn, Ms. Marvel gains 'Ms. Marvel's base power is equal
+      to the number of cards in your hand.'" =
+      `Effects.SetBasePower(EffectTarget.Self, DynamicAmounts.cardsInYourHand(), Duration.EndOfTurn,
+      reevaluateContinuously = true)`.
+    Either way the *affected set* is locked in at resolution (CR 611.2c); only the number moves. A
+    self-granted clause like Ms. Marvel's is **not** a CDA (CR 604.3a criterion 2 — printed on the card it
+    affects — and criterion 4 — not an ability an object grants to itself), so it applies in layer 7b per
+    CR 613.4b ("effects that refer to the base power and/or toughness of a creature apply in this layer"),
+    not 7a. Counters and pump effects are layer 7c and still apply on top.
+    Three limits apply to `true` and not to the snapshot mode, all of them because the projector — not the
+    resolution — reads the number:
+    - **Only projection-scoped `DynamicAmount`s.** The amount is re-evaluated with just the source, its
+      controller and the affected entity in scope, so `XValue`/`CastX`, `ContextProperty`, pipeline
+      collections, and any `EntityReference`/`Player` naming a target, the triggering object, or something
+      sacrificed/tapped as a cost have nothing to resolve against. Those are **rejected at resolution**
+      rather than read as 0 (so the snapshot-mode template "base power becomes target creature's power"
+      must stay `reevaluateContinuously = false`; CR 611.2d also fixes X on resolution). Counts,
+      battlefield/zone aggregates, life totals, hand size and `Source`/`AffectedEntity` properties are all
+      supported.
+    - **"Your" is the source's controller**, not the affected creature's. Correct for a self-granted clause
+      or a grant to a creature you control; a re-evaluated grant handed to an *opponent's* creature would
+      read the granting player's hand. Keep the template to self-grants until an affected-entity-controller
+      player reference exists.
+    - **It applies only while the permanent is a creature** (CR 208.3a — the effect is created but does
+      nothing "unless that permanent becomes a creature"). Re-asked every pass, so a Vehicle crewed later
+      in the turn picks it up. Snapshot mode writes unconditionally.
 - `GrantKeyword(keyword, target, duration, condition = null)` — grant a keyword for a duration. The target may be a battlefield permanent **or a permanent spell still on the stack**: a permanent spell keeps its entity id as it resolves, so a keyword granted to `EffectTarget.TriggeringEntity` inside a "when you next cast a creature spell this turn" delayed trigger carries onto the creature the moment it enters (Summon: Brynhildr's Gestalt Mode = "it gains haste until end of turn"). On a non-permanent spell the floating effect simply never has a permanent to apply to.
   **`condition`** makes the granted keyword *conditionally live* rather than gating whether the grant happens: the grant always happens and still expires with `duration`, but the condition rides along as the floating effect's `sourceCondition` and is re-asked on every projection — the durational sibling of a printed `ConditionalStaticAbility`'s "as long as …" clause. This is how a **quoted conditional ability handed out by an animate effect** is modelled: Restless Spire's "{U}{R}: … becomes a 2/1 blue and red Elemental creature with *'During your turn, this creature has first strike.'*" is `Effects.Composite(Effects.BecomeCreature(...), Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self, Duration.EndOfTurn, Conditions.IsYourTurn))`. "You" resolves to the **source's projected controller**, and Layer 2 has already run when a later layer's modification is applied, so the clause correctly goes dark if another player gains control of the permanent mid-turn — and comes back if control returns. Do **not** reach for a `Duration.While…` here: those latch off permanently once their gate first fails (CR 611.2b), which is right for a "for as long as" duration and wrong for a conditional clause inside a granted ability. Also distinct from wrapping the grant in a `ConditionalEffect`, which tests the condition **once** at resolution and then grants unconditionally.
 - `GrantStaticAbility(ability, target, duration)` — grant a printed-shape `StaticAbility` (e.g. `CantBeBlockedByMoreThan(1)`) to a permanent for a duration. The runtime sibling of a printed static ability: unlike keyword grants (which flow through projected keywords) it is recorded as a `GrantedStaticAbility` keyed to the entity in `GameState.grantedStaticAbilities` and read **at the point of use** — combat blocker validation (`BlockPhaseManager`, CR 509.1b) consults granted `CantBeBlockedByMoreThan` alongside the creature's printed static abilities; the grant expires in the cleanup step (EndOfTurn). Compose inside `ForEachInGroup` with `EffectTarget.Self` for "each creature you control gains ..." (Full Steam Ahead = `ModifyStats(2,2)` + `GrantKeyword(TRAMPLE)` + `GrantStaticAbility(CantBeBlockedByMoreThan(1))`). `CantBeBlockedByMoreThan` (combat), `MayCastFromGraveyard` (graveyard-cast enumerator + `CastZoneResolver`, e.g. Forgotten Cellar's "cast spells from your graveyard this turn"), and `PreventActivatedAbilities` (activation legality: `CastPermissionUtils.isActivationPrevented`, consulted by the ability handler and both ability enumerators) are wired into read sites today; granting another `StaticAbility` kind compiles and stores but needs its own point-of-use read to take effect. A granted `PreventActivatedAbilities` behaves exactly like the printed form anchored to the grant's holder: its filter is evaluated with the holder as source, so the self-scoped `PreventActivatedAbilities(GameObjectFilter.Permanent.sourceItself())` locks the *holder's own* activated abilities — mana abilities included unless `nonManaAbilitiesOnly = true`. Pair it with `Duration.WhileAffectedTapped` ("for as long as it remains tapped", keyed to the granted-to permanent) for the Braided Net shape — "Tap another target nonland permanent. Its activated abilities can't be activated for as long as it remains tapped." = `Effects.Tap(target)` + `Effects.GrantStaticAbility(PreventActivatedAbilities(GameObjectFilter.Permanent.sourceItself()), target, Duration.WhileAffectedTapped)`. Like every "for as long as …" duration it is one-way (CR 611.2b): the read site gates per-frame, and `EndedDurationExpiryCheck` physically removes the grant the moment the permanent untaps (or leaves the battlefield), so a later re-tap does not re-lock it.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3525,6 +3525,26 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   printed cost. Face-down objects (no mana cost) never match; the cast-record path returns `false`
   (a record stores the resolved mana value, not the printed cost). Used by *Paradox Surveyor*
   ("a card with {X} in its mana cost"). Underlying predicate: `CardPredicate.HasXInManaCost`.
+- `.coloredManaSymbolsAtLeast(vararg colors, min = 1)` — the card's **printed** mana cost contains
+  at least `min` mana symbols of `colors`: "a noncreature spell with one or more blue mana symbols
+  in its mana cost" (*Namor the Sub-Mariner*, `coloredManaSymbolsAtLeast(Color.BLUE)`), and the
+  same shape over every colour at a higher threshold for *Omnath, Locus of All*'s "three or more
+  colored mana symbols in its mana cost" (`coloredManaSymbolsAtLeast(*Color.entries.toTypedArray(),
+  min = 3)`). `min` comes after the varargs, so it must be named. Both `min < 1` and an empty
+  colour list are rejected at construction — they would match every object, including costless
+  ones. **Not `.withColor(BLUE)`** — colour is a characteristic that layer 5,
+  colour indicators and devoid can change, this is the pips printed on the card. A hybrid symbol is
+  all of its component colours and a Phyrexian symbol is its colour (CR 107.4e/f), so `{U/R}`,
+  `{2/U}` and `{U/P}` each count as one blue symbol; generic, `{C}` and `{X}` count as none.
+  A symbol that is two of the requested colours counts once. Counting is
+  `ManaCost.coloredSymbolCount`, shared with `EntityNumericProperty.ColoredManaSymbolCount` so the
+  filter and the amount can never disagree. Honored in all five object-evaluation sites (resolution
+  predicate, trigger matcher, layer projection, cast-zone resolver, cost calculation); face-down
+  objects never match (CR 708.2a) and the cast-record path returns `false` (a record stores the
+  resolved mana value, not the printed cost). Underlying predicate:
+  `CardPredicate.ColoredManaSymbolsAtLeast`. **Per-object only** — a card that totals pips across a
+  chosen *group* ("fifteen or more black mana symbols **among their mana costs**", *Baron Helmut
+  Zemo*) is a different shape and this predicate does not serve it.
 - `.toughnessAtMost(n)` / `.toughnessAtLeast(n)` — toughness comparator.
 - `.powerOrToughnessAtLeast(n)` / `.powerOrToughnessAtMost(n)` — **OR** caps over power and
   toughness: matches when *either* power or toughness is ≥ (resp. ≤) `n`. `powerOrToughnessAtMost`
@@ -8568,7 +8588,9 @@ Numbers computed at resolution time.
   twobrid ({2/B} is black), and Phyrexian ({B/P} is black); generic/colorless/{X} never count.
   Face-down permanents have no mana cost and contribute 0. Controller read via projected state.
   Facade: `DynamicAmounts.devotionTo(color, …)`. Used by "draw cards equal to your devotion to red"
-  (Clive, Ifrit's Dominant).
+  (Clive, Ifrit's Dominant). For the pips inside **one object's** cost ("a spell with one or more
+  blue mana symbols in its mana cost") use `DynamicAmounts.coloredManaSymbolsOf(entity, …)` — same
+  counting rule (`ManaCost.coloredSymbolCount`), different scope.
 - `UnlockedDoors(player = You, distinctNames = false)` — the number of unlocked doors among Rooms
   `player` controls (CR 709.5). Reads per-face door state, so a single Room with **both** doors
   unlocked counts as **two** — an entity-level `AggregateBattlefield`/`Count` cannot see this. With
@@ -8847,6 +8869,23 @@ both spellings, and the ability its bare-noun line grants says "Regenerate this 
   `EntityProperty(entity, EntityNumericProperty.ColorCount)`. Read from projected state for
   battlefield permanents (honors layer-5 color-changing — a creature turned colorless counts 0).
   Powers "for each color of [it]" amounts, e.g. Dragonfire Blade's equip cost reduction.
+- `DynamicAmounts.coloredManaSymbolsOf(entity, vararg colors)` — the number of mana symbols of
+  `colors` in **that one entity's printed mana cost**. Desugars to
+  `EntityProperty(entity, EntityNumericProperty.ColoredManaSymbolCount(colors))`. Namor the
+  Sub-Mariner's "…with one or more blue mana symbols in its mana cost, create **that many** 1/1 blue
+  Merfolk creature tokens" is `coloredManaSymbolsOf(EntityReference.Triggering, Color.BLUE)`, paired
+  with the `.coloredManaSymbolsAtLeast(Color.BLUE)` filter on the trigger. Hybrid and Phyrexian
+  pips count for their colour(s) (CR 107.4e/f); generic, `{C}` and `{X}` count for none, whatever
+  value was announced for X (`{X}` is a generic symbol, CR 107.4b). The *printed* cost is what is
+  read — a card's mana cost is the symbols printed on it (CR 202.1/202.1a), while alternative
+  costs, additional costs and cost reductions only build the spell's **total cost** (CR 601.2f) —
+  so none of them change the count. Face-down objects have no mana cost and count 0
+  (CR 708.2a); a missing entity counts 0.
+  **Not `DevotionTo`** — devotion (CR 700.5) counts the same symbols across every permanent a
+  player controls, this counts them inside one object's cost. The two share one counting rule
+  (`ManaCost.coloredSymbolCount`), so they agree symbol-for-symbol and differ only in scope.
+  Being `Triggering`-scoped, it is rejected by `SetBaseStatsEffect(reevaluateContinuously = true)`
+  like every other context-scoped amount; read off `EntityReference.Source` it is projector-safe.
 - `EntityProperty(entity, EntityNumericProperty.ExcessMarkedDamage)` — the excess damage (CR 120.4a)
   marked on a creature: `max(0, marked − toughness)`, read from post-damage state. Amount-valued twin of
   the `TargetMarkedDamageExceedsToughness` condition. Read it AFTER a deal-damage step in the same

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5529,6 +5529,17 @@ staticAbility {
   toughness rather than its power"), grant the `AbilityFlag.ASSIGNS_COMBAT_DAMAGE_AS_TOUGHNESS` flag via
   `Effects.GrantKeyword(AbilityFlag.ASSIGNS_COMBAT_DAMAGE_AS_TOUGHNESS, target, duration)`; the same combat
   util reads it from projected keywords (unconditional — no toughness > power gate).
+- `GrantKeyword(AbilityFlag.MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY.name, filter)` — "you may activate
+  abilities of [filter] as though those creatures had haste" (Thousand-Year Elixir, Shang-Chi, Master of
+  Kung Fu). CR 302.6 gates a creature's `{T}`/`{Q}` activated abilities *and* its ability to attack on the
+  same condition; haste (CR 702.10b/c) lifts both, and this flag lifts **only the ability half** — so it is
+  deliberately not `Keyword.HASTE`, and an affected creature still can't attack the turn it arrives. Use
+  `GroupFilter.AllCreaturesYouControl` for the printed "creatures you control" wording. Read by exactly one
+  place, `SummoningSicknessRules.blocksTapOrUntapCost` (`rules-engine/mechanics/`), which every `{T}`/`{Q}`
+  activation gate routes through — the mana solver, both ability enumerators, the cost helpers and
+  `ActivateAbilityHandler`'s authoritative re-check. Combat's `AttackRestrictionRules` keeps its own plain
+  haste check and never consults it; `SummoningSicknessGateEnforcementTest` fails the build if a new
+  open-coded `has<SummoningSicknessComponent>()` gate appears outside the allowlisted files.
 - **Untap restriction flags** — granted via `GrantKeyword(AbilityFlag.X.name)` and read off projected keywords,
   so they vanish when the granting source leaves play. The two "can't untap" flags differ in *scope*:
   - `AbilityFlag.CANT_BECOME_UNTAPPED` — "can't become untapped" (Blossombind). The **stronger**

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1095,16 +1095,18 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     affects — and criterion 4 — not an ability an object grants to itself), so it applies in layer 7b per
     CR 613.4b ("effects that refer to the base power and/or toughness of a creature apply in this layer"),
     not 7a. Counters and pump effects are layer 7c and still apply on top.
-    Three limits apply to `true` and not to the snapshot mode, all of them because the projector — not the
-    resolution — reads the number:
+    Four limits apply to `true` and not to the snapshot mode; the first three because the projector — not
+    the resolution — reads the number:
     - **Only projection-scoped `DynamicAmount`s.** The amount is re-evaluated with just the source, its
       controller and the affected entity in scope, so `XValue`/`CastX`, `ContextProperty`, pipeline
       collections, and any `EntityReference`/`Player` naming a target, the triggering object, or something
-      sacrificed/tapped as a cost have nothing to resolve against. Those are **rejected at resolution**
-      rather than read as 0 (so the snapshot-mode template "base power becomes target creature's power"
-      must stay `reevaluateContinuously = false`; CR 611.2d also fixes X on resolution). Counts,
-      battlefield/zone aggregates, life totals, hand size and `Source`/`AffectedEntity` properties are all
-      supported.
+      sacrificed/tapped as a cost have nothing to resolve against. Those are **rejected at card load** —
+      `SetBaseStatsEffect`'s `init` runs `contextScopedReferenceIn` (`mtg-sdk/.../scripting/values/`)
+      whenever the flag is set, so a bad amount throws as the `cardDef { }` is built and `CardDiscovery`
+      surfaces it, rather than reading 0 forever or blowing up mid-game. (So the snapshot-mode template
+      "base power becomes target creature's power" must stay `reevaluateContinuously = false`; CR 611.2d
+      also fixes X on resolution.) Counts, battlefield/zone aggregates, life totals, hand size and
+      `Source`/`AffectedEntity` properties are all supported.
     - **"Your" is the source's controller**, not the affected creature's. Correct for a self-granted clause
       or a grant to a creature you control; a re-evaluated grant handed to an *opponent's* creature would
       read the granting player's hand. Keep the template to self-grants until an affected-entity-controller
@@ -1112,6 +1114,12 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     - **It applies only while the permanent is a creature** (CR 208.3a — the effect is created but does
       nothing "unless that permanent becomes a creature"). Re-asked every pass, so a Vehicle crewed later
       in the turn picks it up. Snapshot mode writes unconditionally.
+    - **The quoted clause is not an ability the creature has**, so `LoseAllAbilities` can't strip it. Paper
+      settles "gains '…'" against Humility by layer-6 timestamp; here it is a layer-7b floating effect with
+      nothing for layer 6 to remove, so the two agree whenever the grant is the later effect (the common
+      case) and diverge only when ability-removal lands afterwards. Handing out a *whole* quoted static
+      instead wants `StaticAbilityHandler.lowerToContinuousEffectData`, the route `BecomeArtifactExecutor`
+      already uses — not `GrantStaticAbility`, whose grants are read at points of use and never projected.
 - `GrantKeyword(keyword, target, duration, condition = null)` — grant a keyword for a duration. The target may be a battlefield permanent **or a permanent spell still on the stack**: a permanent spell keeps its entity id as it resolves, so a keyword granted to `EffectTarget.TriggeringEntity` inside a "when you next cast a creature spell this turn" delayed trigger carries onto the creature the moment it enters (Summon: Brynhildr's Gestalt Mode = "it gains haste until end of turn"). On a non-permanent spell the floating effect simply never has a permanent to apply to.
   **`condition`** makes the granted keyword *conditionally live* rather than gating whether the grant happens: the grant always happens and still expires with `duration`, but the condition rides along as the floating effect's `sourceCondition` and is re-asked on every projection — the durational sibling of a printed `ConditionalStaticAbility`'s "as long as …" clause. This is how a **quoted conditional ability handed out by an animate effect** is modelled: Restless Spire's "{U}{R}: … becomes a 2/1 blue and red Elemental creature with *'During your turn, this creature has first strike.'*" is `Effects.Composite(Effects.BecomeCreature(...), Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self, Duration.EndOfTurn, Conditions.IsYourTurn))`. "You" resolves to the **source's projected controller**, and Layer 2 has already run when a later layer's modification is applied, so the clause correctly goes dark if another player gains control of the permanent mid-turn — and comes back if control returns. Do **not** reach for a `Duration.While…` here: those latch off permanently once their gate first fails (CR 611.2b), which is right for a "for as long as" duration and wrong for a conditional clause inside a granted ability. Also distinct from wrapping the grant in a `ConditionalEffect`, which tests the condition **once** at resolution and then grants unconditionally.
 - `GrantStaticAbility(ability, target, duration)` — grant a printed-shape `StaticAbility` (e.g. `CantBeBlockedByMoreThan(1)`) to a permanent for a duration. The runtime sibling of a printed static ability: unlike keyword grants (which flow through projected keywords) it is recorded as a `GrantedStaticAbility` keyed to the entity in `GameState.grantedStaticAbilities` and read **at the point of use** — combat blocker validation (`BlockPhaseManager`, CR 509.1b) consults granted `CantBeBlockedByMoreThan` alongside the creature's printed static abilities; the grant expires in the cleanup step (EndOfTurn). Compose inside `ForEachInGroup` with `EffectTarget.Self` for "each creature you control gains ..." (Full Steam Ahead = `ModifyStats(2,2)` + `GrantKeyword(TRAMPLE)` + `GrantStaticAbility(CantBeBlockedByMoreThan(1))`). `CantBeBlockedByMoreThan` (combat), `MayCastFromGraveyard` (graveyard-cast enumerator + `CastZoneResolver`, e.g. Forgotten Cellar's "cast spells from your graveyard this turn"), and `PreventActivatedAbilities` (activation legality: `CastPermissionUtils.isActivationPrevented`, consulted by the ability handler and both ability enumerators) are wired into read sites today; granting another `StaticAbility` kind compiles and stores but needs its own point-of-use read to take effect. A granted `PreventActivatedAbilities` behaves exactly like the printed form anchored to the grant's holder: its filter is evaluated with the holder as source, so the self-scoped `PreventActivatedAbilities(GameObjectFilter.Permanent.sourceItself())` locks the *holder's own* activated abilities — mana abilities included unless `nonManaAbilitiesOnly = true`. Pair it with `Duration.WhileAffectedTapped` ("for as long as it remains tapped", keyed to the granted-to permanent) for the Braided Net shape — "Tap another target nonland permanent. Its activated abilities can't be activated for as long as it remains tapped." = `Effects.Tap(target)` + `Effects.GrantStaticAbility(PreventActivatedAbilities(GameObjectFilter.Permanent.sourceItself()), target, Duration.WhileAffectedTapped)`. Like every "for as long as …" duration it is one-way (CR 611.2b): the read site gates per-frame, and `EndedDurationExpiryCheck` physically removes the grant the moment the permanent untaps (or leaves the battlefield), so a later re-tap does not re-lock it.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1381,6 +1381,37 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   a set they can't pay for. Magnetic Mountain ("pay {4} for each tapped blue creature chosen, untap them") composes
   all three: the capped selection, then the dynamic cost in a `Gate.MayPay` whose `decisionMaker` is the same
   `Player.TriggeringPlayer`.
+- `PayRepeatedly(cost, upTo?, storeCountAs?)` → `PayManaCostRepeatedlyEffect` — **"pay {1} up to three times"**
+  / "pay {2}{R} any number of times", the repeatable optional payment whose payoff scales with the number of
+  repetitions (Hawkeye, Master Marksman; Tranquil Frillback; the Adversary cycle). The payer names a count and
+  pays `cost * n` in one auto-tapped payment; the count is published to the resolution pipeline under
+  `storeCountAs` (default `"times_paid"`), read back with `DynamicAmounts.timesPaid()`.
+  - **The offered ceiling is affordability-aware and color-aware.** The cap is the smaller of `upTo` (null =
+    "any number of times", bounded only by available mana) and how many repetitions the payer can actually make,
+    tested as `cost * n` — `{G}` three times needs three *green*, not three mana. The probe is the *same*
+    auto-tap predicate the payment itself uses (floating mana, then `ManaSolver.solve`), **not**
+    `ManaSolver.canPay`: `canPay` also counts mana the auto-tapper refuses to spend for you (sacrificing a
+    Treasure, Springleaf Drum's tap-a-creature sub-cost), so capping with it would offer a count the payment
+    then errors on. Because the two agree, the prompt never offers a payment that fails mid-resolution.
+  - **The floor is one repetition, not zero — declining belongs to the wrapper.** Wrap it in
+    `ReflexiveTriggerEffect(action = …, optional = true)` for the printed "you **may** pay … **when you do**"
+    (CR 603.12; and per CR 603.12a the reflexive half triggers **once**, not once per repetition) or in a
+    `Gate.MayPay` for "if you do" — `Gate.MayPay` scores this cost's affordability, so the gate's "yes" is
+    absent when even one repetition is unaffordable. A payer who can't afford even one repetition gets a
+    *failure*, which is what keeps the reflexive half from firing; `ReflexiveTriggerEffectExecutor.isActionFeasible`
+    scores it up front so the may-question isn't raised at all in that case. A cap of exactly 1 pays without a
+    prompt — the payer has already consented and there is nothing left to choose.
+  - **Why a stored number rather than an X value:** an effect result carries no X channel. A sub-effect hands its
+    outputs back up as collections, stored numbers and chosen values — that is the whole list — so there is no
+    way for this effect to *write* an X for the reflexive ability to read. (A trigger's own `xValue` does survive
+    the CR 603.12 round-trip, riding the carried trigger context; it just isn't settable from here.) Feeding the
+    stored count to a modal's `dynamicChooseCount` is the "choose up to **that many** —" payoff (Hawkeye), and it
+    is equally at home in "put **that many** +1/+1 counters" (`DynamicAmounts.timesPaid()` into `AddCounters`).
+  - Distinct from `Gate.MayPayX`, which is a single *variable-size* generic payment binding X: no cap, no repeat
+    unit, no colored pips. **Mind the opposite floor conventions** when picking between them: `MayPayX` prompts
+    `0..max` and reads 0 as "decline", while `PayRepeatedly` prompts `1..cap` because the wrapper already asked
+    the decline question. Reach for `MayPayX` when the payment *is* X; for `PayRepeatedly` when a fixed unit —
+    especially a colored one — repeats.
 
 ### Tokens & emblems
 
@@ -2145,7 +2176,9 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     X = 0 declines → `otherwise`. An unaffordable gate (no mana) is skipped silently. A parameterless
     `data object` (the {X} cost is implicit). The executor builds a `ChooseNumberDecision` and reuses
     the existing `MayPayXContinuation`/`resumeMayPayX` to auto-tap and bind X. Replaces
-    `MayPayXForEffect` (see "Optional & gated" below).
+    `MayPayXForEffect` (see "Optional & gated" below). For the *repeated fixed* cost — "pay {1} up
+    to three times", where the count rather than the size is the variable — use
+    `Effects.PayRepeatedly` (see "Mana" above) as the gate's cost or as a reflexive trigger's action.
   - `Gate.OnceEachTurn(abilityId, spend = true)` — **not a decision, a per-turn action budget.** The
     lowered form of `TriggeredAbility.effectOncePerTurn` ("Do this only once each turn", CR 603.2h).
     Succeeds iff the source permanent's controller hasn't yet taken this ability's action this turn;
@@ -9436,6 +9469,12 @@ The cap is any `DynamicAmount` — e.g. **Bumi, King of Three Trials** uses
 own per-mode targets here just as in a fixed modal — each chosen mode's target (referenced as its
 mode-local `EffectTarget.ContextTarget(0)`) is only demanded when that mode is picked (Bumi's scry
 mode targets a player, its Earthbend mode targets a land).
+The cap may also come from something the *same resolution* just did rather than from board state:
+**Hawkeye, Master Marksman** feeds it `DynamicAmounts.timesPaid()`, the repetition count of the
+`Effects.PayRepeatedly` that formed the action half of its reflexive trigger ("you may pay {1} up to
+three times. When you do, choose up to **that many** —"). That works because the count rides across
+the CR 603.12 stack round-trip in the reflexive ability's carried pipeline, and the trigger-time
+evaluation site reads the pipeline (see `EffectContext.forTriggeredAbility`).
 
 **Cast-time mode-selection UX (Spree / "choose one or more").** A choose-N modal *spell* cast
 by a human is presented as a **single mode-selection panel** (web client), not a sequential

--- a/manual-scenarios/cards/h/hawkeye-master-marksman-trick-arrows.json
+++ b/manual-scenarios/cards/h/hawkeye-master-marksman-trick-arrows.json
@@ -1,0 +1,85 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears",
+      "Hill Giant"
+    ],
+    "battlefield": [
+      {
+        "name": "Hawkeye, Master Marksman"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain",
+      "Grizzly Bears",
+      "Mountain",
+      "Hill Giant",
+      "Mountain"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {
+        "name": "Grizzly Bears"
+      },
+      {
+        "name": "Hill Giant"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Grizzly Bears",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "PRECOMBAT_MAIN",
+    "DECLARE_ATTACKERS",
+    "DECLARE_BLOCKERS",
+    "COMBAT_DAMAGE",
+    "POSTCOMBAT_MAIN"
+  ],
+  "player2StopAtSteps": [
+    "PRECOMBAT_MAIN"
+  ],
+  "player1OpponentStopAtSteps": [
+    "PRECOMBAT_MAIN"
+  ],
+  "player2OpponentStopAtSteps": [
+    "DECLARE_BLOCKERS",
+    "POSTCOMBAT_MAIN"
+  ],
+  "mode": "SELF"
+}

--- a/manual-scenarios/sets/msh/loop-msh-u29-shang-chi-master-of-kung-fu.json
+++ b/manual-scenarios/sets/msh/loop-msh-u29-shang-chi-master-of-kung-fu.json
@@ -1,0 +1,88 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Shang-Chi, Master of Kung Fu",
+      "Llanowar Elves",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Llanowar Elves",
+        "summoningSickness": true
+      },
+      {
+        "name": "Birds of Paradise",
+        "summoningSickness": true
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Forest",
+      "Grizzly Bears",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Murder"
+    ],
+    "battlefield": [
+      {
+        "name": "Grizzly Bears"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "PRECOMBAT_MAIN",
+    "DECLARE_ATTACKERS",
+    "POSTCOMBAT_MAIN"
+  ],
+  "player2StopAtSteps": [
+    "PRECOMBAT_MAIN"
+  ],
+  "player1OpponentStopAtSteps": [
+    "PRECOMBAT_MAIN"
+  ],
+  "player2OpponentStopAtSteps": [
+    "PRECOMBAT_MAIN",
+    "POSTCOMBAT_MAIN"
+  ],
+  "mode": "SELF"
+}

--- a/manual-scenarios/sets/msh/loop-msh-u35-ms-marvel-kamala-khan.json
+++ b/manual-scenarios/sets/msh/loop-msh-u35-ms-marvel-kamala-khan.json
@@ -1,0 +1,110 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Giant Growth",
+      "Shock",
+      "Divination",
+      "Grizzly Bears",
+      "Centaur Courser",
+      "Island",
+      "Island"
+    ],
+    "battlefield": [
+      {
+        "name": "Ms. Marvel, Kamala Khan"
+      },
+      {
+        "name": "Grizzly Bears"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Island",
+      "Island",
+      "Forest",
+      "Island",
+      "Forest",
+      "Island",
+      "Forest",
+      "Island"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Shock",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Savannah Lions"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain",
+      "Mountain",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "UPKEEP",
+    "PRECOMBAT_MAIN",
+    "DECLARE_ATTACKERS",
+    "POSTCOMBAT_MAIN",
+    "END"
+  ],
+  "player2StopAtSteps": [
+    "PRECOMBAT_MAIN",
+    "POSTCOMBAT_MAIN"
+  ],
+  "player1OpponentStopAtSteps": [
+    "UPKEEP",
+    "PRECOMBAT_MAIN",
+    "DECLARE_ATTACKERS",
+    "POSTCOMBAT_MAIN",
+    "END"
+  ],
+  "player2OpponentStopAtSteps": [
+    "PRECOMBAT_MAIN",
+    "POSTCOMBAT_MAIN"
+  ],
+  "mode": "SELF"
+}

--- a/manual-scenarios/sets/msh/loop-msh-u36-namor-the-sub-mariner.json
+++ b/manual-scenarios/sets/msh/loop-msh-u36-namor-the-sub-mariner.json
@@ -1,0 +1,110 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Counterspell",
+      "Divination",
+      "Opt",
+      "Unsummon",
+      "Shock",
+      "Grizzly Bears",
+      "Island"
+    ],
+    "battlefield": [
+      {
+        "name": "Namor the Sub-Mariner"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Forest"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Island",
+      "Island",
+      "Island",
+      "Island",
+      "Forest",
+      "Mountain",
+      "Island",
+      "Island"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Divination",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Savannah Lions"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Mountain"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Island",
+      "Island",
+      "Mountain",
+      "Mountain"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "UPKEEP",
+    "PRECOMBAT_MAIN",
+    "DECLARE_ATTACKERS",
+    "POSTCOMBAT_MAIN",
+    "END"
+  ],
+  "player2StopAtSteps": [
+    "PRECOMBAT_MAIN",
+    "POSTCOMBAT_MAIN"
+  ],
+  "player1OpponentStopAtSteps": [
+    "UPKEEP",
+    "PRECOMBAT_MAIN",
+    "DECLARE_ATTACKERS",
+    "POSTCOMBAT_MAIN",
+    "END"
+  ],
+  "player2OpponentStopAtSteps": [
+    "PRECOMBAT_MAIN",
+    "POSTCOMBAT_MAIN"
+  ],
+  "mode": "SELF"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/AbilityFlag.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/AbilityFlag.kt
@@ -75,5 +75,24 @@ enum class AbilityFlag(val displayName: String) {
     CANT_TRANSFORM("Can't transform"),
 
     // ── Combat damage assignment flags ──────────────────────────
-    ASSIGNS_COMBAT_DAMAGE_AS_TOUGHNESS("Assigns combat damage equal to its toughness rather than its power")
+    ASSIGNS_COMBAT_DAMAGE_AS_TOUGHNESS("Assigns combat damage equal to its toughness rather than its power"),
+
+    // ── Summoning-sickness flags ────────────────────────────────
+    /**
+     * "You may activate abilities of this creature as though it had haste" — the
+     * Thousand-Year Elixir / Shang-Chi, Master of Kung Fu permission.
+     *
+     * CR 302.6 gates two separate things on the same condition: a creature can't activate an
+     * activated ability whose cost includes `{T}` or `{Q}`, *and* a creature can't attack. Haste
+     * (CR 702.10b/c) lifts both. This flag lifts **only the ability half** — a creature carrying it
+     * still can't attack the turn it arrives, which is exactly what "as though those creatures had
+     * haste" (limited to activating abilities) means.
+     *
+     * So it is deliberately *not* [Keyword.HASTE]: grant it with
+     * `GrantKeyword(AbilityFlag.MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY, <filter>)` and the layer
+     * system carries it like any other granted keyword. It is read only by
+     * `SummoningSicknessRules` (the shared `{T}`/`{Q}` gate); `AttackRestrictionRules` keeps its own
+     * plain haste check, so the attack half is structurally unaffected.
+     */
+    MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY("You may activate its abilities as though it had haste")
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/ManaCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/ManaCost.kt
@@ -10,15 +10,26 @@ data class ManaCost(val symbols: List<ManaSymbol>) {
         get() = symbols.sumOf { it.cmc }
 
     val colors: Set<Color>
-        get() = symbols.flatMap { symbol ->
-            when (symbol) {
-                is ManaSymbol.Colored -> listOf(symbol.color)
-                is ManaSymbol.Hybrid -> listOf(symbol.color1, symbol.color2)
-                is ManaSymbol.Phyrexian -> listOf(symbol.color)
-                is ManaSymbol.MonocolorHybrid -> listOf(symbol.color)
-                else -> emptyList()
-            }
-        }.toSet()
+        get() = symbols.flatMapTo(mutableSetOf()) { it.colors }
+
+    /**
+     * The number of mana symbols in this cost that are any of [colors] — the count behind
+     * devotion (CR 700.5, summed over a player's permanents) and behind "a spell with one or more
+     * blue mana symbols in its mana cost" (Namor the Sub-Mariner, read from one object's cost).
+     *
+     * Which symbols are which colors is [ManaSymbol.colors]: hybrid and Phyrexian pips count for
+     * their color(s) (CR 107.4e/f), generic/colorless/`{X}` count for none. A symbol that is more
+     * than one of the requested colors — `{U/R}` against "blue or red" — is still **one** symbol
+     * and is counted once, exactly as CR 700.5 defines devotion to two colors.
+     *
+     * An empty [colors] counts nothing. Callers that read an object's *printed* cost are
+     * responsible for the zone-level rules around it (a face-down object has no mana cost,
+     * CR 708.2).
+     */
+    fun coloredSymbolCount(colors: Set<Color>): Int {
+        if (colors.isEmpty()) return 0
+        return symbols.count { symbol -> symbol.colors.any { it in colors } }
+    }
 
     val colorCount: Map<Color, Int>
         get() = symbols

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/ManaSymbol.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/ManaSymbol.kt
@@ -6,6 +6,29 @@ import kotlinx.serialization.Serializable
 sealed interface ManaSymbol {
     val cmc: Int
 
+    /**
+     * The color(s) this one symbol *is* — the single rule every "count/collect the colored mana
+     * symbols" read in the engine goes through (object color CR 202.2, devotion CR 700.5, and
+     * "with one or more blue mana symbols in its mana cost").
+     *
+     * Per CR 107.4e a hybrid symbol is also a colored mana symbol and **is all of its component
+     * colors**, so `{U/R}` is both blue and red and a monocolored hybrid `{2/U}` is blue. Per
+     * CR 107.4f a Phyrexian symbol is a colored mana symbol of its color, so `{U/P}` is blue.
+     * Generic (`{2}`), colorless (`{C}`) and `{X}` symbols are no color at all (CR 107.4b/c).
+     *
+     * A symbol is one symbol however many colors it is: counting *symbols* matching a color set
+     * must count the symbol once, which is why this returns a set and callers use `any { }` rather
+     * than summing (CR 700.5's "devotion to [color 1] and [color 2]" says the same thing).
+     */
+    val colors: Set<Color>
+        get() = when (this) {
+            is Colored -> setOf(color)
+            is Hybrid -> setOf(color1, color2)
+            is Phyrexian -> setOf(color)
+            is MonocolorHybrid -> setOf(color)
+            is Generic, Colorless, X -> emptySet()
+        }
+
     @Serializable
     data class Colored(val color: Color) : ManaSymbol {
         override val cmc: Int = 1

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -610,6 +610,15 @@ object DynamicAmounts {
     fun colorCountOf(entity: EntityReference): DynamicAmount =
         DynamicAmount.EntityProperty(entity, EntityNumericProperty.ColorCount)
 
+    /**
+     * The number of mana symbols of [colors] in the referenced entity's printed mana cost — the
+     * per-object pip count ("with one or more blue mana symbols in its mana cost … create that
+     * many", Namor the Sub-Mariner), *not* devotion. Use [devotionTo] for the whole-battlefield
+     * count of CR 700.5. Hybrid and Phyrexian pips count for their colour(s) (CR 107.4e/f).
+     */
+    fun coloredManaSymbolsOf(entity: EntityReference, vararg colors: Color): DynamicAmount =
+        DynamicAmount.EntityProperty(entity, EntityNumericProperty.ColoredManaSymbolCount(colors.toList()))
+
     fun sacrificedPower(index: Int = 0): DynamicAmount =
         DynamicAmount.EntityProperty(EntityReference.Sacrificed(index), EntityNumericProperty.Power)
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -694,4 +694,19 @@ object DynamicAmounts {
      */
     fun permanentsSacrificedThisWay(): DynamicAmount =
         DynamicAmount.PermanentsSacrificedThisWay
+
+    /**
+     * "That many" — the number of repetitions a
+     * [com.wingedsheep.sdk.scripting.effects.PayManaCostRepeatedlyEffect] was paid, read back out
+     * of the resolution pipeline. Pair it with the matching `storeCountAs` when the effect uses a
+     * non-default name.
+     *
+     * Hawkeye, Master Marksman: "you may pay {1} up to three times. When you do, choose up to
+     * **that many** —" is `dynamicChooseCount = DynamicAmounts.timesPaid()` on the reflexive
+     * trigger's modal.
+     */
+    fun timesPaid(
+        storeCountAs: String =
+            com.wingedsheep.sdk.scripting.effects.PayManaCostRepeatedlyEffect.TIMES_PAID
+    ): DynamicAmount = DynamicAmount.VariableReference(storeCountAs)
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2206,6 +2206,28 @@ object Effects {
         com.wingedsheep.sdk.scripting.effects.PayDynamicManaCostEffect(amount, payer, color)
 
     /**
+     * "Pay [cost] up to [upTo] times" (or "any number of times" when [upTo] is null) — a
+     * repeatable optional payment at resolution whose payoff scales with the number of
+     * repetitions. See [com.wingedsheep.sdk.scripting.effects.PayManaCostRepeatedlyEffect]: the
+     * offered cap is affordability-aware, the count lands in the pipeline under [storeCountAs]
+     * (read it with [DynamicAmounts.timesPaid]), and the decline path belongs to the wrapping
+     * `ReflexiveTriggerEffect(optional = true)` / `Gate.MayPay`.
+     *
+     * Hawkeye, Master Marksman: `PayRepeatedly("{1}", upTo = 3)` as the action half of a reflexive
+     * trigger whose modal reads `dynamicChooseCount = DynamicAmounts.timesPaid`.
+     */
+    fun PayRepeatedly(
+        cost: String,
+        upTo: Int? = null,
+        storeCountAs: String =
+            com.wingedsheep.sdk.scripting.effects.PayManaCostRepeatedlyEffect.TIMES_PAID
+    ): Effect = com.wingedsheep.sdk.scripting.effects.PayManaCostRepeatedlyEffect(
+        cost = ManaCost.parse(cost),
+        maxTimes = upTo,
+        storeCountAs = storeCountAs
+    )
+
+    /**
      * Add mana of a color the player chooses from a [ManaColorSet] resolved at resolution
      * time. The unified "choose-from-set" primitive — see [AddManaOfChoiceEffect].
      *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2082,22 +2082,42 @@ object Effects {
     /**
      * Set a creature's base power to a dynamic value (Layer 7b, set values), leaving toughness alone.
      * "Change this creature's base power to target creature's power."
+     *
+     * [reevaluateContinuously] recomputes [power] on every projection pass instead of freezing the
+     * number at resolution — what "gains 'this creature's base power is equal to …'" needs
+     * (Ms. Marvel, Kamala Khan). It accepts only amounts the projector can still evaluate (no
+     * target-, X-, triggering- or cost-scoped references — those are rejected at resolution),
+     * reads "your" as the *source's* controller, and applies only while the permanent is a
+     * creature. See [SetBaseStatsEffect] for the full contract and for why this is layer 7b and
+     * not a CDA.
      */
     fun SetBasePower(
         target: EffectTarget = EffectTarget.Self,
         power: DynamicAmount,
-        duration: Duration = Duration.Permanent
-    ): Effect = SetBaseStatsEffect(target, power = power, duration = duration)
+        duration: Duration = Duration.Permanent,
+        reevaluateContinuously: Boolean = false
+    ): Effect = SetBaseStatsEffect(
+        target,
+        power = power,
+        duration = duration,
+        reevaluateContinuously = reevaluateContinuously
+    )
 
     /**
      * Set a creature's base toughness to a dynamic value (Layer 7b, set values), leaving power alone.
-     * The toughness-only sibling of [SetBasePower].
+     * The toughness-only sibling of [SetBasePower], including [reevaluateContinuously].
      */
     fun SetBaseToughness(
         target: EffectTarget = EffectTarget.Self,
         toughness: DynamicAmount,
-        duration: Duration = Duration.Permanent
-    ): Effect = SetBaseStatsEffect(target, toughness = toughness, duration = duration)
+        duration: Duration = Duration.Permanent,
+        reevaluateContinuously: Boolean = false
+    ): Effect = SetBaseStatsEffect(
+        target,
+        toughness = toughness,
+        duration = duration,
+        reevaluateContinuously = reevaluateContinuously
+    )
 
     /**
      * Set a creature's base power AND toughness to fixed values (Layer 7b, set values).
@@ -2113,14 +2133,15 @@ object Effects {
     /**
      * Set a creature's base power AND toughness to dynamic values (Layer 7b, set values).
      * "Base power and toughness each become equal to ..." — the dynamic counterpart of the fixed
-     * overload above.
+     * overload above. [reevaluateContinuously] behaves as on [SetBasePower].
      */
     fun SetBasePowerAndToughness(
         power: DynamicAmount,
         toughness: DynamicAmount,
         target: EffectTarget = EffectTarget.ContextTarget(0),
-        duration: Duration = Duration.EndOfTurn
-    ): Effect = SetBaseStatsEffect(target, power, toughness, duration)
+        duration: Duration = Duration.EndOfTurn,
+        reevaluateContinuously: Boolean = false
+    ): Effect = SetBaseStatsEffect(target, power, toughness, duration, reevaluateContinuously)
 
     // =========================================================================
     // Mana Effects

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaEffects.kt
@@ -77,6 +77,69 @@ data class PayDynamicManaCostEffect(
 }
 
 /**
+ * "Pay [cost] up to [maxTimes] times" / "…any number of times" — a **repeatable** optional mana
+ * payment made during resolution, whose payoff scales with *how many times* it was paid
+ * (Hawkeye, Master Marksman; Tranquil Frillback; the Innistrad Adversary cycle).
+ *
+ * The payer names a number of repetitions and pays `cost` that many times in one go — one payment,
+ * and (CR 603.12a) one reflexive trigger, not one per repetition. The cap is the smaller of
+ * [maxTimes] and how many repetitions they can actually afford, computed color-aware from `cost * n`
+ * through the same auto-tap predicate the payment itself uses — so the prompt never offers a count
+ * the payment would then fail on. Paying is not optional *within* this effect: the number is
+ * chosen from `1..cap`, and the effect **fails** when the payer cannot afford a single repetition.
+ * The decline path belongs to the wrapper:
+ *
+ *  - `ReflexiveTriggerEffect(action = this, optional = true, reflexiveEffect = …)` — "you **may**
+ *    pay {1} up to three times. **When you do**, …" (CR 603.12). The yes/no is the decline, the
+ *    number chooser is the count, and the reflexive half never triggers when either is refused.
+ *  - `GatedEffect(Gate.MayPay(this), then = …)` for the "if you do" templating.
+ *
+ * The number of repetitions is written into the resolution pipeline under [storeCountAs], read
+ * back with `DynamicAmount.VariableReference` ([com.wingedsheep.sdk.dsl.DynamicAmounts.timesPaid]).
+ * A stored *number* rather than an X value, because an effect result carries no X channel: a
+ * sub-effect can hand its outputs back up as collections, stored numbers and chosen values, and
+ * that is the whole list — there is no way for this effect to *write* an X that the reflexive
+ * ability would later read. (A trigger's own `xValue` does survive the CR 603.12 round-trip; it
+ * rides the carried trigger context. It just isn't something a sub-effect can set.) Feeding the
+ * stored number to a modal's [ModalEffect.dynamicChooseCount] is the "choose up to **that many** —"
+ * payoff.
+ *
+ * Distinct from [Gate.MayPayX], which is one *variable-size* generic payment binding X (no cap, no
+ * repeat unit, no colored pips): here the unit cost is fixed and repeated, so `{G}` three times
+ * costs `{G}{G}{G}` and cannot be paid with three colorless.
+ *
+ * @property cost One repetition's cost. Repeated with `ManaCost.times`, so colored pips repeat too.
+ * @property maxTimes Cap on repetitions; `null` is the uncapped "any number of times" wording.
+ * @property storeCountAs Pipeline variable the repetition count is written to.
+ */
+@SerialName("PayManaCostRepeatedly")
+@Serializable
+data class PayManaCostRepeatedlyEffect(
+    val cost: ManaCost,
+    val maxTimes: Int? = null,
+    val storeCountAs: String = TIMES_PAID
+) : Effect {
+    init {
+        require(maxTimes == null || maxTimes >= 1) {
+            "maxTimes must be at least 1 when set, was $maxTimes"
+        }
+    }
+
+    override val description: String = buildString {
+        append("Pay $cost ")
+        append(
+            if (maxTimes == null) "any number of times"
+            else "up to ${com.wingedsheep.sdk.scripting.util.numberToWord(maxTimes)} times"
+        )
+    }
+
+    companion object {
+        /** Default [storeCountAs] name — the count of repetitions actually paid. */
+        const val TIMES_PAID: String = "times_paid"
+    }
+}
+
+/**
  * Add mana effect.
  * "Add {G}" or "Add {R}{R}" or "Add {R} for each Goblin on the battlefield."
  *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StatsEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StatsEffects.kt
@@ -64,9 +64,8 @@ data class ModifyStatsEffect(
 }
 
 /**
- * Set a creature's base power and/or toughness to specific values via a one-shot floating
- * continuous effect at Layer.POWER_TOUGHNESS, Sublayer.SET_VALUES (CR 613.4b, layer 7b),
- * evaluated at resolution time.
+ * Set a creature's base power and/or toughness via a floating continuous effect at
+ * Layer.POWER_TOUGHNESS, Sublayer.SET_VALUES (CR 613.4b, layer 7b).
  *
  * A `null` [power] or [toughness] leaves that stat unchanged, so this single atom expresses every
  * shape the engine needs:
@@ -76,20 +75,59 @@ data class ModifyStatsEffect(
  * Both are [DynamicAmount] (the asymmetry the two predecessors carried — power-only was dynamic,
  * power-and-toughness was fixed Int — is gone), so either value can be read from game state.
  *
- * This is the one-shot, resolution-time *set*. It is deliberately distinct from:
+ * [reevaluateContinuously] picks *when* those `DynamicAmount`s are read — the headline difference
+ * between two genuinely different Magic templates on the same layer-7b set, though not the only one
+ * (see the three limits below):
+ *  - `false` (default) — **snapshot**: the amounts are evaluated once as the effect resolves and the
+ *    number is frozen for the duration. "Change this creature's base power to target creature's
+ *    power" keeps the number it saw even if that other creature is later pumped or dies.
+ *  - `true` — **re-evaluated**: the `DynamicAmount`s travel into the projection and are recomputed on
+ *    every layer pass, so the stat tracks the game state. This is what an effect that hands a
+ *    creature a *quoted static ability* needs — Ms. Marvel, Kamala Khan's "Until end of turn, this
+ *    creature gains 'This creature's base power is equal to the number of cards in your hand.'"
+ *    Note that a self-granted ability like that is **not** a characteristic-defining ability
+ *    (CR 604.3a criteria 2 and 4: not printed on the card, and granted by the object to itself), so
+ *    it belongs in layer 7b with the timestamp of the grant, not in layer 7a.
+ * Either way the *affected set* is locked in at resolution (CR 611.2c) — only the number moves.
+ *
+ * Three limits on `reevaluateContinuously = true`, none of which apply to the snapshot mode. They
+ * follow from the number being read by the layer projector rather than at resolution:
+ *  - **Only projection-scoped `DynamicAmount`s are supported.** The projector re-evaluates the
+ *    amount with just the source, its controller and the affected entity in scope, so anything
+ *    reading the resolution context — `XValue`/`CastX`, `ContextProperty`, the pipeline's stored
+ *    collections, or an `EntityReference`/`Player` naming a target, the triggering object or
+ *    something sacrificed or tapped as a cost — has nothing to resolve against. The executor
+ *    rejects those at resolution instead of reading them as 0 forever, so
+ *    `SetBasePower(t, EntityProperty(Triggering, Power), reevaluateContinuously = true)` is a load
+ *    error, not a silent zero. For X specifically, re-evaluation is also a rules error: CR 611.2d
+ *    fixes a continuous effect's X on resolution. Counts, battlefield/zone aggregates, life totals,
+ *    hand size and `EntityReference.Source`/`AffectedEntity` properties are all fine.
+ *  - **"Your" means the *source's* controller**, not the affected creature's — the projector
+ *    rebuilds the context from `sourceId`. That is right for a self-granted clause (Ms. Marvel:
+ *    source and affected permanent are the same object, so it follows her controller even after a
+ *    control change) and for a grant to a creature you control, but a re-evaluated grant handed to
+ *    another player's creature would read the granting player's hand rather than the creature
+ *    controller's. Keep the template to self-grants and creatures you control until an
+ *    affected-entity-controller player reference exists.
+ *  - **It applies only while the affected permanent is a creature** (CR 208.3a — the effect is still
+ *    created, it just "doesn't do anything unless that permanent becomes a creature"). The gate is
+ *    re-asked every projection pass, so a Vehicle crewed later in the turn picks the value up. The
+ *    snapshot mode writes its number unconditionally.
+ *
+ * It is deliberately distinct from:
  *  - [ModifyStatsEffect] — a +N/+N *modifier* (layer 7c), not a set.
  *  - the `SetBasePowerToughness*Static` characteristic-defining abilities — applied for as long as
- *    a static ability is active, not a one-shot floating effect.
- *  - the projector's `SetPowerToughnessDynamic` modification — re-evaluated per affected entity at
- *    projection time (mass animate), not once at resolution.
+ *    a static ability printed on a permanent is active, not a floating effect with a duration.
  *
- * Reach it through the [com.wingedsheep.sdk.dsl.Effects] `SetBasePower` / `SetBasePowerAndToughness`
- * facades rather than constructing it directly.
+ * Reach it through the [com.wingedsheep.sdk.dsl.Effects] `SetBasePower` / `SetBaseToughness` /
+ * `SetBasePowerAndToughness` facades rather than constructing it directly.
  *
  * @property target The creature whose base stats are being set
- * @property power The value to set base power to (evaluated at resolution time), or null to leave it
+ * @property power The value to set base power to, or null to leave it
  * @property toughness The value to set base toughness to, or null to leave it
  * @property duration How long the effect lasts (typically Permanent for indefinite effects)
+ * @property reevaluateContinuously Recompute [power]/[toughness] on every projection pass instead of
+ *   snapshotting them at resolution
  */
 @SerialName("SetBaseStats")
 @Serializable
@@ -97,7 +135,8 @@ data class SetBaseStatsEffect(
     val target: EffectTarget,
     val power: DynamicAmount? = null,
     val toughness: DynamicAmount? = null,
-    val duration: Duration = Duration.Permanent
+    val duration: Duration = Duration.Permanent,
+    val reevaluateContinuously: Boolean = false
 ) : Effect {
     override val description: String = buildString {
         when {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StatsEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StatsEffects.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.text.TextReplacer
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.contextScopedReferenceIn
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -90,18 +91,20 @@ data class ModifyStatsEffect(
  *    it belongs in layer 7b with the timestamp of the grant, not in layer 7a.
  * Either way the *affected set* is locked in at resolution (CR 611.2c) — only the number moves.
  *
- * Three limits on `reevaluateContinuously = true`, none of which apply to the snapshot mode. They
- * follow from the number being read by the layer projector rather than at resolution:
+ * Four limits on `reevaluateContinuously = true`, none of which apply to the snapshot mode. The
+ * first three follow from the number being read by the layer projector rather than at resolution:
  *  - **Only projection-scoped `DynamicAmount`s are supported.** The projector re-evaluates the
  *    amount with just the source, its controller and the affected entity in scope, so anything
  *    reading the resolution context — `XValue`/`CastX`, `ContextProperty`, the pipeline's stored
  *    collections, or an `EntityReference`/`Player` naming a target, the triggering object or
- *    something sacrificed or tapped as a cost — has nothing to resolve against. The executor
- *    rejects those at resolution instead of reading them as 0 forever, so
- *    `SetBasePower(t, EntityProperty(Triggering, Power), reevaluateContinuously = true)` is a load
- *    error, not a silent zero. For X specifically, re-evaluation is also a rules error: CR 611.2d
- *    fixes a continuous effect's X on resolution. Counts, battlefield/zone aggregates, life totals,
- *    hand size and `EntityReference.Source`/`AffectedEntity` properties are all fine.
+ *    something sacrificed or tapped as a cost — has nothing to resolve against. This class's `init`
+ *    rejects those via
+ *    [com.wingedsheep.sdk.scripting.values.contextScopedReferenceIn] instead of letting them read as
+ *    0 forever, so `SetBasePower(t, EntityProperty(Triggering, Power), reevaluateContinuously =
+ *    true)` fails as the card is **loaded**, not silently at resolution. For X specifically,
+ *    re-evaluation is also a rules error: CR 611.2d fixes a continuous effect's X on resolution.
+ *    Counts, battlefield/zone aggregates, life totals, hand size and
+ *    `EntityReference.Source`/`AffectedEntity` properties are all fine.
  *  - **"Your" means the *source's* controller**, not the affected creature's — the projector
  *    rebuilds the context from `sourceId`. That is right for a self-granted clause (Ms. Marvel:
  *    source and affected permanent are the same object, so it follows her controller even after a
@@ -113,6 +116,14 @@ data class ModifyStatsEffect(
  *    created, it just "doesn't do anything unless that permanent becomes a creature"). The gate is
  *    re-asked every projection pass, so a Vehicle crewed later in the turn picks the value up. The
  *    snapshot mode writes its number unconditionally.
+ *  - **A quoted clause modelled this way is not an ability the creature actually has**, so
+ *    `LoseAllAbilities` cannot strip it. In paper, "gains '…'" and Humility are both layer 6 and the
+ *    later timestamp wins; here the grant is a layer-7b floating effect with nothing for layer 6 to
+ *    remove, so it keeps applying. The two agree whenever the grant is the later effect — the
+ *    common case, and Ms. Marvel's — and diverge only when the ability-removal arrives afterwards.
+ *    Routing a runtime-granted static through `StaticAbilityHandler.lowerToContinuousEffectData`
+ *    (as `BecomeArtifactExecutor` already does) is the shape that would close this; reach for it if
+ *    a card ever needs to hand out a whole quoted static ability rather than one base-P/T clause.
  *
  * It is deliberately distinct from:
  *  - [ModifyStatsEffect] — a +N/+N *modifier* (layer 7c), not a set.
@@ -138,6 +149,28 @@ data class SetBaseStatsEffect(
     val duration: Duration = Duration.Permanent,
     val reevaluateContinuously: Boolean = false
 ) : Effect {
+    init {
+        // Load-time, not resolution-time: an amount the projector cannot re-evaluate is an
+        // authoring mistake, and it should fail as the cardDef is built (CardDiscovery, the corpus
+        // tests) rather than throw mid-game the first time this effect happens to resolve. Only
+        // reached when the flag is set, so the JSON scan costs nothing for the common snapshot mode.
+        if (reevaluateContinuously) {
+            listOfNotNull(power, toughness).forEach { amount ->
+                val offending = contextScopedReferenceIn(amount)
+                require(offending == null) {
+                    "SetBaseStatsEffect(reevaluateContinuously = true) cannot carry the " +
+                        "context-scoped reference '$offending' in ${amount.description}: the " +
+                        "projector re-evaluates the amount with only the source, its controller " +
+                        "and the affected entity in scope, so target-, X-, triggering- and " +
+                        "cost-scoped references resolve to nothing on every pass. Use the default " +
+                        "snapshot mode (CR 611.2d requires X to be fixed on resolution anyway), " +
+                        "or an amount computable from the source, the affected entity and global " +
+                        "game state."
+                }
+            }
+        }
+    }
+
     override val description: String = buildString {
         when {
             power != null && toughness != null ->

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -477,6 +477,21 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.HasXInManaCost
     )
 
+    /**
+     * Printed mana cost contains at least [min] mana symbols of [colors] — "with one or more blue
+     * mana symbols in its mana cost" (Namor the Sub-Mariner), or every colour at `min = 3` for
+     * Omnath, Locus of All's "three or more colored mana symbols in its mana cost". Hybrid and
+     * Phyrexian pips count for their colour(s); this is the printed cost, not the object's colour
+     * (see [CardPredicate.ColoredManaSymbolsAtLeast]).
+     *
+     * Colours are varargs to match the amount-side facade
+     * [com.wingedsheep.sdk.dsl.DynamicAmounts.coloredManaSymbolsOf], so the gate and the count
+     * read the same way at a card's two call sites; [min] follows them and must be named.
+     */
+    fun coloredManaSymbolsAtLeast(vararg colors: Color, min: Int = 1) = copy(
+        cardPredicates = cardPredicates + CardPredicate.ColoredManaSymbolsAtLeast(colors.toList(), min)
+    )
+
     /** Power equals */
     fun power(value: Int) = copy(
         cardPredicates = cardPredicates + CardPredicate.PowerEquals(value)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.sdk.scripting.ChoiceSlot
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.text.TextReplaceable
 import com.wingedsheep.sdk.scripting.text.TextReplacer
+import com.wingedsheep.sdk.scripting.util.numberToWord
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.scripting.values.EntityReference
 import kotlinx.serialization.SerialName
@@ -595,6 +596,51 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         override val description: String = "with {X} in its mana cost"
     }
 
+    /**
+     * Matches an object whose printed mana cost contains at least [min] mana symbols of [colors]
+     * — "a noncreature spell with one or more blue mana symbols in its mana cost" (Namor the
+     * Sub-Mariner) with the default `min = 1`, and the same shape over every colour at a higher
+     * threshold for Omnath, Locus of All's "if it has three or more colored mana symbols in its
+     * mana cost" (`colors` = all five, `min = 3`).
+     *
+     * **Not the same as [HasColor].** Colour is a characteristic that layer-5 effects, colour
+     * indicators and devoid can change; this reads the printed cost's pips. A blue-pipped spell
+     * made colourless still matches, and a card that is blue only by colour indicator does not.
+     *
+     * Counting is [com.wingedsheep.sdk.core.ManaCost.coloredSymbolCount], shared with
+     * [com.wingedsheep.sdk.scripting.values.EntityNumericProperty.ColoredManaSymbolCount] so the
+     * "does it match" and the "how many" sides of one card can never disagree: hybrid and
+     * Phyrexian pips count for their colour(s) (CR 107.4e/f), generic/colorless/`{X}` count for
+     * none, and a pip that is two of the requested colours counts once. Face-down objects have no
+     * mana cost (CR 708.2) and never match.
+     *
+     * This is a **per-object** read. A card that totals its pips across a chosen *group* — Baron
+     * Helmut Zemo's "exile any number of black cards from your graveyard with fifteen or more
+     * black mana symbols among their mana costs" — is not this predicate; it needs the count
+     * aggregated over the selection, not a per-card threshold.
+     */
+    @SerialName("ColoredManaSymbolsAtLeast")
+    @Serializable
+    data class ColoredManaSymbolsAtLeast(
+        val colors: List<Color>,
+        val min: Int = 1
+    ) : CardPredicate {
+        init {
+            // Both degenerate values would silently match *every* object (the count is 0 and
+            // `0 >= 0`), which is never what a caller asking for coloured pips means.
+            require(colors.isNotEmpty()) { "ColoredManaSymbolsAtLeast needs at least one color" }
+            require(min >= 1) { "ColoredManaSymbolsAtLeast needs min >= 1, got $min" }
+        }
+
+        override val description: String =
+            "with ${numberToWord(min)} or more ${colorPhrase(colors)} mana symbols in its mana cost"
+
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate {
+            val replaced = colors.map { replacer.replaceColor(it) }.distinct()
+            return if (replaced != colors) copy(colors = replaced) else this
+        }
+    }
+
     // =============================================================================
     // Power/Toughness Predicates
     // =============================================================================
@@ -1131,3 +1177,12 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         }
     }
 }
+
+/**
+ * How a colour set reads inside a "…mana symbols in its mana cost" phrase. All five colours is
+ * oracle's "colored" (Omnath, Locus of All: "three or more colored mana symbols"); anything
+ * narrower is listed — "blue", "blue or red".
+ */
+private fun colorPhrase(colors: List<Color>): String =
+    if (colors.toSet() == Color.entries.toSet()) "colored"
+    else colors.joinToString(" or ") { it.displayName.lowercase() }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityNumericProperty.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityNumericProperty.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.sdk.scripting.values
 
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -135,6 +136,35 @@ sealed interface EntityNumericProperty {
     @Serializable
     data object ColorCount : EntityNumericProperty {
         override val description: String = "the number of its colors"
+    }
+
+    /**
+     * The number of mana symbols of [colors] in **this one entity's** printed mana cost —
+     * `{1}{U}{U}` counts 2 blue, `{U/R}{R}` counts 1 blue. Delegates to
+     * [com.wingedsheep.sdk.core.ManaCost.coloredSymbolCount], so hybrid and Phyrexian pips count
+     * for their color(s) (CR 107.4e/f) and a pip that is two of the requested colors is counted
+     * once. Reads the *printed* cost — a card's mana cost is the mana symbols printed on it
+     * (CR 202.1/202.1a), while additional costs, cost increases and cost reductions only produce
+     * the spell's *total cost* (CR 601.2f), so none of them change what this counts; `{X}` is a
+     * generic symbol (CR 107.4b) and counts nothing whatever value was announced for it. A
+     * face-down object has no mana cost and counts 0 (CR 708.2a).
+     *
+     * The per-object counterpart of [com.wingedsheep.sdk.scripting.values.DynamicAmount.DevotionTo],
+     * which counts the same symbols but across every permanent a player controls (CR 700.5). Do not
+     * reach for `DevotionTo` when the card says "in its mana cost" — the scopes are different.
+     *
+     * Namor the Sub-Mariner: "Whenever you cast a noncreature spell with one or more blue mana
+     * symbols in its mana cost, create that many 1/1 blue Merfolk creature tokens" is
+     * `EntityProperty(EntityReference.Triggering, ColoredManaSymbolCount(listOf(Color.BLUE)))`. The
+     * matching filter side is
+     * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.ColoredManaSymbolsAtLeast].
+     */
+    @SerialName("ColoredManaSymbolCount")
+    @Serializable
+    data class ColoredManaSymbolCount(val colors: List<Color>) : EntityNumericProperty {
+        override val description: String =
+            "the number of ${colors.joinToString(" or ") { it.displayName.lowercase() }} " +
+                "mana symbols in its mana cost"
     }
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/ProjectionScopedAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/ProjectionScopedAmounts.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.sdk.scripting.values
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.encodeToJsonElement
+
+/**
+ * Serial names of the [DynamicAmount] / [EntityReference] /
+ * [com.wingedsheep.sdk.scripting.references.Player] shapes whose value lives in the resolution-time
+ * `EffectContext` — the chosen targets, the announced X, the triggering object, the things
+ * sacrificed or tapped to pay a cost, the resolution pipeline's stored collections.
+ *
+ * The engine's layer projector rebuilds a bare `EffectContext(sourceId, controllerId,
+ * affectedEntityId)` on every pass, so none of these can resolve there; an amount containing one
+ * would read as absent (0, or an empty player/entity list) forever. They are therefore rejected by
+ * any effect that carries a `DynamicAmount` into the projection — today
+ * [com.wingedsheep.sdk.scripting.effects.SetBaseStatsEffect]'s `reevaluateContinuously` — rather
+ * than silently mis-evaluated. Everything not listed here is computable from the source, the
+ * affected entity, or global game state, all of which the projector does carry.
+ *
+ * Kept as a deny list rather than an allow list because the projector-safe set is open-ended (every
+ * `Count`/`AggregateBattlefield`/`EntityProperty(Source | AffectedEntity)` shape works); the
+ * *traversal* is what has to be exhaustive, and encoding to JSON makes it so — no nesting site can
+ * be missed the way a hand-written `when` over the composite amounts could.
+ *
+ * Two entries that look like they belong on the safe side but do not:
+ *  - `ControllerOf` / `OwnerOf` take a `targetDescription` string and resolve through
+ *    `context.targets`, so they are chosen-target reads despite naming no target type.
+ *  - `VariableReference` reads the resolution pipeline's stored numbers, which the projector has no
+ *    copy of.
+ * And two that look unsafe but are not, so they are deliberately absent: `DistinctColorsManaSpent`
+ * and `ManaSpentFromSubtype` read components stamped on the source entity, not the context, as do
+ * the `CraftedMaterials*` amounts.
+ */
+private val CONTEXT_SCOPED_SERIAL_NAMES: Set<String> = setOf(
+    // DynamicAmount
+    "XValue", "CastX", "CastChoice", "ContextProperty", "VariableReference", "StoredCardManaValue",
+    "DistinctEntitiesInCollections", "DistinctCardTypesInCollections", "ManaValueSumOfCollection",
+    "TotalManaSpent", "ManaSpentOnX", "PermanentsSacrificedThisWay", "StationCharge",
+    "LastKnownSourceCounters", "LastKnownDamageDealtToSource",
+    // EntityReference
+    "Target", "Triggering", "Sacrificed", "TappedAsCost", "FromCostStorage", "AmassedArmy",
+    "IterationEntity",
+    // Player
+    "TargetPlayer", "TargetOpponent", "ContextPlayer", "TriggeringPlayer", "ControllerOf", "OwnerOf",
+)
+
+private val CONTEXT_SCAN_JSON = Json
+
+/**
+ * The serial name of the first context-scoped reference anywhere inside [amount], or null when the
+ * whole tree is projector-safe. See [CONTEXT_SCOPED_SERIAL_NAMES].
+ *
+ * Lives in the SDK, and is called from `init` blocks, so that "this amount can't be re-evaluated by
+ * the projector" is a **card-load** failure — thrown as the `cardDef { }` is built and caught by
+ * `CardDiscovery` and the corpus tests — rather than an exception raised mid-game the first time
+ * the effect happens to resolve.
+ */
+fun contextScopedReferenceIn(amount: DynamicAmount): String? =
+    findContextScoped(CONTEXT_SCAN_JSON.encodeToJsonElement<DynamicAmount>(amount))
+
+private fun findContextScoped(element: JsonElement): String? = when (element) {
+    is JsonObject -> element.entries.firstNotNullOfOrNull { (key, value) ->
+        val discriminator = (value as? JsonPrimitive)?.takeIf { it.isString }?.content
+        if (key == "type" && discriminator in CONTEXT_SCOPED_SERIAL_NAMES) discriminator
+        else findContextScoped(value)
+    }
+    is JsonArray -> element.firstNotNullOfOrNull { findContextScoped(it) }
+    else -> null
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -314,6 +314,7 @@ object CardLinter {
         put("DrawUpTo" to "storeNotDrawnAs", write(Space.NUMBER))
         put("Fight" to "excessDamageVariable", write(Space.NUMBER))
         put("PayCounters" to "storeAmountAs", write(Space.NUMBER))
+        put("PayManaCostRepeatedly" to "storeCountAs", write(Space.NUMBER))
         put("ChooseOption" to "storeAs", write(Space.CHOSEN))
         put("NoteCreatureType" to "storeAs", write(Space.CHOSEN))
         put("StoreCardName" to "storeAs", write(Space.CHOSEN))

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/core/ManaCostColoredSymbolCountTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/core/ManaCostColoredSymbolCountTest.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.sdk.core
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [ManaCost.coloredSymbolCount] and the [ManaSymbol.colors] rule under it — the single "which mana
+ * symbols are which colours" implementation shared by devotion (CR 700.5, summed across a player's
+ * permanents) and by the per-object pip reads
+ * ([com.wingedsheep.sdk.scripting.values.EntityNumericProperty.ColoredManaSymbolCount] /
+ * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.ColoredManaSymbolsAtLeast], Namor the
+ * Sub-Mariner).
+ *
+ * The rules being pinned down:
+ *  - CR 107.4e — a hybrid symbol *is* a colored mana symbol and is **all** of its component
+ *    colours, and a monocolored hybrid ("twobrid") `{2/U}` is its colour.
+ *  - CR 107.4f — a Phyrexian symbol is a colored mana symbol of its colour.
+ *  - CR 107.4b/c — numerical, `{X}` and `{C}` symbols are not colored mana symbols.
+ *  - CR 700.5 — "devotion to [c1] and [c2]" counts a symbol that is either colour, so a symbol
+ *    which is *both* requested colours is still one symbol.
+ *
+ * **Out of scope here:** how a two-faced card presents a cost to be counted. `ManaCost` is handed
+ * one cost and counts it; which cost a split card or MDFC exposes is a `CardDefinition`/zone
+ * question (CR 709.3b — while on the stack only the cast half's characteristics exist; CR 709.4b —
+ * an effect referring specifically to the symbols in a split card's mana cost sees the separate
+ * symbols rather than the whole mana cost). Nothing in this file can assert that, so it doesn't
+ * pretend to.
+ */
+class ManaCostColoredSymbolCountTest : StringSpec({
+
+    fun count(cost: String, vararg colors: Color) =
+        ManaCost.parse(cost).coloredSymbolCount(colors.toSet())
+
+    // ----- plain colored pips -------------------------------------------------------------
+
+    "a mono-blue cost counts its one blue pip" {
+        count("{U}", Color.BLUE) shouldBe 1
+    }
+    "several blue pips are counted separately" {
+        count("{1}{U}{U}", Color.BLUE) shouldBe 2
+        count("{U}{U}{U}{U}", Color.BLUE) shouldBe 4
+    }
+    "off-colour pips are not counted" {
+        count("{2}{R}{G}", Color.BLUE) shouldBe 0
+        count("{U}{R}", Color.RED) shouldBe 1
+    }
+
+    // ----- costs with no colored pips at all ----------------------------------------------
+
+    "a generic-only cost counts nothing" {
+        count("{5}", Color.BLUE) shouldBe 0
+    }
+    "colorless {C} is not a colour and counts nothing" {
+        count("{C}{C}", Color.BLUE) shouldBe 0
+    }
+    "{X} is generic (CR 107.4b) and counts nothing, whatever X was announced" {
+        count("{X}", Color.BLUE) shouldBe 0
+        count("{X}{X}{U}", Color.BLUE) shouldBe 1
+        ManaCost.parse("{X}{U}").withXAs(7).coloredSymbolCount(setOf(Color.BLUE)) shouldBe 1
+    }
+    "a spell with no mana cost at all counts nothing" {
+        ManaCost.ZERO.coloredSymbolCount(setOf(Color.BLUE)) shouldBe 0
+        count("", Color.BLUE) shouldBe 0
+    }
+
+    // ----- hybrid (CR 107.4e) --------------------------------------------------------------
+
+    "a hybrid {U/R} is a blue mana symbol" {
+        count("{U/R}", Color.BLUE) shouldBe 1
+    }
+    "the same hybrid {U/R} is also a red mana symbol" {
+        count("{U/R}", Color.RED) shouldBe 1
+    }
+    "a hybrid of two other colours is neither" {
+        count("{R/G}", Color.BLUE) shouldBe 0
+    }
+    "hybrids mix with plain pips" {
+        count("{U/R}{U}{R}", Color.BLUE) shouldBe 2
+    }
+    "a monocolored hybrid {2/U} is a blue mana symbol (CR 107.4e)" {
+        count("{2/U}", Color.BLUE) shouldBe 1
+        count("{2/U}{2/U}", Color.BLUE) shouldBe 2
+        count("{2/B}", Color.BLUE) shouldBe 0
+    }
+
+    // ----- Phyrexian (CR 107.4f) -----------------------------------------------------------
+
+    "a Phyrexian {U/P} is a blue mana symbol" {
+        count("{U/P}", Color.BLUE) shouldBe 1
+        count("{1}{U/P}{U}", Color.BLUE) shouldBe 2
+    }
+    "a Phyrexian pip of another colour is not blue" {
+        count("{G/P}", Color.BLUE) shouldBe 0
+    }
+
+    // ----- multi-colour requests (CR 700.5's two-colour devotion) ---------------------------
+
+    "asking for two colours counts a pip of either" {
+        count("{U}{R}{G}", Color.BLUE, Color.RED) shouldBe 2
+    }
+    "a hybrid that is both requested colours is still one symbol" {
+        count("{U/R}", Color.BLUE, Color.RED) shouldBe 1
+    }
+    "an empty colour set counts nothing" {
+        ManaCost.parse("{U}{U}").coloredSymbolCount(emptySet()) shouldBe 0
+    }
+
+    // ----- the ManaSymbol.colors rule itself ------------------------------------------------
+
+    "ManaSymbol.colors: a hybrid is all of its component colours (CR 107.4e)" {
+        ManaSymbol.Hybrid(Color.BLUE, Color.RED).colors shouldBe setOf(Color.BLUE, Color.RED)
+    }
+    "ManaSymbol.colors: a Phyrexian pip is its colour (CR 107.4f)" {
+        ManaSymbol.Phyrexian(Color.BLUE).colors shouldBe setOf(Color.BLUE)
+    }
+    "ManaSymbol.colors: a twobrid is its colour, not colourless" {
+        ManaSymbol.MonocolorHybrid(2, Color.BLUE).colors shouldBe setOf(Color.BLUE)
+    }
+    "ManaSymbol.colors: generic, colorless and X are no colour" {
+        ManaSymbol.Generic(3).colors shouldBe emptySet()
+        ManaSymbol.Colorless.colors shouldBe emptySet()
+        ManaSymbol.X.colors shouldBe emptySet()
+    }
+
+    // ----- ManaCost.colors still agrees with the shared rule (CR 202.2c/d) -------------------
+
+    "ManaCost.colors reads the same symbol rule — hybrids and Phyrexians colour the object" {
+        ManaCost.parse("{2}{U/R}").colors shouldBe setOf(Color.BLUE, Color.RED)
+        ManaCost.parse("{U/P}{G}").colors shouldBe setOf(Color.BLUE, Color.GREEN)
+        ManaCost.parse("{2/B}").colors shouldBe setOf(Color.BLACK)
+        ManaCost.parse("{4}{C}{X}").colors shouldBe emptySet()
+    }
+})

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/HawkeyeMasterMarksman.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/HawkeyeMasterMarksman.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Hawkeye, Master Marksman — Marvel Super Heroes #130
+ * {1}{R} · Legendary Creature — Human Archer Hero · Rare · 2/2
+ *
+ * Reach, first strike
+ * Trick Arrows — Whenever Hawkeye becomes tapped, you may pay {1} up to three times. When you do,
+ * choose up to that many —
+ * • Net — Target creature can't block this turn.
+ * • Explosive — Hawkeye deals 2 damage to target player.
+ * • Boomerang — Discard a card, then draw a card.
+ *
+ * Modeling notes:
+ *  - "Trick Arrows" is a flavor ability word (CR 207.2c) with no rules meaning; it lives in the
+ *    oracle text and the ability's description only.
+ *  - The whole ability is one [Triggers.BecomesTapped] trigger — cause-agnostic, so tapping him to
+ *    attack, to crew, to pay a teamwork cost, or an opponent's Twiddle all trigger it. First strike
+ *    plus a tap payoff is deliberate: attacking is the usual way to turn it on, and vigilance would
+ *    turn it *off*.
+ *  - "You may pay {1} up to three times. **When you do**, …" is the CR 603.12 reflexive shape:
+ *    [ReflexiveTriggerEffect] with the repeated payment as the `action` and the modal as the
+ *    `reflexiveEffect`, so the modes are announced on a second, separately-responded-to stack
+ *    object *after* the payment is known — which is exactly what "up to that many" needs. The
+ *    reflexive half never triggers when the controller declines or cannot pay.
+ *  - The payment itself is [Effects.PayRepeatedly]: the count offered is capped at three *and* at
+ *    what the controller can actually afford, and the number of repetitions is published to the
+ *    resolution pipeline, where the modal reads it as [DynamicAmounts.timesPaid] for its
+ *    `dynamicChooseCount`. "Up to that many" is a ceiling with a floor of zero, which is what a
+ *    dynamic choose-count already means at the trigger-time evaluation site — so no
+ *    `dynamicMinChooseCount`: paying twice and then taking one mode (or none) is legal.
+ *  - Each mode carries its own target requirement and reads it as `ContextTarget(0)`, the standard
+ *    per-mode targeting shape; the modes are picked and targeted as the reflexive ability goes on
+ *    the stack (CR 603.3c/603.3d). `allowRepeat` stays false — CR 700.2d, no mode twice — so
+ *    paying three times means all three arrows, not one arrow thrice.
+ *  - "Hawkeye deals 2 damage" names *Hawkeye*, not the ability, so the damage source is the
+ *    permanent — which is already the reflexive ability's source, hence no explicit `damageSource`.
+ *    His first strike is irrelevant to it (this is not combat damage).
+ */
+val HawkeyeMasterMarksman = card("Hawkeye, Master Marksman") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Archer Hero"
+    power = 2
+    toughness = 2
+    oracleText = "Reach, first strike\n" +
+        "Trick Arrows — Whenever Hawkeye becomes tapped, you may pay {1} up to three times. " +
+        "When you do, choose up to that many —\n" +
+        "• Net — Target creature can't block this turn.\n" +
+        "• Explosive — Hawkeye deals 2 damage to target player.\n" +
+        "• Boomerang — Discard a card, then draw a card."
+
+    keywords(Keyword.REACH, Keyword.FIRST_STRIKE)
+
+    // Trick Arrows — Whenever Hawkeye becomes tapped, you may pay {1} up to three times.
+    // When you do, choose up to that many —
+    triggeredAbility {
+        trigger = Triggers.BecomesTapped
+        effect = ReflexiveTriggerEffect(
+            action = Effects.PayRepeatedly("{1}", upTo = 3),
+            optional = true,
+            reflexiveEffect = ModalEffect(
+                modes = listOf(
+                    Mode.withTarget(
+                        effect = Effects.CantBlock(EffectTarget.ContextTarget(0)),
+                        target = TargetCreature(),
+                        description = "Net — Target creature can't block this turn."
+                    ),
+                    Mode.withTarget(
+                        effect = Effects.DealDamage(2, EffectTarget.ContextTarget(0)),
+                        target = TargetPlayer(),
+                        description = "Explosive — Hawkeye deals 2 damage to target player."
+                    ),
+                    Mode.noTarget(
+                        effect = Effects.Composite(
+                            Patterns.Hand.discardCards(1),
+                            Effects.DrawCards(1)
+                        ),
+                        description = "Boomerang — Discard a card, then draw a card."
+                    )
+                ),
+                dynamicChooseCount = DynamicAmounts.timesPaid()
+            ),
+            descriptionOverride = "You may pay {1} up to three times. When you do, choose up to " +
+                "that many —\n" +
+                "• Net — Target creature can't block this turn.\n" +
+                "• Explosive — Hawkeye deals 2 damage to target player.\n" +
+                "• Boomerang — Discard a card, then draw a card."
+        )
+        description = "Trick Arrows — Whenever Hawkeye becomes tapped, you may pay {1} up to " +
+            "three times. When you do, choose up to that many — Net — Target creature can't " +
+            "block this turn.; Explosive — Hawkeye deals 2 damage to target player.; " +
+            "Boomerang — Discard a card, then draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "130"
+        artist = "Bachzim"
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/9991b684-0ae0-4aa4-8f22-a9c473f5d69c.jpg?1783902931"
+    }
+}

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/MsMarvelKamalaKhan.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/MsMarvelKamalaKhan.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.NoMaximumHandSize
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ms. Marvel, Kamala Khan — Marvel Super Heroes #67 (rare)
+ * {2}{U} · Legendary Creature — Mutant Inhuman Hero · 1/4
+ *
+ * Reach, vigilance
+ * You have no maximum hand size.
+ * Embiggen Fist — Whenever you cast a spell that targets a creature you control, draw a card.
+ * Until end of turn, Ms. Marvel gains "Ms. Marvel's base power is equal to the number of cards in
+ * your hand."
+ *
+ * Three of the four lines are existing vocabulary: the two keywords, [NoMaximumHandSize] (a
+ * turn-based read in the cleanup step, not a Rule 613 continuous effect), and
+ * [Triggers.youCastSpellTargeting] over `Creature.youControl()` — the same facade Iron Fist,
+ * Mockingbird and Colleen Wing use in this set. Ms. Marvel is herself "a creature you control", so
+ * a spell aimed at her arms the trigger too.
+ *
+ * The fourth line is the reason this card needed engine work. The granted clause must keep
+ * *tracking* the hand for the rest of the turn — it is a quoted static ability, not a one-shot
+ * number. `Effects.SetBasePower` used to evaluate its `DynamicAmount` once at resolution and stamp
+ * a fixed value, which froze her power at whatever the hand happened to be. It now takes
+ * `reevaluateContinuously = true`, which carries the `DynamicAmount` into the layer-7b floating
+ * effect and re-reads it on every projection pass.
+ *
+ * Two rules notes on that clause:
+ *  - It is **not** a characteristic-defining ability. CR 604.3a requires the ability to be printed
+ *    on the card it affects (criterion 2) and to not be one the object grants to itself
+ *    (criterion 4); this one fails both. So it applies in layer 7b — CR 613.4b, "effects that refer
+ *    to the base power and/or toughness of a creature apply in this layer" — with the timestamp of
+ *    the grant, rather than in layer 7a.
+ *  - Only *power* is set. Her printed toughness of 4 is untouched, which is why the effect carries a
+ *    null toughness rather than reusing the both-stats `SetBasePowerAndToughness`. Counters and pump
+ *    spells are layer 7c and still apply on top.
+ *
+ * Ordering inside the trigger follows the printed text: draw first, then grant. Because the grant
+ * re-evaluates, the drawn card is counted either way — the order is fidelity, not arithmetic.
+ */
+val MsMarvelKamalaKhan = card("Ms. Marvel, Kamala Khan") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Mutant Inhuman Hero"
+    power = 1
+    toughness = 4
+    oracleText = "Reach, vigilance\n" +
+        "You have no maximum hand size.\n" +
+        "Embiggen Fist — Whenever you cast a spell that targets a creature you control, draw a " +
+        "card. Until end of turn, Ms. Marvel gains \"Ms. Marvel's base power is equal to the " +
+        "number of cards in your hand.\""
+
+    keywords(Keyword.REACH, Keyword.VIGILANCE)
+
+    staticAbility {
+        ability = NoMaximumHandSize
+    }
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpellTargeting(GameObjectFilter.Creature.youControl())
+        effect = Effects.Composite(
+            Effects.DrawCards(1),
+            Effects.SetBasePower(
+                target = EffectTarget.Self,
+                power = DynamicAmounts.cardsInYourHand(),
+                duration = Duration.EndOfTurn,
+                reevaluateContinuously = true,
+            ),
+        )
+        description = "Embiggen Fist — Whenever you cast a spell that targets a creature you " +
+            "control, draw a card. Until end of turn, Ms. Marvel gains \"Ms. Marvel's base power " +
+            "is equal to the number of cards in your hand.\""
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "67"
+        artist = "Smirtouille"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9dd2d627-10fc-4045-8545-03bcf75e60ca.jpg?1783902954"
+    }
+}

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/NamorTheSubMariner.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/NamorTheSubMariner.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Namor the Sub-Mariner — Marvel Super Heroes #69
+ * {1}{U}{U} · Legendary Creature — Mutant Merfolk Villain · Mythic
+ *
+ * Flying
+ * Namor's power is equal to the number of Merfolk you control.
+ * Whenever you cast a noncreature spell with one or more blue mana symbols in its mana cost,
+ * create that many 1/1 blue Merfolk creature tokens.
+ *
+ * **Power** is a characteristic-defining ability (printed `*`/4), so only power is dynamic:
+ * `dynamicPower` over the count of Merfolk on the battlefield under your control. Namor is himself
+ * a Merfolk, so he counts himself — an alone-on-an-empty-board Namor is 1/4. The filter is
+ * `Any.withSubtype(MERFOLK)` rather than `Creature.withSubtype(...)` because the card says "the
+ * number of Merfolk you control", not "Merfolk creatures"; a noncreature permanent that has the
+ * Merfolk subtype counts. Counting runs over projected subtypes, so Changeling and type-changing
+ * effects are picked up.
+ *
+ * **The trigger** is the reason this card needed new SDK vocabulary. "With one or more blue mana
+ * symbols in its mana cost" is a read of the *printed cost's pips*, which is not the same question
+ * as "is the spell blue": colour is a characteristic layer 5, colour indicators and devoid can
+ * change, while `{U}` pips on the card cannot. Two new primitives, sharing one counting rule
+ * (`ManaCost.coloredSymbolCount`) so the filter and the token count can never disagree:
+ *  - `CardPredicate.ColoredManaSymbolsAtLeast(listOf(BLUE))` — the trigger's "one or more" gate,
+ *    reached here through `GameObjectFilter.coloredManaSymbolsAtLeast`.
+ *  - `EntityNumericProperty.ColoredManaSymbolCount(listOf(BLUE))` read off
+ *    `EntityReference.Triggering` — the "that many" token count.
+ *
+ * Both follow CR 107.4e/f: a hybrid symbol *is* all of its component colours, so `{U/R}` and
+ * `{2/U}` each count as one blue symbol, and a Phyrexian `{U/P}` is blue. `{X}`, generic and `{C}`
+ * are no colour at all and count nothing, whatever value was chosen for X (CR 107.4b). What is
+ * read is the *printed* cost — the mana symbols printed on the card (CR 202.1/202.1a) — while
+ * alternative costs, additional costs and cost reductions only build the spell's *total* cost
+ * (CR 601.2f), so none of them move the pip count.
+ *
+ * The trigger fires on *cast* (CR 601.2i), so the count is taken from a spell that was on the
+ * stack; countering that spell in response does not undo the tokens. Pinned by
+ * `NamorTheSubMarinerScenarioTest`'s "a counterspell in response does not undo the tokens".
+ */
+val NamorTheSubMariner = card("Namor the Sub-Mariner") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Mutant Merfolk Villain"
+    oracleText = "Flying\n" +
+        "Namor's power is equal to the number of Merfolk you control.\n" +
+        "Whenever you cast a noncreature spell with one or more blue mana symbols in its mana " +
+        "cost, create that many 1/1 blue Merfolk creature tokens."
+    dynamicPower(
+        DynamicAmounts.battlefield(Player.You, GameObjectFilter.Any.withSubtype(Subtype.MERFOLK)).count()
+    )
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Noncreature.coloredManaSymbolsAtLeast(Color.BLUE)
+        )
+        effect = Effects.CreateToken(
+            count = DynamicAmounts.coloredManaSymbolsOf(EntityReference.Triggering, Color.BLUE),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Merfolk"),
+            imageUri = "https://cards.scryfall.io/normal/front/7/f/7f7a4f95-f12b-4c28-a6f7-f3c64364abba.jpg?1783902797",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "69"
+        artist = "Chris Rallis"
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7aaefcf9-fbe1-4767-92a5-09825761d116.jpg?1783902956"
+    }
+}

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/ShangChiMasterOfKungFu.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/ShangChiMasterOfKungFu.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Shang-Chi, Master of Kung Fu
+ * {1}{G}
+ * Legendary Creature — Human Warrior Hero
+ * 2/2
+ *
+ * You may activate abilities of creatures you control as though those creatures had haste.
+ * {T}: Add two mana of any one color. Spend this mana only to activate abilities of creature sources.
+ *
+ * The static is the Thousand-Year Elixir permission, and it is deliberately *not* a haste grant:
+ * CR 302.6 gates a creature's `{T}`/`{Q}` abilities and its ability to attack on the same condition,
+ * and this lifts only the first half. It is expressed as
+ * [GrantKeyword]([AbilityFlag.MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY], creatures you control), so the
+ * layer system carries it like any other granted keyword; only
+ * `SummoningSicknessRules` — the shared `{T}`/`{Q}` gate — reads it, while combat keeps its own plain
+ * haste check. The filter includes Shang-Chi itself ("creatures you control"), so its own mana ability
+ * is live the turn it enters.
+ *
+ * The mana ability is `Effects.AddAnyColorMana(2, …)` — two mana of one chosen color — carrying
+ * [ManaRestriction.CardTypeSpellsOrAbilitiesOnly](CREATURE) with `allowSpells = false`: the oracle
+ * says "activate abilities of creature sources" and nothing about casting.
+ */
+val ShangChiMasterOfKungFu = card("Shang-Chi, Master of Kung Fu") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Human Warrior Hero"
+    power = 2
+    toughness = 2
+    oracleText = "You may activate abilities of creatures you control as though those creatures " +
+        "had haste.\n" +
+        "{T}: Add two mana of any one color. Spend this mana only to activate abilities of " +
+        "creature sources."
+
+    staticAbility {
+        ability = GrantKeyword(
+            AbilityFlag.MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY.name,
+            GroupFilter.AllCreaturesYouControl,
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(
+            amount = 2,
+            restriction = ManaRestriction.CardTypeSpellsOrAbilitiesOnly(
+                cardType = CardType.CREATURE,
+                allowSpells = false,
+                allowAbilities = true,
+            )
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "187"
+        artist = "Lee Woo-chul"
+        flavorText = "\"Many underestimate me because I carry no weapon. But I am the weapon.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2edbb62f-ad45-4422-850b-68dcc18b4c73.jpg?1783902911"
+    }
+}

--- a/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HawkeyeMasterMarksmanScenarioTest.kt
+++ b/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HawkeyeMasterMarksmanScenarioTest.kt
@@ -1,0 +1,317 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Hawkeye, Master Marksman (Marvel Super Heroes #130).
+ *
+ * {1}{R} · Legendary Creature — Human Archer Hero · 2/2
+ *   Reach, first strike
+ *   Trick Arrows — Whenever Hawkeye becomes tapped, you may pay {1} up to three times. When you do,
+ *   choose up to that many —
+ *   • Net — Target creature can't block this turn.
+ *   • Explosive — Hawkeye deals 2 damage to target player.
+ *   • Boomerang — Discard a card, then draw a card.
+ *
+ * The repeated-payment primitive itself (its affordability cap, colour-awareness, decline paths and
+ * the count surviving the CR 603.12 stack round-trip) is covered at engine level in
+ * `PayManaCostRepeatedlyTest`. These cover the *card*: that the payment count is what caps the
+ * modes, that each arrow does what it prints, and that attacking is a way of becoming tapped.
+ */
+class HawkeyeMasterMarksmanScenarioTest : ScenarioTestBase() {
+
+    /** A free Twiddle, so a test can tap Hawkeye without dragging combat in. */
+    private val tapper = card("Test Tapper") {
+        manaCost = "{0}"
+        typeLine = "Instant"
+        spell {
+            target = TargetCreature()
+            effect = Effects.Tap(EffectTarget.ContextTarget(0))
+        }
+    }
+
+    private val bear = card("Test Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    /** A 2/2 flier, for the reach + first-strike block. */
+    private val flier = card("Test Flier") {
+        manaCost = "{1}{U}"
+        typeLine = "Creature — Bird"
+        power = 2
+        toughness = 2
+        keywords(Keyword.FLYING)
+    }
+
+    private fun modeQuestion(game: TestGame): ChooseOptionDecision =
+        game.getPendingDecision() as? ChooseOptionDecision
+            ?: error("expected a mode question; got ${game.getPendingDecision()}")
+
+    /** Pick the offered mode whose label contains [label]. */
+    private fun chooseMode(game: TestGame, label: String) {
+        val decision = modeQuestion(game)
+        val index = decision.options.indexOfFirst { it.contains(label, ignoreCase = true) }
+        check(index >= 0) { "$label not offered; options=${decision.options}" }
+        game.submitDecision(OptionChosenResponse(decision.id, optionIndex = index))
+    }
+
+    /**
+     * Answer whatever target question is pending, one legal target per requirement — the opponent
+     * for Explosive's player requirement, the Bear for Net's creature requirement. Handles both a
+     * single multi-requirement decision and a sequence of one-requirement ones.
+     */
+    private fun answerTargetsIfAsked(game: TestGame) {
+        while (true) {
+            val decision = game.getPendingDecision() as? ChooseTargetsDecision ?: return
+            val bear = game.findPermanent("Test Bear")
+            val picks = decision.targetRequirements.associate { requirement ->
+                val legal = decision.legalTargets[requirement.index].orEmpty()
+                val pick = legal.firstOrNull { it == game.player2Id }
+                    ?: legal.firstOrNull { it == bear }
+                    ?: legal.first()
+                requirement.index to listOf(pick)
+            }
+            game.submitDecision(TargetsResponse(decision.id, picks))
+        }
+    }
+
+    /**
+     * Hawkeye and [mountains] untapped Mountains for Player 1, an opposing Bear, and the free
+     * tapper in hand. Stops on the "you may pay {1} up to three times" question.
+     */
+    private fun hawkeyeTappedByEffect(mountains: Int = 5, extraHandCard: String? = null): TestGame {
+        val builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardOnBattlefield(1, "Hawkeye, Master Marksman")
+            .withLandsOnBattlefield(1, "Mountain", mountains)
+            .withCardInHand(1, "Test Tapper")
+            // Exactly one card in the library, so Boomerang's draw is observable.
+            .withCardInLibrary(1, "Mountain")
+            .withCardOnBattlefield(2, "Test Bear")
+            .withActivePlayer(1)
+            .withPriorityPlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        if (extraHandCard != null) builder.withCardInHand(1, extraHandCard)
+        val game = builder.build()
+
+        val hawkeye = game.findPermanent("Hawkeye, Master Marksman")!!
+        game.castSpell(1, "Test Tapper", targetId = hawkeye).error shouldBe null
+        game.resolveStack()
+        return game
+    }
+
+    init {
+        cardRegistry.register(tapper)
+        cardRegistry.register(bear)
+        cardRegistry.register(flier)
+
+        context("Trick Arrows — the payment gates the arrows") {
+
+            test("becoming tapped offers the payment, capped at three") {
+                val game = hawkeyeTappedByEffect()
+
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(true)
+
+                val count = game.getPendingDecision() as? ChooseNumberDecision
+                    ?: error("expected the repeat-count question; got ${game.getPendingDecision()}")
+                count.minValue shouldBe 1
+                withClue("'up to three times', even with five Mountains untapped") {
+                    count.maxValue shouldBe 3
+                }
+            }
+
+            test("declining fires no arrows at all") {
+                val game = hawkeyeTappedByEffect()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("no mode question, no damage — the reflexive half never triggered") {
+                    (game.getPendingDecision() is ChooseOptionDecision) shouldBe false
+                }
+                game.getLifeTotal(2) shouldBe 20
+            }
+
+            test("paying once allows exactly one arrow") {
+                val game = hawkeyeTappedByEffect()
+                game.answerYesNo(true)
+                game.chooseNumber(1)
+
+                chooseMode(game, "Explosive")
+                if (game.getPendingDecision() is ChooseTargetsDecision) {
+                    game.selectTargets(listOf(game.player2Id))
+                }
+                withClue("one payment, one mode — no second mode question") {
+                    (game.getPendingDecision() is ChooseOptionDecision) shouldBe false
+                }
+
+                game.resolveStack()
+                game.getLifeTotal(2) shouldBe 18
+            }
+
+            test("paying twice allows two different arrows") {
+                val game = hawkeyeTappedByEffect(extraHandCard = "Test Bear")
+                // Player 1's graveyard already holds the resolved Test Tapper, and the only card
+                // left in hand is the Bear — so "the Bear reached the graveyard" is the discard,
+                // and nothing else in this test can put it there.
+                game.graveyardSize(1) shouldBe 1
+                game.librarySize(1) shouldBe 1
+
+                game.answerYesNo(true)
+                game.chooseNumber(2)
+
+                chooseMode(game, "Explosive")
+                chooseMode(game, "Boomerang")
+
+                answerTargetsIfAsked(game)
+                game.resolveStack()
+
+                // The Boomerang discard may ask which card to pitch.
+                (game.getPendingDecision() as? SelectCardsDecision)?.let { pick ->
+                    game.selectCards(pick.options.take(1))
+                    game.resolveStack()
+                }
+
+                withClue("Explosive resolved") { game.getLifeTotal(2) shouldBe 18 }
+                withClue("Boomerang discarded the one card in hand") {
+                    game.findCardsInGraveyard(1, "Test Bear").size shouldBe 1
+                    game.graveyardSize(1) shouldBe 2
+                }
+                withClue("…and then drew one: the library's only card is now the only card in hand") {
+                    game.librarySize(1) shouldBe 0
+                    game.handSize(1) shouldBe 1
+                }
+            }
+
+            test("paying the printed maximum asks three times and no fourth") {
+                val game = hawkeyeTappedByEffect(extraHandCard = "Test Bear")
+                game.answerYesNo(true)
+                game.chooseNumber(3)
+
+                chooseMode(game, "Net")
+                chooseMode(game, "Explosive")
+                chooseMode(game, "Boomerang")
+
+                withClue("three payments, three modes — 'up to that many' is not off by one") {
+                    (game.getPendingDecision() is ChooseOptionDecision) shouldBe false
+                }
+
+                answerTargetsIfAsked(game)
+                game.resolveStack()
+                (game.getPendingDecision() as? SelectCardsDecision)?.let { pick ->
+                    game.selectCards(pick.options.take(1))
+                    game.resolveStack()
+                }
+
+                withClue("all three arrows resolved") {
+                    game.getLifeTotal(2) shouldBe 18
+                    game.findCardsInGraveyard(1, "Test Bear").size shouldBe 1
+                }
+                withClue("three repetitions of {1} tapped three of the five Mountains") {
+                    game.findPermanents("Mountain").count {
+                        game.state.getEntity(it)?.get<TappedComponent>() != null
+                    } shouldBe 3
+                }
+            }
+        }
+
+        context("Trick Arrows — attacking is a way of becoming tapped") {
+
+            test("attacking turns the ability on, and Net keeps a blocker out of combat") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hawkeye, Master Marksman")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(2, "Test Bear")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Hawkeye, Master Marksman" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("attacking taps him, which is 'becomes tapped'") {
+                    game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                }
+                game.answerYesNo(true)
+                game.chooseNumber(1)
+
+                chooseMode(game, "Net")
+                val bearId = game.findPermanent("Test Bear")!!
+                if (game.getPendingDecision() is ChooseTargetsDecision) {
+                    game.selectTargets(listOf(bearId))
+                }
+                game.resolveStack()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                val block = game.declareBlockers(
+                    mapOf("Test Bear" to listOf("Hawkeye, Master Marksman"))
+                )
+                withClue("the netted creature can't block this turn") {
+                    block.error shouldNotBe null
+                }
+            }
+        }
+
+        context("the printed evasion") {
+
+            test("reach blocks the flier, first strike kills it before it hits back") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hawkeye, Master Marksman", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Test Flier", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(2)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Test Flier" to 1)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("reach — a grounded archer with no reach could not block a flier") {
+                    game.declareBlockers(
+                        mapOf("Hawkeye, Master Marksman" to listOf("Test Flier"))
+                    ).error shouldBe null
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.getPendingDecision() != null) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("first strike — the 2/2 flier dies before dealing its damage") {
+                    game.findPermanent("Test Flier") shouldBe null
+                }
+                withClue("…so Hawkeye takes none of it and survives") {
+                    game.findPermanent("Hawkeye, Master Marksman") shouldNotBe null
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HawkeyeMasterMarksmanScenarioTest.kt
+++ b/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HawkeyeMasterMarksmanScenarioTest.kt
@@ -205,6 +205,38 @@ class HawkeyeMasterMarksmanScenarioTest : ScenarioTestBase() {
                 }
             }
 
+            test("'up to that many' is a ceiling, not a quota — pay twice, fire one arrow") {
+                // The payment count caps the modes; it does not oblige them. This is why the modal
+                // carries only `dynamicChooseCount` and no `dynamicMinChooseCount`: the minimum
+                // stays 0, so the executor offers a decline option once the first mode is picked.
+                val game = hawkeyeTappedByEffect()
+                game.answerYesNo(true)
+                game.chooseNumber(2)
+
+                chooseMode(game, "Explosive")
+
+                withClue("a second mode is offered, and declining it is one of the options") {
+                    modeQuestion(game).options.any {
+                        it.contains("Don't choose a mode", ignoreCase = true)
+                    } shouldBe true
+                }
+                chooseMode(game, "Don't choose a mode")
+
+                answerTargetsIfAsked(game)
+                game.resolveStack()
+
+                withClue("the one arrow chosen resolved") { game.getLifeTotal(2) shouldBe 18 }
+                withClue("the declined arrows did not — no discard, nothing drawn") {
+                    game.graveyardSize(1) shouldBe 1
+                    game.librarySize(1) shouldBe 1
+                }
+                withClue("both repetitions were still paid — the mana is spent either way") {
+                    game.findPermanents("Mountain").count {
+                        game.state.getEntity(it)?.get<TappedComponent>() != null
+                    } shouldBe 2
+                }
+            }
+
             test("paying the printed maximum asks three times and no fourth") {
                 val game = hawkeyeTappedByEffect(extraHandCard = "Test Bear")
                 game.answerYesNo(true)

--- a/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MsMarvelKamalaKhanScenarioTest.kt
+++ b/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MsMarvelKamalaKhanScenarioTest.kt
@@ -1,0 +1,184 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ms. Marvel, Kamala Khan (MSH #67) — {2}{U} Legendary Creature — Mutant Inhuman Hero, 1/4.
+ *
+ * "Reach, vigilance
+ *  You have no maximum hand size.
+ *  Embiggen Fist — Whenever you cast a spell that targets a creature you control, draw a card.
+ *  Until end of turn, Ms. Marvel gains 'Ms. Marvel's base power is equal to the number of cards in
+ *  your hand.'"
+ *
+ * The line under test is the granted base-power clause, which must keep tracking the hand for the
+ * rest of the turn rather than freezing the number the trigger saw. It rides on
+ * `Effects.SetBasePower(..., reevaluateContinuously = true)`; the primitive's own matrix (counters,
+ * pump, duration, granter leaving) lives in `SetBaseStatsContinuousScenarioTest`.
+ */
+class MsMarvelKamalaKhanScenarioTest : ScenarioTestBase() {
+
+    private val pump = card("Ms Marvel Pump Test") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        oracleText = "Target creature gets +1/+1 until end of turn."
+        spell {
+            val creature = target("creature", Targets.Creature)
+            effect = Effects.ModifyStats(1, 1, creature)
+        }
+    }
+
+    private val drawTwo = card("Ms Marvel Draw Two Test") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        oracleText = "Draw two cards."
+        spell {
+            effect = Effects.DrawCards(2)
+        }
+    }
+
+    init {
+        cardRegistry.register(listOf(pump, drawTwo))
+
+        // Ms. Marvel is auto-discovered from the MSH package, so she is already in the registry.
+        fun build(vararg handCards: String, libraryCards: Int = 6) = scenario()
+            .withPlayers()
+            .withCardOnBattlefield(1, "Ms. Marvel, Kamala Khan")
+            .withCardOnBattlefield(1, "Grizzly Bears")
+            .withCardOnBattlefield(2, "Hill Giant")
+            .withLandsOnBattlefield(1, "Island", 6)
+            .let { builder ->
+                var acc = builder
+                repeat(libraryCards) { acc = acc.withCardInLibrary(1, "Hill Giant") }
+                handCards.fold(acc) { b, name -> b.withCardInHand(1, name) }
+            }
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+
+        fun TestGame.castAndResolve(spellName: String, targetId: EntityId? = null) {
+            val result = castSpell(1, spellName, targetId)
+            withClue("casting $spellName should succeed: ${result.error}") { result.error shouldBe null }
+            if (getPendingDecision() is SelectManaSourcesDecision) submitManaSourcesAutoPay()
+            resolveStack()
+        }
+
+        test("Embiggen Fist draws a card and sets base power to the hand size, leaving toughness at 4") {
+            val game = build("Ms Marvel Pump Test", "Hill Giant", "Hill Giant", "Hill Giant")
+            val marvel = game.findPermanent("Ms. Marvel, Kamala Khan")!!
+            val bear = game.findPermanent("Grizzly Bears")!!
+
+            withClue("printed 1/4 before anything happens") {
+                game.state.projectedState.getPower(marvel) shouldBe 1
+                game.state.projectedState.getToughness(marvel) shouldBe 4
+            }
+
+            // Hand 4 -> the pump leaves the hand (3) -> the trigger draws one (4).
+            game.castAndResolve("Ms Marvel Pump Test", bear)
+
+            withClue("Embiggen Fist drew a card") { game.handSize(1) shouldBe 4 }
+            game.state.projectedState.getPower(marvel) shouldBe 4
+            withClue("only base power is set; the printed toughness is untouched") {
+                game.state.projectedState.getToughness(marvel) shouldBe 4
+            }
+            withClue("the pump went to the Bears, not to Ms. Marvel") {
+                game.state.projectedState.getPower(bear) shouldBe 3
+            }
+        }
+
+        test("her base power keeps tracking the hand after the trigger has resolved") {
+            val game = build(
+                "Ms Marvel Pump Test", "Ms Marvel Draw Two Test",
+                "Hill Giant", "Hill Giant", "Hill Giant",
+            )
+            val marvel = game.findPermanent("Ms. Marvel, Kamala Khan")!!
+            val bear = game.findPermanent("Grizzly Bears")!!
+
+            // Hand 5 -> pump leaves (4) -> trigger draws one (5).
+            game.castAndResolve("Ms Marvel Pump Test", bear)
+            game.handSize(1) shouldBe 5
+            game.state.projectedState.getPower(marvel) shouldBe 5
+
+            // Draw Two targets nothing, so it does not re-trigger Embiggen Fist:
+            // hand 5 -> spell leaves (4) -> draws two (6).
+            game.castAndResolve("Ms Marvel Draw Two Test")
+            game.handSize(1) shouldBe 6
+            withClue("the granted clause re-reads the hand rather than keeping the trigger's number") {
+                game.state.projectedState.getPower(marvel) shouldBe 6
+            }
+            game.state.projectedState.getToughness(marvel) shouldBe 4
+        }
+
+        test("a spell targeting Ms. Marvel herself arms the trigger — she is a creature you control") {
+            val game = build("Ms Marvel Pump Test", "Hill Giant", "Hill Giant", "Hill Giant")
+            val marvel = game.findPermanent("Ms. Marvel, Kamala Khan")!!
+
+            // The trigger goes on the stack above the pump and resolves first: hand 4 -> the pump
+            // leaves the hand (3) -> Embiggen Fist draws one (4), so base power is set to 4. Then
+            // the pump resolves on top of that, in layer 7c: 4+1 power, 4+1 toughness.
+            game.castAndResolve("Ms Marvel Pump Test", marvel)
+
+            withClue("Embiggen Fist drew a card off a spell aimed at Ms. Marvel herself") {
+                game.handSize(1) shouldBe 4
+            }
+            game.state.projectedState.getPower(marvel) shouldBe 5
+            game.state.projectedState.getToughness(marvel) shouldBe 5
+        }
+
+        test("a spell targeting a creature you don't control does not trigger Embiggen Fist") {
+            val game = build("Ms Marvel Pump Test", "Hill Giant", "Hill Giant", "Hill Giant")
+            val marvel = game.findPermanent("Ms. Marvel, Kamala Khan")!!
+            val opposing = game.findPermanent("Hill Giant")!!
+
+            game.castAndResolve("Ms Marvel Pump Test", opposing)
+
+            withClue("no draw — the trigger requires a creature *you control*") {
+                game.handSize(1) shouldBe 3
+            }
+            withClue("base power stays printed") {
+                game.state.projectedState.getPower(marvel) shouldBe 1
+            }
+        }
+
+        test("the granted base-power clause wears off at end of turn") {
+            val game = build("Ms Marvel Pump Test", "Hill Giant", "Hill Giant", "Hill Giant")
+            val marvel = game.findPermanent("Ms. Marvel, Kamala Khan")!!
+            val bear = game.findPermanent("Grizzly Bears")!!
+
+            game.castAndResolve("Ms Marvel Pump Test", bear)
+            game.state.projectedState.getPower(marvel) shouldBe 4
+
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN) // opponent's turn
+
+            withClue("back to the printed 1/4") {
+                game.state.projectedState.getPower(marvel) shouldBe 1
+                game.state.projectedState.getToughness(marvel) shouldBe 4
+            }
+        }
+
+        test("You have no maximum hand size — no discard at cleanup with ten cards in hand") {
+            val game = build(
+                *Array(10) { "Hill Giant" },
+                libraryCards = 6,
+            )
+            game.handSize(1) shouldBe 10
+
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN) // opponent's turn
+
+            withClue("NoMaximumHandSize means the cleanup step discards nothing") {
+                game.handSize(1) shouldBe 10
+            }
+        }
+    }
+}

--- a/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NamorTheSubMarinerScenarioTest.kt
+++ b/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NamorTheSubMarinerScenarioTest.kt
@@ -1,0 +1,374 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.msh.cards.NamorTheSubMariner
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Namor the Sub-Mariner (MSH #69) — {1}{U}{U} Legendary Creature — Mutant Merfolk Villain, `*`/4.
+ *
+ *  - Flying
+ *  - Namor's power is equal to the number of Merfolk you control.
+ *  - Whenever you cast a noncreature spell with one or more blue mana symbols in its mana cost,
+ *    create that many 1/1 blue Merfolk creature tokens.
+ *
+ * The trigger is the behavioural gate on the two new primitives:
+ * `CardPredicate.ColoredManaSymbolsAtLeast` (the filter) and
+ * `EntityNumericProperty.ColoredManaSymbolCount` (the count). Both count hybrid and Phyrexian pips
+ * as their colour(s) per CR 107.4e/f; the symbol-by-symbol rule is pinned in
+ * `ManaCostColoredSymbolCountTest`, the engine wiring in `ColoredManaSymbolCountTest`, and this
+ * file proves the card actually mints the right number of Merfolk.
+ *
+ * The two feed each other: every Merfolk token minted also raises Namor's power, so the power
+ * assertions double as evidence the tokens really are Merfolk.
+ */
+class NamorTheSubMarinerScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    /** Noncreature spells that differ only in their printed mana cost. */
+    fun instant(name: String, cost: String) = CardDefinition(
+        name = name,
+        manaCost = ManaCost.parse(cost),
+        typeLine = TypeLine.instant()
+    )
+
+    val OneBluePip = instant("Namor Test One Blue", "{U}")
+    val TwoBluePips = instant("Namor Test Two Blue", "{1}{U}{U}")
+    val ThreeBluePips = instant("Namor Test Three Blue", "{U}{U}{U}")
+    val NoBluePip = instant("Namor Test No Blue", "{2}")
+    val RedOnly = instant("Namor Test Red", "{1}{R}")
+    val HybridBlueRed = instant("Namor Test Hybrid", "{U/R}")
+    val TwobridBlue = instant("Namor Test Twobrid", "{2/U}")
+    val PhyrexianBlue = instant("Namor Test Phyrexian", "{U/P}")
+    val XAndBlue = instant("Namor Test X Blue", "{X}{U}")
+
+    // A *creature* spell with two blue pips — the "noncreature" half of the filter.
+    val BlueCreatureSpell = CardDefinition.creature(
+        name = "Namor Test Blue Creature",
+        manaCost = ManaCost.parse("{U}{U}"),
+        subtypes = emptySet(),
+        power = 1, toughness = 1
+    )
+
+    // A plain non-Merfolk creature, so the power count can be shown to exclude it.
+    val PlainBeast = CardDefinition.creature(
+        name = "Namor Test Beast",
+        manaCost = ManaCost.parse("{2}{G}"),
+        subtypes = setOf(Subtype("Beast")),
+        power = 2, toughness = 2
+    )
+
+    // A non-token Merfolk, so the power count can be shown to include cards as well as tokens.
+    val PlainMerfolk = CardDefinition.creature(
+        name = "Namor Test Merfolk",
+        manaCost = ManaCost.parse("{1}{U}"),
+        subtypes = setOf(Subtype.MERFOLK),
+        power = 1, toughness = 1
+    )
+
+    // A Kindred *noncreature* permanent carrying the Merfolk subtype — the reason Namor's power
+    // filter is `Any.withSubtype(MERFOLK)` and not `Creature.withSubtype(...)`: the card says
+    // "the number of Merfolk you control", not "Merfolk creatures", and a Kindred enchantment's
+    // subtypes *are* creature types (CR 308.2, whose own example is "Kindred Enchantment —
+    // Merfolk").
+    val MerfolkBanner = CardDefinition(
+        name = "Namor Test Merfolk Banner",
+        manaCost = ManaCost.parse("{2}"),
+        typeLine = TypeLine(
+            cardTypes = setOf(CardType.KINDRED, CardType.ENCHANTMENT),
+            subtypes = setOf(Subtype.MERFOLK)
+        )
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(
+                NamorTheSubMariner,
+                OneBluePip, TwoBluePips, ThreeBluePips, NoBluePip, RedOnly,
+                HybridBlueRed, TwobridBlue, PhyrexianBlue, XAndBlue,
+                BlueCreatureSpell, PlainBeast, PlainMerfolk, MerfolkBanner
+            )
+        )
+        return driver
+    }
+
+    /** Resolve the stack to completion (no player decisions are expected). */
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (!isPaused && stackSize > 0 && guard++ < 50) bothPass()
+    }
+
+    fun GameTestDriver.merfolkTokens(player: EntityId): Int =
+        getPermanents(player).count { getCardName(it) == "Merfolk Token" }
+
+    fun GameTestDriver.namorPower(player: EntityId): Int? {
+        val namor = getPermanents(player).first { getCardName(it) == "Namor the Sub-Mariner" }
+        return projector.project(state).getPower(namor)
+    }
+
+    /**
+     * Put Namor out, cast [spellName], and report how many Merfolk tokens exist afterwards.
+     * Mana is handed over generously so payment never becomes the variable under test.
+     */
+    fun castWithNamor(spellName: String): Pair<Int, Int?> {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putPermanentOnBattlefield(player, "Namor the Sub-Mariner")
+        driver.merfolkTokens(player) shouldBe 0
+
+        val spell = driver.putCardInHand(player, spellName)
+        driver.giveMana(player, Color.BLUE, 6)
+        driver.giveMana(player, Color.RED, 3)
+        driver.giveMana(player, Color.GREEN, 3)
+        driver.castSpell(player, spell)
+        driver.resolveStack()
+        return driver.merfolkTokens(player) to driver.namorPower(player)
+    }
+
+    test("one blue pip mints one Merfolk token") {
+        val (tokens, power) = castWithNamor("Namor Test One Blue")
+        tokens shouldBe 1
+        withClue("Namor counts himself plus the new token") { power shouldBe 2 }
+    }
+
+    test("two blue pips mint two tokens, three mint three") {
+        castWithNamor("Namor Test Two Blue").first shouldBe 2
+        castWithNamor("Namor Test Three Blue").first shouldBe 3
+    }
+
+    test("a noncreature spell with no blue mana symbol mints nothing") {
+        val (generic, genericPower) = castWithNamor("Namor Test No Blue")
+        generic shouldBe 0
+        withClue("Namor alone is a 1/4") { genericPower shouldBe 1 }
+        castWithNamor("Namor Test Red").first shouldBe 0
+    }
+
+    test("the trigger itself does not go on the stack for a spell with no blue pip") {
+        // Distinct from "mints nothing": a fired trigger with a count of 0 and a trigger that
+        // never fired both leave zero tokens behind, so the token count alone cannot tell the
+        // filter apart from the amount. Observe the stack directly, before resolution.
+        fun stackAfterCasting(spellName: String): Int {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+            val player = driver.activePlayer!!
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+            driver.putPermanentOnBattlefield(player, "Namor the Sub-Mariner")
+            val spell = driver.putCardInHand(player, spellName)
+            driver.giveMana(player, Color.BLUE, 6)
+            driver.giveMana(player, Color.RED, 3)
+            driver.castSpell(player, spell)
+            return driver.stackSize
+        }
+
+        withClue("{U} — the spell plus Namor's trigger") {
+            stackAfterCasting("Namor Test One Blue") shouldBe 2
+        }
+        withClue("{2} — no blue mana symbol, so only the spell is on the stack") {
+            stackAfterCasting("Namor Test No Blue") shouldBe 1
+        }
+        withClue("{1}{R} — no blue mana symbol, so only the spell is on the stack") {
+            stackAfterCasting("Namor Test Red") shouldBe 1
+        }
+    }
+
+    test("a hybrid {U/R} is one blue mana symbol (CR 107.4e)") {
+        castWithNamor("Namor Test Hybrid").first shouldBe 1
+    }
+
+    test("a monocolored hybrid {2/U} is one blue mana symbol (CR 107.4e)") {
+        castWithNamor("Namor Test Twobrid").first shouldBe 1
+    }
+
+    test("a Phyrexian {U/P} is one blue mana symbol (CR 107.4f)") {
+        castWithNamor("Namor Test Phyrexian").first shouldBe 1
+    }
+
+    test("{X} contributes nothing — {X}{U} mints exactly one token") {
+        // "In its mana cost" reads the symbols printed on the card (CR 202.1/202.1a), and {X} is
+        // a generic symbol (CR 107.4b), so the announced value of X never changes the pip count.
+        castWithNamor("Namor Test X Blue").first shouldBe 1
+    }
+
+    test("a counterspell in response does not undo the tokens") {
+        // The trigger fires on *cast* (CR 601.2i) and is independent of the spell it triggered
+        // off: countering that spell does nothing to the trigger already on the stack, and the
+        // trigger still reads the pip count off the (now graveyard-bound) spell object. Without
+        // that, the token count would silently collapse to 0 — which is exactly the shape a
+        // last-known-information refactor could introduce.
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putPermanentOnBattlefield(player, "Namor the Sub-Mariner")
+
+        val spell = driver.putCardInHand(player, "Namor Test Two Blue")
+        driver.giveMana(player, Color.BLUE, 6)
+        driver.castSpell(player, spell)
+        withClue("the {1}{U}{U} instant plus Namor's trigger") { driver.stackSize shouldBe 2 }
+        val spellOnStack = driver.state.stack.first { driver.getCardName(it) == "Namor Test Two Blue" }
+
+        driver.passPriority(player)
+        driver.giveMana(opponent, Color.BLUE, 2)
+        val counter = driver.putCardInHand(opponent, "Counterspell")
+        driver.submit(
+            CastSpell(
+                playerId = opponent,
+                cardId = counter,
+                targets = listOf(ChosenTarget.Spell(spellOnStack)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        driver.resolveStack()
+
+        withClue("the instant really was countered") {
+            driver.getGraveyardCardNames(player) shouldContain "Namor Test Two Blue"
+        }
+        withClue("the trigger resolved anyway and still saw two blue pips") {
+            driver.merfolkTokens(player) shouldBe 2
+        }
+    }
+
+    test("a creature spell with blue pips does not trigger the noncreature filter") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putPermanentOnBattlefield(player, "Namor the Sub-Mariner")
+
+        val creature = driver.putCardInHand(player, "Namor Test Blue Creature")
+        driver.giveMana(player, Color.BLUE, 6)
+        driver.castSpell(player, creature)
+        driver.resolveStack()
+
+        withClue("{U}{U} on a creature spell is filtered out by 'noncreature'") {
+            driver.merfolkTokens(player) shouldBe 0
+        }
+    }
+
+    test("Namor's power is the number of Merfolk he controls, himself included") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(player, "Namor the Sub-Mariner")
+        withClue("alone, Namor is a 1/4 — he is himself a Merfolk") {
+            driver.namorPower(player) shouldBe 1
+        }
+
+        driver.putCreatureOnBattlefield(player, "Namor Test Beast")
+        withClue("a Beast is not a Merfolk") { driver.namorPower(player) shouldBe 1 }
+
+        driver.putCreatureOnBattlefield(player, "Namor Test Merfolk")
+        driver.putCreatureOnBattlefield(player, "Namor Test Merfolk")
+        withClue("two more Merfolk cards → 3") { driver.namorPower(player) shouldBe 3 }
+    }
+
+    test("a noncreature Merfolk permanent counts toward Namor's power") {
+        // Pins the deliberate `Any.withSubtype(MERFOLK)` filter: "Merfolk you control" is not
+        // "Merfolk creatures you control", so a Kindred Enchantment — Merfolk counts (CR 308.2).
+        // With `Creature.withSubtype(...)` instead, Namor would stay a 1/4 here.
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(player, "Namor the Sub-Mariner")
+        driver.namorPower(player) shouldBe 1
+
+        driver.putPermanentOnBattlefield(player, "Namor Test Merfolk Banner")
+        withClue("a Kindred Enchantment — Merfolk is a Merfolk you control") {
+            driver.namorPower(player) shouldBe 2
+        }
+    }
+
+    test("Namor has flying") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val namor = driver.putPermanentOnBattlefield(player, "Namor the Sub-Mariner")
+
+        projector.project(driver.state).hasKeyword(namor, Keyword.FLYING) shouldBe true
+    }
+
+    test("an opponent's Merfolk does not raise Namor's power") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(player, "Namor the Sub-Mariner")
+        driver.putCreatureOnBattlefield(opponent, "Namor Test Merfolk")
+        driver.putCreatureOnBattlefield(opponent, "Namor Test Merfolk")
+
+        withClue("'Merfolk you control' excludes the opponent's") {
+            driver.namorPower(player) shouldBe 1
+        }
+    }
+
+    test("an opponent casting a blue noncreature spell does not trigger Namor") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(player, "Namor the Sub-Mariner")
+        val spell = driver.putCardInHand(opponent, "Namor Test Two Blue")
+        driver.giveMana(opponent, Color.BLUE, 6)
+        driver.castSpell(opponent, spell)
+        driver.resolveStack()
+
+        withClue("the trigger is 'whenever YOU cast'") {
+            driver.merfolkTokens(player) shouldBe 0
+            driver.merfolkTokens(opponent) shouldBe 0
+        }
+    }
+
+    test("the minted tokens are 1/1 blue Merfolk") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putPermanentOnBattlefield(player, "Namor the Sub-Mariner")
+
+        val spell = driver.putCardInHand(player, "Namor Test One Blue")
+        driver.giveMana(player, Color.BLUE, 6)
+        driver.castSpell(player, spell)
+        driver.resolveStack()
+
+        val token = driver.getPermanents(player).first { driver.getCardName(it) == "Merfolk Token" }
+        val projected = projector.project(driver.state)
+        projected.getPower(token) shouldBe 1
+        projected.getToughness(token) shouldBe 1
+        projected.getColors(token) shouldBe setOf(Color.BLUE.name)
+        withClue("the token has the Merfolk subtype") {
+            projected.getSubtypes(token).any { it.equals("Merfolk", ignoreCase = true) } shouldBe true
+        }
+    }
+})

--- a/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ShangChiMasterOfKungFuScenarioTest.kt
+++ b/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ShangChiMasterOfKungFuScenarioTest.kt
@@ -1,0 +1,306 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.msh.cards.ShangChiMasterOfKungFu
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Shang-Chi, Master of Kung Fu (Marvel Super Heroes #187).
+ *
+ * {1}{G} · Legendary Creature — Human Warrior Hero · 2/2
+ *   You may activate abilities of creatures you control as though those creatures had haste.
+ *   {T}: Add two mana of any one color. Spend this mana only to activate abilities of creature
+ *   sources.
+ *
+ * The permission itself (the `MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY` flag, the shared
+ * `SummoningSicknessRules` gate, `{Q}`, the grant leaving play) is covered at engine level in
+ * `ActivateAbilitiesAsThoughHastyTest`. These cover the *card*: that its own mana ability is live
+ * the turn it enters, that it reaches the other creatures its controller controls, that it grants no
+ * attack rights, and that the restricted mana spends exactly as printed.
+ */
+class ShangChiMasterOfKungFuScenarioTest : ScenarioTestBase() {
+
+    /**
+     * A creature with one `{T}` ability (gated by CR 302.6) and one mana-cost ability (never
+     * gated), so a single card exercises both the permission and the mana restriction.
+     */
+    private val dummy = card("Kung Fu Training Dummy") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Monk"
+        power = 1
+        toughness = 1
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.GainLife(1)
+            description = "{T}: You gain 1 life."
+        }
+        activatedAbility {
+            cost = Costs.Mana("{1}")
+            effect = Effects.GainLife(2)
+            description = "{1}: You gain 2 life."
+        }
+    }
+
+    /**
+     * A *non*-creature source with the same `{1}:` ability as [dummy]'s second one. It is the
+     * discriminator for the `CardType.CREATURE` half of the mana restriction: identical cost,
+     * identical effect, only the source's card type differs.
+     */
+    private val scroll = card("Kung Fu Wall Scroll") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        activatedAbility {
+            cost = Costs.Mana("{1}")
+            effect = Effects.GainLife(2)
+            description = "{1}: You gain 2 life."
+        }
+    }
+
+    private val shangChiManaAbilityId = ShangChiMasterOfKungFu.activatedAbilities.single().id
+    private val dummyTapAbilityId = dummy.activatedAbilities[0].id
+    private val dummyManaCostAbilityId = dummy.activatedAbilities[1].id
+    private val scrollManaCostAbilityId = scroll.activatedAbilities.single().id
+
+    private fun restrictedMana(game: TestGame) =
+        game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()?.restrictedMana.orEmpty()
+
+    /** Every enumerated activation of [abilityId] on [sourceId]. Empty means "never offered". */
+    private fun activationsOf(game: TestGame, sourceId: EntityId, abilityId: AbilityId) =
+        game.getLegalActions(1)
+            .mapNotNull { it.action as? ActivateAbility }
+            .filter { it.sourceId == sourceId && it.abilityId == abilityId }
+
+    init {
+        cardRegistry.register(dummy)
+        cardRegistry.register(scroll)
+
+        context("Shang-Chi, Master of Kung Fu — the as-though-haste permission") {
+
+            test("its own {T} mana ability is activatable the turn it enters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shang-Chi, Master of Kung Fu", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val shangChi = game.findPermanent("Shang-Chi, Master of Kung Fu")!!
+
+                withClue("'creatures you control' includes Shang-Chi itself") {
+                    activationsOf(game, shangChi, shangChiManaAbilityId).size shouldBe 1
+                }
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = shangChi,
+                        abilityId = shangChiManaAbilityId,
+                        manaColorChoice = Color.GREEN,
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+
+                val floating = restrictedMana(game)
+                floating.size shouldBe 2
+                floating.all { it.color == Color.GREEN } shouldBe true
+                floating.map { it.restriction }.distinct() shouldBe listOf(
+                    ManaRestriction.CardTypeSpellsOrAbilitiesOnly(
+                        cardType = CardType.CREATURE,
+                        allowSpells = false,
+                        allowAbilities = true,
+                    )
+                )
+                // A mana ability doesn't use the stack (CR 605.3b).
+                game.state.stack.size shouldBe 0
+            }
+
+            test("another summoning-sick creature's {T} ability becomes activatable") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shang-Chi, Master of Kung Fu")
+                    .withCardOnBattlefield(1, "Kung Fu Training Dummy", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dummyId = game.findPermanent("Kung Fu Training Dummy")!!
+
+                activationsOf(game, dummyId, dummyTapAbilityId).size shouldBe 1
+
+                val lifeBefore = game.getLifeTotal(1)
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = dummyId,
+                        abilityId = dummyTapAbilityId,
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+                game.getLifeTotal(1) shouldBe lifeBefore + 1
+            }
+
+            test("without Shang-Chi the same {T} ability is not offered") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Kung Fu Training Dummy", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dummyId = game.findPermanent("Kung Fu Training Dummy")!!
+
+                withClue("this is the control — the permission is the only thing that changes") {
+                    activationsOf(game, dummyId, dummyTapAbilityId).size shouldBe 0
+                }
+            }
+
+            test("it grants no attack rights — neither creature can attack the turn it enters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shang-Chi, Master of Kung Fu", summoningSickness = true)
+                    .withCardOnBattlefield(1, "Kung Fu Training Dummy", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val offeredAttackers = game.getLegalActions(1)
+                    .firstOrNull { it.actionType == "DeclareAttackers" }
+                    ?.validAttackers.orEmpty()
+                withClue("CR 302.6's attack half is untouched by 'as though those creatures had haste'") {
+                    offeredAttackers shouldBe emptyList()
+                }
+
+                game.declareAttackers(mapOf("Kung Fu Training Dummy" to 2)).error shouldNotBe null
+                game.declareAttackers(mapOf("Shang-Chi, Master of Kung Fu" to 2)).error shouldNotBe null
+            }
+        }
+
+        context("Shang-Chi, Master of Kung Fu — the restricted mana") {
+
+            test("the mana pays a creature's activated ability") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shang-Chi, Master of Kung Fu", summoningSickness = true)
+                    .withCardOnBattlefield(1, "Kung Fu Training Dummy", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val shangChi = game.findPermanent("Shang-Chi, Master of Kung Fu")!!
+                val dummyId = game.findPermanent("Kung Fu Training Dummy")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = shangChi,
+                        abilityId = shangChiManaAbilityId,
+                        manaColorChoice = Color.GREEN,
+                    )
+                ).error shouldBe null
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = dummyId,
+                        abilityId = dummyManaCostAbilityId,
+                    )
+                )
+                withClue("a creature source's ability must be payable: ${result.error}") {
+                    result.error shouldBe null
+                }
+                restrictedMana(game).size shouldBe 1
+            }
+
+            test("the mana can't pay for a non-creature source's ability") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shang-Chi, Master of Kung Fu", summoningSickness = true)
+                    .withCardOnBattlefield(1, "Kung Fu Wall Scroll")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val shangChi = game.findPermanent("Shang-Chi, Master of Kung Fu")!!
+                val scrollId = game.findPermanent("Kung Fu Wall Scroll")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = shangChi,
+                        abilityId = shangChiManaAbilityId,
+                        manaColorChoice = Color.GREEN,
+                    )
+                ).error shouldBe null
+
+                // Same {1}: cost the Training Dummy pays with this mana one test above — the only
+                // difference is that this source is an Artifact, not a Creature.
+                withClue("'abilities of creature sources' — an Artifact's ability is not one") {
+                    game.execute(
+                        ActivateAbility(
+                            playerId = game.player1Id,
+                            sourceId = scrollId,
+                            abilityId = scrollManaCostAbilityId,
+                        )
+                    ).error shouldNotBe null
+                }
+                withClue("a rejected activation must not have spent any of the restricted mana") {
+                    restrictedMana(game).size shouldBe 2
+                }
+                // Deliberately not asserted here: the *enumerator* does still offer this activation.
+                // `ManaSolver`'s affordability pass doesn't carry the ability source's card type, so
+                // it treats the restricted mana as spendable and `ActivateAbilityHandler`'s
+                // authoritative payment is the only thing that rejects it. That divergence is
+                // pre-existing and general to `ManaRestriction.CardTypeSpellsOrAbilitiesOnly`
+                // (Castle Doom, Mishra's Workshop, …), not something this card introduces — fixing
+                // it is engine work in its own right.
+            }
+
+            test("the mana can't cast a creature spell") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Shang-Chi, Master of Kung Fu", summoningSickness = true)
+                    .withCardInHand(1, "Kung Fu Training Dummy")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val shangChi = game.findPermanent("Shang-Chi, Master of Kung Fu")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = shangChi,
+                        abilityId = shangChiManaAbilityId,
+                        manaColorChoice = Color.GREEN,
+                    )
+                ).error shouldBe null
+
+                withClue("the oracle allows abilities only — allowSpells = false") {
+                    game.castSpell(1, "Kung Fu Training Dummy").error shouldNotBe null
+                }
+                restrictedMana(game).size shouldBe 2
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MSH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MSH.json
@@ -10736,6 +10736,75 @@
     ]
 }
 
+// Ms. Marvel, Kamala Khan
+{
+    "name": "Ms. Marvel, Kamala Khan",
+    "manaCost": "{2}{U}",
+    "typeLine": "Legendary Creature — Mutant Inhuman Hero",
+    "oracleText": "Reach, vigilance\nYou have no maximum hand size.\nEmbiggen Fist — Whenever you cast a spell that targets a creature you control, draw a card. Until end of turn, Ms. Marvel gains \"Ms. Marvel's base power is equal to the number of cards in your hand.\"",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH",
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "requires": [
+                        {
+                            "type": "SpellTargetsMatching",
+                            "filter": "creature ctrl:you"
+                        }
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "SetBaseStats",
+                            "target": "Self",
+                            "power": {
+                                "type": "Count",
+                                "player": "You",
+                                "zone": "Hand"
+                            },
+                            "duration": "EndOfTurn",
+                            "reevaluateContinuously": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "Embiggen Fist — Whenever you cast a spell that targets a creature you control, draw a card. Until end of turn, Ms. Marvel gains \"Ms. Marvel's base power is equal to the number of cards in your hand.\""
+            }
+        ],
+        "staticAbilities": [
+            "NoMaximumHandSize"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "67",
+        "rarity": "RARE",
+        "artist": "Smirtouille",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9dd2d627-10fc-4045-8545-03bcf75e60ca.jpg?1783902954"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Multiversal Incursion
 {
     "name": "Multiversal Incursion",

--- a/mtg-sets/src/test/resources/snapshots/cards/MSH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MSH.json
@@ -10959,6 +10959,81 @@
     ]
 }
 
+// Namor the Sub-Mariner
+{
+    "name": "Namor the Sub-Mariner",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Legendary Creature — Mutant Merfolk Villain",
+    "oracleText": "Flying\nNamor's power is equal to the number of Merfolk you control.\nWhenever you cast a noncreature spell with one or more blue mana symbols in its mana cost, create that many 1/1 blue Merfolk creature tokens.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "Merfolk"
+            }
+        },
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature",
+                            {
+                                "type": "ColoredManaSymbolsAtLeast",
+                                "colors": [
+                                    "BLUE"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "EntityProperty",
+                        "entity": "Triggering",
+                        "numericProperty": {
+                            "type": "ColoredManaSymbolCount",
+                            "colors": [
+                                "BLUE"
+                            ]
+                        }
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Merfolk"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f7a4f95-f12b-4c28-a6f7-f3c64364abba.jpg?1783902797"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "rarity": "MYTHIC",
+        "artist": "Chris Rallis",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7aaefcf9-fbe1-4767-92a5-09825761d116.jpg?1783902956"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Night Nurse, Healer of Heroes
 {
     "name": "Night Nurse, Healer of Heroes",

--- a/mtg-sets/src/test/resources/snapshots/cards/MSH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MSH.json
@@ -6877,6 +6877,143 @@
     ]
 }
 
+// Hawkeye, Master Marksman
+{
+    "name": "Hawkeye, Master Marksman",
+    "manaCost": "{1}{R}",
+    "typeLine": "Legendary Creature — Human Archer Hero",
+    "oracleText": "Reach, first strike\nTrick Arrows — Whenever Hawkeye becomes tapped, you may pay {1} up to three times. When you do, choose up to that many —\n• Net — Target creature can't block this turn.\n• Explosive — Hawkeye deals 2 damage to target player.\n• Boomerang — Discard a card, then draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "REACH",
+        "FIRST_STRIKE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TapEvent",
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "PayManaCostRepeatedly",
+                        "cost": "{1}",
+                        "maxTimes": 3
+                    },
+                    "reflexiveEffect": {
+                        "type": "Modal",
+                        "modes": [
+                            {
+                                "effect": {
+                                    "type": "CantBlockTargetCreatures",
+                                    "target": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    }
+                                },
+                                "targetRequirements": [
+                                    {
+                                        "type": "TargetObject",
+                                        "filter": {
+                                            "baseFilter": "creature"
+                                        }
+                                    }
+                                ],
+                                "description": "Net — Target creature can't block this turn."
+                            },
+                            {
+                                "effect": {
+                                    "type": "DealDamage",
+                                    "amount": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    },
+                                    "target": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    }
+                                },
+                                "targetRequirements": [
+                                    "TargetPlayer"
+                                ],
+                                "description": "Explosive — Hawkeye deals 2 damage to target player."
+                            },
+                            {
+                                "effect": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "Composite",
+                                            "effects": [
+                                                {
+                                                    "type": "GatherCards",
+                                                    "source": {
+                                                        "type": "FromZone",
+                                                        "zone": "Hand"
+                                                    },
+                                                    "storeAs": "hand"
+                                                },
+                                                {
+                                                    "type": "SelectFromCollection",
+                                                    "from": "hand",
+                                                    "selection": {
+                                                        "type": "ChooseExactly",
+                                                        "count": {
+                                                            "type": "Fixed",
+                                                            "amount": 1
+                                                        }
+                                                    },
+                                                    "storeSelected": "discarded",
+                                                    "prompt": "Choose 1 card to discard"
+                                                },
+                                                {
+                                                    "type": "MoveCollection",
+                                                    "from": "discarded",
+                                                    "destination": {
+                                                        "type": "ToZone",
+                                                        "zone": "Graveyard"
+                                                    },
+                                                    "moveType": "Discard"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "type": "DrawCards",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        }
+                                    ]
+                                },
+                                "description": "Boomerang — Discard a card, then draw a card."
+                            }
+                        ],
+                        "dynamicChooseCount": {
+                            "type": "VariableReference",
+                            "variableName": "times_paid"
+                        }
+                    },
+                    "descriptionOverride": "You may pay {1} up to three times. When you do, choose up to that many —\n• Net — Target creature can't block this turn.\n• Explosive — Hawkeye deals 2 damage to target player.\n• Boomerang — Discard a card, then draw a card."
+                },
+                "descriptionOverride": "Trick Arrows — Whenever Hawkeye becomes tapped, you may pay {1} up to three times. When you do, choose up to that many — Net — Target creature can't block this turn.; Explosive — Hawkeye deals 2 damage to target player.; Boomerang — Discard a card, then draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "rarity": "RARE",
+        "artist": "Bachzim",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/9991b684-0ae0-4aa4-8f22-a9c473f5d69c.jpg?1783902931"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Hawkeye, Young Avenger
 {
     "name": "Hawkeye, Young Avenger",

--- a/mtg-sets/src/test/resources/snapshots/cards/MSH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MSH.json
@@ -13818,6 +13818,60 @@
     ]
 }
 
+// Shang-Chi, Master of Kung Fu
+{
+    "name": "Shang-Chi, Master of Kung Fu",
+    "manaCost": "{1}{G}",
+    "typeLine": "Legendary Creature — Human Warrior Hero",
+    "oracleText": "You may activate abilities of creatures you control as though those creatures had haste.\n{T}: Add two mana of any one color. Spend this mana only to activate abilities of creature sources.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "restriction": {
+                        "type": "CardTypeSpellsOrAbilitiesOnly",
+                        "cardType": "CREATURE",
+                        "allowSpells": false,
+                        "allowAbilities": true
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "rarity": "MYTHIC",
+        "artist": "Lee Woo-chul",
+        "flavorText": "\"Many underestimate me because I carry no weapon. But I am the weapon.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2edbb62f-ad45-4422-850b-68dcc18b4c73.jpg?1783902911"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // She-Hulk, Jade Defender
 {
     "name": "She-Hulk, Jade Defender",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaContinuations.kt
@@ -124,6 +124,26 @@ data class MayPayXContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume after the payer names how many times to pay a
+ * [com.wingedsheep.sdk.scripting.effects.PayManaCostRepeatedlyEffect] ("pay {1} up to three
+ * times"). The chosen count is multiplied into one `cost * n` payment and then published to the
+ * frame beneath as [storeCountAs], so a "when you do, choose up to **that many**" reflexive
+ * trigger can read it after the stack round-trip.
+ *
+ * @property cost One repetition's cost — repeated, not divided, so colored pips repeat with it.
+ * @property maxTimes The affordability-capped ceiling that was offered, kept for validation.
+ * @property storeCountAs Pipeline variable the repetition count is published under.
+ */
+@Serializable
+data class PayManaCostRepeatedlyContinuation(
+    override val decisionId: String,
+    val playerId: EntityId,
+    val cost: ManaCost,
+    val maxTimes: Int,
+    val storeCountAs: String
+) : ContinuationFrame
+
+/**
  * Resume after the controller decides whether to pay a mana cost for a triggered
  * ability that also requires targets (e.g., Lightning Rift).
  *

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -333,6 +333,7 @@ val engineSerializersModule = SerializersModule {
         subclass(MayPayManaSelectionContinuation::class)
         subclass(MayPayManaTriggerContinuation::class)
         subclass(MayPayXContinuation::class)
+        subclass(PayManaCostRepeatedlyContinuation::class)
         subclass(MayTriggerContinuation::class)
         subclass(BatchMayTriggerContinuation::class)
         subclass(PutOnBottomOfLibraryContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1191,6 +1191,12 @@ class TriggerMatcher(
             com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasXInManaCost ->
                 // Printed cost's {X} symbol, not the computed CMC. Face-down has no mana cost.
                 if (isFaceDown) false else cardComponent.manaCost.hasX
+            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.ColoredManaSymbolsAtLeast ->
+                // "a noncreature spell with one or more blue mana symbols in its mana cost"
+                // (Namor the Sub-Mariner). Printed cost, shared counting rule (CR 107.4e/f);
+                // face-down objects have no mana cost (CR 708.2).
+                if (isFaceDown) false
+                else cardComponent.manaCost.coloredSymbolCount(predicate.colors.toSet()) >= predicate.min
             is com.wingedsheep.sdk.scripting.predicates.CardPredicate.PowerAtLeast -> {
                 val power = if (isFaceDown) 2
                     else lastKnownPower ?: projected.getPower(entityId) ?: cardComponent.baseStats?.basePower ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.handlers.effects.library.MillAmountModifier
 import com.wingedsheep.engine.handlers.effects.life.LifePaymentService
 import com.wingedsheep.engine.handlers.effects.permanent.counters.resolveCounterType
+import com.wingedsheep.engine.mechanics.SummoningSicknessRules
 import com.wingedsheep.engine.mechanics.cost.CostPaymentService
 import com.wingedsheep.engine.mechanics.cost.VariablePermanentsCost
 import com.wingedsheep.engine.mechanics.mana.ManaPool
@@ -168,11 +169,9 @@ class CostHandler {
                 // Check summoning sickness on the attached creature. Read creature-ness and
                 // haste from projected state so a Vehicle / animated permanent currently
                 // being a creature is gated correctly.
-                if (state.projectedState.isCreature(attachedId)) {
-                    val hasSummoningSickness = attachedEntity.has<SummoningSicknessComponent>()
-                    val hasHaste = state.projectedState.hasKeyword(attachedId, com.wingedsheep.sdk.core.Keyword.HASTE)
-                    if (hasSummoningSickness && !hasHaste) return false
-                }
+                if (state.projectedState.isCreature(attachedId) &&
+                    SummoningSicknessRules.blocksTapOrUntapCost(attachedId, attachedEntity, state.projectedState)
+                ) return false
                 true
             }
             is AbilityCost.Forage ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -24,9 +24,7 @@ import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.state.components.identity.RoomComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
-import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.CounterType
-import com.wingedsheep.sdk.core.ManaSymbol
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CharacteristicValue
@@ -350,7 +348,7 @@ class DynamicAmountEvaluator(
             // and Phyrexian ({B/P}) symbols each count toward their color(s); a symbol matching more
             // than one of the requested colors is still counted once. Controller is read from
             // projection so control-changing effects are honored (700.5a). Face-down permanents have
-            // no mana cost (CR 711.4) and contribute nothing.
+            // no mana cost (CR 708.2a) and contribute nothing.
             is DynamicAmount.DevotionTo -> {
                 val playerIds = resolveUnifiedPlayerIds(state, amount.player, context).toSet()
                 if (playerIds.isEmpty()) return 0
@@ -361,7 +359,7 @@ class DynamicAmountEvaluator(
                     val entity = state.getEntity(entityId) ?: return@sumOf 0
                     if (entity.has<FaceDownComponent>()) return@sumOf 0
                     val cost = entity.get<CardComponent>()?.manaCost ?: return@sumOf 0
-                    cost.symbols.count { symbol -> manaSymbolColors(symbol).any { it in wanted } }
+                    cost.coloredSymbolCount(wanted)
                 }
             }
 
@@ -1214,6 +1212,18 @@ class DynamicAmountEvaluator(
             is EntityNumericProperty.ColorCount ->
                 resolveColorCount(state, entityId, useProjected, explicitProjected)
 
+            // Pips of the named colors in *this* object's printed mana cost — the per-object twin
+            // of DevotionTo, sharing its counting rule via ManaCost.coloredSymbolCount (hybrid and
+            // Phyrexian pips count for their colors, CR 107.4e/f). Never projected: a card's mana
+            // cost is the symbols printed on it (CR 202.1/202.1a), and cost increases/reductions
+            // only build the spell's total cost (CR 601.2f), so they never change this count.
+            // A face-down object has no mana cost (CR 708.2a) and counts 0.
+            is EntityNumericProperty.ColoredManaSymbolCount -> {
+                val entity = state.getEntity(entityId) ?: return 0
+                if (entity.has<FaceDownComponent>()) return 0
+                entity.get<CardComponent>()?.manaCost?.coloredSymbolCount(property.colors.toSet()) ?: 0
+            }
+
             // Excess damage (CR 120.4a) marked on the creature: max(0, marked − toughness).
             // Amount-valued twin of the TargetMarkedDamageExceedsToughness condition — read it after
             // a deal-damage step in the same composite (Hell to Pay's "excess damage dealt this
@@ -1336,19 +1346,6 @@ class DynamicAmountEvaluator(
             is CounterTypeFilter.Any -> counters.counters.values.sum()
             else -> counters.getCount(resolveCounterType(filter))
         }
-    }
-
-    /**
-     * The color(s) a single mana symbol contributes to devotion (CR 700.5). A two-color hybrid
-     * contributes both halves; a monocolored hybrid ({2/B}) and a Phyrexian symbol ({B/P})
-     * contribute their one color. Generic, colorless, and {X} symbols contribute nothing.
-     */
-    private fun manaSymbolColors(symbol: ManaSymbol): List<Color> = when (symbol) {
-        is ManaSymbol.Colored -> listOf(symbol.color)
-        is ManaSymbol.Hybrid -> listOf(symbol.color1, symbol.color2)
-        is ManaSymbol.Phyrexian -> listOf(symbol.color)
-        is ManaSymbol.MonocolorHybrid -> listOf(symbol.color)
-        else -> emptyList()
     }
 
     private fun resolveCounterType(filter: CounterTypeFilter): CounterType {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -634,6 +634,12 @@ class PredicateEvaluator {
                 // (Rule 708.2 — no mana cost) never match.
                 if (projectedValues?.isFaceDown == true) false else card.manaCost.hasX
             }
+            is CardPredicate.ColoredManaSymbolsAtLeast -> {
+                // Printed cost's colored pips (CR 107.4e/f via ManaCost.coloredSymbolCount) — not
+                // the object's color, which layer 5 can change. Face-down: no mana cost (CR 708.2).
+                if (projectedValues?.isFaceDown == true) false
+                else card.manaCost.coloredSymbolCount(predicate.colors.toSet()) >= predicate.min
+            }
 
             // Power/toughness predicates - use projected P/T
             is CardPredicate.PowerEquals -> {
@@ -1751,8 +1757,9 @@ class PredicateEvaluator {
             CardPredicate.ManaValueIsEven -> record.manaValue % 2 == 0
             CardPredicate.ManaValueIsOdd -> record.manaValue % 2 != 0
             // A cast-spell record stores the resolved mana value, not the printed cost, so we
-            // cannot recover whether {X} was in the printed cost.
+            // cannot recover whether {X} was in the printed cost — nor its colored pips.
             CardPredicate.HasXInManaCost -> false
+            is CardPredicate.ColoredManaSymbolsAtLeast -> false
 
             // Power/toughness — not meaningful for cast records
             is CardPredicate.PowerEquals, is CardPredicate.PowerAtMost, is CardPredicate.PowerAtLeast,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -412,11 +412,9 @@ class ActivateAbilityHandler(
         // became a creature this turn is gated correctly. The `!typeLine.isLand` carve-out is
         // preserved (basic-land mana abilities are not restricted by summoning sickness).
         //
-        // `ActivatedAbilityEnumerator` mirrors this for a bare `AbilityCost.Untap`, so the two
-        // agree on `{Q}`. A `Composite` *containing* `Untap` is still enumerated ungated (the
-        // enumerator's composite sub-`when` falls through to `else -> {}` for it) — no shipped card
-        // uses `Costs.Untap` at all, so the divergence is latent, but this re-check is
-        // authoritative and has to be right regardless of what the enumerator offered.
+        // `ActivatedAbilityEnumerator` mirrors this for `AbilityCost.Untap` both bare and inside a
+        // `Composite`, so the two agree on `{Q}` in either shape and the enumerator never offers an
+        // activation this re-check then rejects. This one stays authoritative regardless.
         val costTouchesTapSymbol = { c: AbilityCost -> c is AbilityCost.Tap || c is AbilityCost.Untap }
         if (costTouchesTapSymbol(effectiveCost) ||
             (effectiveCost is AbilityCost.Composite && effectiveCost.costs.any(costTouchesTapSymbol))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -21,6 +21,7 @@ import com.wingedsheep.engine.handlers.actions.ActionHandler
 import com.wingedsheep.engine.handlers.effects.EffectExecutorRegistry
 import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils.toEntityId
 import com.wingedsheep.engine.handlers.effects.bend.BendEvents
+import com.wingedsheep.engine.mechanics.SummoningSicknessRules
 import com.wingedsheep.engine.mechanics.mana.AlternativePaymentHandler
 import com.wingedsheep.engine.mechanics.mana.IntrinsicManaAbilities
 import com.wingedsheep.engine.core.SelectManaSourcesDecision
@@ -39,7 +40,6 @@ import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.battlefield.AbilityActivatedEverComponent
 import com.wingedsheep.engine.state.components.battlefield.AbilityActivatedThisTurnComponent
-import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
@@ -51,7 +51,6 @@ import com.wingedsheep.engine.state.components.stack.captureEntitySnapshots
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.BendType
-import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.costs.CostAtom
@@ -336,12 +335,12 @@ class ActivateAbilityHandler(
             val attachedId = container.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()?.targetId
             if (attachedId != null) {
                 val attachedContainer = state.getEntity(attachedId)
-                if (attachedContainer != null && state.projectedState.isCreature(attachedId)) {
-                    val hasSummoningSickness = attachedContainer.has<SummoningSicknessComponent>()
-                    val hasHaste = state.projectedState.hasKeyword(attachedId, Keyword.HASTE)
-                    if (hasSummoningSickness && !hasHaste) {
-                        return "Enchanted creature has summoning sickness"
-                    }
+                if (attachedContainer != null && state.projectedState.isCreature(attachedId) &&
+                    SummoningSicknessRules.blocksTapOrUntapCost(
+                        attachedId, attachedContainer, state.projectedState
+                    )
+                ) {
+                    return "Enchanted creature has summoning sickness"
                 }
             }
         }
@@ -407,19 +406,25 @@ class ActivateAbilityHandler(
             }
         }
 
-        // Check summoning sickness for tap abilities. CR 302.6 restricts a *creature's* {T}/{Q}
-        // activated ability — read creature-ness and haste from projected state so a Vehicle
-        // or animated permanent that became a creature this turn is gated correctly. The
-        // `!typeLine.isLand` carve-out is preserved (basic-land mana abilities are not
-        // restricted by summoning sickness).
-        if (effectiveCost is AbilityCost.Tap ||
-            (effectiveCost is AbilityCost.Composite && effectiveCost.costs.any { it is AbilityCost.Tap })) {
-            if (!cardComponent.typeLine.isLand && state.projectedState.isCreature(action.sourceId)) {
-                val hasSummoningSickness = container.has<SummoningSicknessComponent>()
-                val hasHaste = state.projectedState.hasKeyword(action.sourceId, Keyword.HASTE)
-                if (hasSummoningSickness && !hasHaste) {
-                    return "This creature has summoning sickness"
-                }
+        // Check summoning sickness for tap/untap abilities. CR 302.6 restricts a *creature's*
+        // activated ability whose cost includes the tap symbol **or the untap symbol** — read
+        // creature-ness and haste from projected state so a Vehicle or animated permanent that
+        // became a creature this turn is gated correctly. The `!typeLine.isLand` carve-out is
+        // preserved (basic-land mana abilities are not restricted by summoning sickness).
+        //
+        // `ActivatedAbilityEnumerator` mirrors this for a bare `AbilityCost.Untap`, so the two
+        // agree on `{Q}`. A `Composite` *containing* `Untap` is still enumerated ungated (the
+        // enumerator's composite sub-`when` falls through to `else -> {}` for it) — no shipped card
+        // uses `Costs.Untap` at all, so the divergence is latent, but this re-check is
+        // authoritative and has to be right regardless of what the enumerator offered.
+        val costTouchesTapSymbol = { c: AbilityCost -> c is AbilityCost.Tap || c is AbilityCost.Untap }
+        if (costTouchesTapSymbol(effectiveCost) ||
+            (effectiveCost is AbilityCost.Composite && effectiveCost.costs.any(costTouchesTapSymbol))
+        ) {
+            if (!cardComponent.typeLine.isLand && state.projectedState.isCreature(action.sourceId) &&
+                SummoningSicknessRules.blocksTapOrUntapCost(action.sourceId, container, state.projectedState)
+            ) {
+                return "This creature has summoning sickness"
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -924,6 +924,8 @@ class CastZoneResolver(
                 is CardPredicate.ManaValueIsEven -> cmc % 2 == 0
                 is CardPredicate.ManaValueIsOdd -> cmc % 2 != 0
                 is CardPredicate.HasXInManaCost -> card.manaCost.hasX
+                is CardPredicate.ColoredManaSymbolsAtLeast ->
+                    card.manaCost.coloredSymbolCount(predicate.colors.toSet()) >= predicate.min
                 // --- Power / toughness (null base P/T — e.g. */noncreature — never matches) ---
                 is CardPredicate.PowerEquals -> power == predicate.value
                 is CardPredicate.PowerAtMost -> power != null && power <= predicate.max

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
@@ -21,6 +21,7 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.effects.composite.asOptionalManaPayment
+import com.wingedsheep.engine.handlers.effects.composite.payManaCostFromPool
 
 class ManaPaymentContinuationResumer(
     private val services: com.wingedsheep.engine.core.EngineServices
@@ -41,8 +42,54 @@ class ManaPaymentContinuationResumer(
         resumer(MayPayManaSelectionContinuation::class, ::resumeMayPayManaSelection),
         resumer(MayPayManaTriggerContinuation::class, ::resumeMayPayManaTrigger),
         resumer(MayPayXContinuation::class, ::resumeMayPayX),
+        resumer(PayManaCostRepeatedlyContinuation::class, ::resumePayManaCostRepeatedly),
         resumer(ManaSourceSelectionContinuation::class, ::resumeManaSourceSelection)
     )
+
+    /**
+     * Resume after the payer names how many times to pay a repeatable cost ("pay {1} up to three
+     * times"). The repetitions are charged as a single `cost * n` auto-tapped payment — separate
+     * payments of the same instruction during one resolution are indistinguishable, and one
+     * payment lets the solver pick a legal combination of sources for the whole amount rather than
+     * stranding itself on a greedy first pick.
+     *
+     * The count is then published to the frame beneath via [exposeCollectionsToNextFrame] rather
+     * than `DrawUpToExecutor.injectStoredNumber`, because the consumer here is usually a
+     * [ReflexiveTriggerTargetContinuation] ("when you do, choose up to that many"), which the
+     * narrower injector does not reach.
+     */
+    fun resumePayManaCostRepeatedly(
+        state: GameState,
+        continuation: PayManaCostRepeatedlyContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is NumberChosenResponse) {
+            return ExecutionResult.error(state, "Expected number chosen response for repeated payment")
+        }
+        // The prompt's floor is 1 — declining is the wrapper's question, not this one — so an
+        // out-of-range answer is a protocol error, not a decline. Never clamp: clamping a 0 *up*
+        // to 1 would spend mana the payer didn't authorize. (DecisionValidators already rejects
+        // these, so this is the belt to that braces.)
+        val times = response.number
+        if (times < 1 || times > continuation.maxTimes) {
+            return ExecutionResult.error(
+                state, "Repeat count $times is outside 1..${continuation.maxTimes}"
+            )
+        }
+
+        val paid = payManaCostFromPool(
+            state, continuation.playerId, continuation.cost * times, services.cardRegistry
+        )
+        if (paid.error != null) return paid.toExecutionResult()
+
+        val published = exposeCollectionsToNextFrame(
+            paid.state,
+            collections = emptyMap(),
+            numbers = mapOf(continuation.storeCountAs to times)
+        )
+        return checkForMore(published, paid.events.toList())
+    }
 
     fun resumeCounterUnlessPays(
         state: GameState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeExecutors.kt
@@ -34,7 +34,8 @@ class CompositeExecutors(
     private val gatedEffectExecutor by lazy { GatedEffectExecutor(cardRegistry, effectExecutor) }
     private val payManaCostExecutor by lazy { PayManaCostExecutor(cardRegistry) }
     private val payDynamicManaCostExecutor by lazy { PayDynamicManaCostExecutor(cardRegistry) }
-    private val reflexiveTriggerEffectExecutor by lazy { ReflexiveTriggerEffectExecutor(effectExecutor, targetFinder, decisionHandler) }
+    private val payManaCostRepeatedlyExecutor by lazy { PayManaCostRepeatedlyExecutor(cardRegistry, decisionHandler) }
+    private val reflexiveTriggerEffectExecutor by lazy { ReflexiveTriggerEffectExecutor(effectExecutor, targetFinder, decisionHandler, cardRegistry) }
     private val flipCoinExecutor by lazy { FlipCoinExecutor(cardRegistry, effectExecutor) }
     private val repeatWhileExecutor by lazy { RepeatWhileExecutor(effectExecutor) }
     private val conditionalOnCollectionExecutor by lazy { ConditionalOnCollectionExecutor(effectExecutor) }
@@ -65,6 +66,7 @@ class CompositeExecutors(
         gatedEffectExecutor,
         payManaCostExecutor,
         payDynamicManaCostExecutor,
+        payManaCostRepeatedlyExecutor,
         reflexiveTriggerEffectExecutor,
         flipCoinExecutor,
         flipTwoCoinsExecutor,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -36,6 +36,7 @@ import com.wingedsheep.sdk.scripting.effects.PayDynamicLifeEffect
 import com.wingedsheep.sdk.scripting.effects.PayDynamicManaCostEffect
 import com.wingedsheep.sdk.scripting.effects.PayLifeEffect
 import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+import com.wingedsheep.sdk.scripting.effects.PayManaCostRepeatedlyEffect
 import com.wingedsheep.sdk.scripting.effects.DamageRecipient
 import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import com.wingedsheep.sdk.scripting.references.Player
@@ -586,8 +587,9 @@ class GatedEffectExecutor(
     /**
      * Whether [playerId] can pay [cost] right now. Mirrors the former
      * `OptionalCostEffectExecutor`: recognizes the payment primitives that appear in a
-     * [Gate.MayPay] cost slot ([PayManaCostEffect], [PayDynamicManaCostEffect], [PayLifeEffect], and
-     * a [CompositeEffect] composing them). The dynamic-mana branch charges the cost's own `payer`, so
+     * [Gate.MayPay] cost slot ([PayManaCostEffect], [PayDynamicManaCostEffect], [PayLifeEffect],
+     * [PayManaCostRepeatedlyEffect], and a [CompositeEffect] composing them). The dynamic-mana branch
+     * charges the cost's own `payer`, so
      * affordability stays correct even when it differs from the gate's decisionMaker. Unknown shapes
      * fail open (assumed payable) so exotic cost pipelines still prompt and abort later via the
      * resumer's `stopOnError` composite.
@@ -619,6 +621,13 @@ class GatedEffectExecutor(
                     ?: playerId
                 amount <= 0 || state.lifeTotal(payerId) >= amount
             }
+            // "You may pay {1} up to three times" as a gate cost: the repeated payment's floor is
+            // one repetition, so a payer who can't afford even that must not be offered the "yes"
+            // (the cost would then error and `stopOnError` would swallow the whole payoff). Mirrors
+            // ReflexiveTriggerEffectExecutor.isActionFeasible, which scores the same shape.
+            is PayManaCostRepeatedlyEffect -> PayManaCostRepeatedlyExecutor.affordableRepetitions(
+                state, playerId, cost.cost, cost.maxTimes, cardRegistry
+            ) >= 1
             is CompositeEffect -> cost.effects.all { canAfford(state, playerId, it, context) }
             // "You may sacrifice [filter]" — payable only if the player controls enough matching
             // permanents (`any = true`, "sacrifice any number", is always payable: zero is legal).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ManaCostPayment.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ManaCostPayment.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.mechanics.mana.ManaSource
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
@@ -83,4 +84,44 @@ fun payManaCostFromPool(
     }
 
     return EffectResult.success(currentState, events)
+}
+
+/**
+ * Whether [player] can pay [cost] *through the path [payManaCostFromPool] actually takes*: floating
+ * mana first, then auto-tap for the remainder.
+ *
+ * Deliberately **not** [ManaSolver.canPay]. `canPay` answers the broader question "is this cost
+ * payable at all", counting mana the auto-tap solver refuses to spend on the player's behalf —
+ * sacrificing a Treasure, Springleaf Drum's tap-a-creature sub-cost, an explicitly-activated
+ * ability (see the extras fallback in `ManaSolver.canPay`, and the matching `requiresSacrifice` /
+ * `tapPermanentsSubCost` filters in `ManaSolver.solve`). A caller that *gates* on `canPay` and then
+ * *pays* with [payManaCostFromPool] can therefore offer a payment that errors mid-resolution. Gate
+ * on this instead whenever the payment is the auto-tapped one.
+ *
+ * [precomputedSources] is threaded straight to [ManaSolver.solve]; hoist it once with
+ * [ManaSolver.findAvailableManaSources] when probing the same state repeatedly.
+ */
+fun canAutoPayManaCost(
+    state: GameState,
+    player: EntityId,
+    cost: ManaCost,
+    cardRegistry: CardRegistry,
+    precomputedSources: List<ManaSource>? = null
+): Boolean {
+    val manaPoolComponent = state.getEntity(player)?.get<ManaPoolComponent>() ?: return false
+
+    val manaPool = ManaPool(
+        manaPoolComponent.white,
+        manaPoolComponent.blue,
+        manaPoolComponent.black,
+        manaPoolComponent.red,
+        manaPoolComponent.green,
+        manaPoolComponent.colorless
+    )
+
+    val remainingCost = manaPool.payPartial(cost).remainingCost
+    if (remainingCost.isEmpty()) return true
+
+    return ManaSolver(cardRegistry)
+        .solve(state, player, remainingCost, precomputedSources = precomputedSources) != null
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/PayManaCostRepeatedlyExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/PayManaCostRepeatedlyExecutor.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine.handlers.effects.composite
+
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.PayManaCostRepeatedlyContinuation
+import com.wingedsheep.engine.handlers.DecisionHandler
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.PayManaCostRepeatedlyEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [PayManaCostRepeatedlyEffect] — "pay {1} up to three times" / "…any number of
+ * times", the repeatable optional payment whose payoff scales with the repetition count.
+ *
+ * Two steps, one prompt:
+ *  1. [affordableRepetitions] computes how many repetitions the payer can actually make, testing
+ *     `cost * n` color-aware through the same auto-tap predicate the payment itself uses
+ *     ([canAutoPayManaCost]) rather than dividing total mana by the mana value — `{G}` three times
+ *     needs three *green*, and three Mountains can't pay it.
+ *  2. The payer names a number in `1..cap`; the whole `cost * n` is then paid in one auto-tapped
+ *     payment ([payManaCostFromPool]) and `n` is written into the pipeline under
+ *     [PayManaCostRepeatedlyEffect.storeCountAs].
+ *
+ * The floor is 1, not 0: declining belongs to the wrapper (`ReflexiveTriggerEffect(optional =
+ * true)`, `Gate.MayPay`), not to this effect, so the two questions stay one "do you want to?" and
+ * one "how many?" instead of a redundant pair of decline paths. Consistently, a payer who cannot
+ * afford even one repetition gets a *failure*, which is what stops a CR 603.12 reflexive trigger
+ * from firing on a payment that never happened — the same contract `PayFixedCountersEffect` has,
+ * and `ReflexiveTriggerEffectExecutor.isActionFeasible` scores it up front so the may-question is
+ * never raised in that case.
+ *
+ * A cap of exactly 1 has no question to ask (the payer has already consented, and 1 is the only
+ * legal count), so it pays synchronously without a prompt.
+ */
+class PayManaCostRepeatedlyExecutor(
+    private val cardRegistry: CardRegistry,
+    private val decisionHandler: DecisionHandler = DecisionHandler()
+) : EffectExecutor<PayManaCostRepeatedlyEffect> {
+
+    override val effectType: KClass<PayManaCostRepeatedlyEffect> = PayManaCostRepeatedlyEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: PayManaCostRepeatedlyEffect,
+        context: EffectContext
+    ): EffectResult {
+        val playerId = context.controllerId
+        val cap = affordableRepetitions(state, playerId, effect.cost, effect.maxTimes, cardRegistry)
+
+        if (cap <= 0) {
+            return EffectResult.error(state, "Cannot pay ${effect.cost} even once")
+        }
+
+        if (cap == 1) {
+            val paid = payManaCostFromPool(state, playerId, effect.cost, cardRegistry)
+            if (paid.error != null) return paid
+            return paid.copy(updatedStoredNumbers = paid.updatedStoredNumbers + (effect.storeCountAs to 1))
+        }
+
+        val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
+
+        val decisionResult = decisionHandler.createNumberDecision(
+            state = state,
+            playerId = playerId,
+            sourceId = context.sourceId,
+            sourceName = sourceName,
+            prompt = "How many times do you want to pay ${effect.cost}? (1-$cap)",
+            minValue = 1,
+            maxValue = cap,
+            phase = DecisionPhase.RESOLUTION
+        )
+        val decision = decisionResult.pendingDecision
+            ?: return EffectResult.error(state, "Failed to create repeat-count decision")
+
+        val continuation = PayManaCostRepeatedlyContinuation(
+            decisionId = decision.id,
+            playerId = playerId,
+            cost = effect.cost,
+            maxTimes = cap,
+            storeCountAs = effect.storeCountAs
+        )
+
+        return EffectResult.paused(
+            decisionResult.state.pushContinuation(continuation),
+            decision,
+            decisionResult.events
+        )
+    }
+
+    companion object {
+        /**
+         * How many times [player] could pay [cost] back to back right now, capped by [maxTimes].
+         *
+         * Walks `cost * n` upward through [canAutoPayManaCost], which is what makes the answer
+         * color-aware; the walk is bounded by [maxTimes] when set and otherwise by the payer's
+         * total available mana (no repetition of a non-empty cost can be free, so that bound can
+         * never cut a reachable count short).
+         *
+         * The probe is [canAutoPayManaCost] and **not** [ManaSolver.canPay] on purpose: the payment
+         * is [payManaCostFromPool], which auto-taps and so refuses to spend "extras" (sacrificing a
+         * Treasure, Springleaf Drum). Capping with `canPay` would count those and offer a count the
+         * payment then fails on. The two must agree, so both go through the same predicate.
+         *
+         * A free cost (`{0}`) is payable any number of times, so an uncapped effect just reports
+         * the mana-count bound — a degenerate shape that should carry an explicit [maxTimes].
+         */
+        fun affordableRepetitions(
+            state: GameState,
+            player: EntityId,
+            cost: ManaCost,
+            maxTimes: Int?,
+            cardRegistry: CardRegistry
+        ): Int {
+            val solver = ManaSolver(cardRegistry)
+            // Hoisted once and threaded through every probe: nothing about the battlefield changes
+            // between them, and the walk is O(bound) solver runs otherwise.
+            val sources = solver.findAvailableManaSources(state, player)
+            val bound = maxTimes ?: solver.getAvailableManaCount(state, player, sources)
+            if (bound <= 0) return 0
+            var paid = 0
+            while (paid < bound &&
+                canAutoPayManaCost(state, player, cost * (paid + 1), cardRegistry, sources)
+            ) {
+                paid++
+            }
+            return paid
+        }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -59,6 +60,7 @@ class ReflexiveTriggerEffectExecutor(
     private val effectExecutor: (GameState, Effect, EffectContext) -> EffectResult,
     private val targetFinder: TargetFinder,
     private val decisionHandler: DecisionHandler,
+    private val cardRegistry: CardRegistry,
     private val amountEvaluator: DynamicAmountEvaluator = DynamicAmountEvaluator()
 ) : EffectExecutor<ReflexiveTriggerEffect> {
 
@@ -229,6 +231,14 @@ class ReflexiveTriggerEffectExecutor(
         is com.wingedsheep.sdk.scripting.effects.RemoveCountersEffect ->
             countersOn(state, context, action.target, kind = action.counterType)
                 ?.let { it >= action.count } ?: true
+        // "You may pay {1} up to three times" (Hawkeye, Master Marksman) — the repeated payment's
+        // floor is one repetition, so a payer who can't afford even that can't perform the action
+        // at all and the may-question must be absent. Without this the executor would raise the
+        // prompt and then fail on every answer.
+        is com.wingedsheep.sdk.scripting.effects.PayManaCostRepeatedlyEffect ->
+            PayManaCostRepeatedlyExecutor.affordableRepetitions(
+                state, context.controllerId, action.cost, action.maxTimes, cardRegistry
+            ) >= 1
         // "You may collect evidence 3" (Sample Collector) — CR 701.59b is explicit that a player
         // unable to exile cards totalling N *can't choose to collect evidence*, so the option must
         // be absent rather than offered and refused. Without this branch the `else -> true` below

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/stats/SetBaseStatsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/stats/SetBaseStatsExecutor.kt
@@ -10,19 +10,49 @@ import com.wingedsheep.engine.mechanics.layers.Sublayer
 import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.sdk.scripting.effects.SetBaseStatsEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.encodeToJsonElement
 import kotlin.reflect.KClass
 
 /**
  * Executor for [SetBaseStatsEffect].
  *
- * Evaluates the dynamic power/toughness amounts and creates a floating effect at
- * Layer.POWER_TOUGHNESS, Sublayer.SET_VALUES that sets whichever stats are non-null:
- *  - both     -> [SerializableModification.SetPowerToughness]
- *  - power    -> [SerializableModification.SetPower]    (toughness unchanged)
- *  - toughness-> [SerializableModification.SetToughness] (power unchanged)
+ * Creates a floating effect at Layer.POWER_TOUGHNESS, Sublayer.SET_VALUES (CR 613.4b) that sets
+ * whichever stats are non-null. Either way the affected set is locked in here, at resolution
+ * (CR 611.2c); the two modes differ in when the number is read, and in the two documented ways
+ * listed underneath:
  *
- * "Change this creature's base power to target creature's power." / "It has base power and
- * toughness 2/2 until your next turn."
+ *  - [SetBaseStatsEffect.reevaluateContinuously] `false` (default) — snapshot: the amounts are
+ *    evaluated now, against this resolution's [EffectContext], and the fixed modification is
+ *    stamped:
+ *      - both     -> [SerializableModification.SetPowerToughness]
+ *      - power    -> [SerializableModification.SetPower]    (toughness unchanged)
+ *      - toughness-> [SerializableModification.SetToughness] (power unchanged)
+ *    "Change this creature's base power to target creature's power." / "It has base power and
+ *    toughness 2/2 until your next turn."
+ *  - `true` — the `DynamicAmount`s are carried into a single
+ *    [SerializableModification.SetPowerToughnessDynamic] (independently nullable) and re-evaluated
+ *    on every projection pass. That is what an effect handing out a quoted "this creature's base
+ *    power is equal to …" static needs (Ms. Marvel, Kamala Khan).
+ *
+ * The two ways the re-evaluated mode is *not* merely a different clock, both of them consequences
+ * of the number being read from the projector rather than from here:
+ *
+ *  1. **Only projection-scoped amounts work.** The projector rebuilds a bare `EffectContext` from
+ *     the source, its controller and the affected entity, so target-, X-, triggering- and
+ *     cost-scoped references have nothing to resolve against and would read as absent on every
+ *     pass. [contextScopedReferenceIn] rejects those at resolution rather than letting them
+ *     silently compute 0 forever; CR 611.2d independently forbids re-evaluating X.
+ *  2. **The re-evaluated set applies only while the permanent is a creature.** `EffectApplicator`
+ *     gates the dynamic branch on the projected type line (CR 208.3a: the effect is still created,
+ *     it just "doesn't do anything unless that permanent becomes a creature"), and re-asks that
+ *     gate every pass, so a Vehicle crewed later in the turn picks the value up. The fixed
+ *     `SetPower`/`SetToughness`/`SetPowerToughness` branches write unconditionally.
  */
 class SetBaseStatsExecutor(
     private val amountEvaluator: DynamicAmountEvaluator = DynamicAmountEvaluator()
@@ -43,14 +73,34 @@ class SetBaseStatsExecutor(
             return EffectResult.success(state)
         }
 
-        val power = effect.power?.let { amountEvaluator.evaluate(state, it, context) }
-        val toughness = effect.toughness?.let { amountEvaluator.evaluate(state, it, context) }
-
-        val modification = when {
-            power != null && toughness != null -> SerializableModification.SetPowerToughness(power, toughness)
-            power != null -> SerializableModification.SetPower(power)
-            toughness != null -> SerializableModification.SetToughness(toughness)
-            else -> return EffectResult.success(state) // nothing to set
+        val modification: SerializableModification = if (effect.reevaluateContinuously) {
+            // Carry the DynamicAmounts through; the projector re-reads them on every pass — which
+            // is only meaningful for amounts it can still evaluate. Fail loudly here rather than
+            // reading 0 on every pass for the rest of the effect's duration.
+            listOfNotNull(effect.power, effect.toughness).forEach { amount ->
+                val offending = contextScopedReferenceIn(amount)
+                require(offending == null) {
+                    "SetBaseStatsEffect(reevaluateContinuously = true) cannot carry the " +
+                        "context-scoped reference '$offending' in ${amount.description}: the " +
+                        "projector re-evaluates the amount with only the source, its controller " +
+                        "and the affected entity in scope, so target-, X-, triggering- and " +
+                        "cost-scoped references resolve to nothing on every pass. Use the default " +
+                        "snapshot mode (CR 611.2d requires X to be fixed on resolution anyway), " +
+                        "or an amount computable from the source, the affected entity and global " +
+                        "game state."
+                }
+            }
+            if (effect.power == null && effect.toughness == null) return EffectResult.success(state)
+            SerializableModification.SetPowerToughnessDynamic(effect.power, effect.toughness)
+        } else {
+            val power = effect.power?.let { amountEvaluator.evaluate(state, it, context) }
+            val toughness = effect.toughness?.let { amountEvaluator.evaluate(state, it, context) }
+            when {
+                power != null && toughness != null -> SerializableModification.SetPowerToughness(power, toughness)
+                power != null -> SerializableModification.SetPower(power)
+                toughness != null -> SerializableModification.SetToughness(toughness)
+                else -> return EffectResult.success(state) // nothing to set
+            }
         }
 
         val newState = state.addFloatingEffect(
@@ -64,4 +114,53 @@ class SetBaseStatsExecutor(
 
         return EffectResult.success(newState)
     }
+}
+
+/**
+ * Serial names of the `DynamicAmount` / `EntityReference` / `Player` shapes whose value lives in
+ * the resolution-time `EffectContext` — the chosen targets, the announced X, the triggering object,
+ * the things sacrificed or tapped to pay a cost, the resolution pipeline's stored collections.
+ *
+ * `EffectApplicator` rebuilds a bare `EffectContext(sourceId, controllerId, affectedEntityId)` on
+ * every projection pass, so none of these can resolve there; an amount containing one would read as
+ * absent (0, or an empty player/entity list) forever. They are therefore rejected for
+ * [SetBaseStatsEffect.reevaluateContinuously] rather than silently mis-evaluated. Everything not
+ * listed here is evaluated from the source, the affected entity, or global game state, which the
+ * projector does carry.
+ *
+ * Kept as a deny list rather than an allow list because the projector-safe set is open-ended (every
+ * `Count`/`AggregateBattlefield`/`EntityProperty(Source | AffectedEntity)` shape works); the
+ * *traversal* is what has to be exhaustive, and encoding to JSON makes it so — no nesting site can
+ * be missed the way a hand-written `when` over the composite amounts could.
+ */
+private val CONTEXT_SCOPED_SERIAL_NAMES: Set<String> = setOf(
+    // DynamicAmount
+    "XValue", "CastX", "CastChoice", "ContextProperty", "VariableReference", "StoredCardManaValue",
+    "DistinctEntitiesInCollections", "DistinctCardTypesInCollections", "ManaValueSumOfCollection",
+    "TotalManaSpent", "ManaSpentOnX", "PermanentsSacrificedThisWay", "StationCharge",
+    "LastKnownSourceCounters", "LastKnownDamageDealtToSource",
+    // EntityReference
+    "Target", "Triggering", "Sacrificed", "TappedAsCost", "FromCostStorage", "AmassedArmy",
+    "IterationEntity",
+    // Player
+    "TargetPlayer", "TargetOpponent", "ContextPlayer", "TriggeringPlayer", "ControllerOf", "OwnerOf",
+)
+
+private val CONTEXT_SCAN_JSON = Json
+
+/**
+ * The serial name of the first context-scoped reference anywhere inside [amount], or null when the
+ * whole tree is projector-safe. See [CONTEXT_SCOPED_SERIAL_NAMES].
+ */
+internal fun contextScopedReferenceIn(amount: DynamicAmount): String? =
+    findContextScoped(CONTEXT_SCAN_JSON.encodeToJsonElement<DynamicAmount>(amount))
+
+private fun findContextScoped(element: JsonElement): String? = when (element) {
+    is JsonObject -> element.entries.firstNotNullOfOrNull { (key, value) ->
+        val discriminator = (value as? JsonPrimitive)?.takeIf { it.isString }?.content
+        if (key == "type" && discriminator in CONTEXT_SCOPED_SERIAL_NAMES) discriminator
+        else findContextScoped(value)
+    }
+    is JsonArray -> element.firstNotNullOfOrNull { findContextScoped(it) }
+    else -> null
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/stats/SetBaseStatsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/stats/SetBaseStatsExecutor.kt
@@ -10,13 +10,6 @@ import com.wingedsheep.engine.mechanics.layers.Sublayer
 import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.sdk.scripting.effects.SetBaseStatsEffect
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.encodeToJsonElement
 import kotlin.reflect.KClass
 
 /**
@@ -46,8 +39,10 @@ import kotlin.reflect.KClass
  *  1. **Only projection-scoped amounts work.** The projector rebuilds a bare `EffectContext` from
  *     the source, its controller and the affected entity, so target-, X-, triggering- and
  *     cost-scoped references have nothing to resolve against and would read as absent on every
- *     pass. [contextScopedReferenceIn] rejects those at resolution rather than letting them
- *     silently compute 0 forever; CR 611.2d independently forbids re-evaluating X.
+ *     pass. Nothing here has to check for them: `SetBaseStatsEffect`'s own `init` rejects them via
+ *     [com.wingedsheep.sdk.scripting.values.contextScopedReferenceIn] when the card is loaded, so
+ *     by the time an effect reaches this executor its amounts are already known re-evaluable.
+ *     CR 611.2d independently forbids re-evaluating X.
  *  2. **The re-evaluated set applies only while the permanent is a creature.** `EffectApplicator`
  *     gates the dynamic branch on the projected type line (CR 208.3a: the effect is still created,
  *     it just "doesn't do anything unless that permanent becomes a creature"), and re-asks that
@@ -74,22 +69,9 @@ class SetBaseStatsExecutor(
         }
 
         val modification: SerializableModification = if (effect.reevaluateContinuously) {
-            // Carry the DynamicAmounts through; the projector re-reads them on every pass — which
-            // is only meaningful for amounts it can still evaluate. Fail loudly here rather than
-            // reading 0 on every pass for the rest of the effect's duration.
-            listOfNotNull(effect.power, effect.toughness).forEach { amount ->
-                val offending = contextScopedReferenceIn(amount)
-                require(offending == null) {
-                    "SetBaseStatsEffect(reevaluateContinuously = true) cannot carry the " +
-                        "context-scoped reference '$offending' in ${amount.description}: the " +
-                        "projector re-evaluates the amount with only the source, its controller " +
-                        "and the affected entity in scope, so target-, X-, triggering- and " +
-                        "cost-scoped references resolve to nothing on every pass. Use the default " +
-                        "snapshot mode (CR 611.2d requires X to be fixed on resolution anyway), " +
-                        "or an amount computable from the source, the affected entity and global " +
-                        "game state."
-                }
-            }
+            // Carry the DynamicAmounts through; the projector re-reads them on every pass. That the
+            // amounts are ones it *can* re-read was settled when the effect was constructed —
+            // SetBaseStatsEffect's init rejects context-scoped references at card-load time.
             if (effect.power == null && effect.toughness == null) return EffectResult.success(state)
             SerializableModification.SetPowerToughnessDynamic(effect.power, effect.toughness)
         } else {
@@ -114,53 +96,4 @@ class SetBaseStatsExecutor(
 
         return EffectResult.success(newState)
     }
-}
-
-/**
- * Serial names of the `DynamicAmount` / `EntityReference` / `Player` shapes whose value lives in
- * the resolution-time `EffectContext` — the chosen targets, the announced X, the triggering object,
- * the things sacrificed or tapped to pay a cost, the resolution pipeline's stored collections.
- *
- * `EffectApplicator` rebuilds a bare `EffectContext(sourceId, controllerId, affectedEntityId)` on
- * every projection pass, so none of these can resolve there; an amount containing one would read as
- * absent (0, or an empty player/entity list) forever. They are therefore rejected for
- * [SetBaseStatsEffect.reevaluateContinuously] rather than silently mis-evaluated. Everything not
- * listed here is evaluated from the source, the affected entity, or global game state, which the
- * projector does carry.
- *
- * Kept as a deny list rather than an allow list because the projector-safe set is open-ended (every
- * `Count`/`AggregateBattlefield`/`EntityProperty(Source | AffectedEntity)` shape works); the
- * *traversal* is what has to be exhaustive, and encoding to JSON makes it so — no nesting site can
- * be missed the way a hand-written `when` over the composite amounts could.
- */
-private val CONTEXT_SCOPED_SERIAL_NAMES: Set<String> = setOf(
-    // DynamicAmount
-    "XValue", "CastX", "CastChoice", "ContextProperty", "VariableReference", "StoredCardManaValue",
-    "DistinctEntitiesInCollections", "DistinctCardTypesInCollections", "ManaValueSumOfCollection",
-    "TotalManaSpent", "ManaSpentOnX", "PermanentsSacrificedThisWay", "StationCharge",
-    "LastKnownSourceCounters", "LastKnownDamageDealtToSource",
-    // EntityReference
-    "Target", "Triggering", "Sacrificed", "TappedAsCost", "FromCostStorage", "AmassedArmy",
-    "IterationEntity",
-    // Player
-    "TargetPlayer", "TargetOpponent", "ContextPlayer", "TriggeringPlayer", "ControllerOf", "OwnerOf",
-)
-
-private val CONTEXT_SCAN_JSON = Json
-
-/**
- * The serial name of the first context-scoped reference anywhere inside [amount], or null when the
- * whole tree is projector-safe. See [CONTEXT_SCOPED_SERIAL_NAMES].
- */
-internal fun contextScopedReferenceIn(amount: DynamicAmount): String? =
-    findContextScoped(CONTEXT_SCAN_JSON.encodeToJsonElement<DynamicAmount>(amount))
-
-private fun findContextScoped(element: JsonElement): String? = when (element) {
-    is JsonObject -> element.entries.firstNotNullOfOrNull { (key, value) ->
-        val discriminator = (value as? JsonPrimitive)?.takeIf { it.isString }?.content
-        if (key == "type" && discriminator in CONTEXT_SCOPED_SERIAL_NAMES) discriminator
-        else findContextScoped(value)
-    }
-    is JsonArray -> element.firstNotNullOfOrNull { findContextScoped(it) }
-    else -> null
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -390,6 +390,23 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                         break
                                     }
                                 }
+                                // `{Q}` as one sub-cost, the mirror of the bare `Untap` branch
+                                // above: CR 302.6 gates the untap symbol exactly as it gates the
+                                // tap symbol, and the permanent must be tapped to untap it. Without
+                                // this the enumerator would offer an activation that
+                                // `ActivateAbilityHandler`'s authoritative re-check then rejects.
+                                is AbilityCost.Untap -> {
+                                    if (!container.has<TappedComponent>()) {
+                                        costCanBePaid = false
+                                        break
+                                    }
+                                    if (!cardComponent.typeLine.isLand && projected.isCreature(entityId) &&
+                                        SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
+                                    ) {
+                                        costCanBePaid = false
+                                        break
+                                    }
+                                }
                                 is AbilityCost.Atom -> when (val atom = subCost.atom) {
                                     is CostAtom.Mana -> {
                                         if (!context.manaSolver.canPay(state, playerId, atom.cost, excludeSources = excludeFromMana, precomputedSources = context.availableManaSources, spellContext = abilityContext)) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.legalactions.enumerators
 import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.handlers.effects.composite.asConditional
 import com.wingedsheep.engine.handlers.effects.permanent.counters.resolveCounterType
+import com.wingedsheep.engine.mechanics.SummoningSicknessRules
 import com.wingedsheep.engine.mechanics.mana.TapForGeneric
 import com.wingedsheep.engine.legalactions.*
 import com.wingedsheep.engine.state.ZoneKey
@@ -15,7 +16,6 @@ import com.wingedsheep.engine.state.components.identity.EmblemActivatedAbilityCo
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.sdk.core.CounterType
-import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.*
@@ -211,22 +211,27 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 when (effectiveCost) {
                     is AbilityCost.Tap -> {
                         if (container.has<TappedComponent>()) continue
-                        if (!cardComponent.typeLine.isLand && projected.isCreature(entityId)) {
-                            val hasSummoningSickness = container.has<SummoningSicknessComponent>()
-                            val hasHaste = projected.hasKeyword(entityId, Keyword.HASTE)
-                            if (hasSummoningSickness && !hasHaste) continue
-                        }
+                        if (!cardComponent.typeLine.isLand && projected.isCreature(entityId) &&
+                            SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
+                        ) continue
+                    }
+                    // The untap symbol, CR 302.6's other half. Mirrors the `{T}` branch with the
+                    // tapped-check inverted — `{Q}` needs a *tapped* permanent to untap — so the
+                    // enumerator and `ActivateAbilityHandler`'s authoritative re-check agree.
+                    is AbilityCost.Untap -> {
+                        if (!container.has<TappedComponent>()) continue
+                        if (!cardComponent.typeLine.isLand && projected.isCreature(entityId) &&
+                            SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
+                        ) continue
                     }
                     is AbilityCost.TapAttachedCreature -> {
                         val attachedId = container.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()?.targetId
                         if (attachedId == null) continue
                         val attachedEntity = state.getEntity(attachedId) ?: continue
                         if (attachedEntity.has<TappedComponent>()) continue
-                        if (projected.isCreature(attachedId)) {
-                            val hasSummoningSickness = attachedEntity.has<SummoningSicknessComponent>()
-                            val hasHaste = projected.hasKeyword(attachedId, Keyword.HASTE)
-                            if (hasSummoningSickness && !hasHaste) continue
-                        }
+                        if (projected.isCreature(attachedId) &&
+                            SummoningSicknessRules.blocksTapOrUntapCost(attachedId, attachedEntity, projected)
+                        ) continue
                     }
                     // "Tap <the granting Equipment>" — an already-tapped (or departed) granter makes
                     // the whole granted ability unactivatable (Fishing Pole).
@@ -378,13 +383,11 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                         costCanBePaid = false
                                         break
                                     }
-                                    if (!cardComponent.typeLine.isLand && projected.isCreature(entityId)) {
-                                        val hasSummoningSickness = container.has<SummoningSicknessComponent>()
-                                        val hasHaste = projected.hasKeyword(entityId, Keyword.HASTE)
-                                        if (hasSummoningSickness && !hasHaste) {
-                                            costCanBePaid = false
-                                            break
-                                        }
+                                    if (!cardComponent.typeLine.isLand && projected.isCreature(entityId) &&
+                                        SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
+                                    ) {
+                                        costCanBePaid = false
+                                        break
                                     }
                                 }
                                 is AbilityCost.Atom -> when (val atom = subCost.atom) {
@@ -552,13 +555,11 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                         costCanBePaid = false
                                         break
                                     }
-                                    if (projected.isCreature(attachedId)) {
-                                        val hasSummoningSickness = attachedEntity.has<SummoningSicknessComponent>()
-                                        val hasHaste = projected.hasKeyword(attachedId, Keyword.HASTE)
-                                        if (hasSummoningSickness && !hasHaste) {
-                                            costCanBePaid = false
-                                            break
-                                        }
+                                    if (projected.isCreature(attachedId) &&
+                                        SummoningSicknessRules.blocksTapOrUntapCost(attachedId, attachedEntity, projected)
+                                    ) {
+                                        costCanBePaid = false
+                                        break
                                     }
                                 }
                                 // "Tap <the granting Equipment>" as one sub-cost of a composite —

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
@@ -6,18 +6,17 @@ import com.wingedsheep.engine.legalactions.ActionEnumerator
 import com.wingedsheep.engine.legalactions.AdditionalCostData
 import com.wingedsheep.engine.legalactions.EnumerationContext
 import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.mechanics.SummoningSicknessRules
 import com.wingedsheep.engine.mechanics.mana.IntrinsicManaAbilities
 import com.wingedsheep.engine.mechanics.mana.LandManaColorInspector
 import com.wingedsheep.engine.mechanics.mana.ManaColorSetResolver
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
-import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.TextReplacementComponent
-import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -194,12 +193,10 @@ class ManaAbilityEnumerator : ActionEnumerator {
                                     if (container.has<TappedComponent>()) {
                                         affordable = false; break
                                     }
-                                    if (!cardComponent.typeLine.isLand && projected.isCreature(entityId)) {
-                                        val hasSummoningSickness = container.has<SummoningSicknessComponent>()
-                                        val hasHaste = projected.hasKeyword(entityId, Keyword.HASTE)
-                                        if (hasSummoningSickness && !hasHaste) {
-                                            affordable = false; break
-                                        }
+                                    if (!cardComponent.typeLine.isLand && projected.isCreature(entityId) &&
+                                        SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
+                                    ) {
+                                        affordable = false; break
                                     }
                                 }
                                 is AbilityCost.Atom -> when (val atom = subCost.atom) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.effects.permanent.counters.counterTypeToString
 import com.wingedsheep.engine.legalactions.*
+import com.wingedsheep.engine.mechanics.SummoningSicknessRules
 import com.wingedsheep.engine.mechanics.mana.CostCalculator
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.mechanics.mana.ManaSource
@@ -14,11 +15,9 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
-import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Color
-import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -501,11 +500,9 @@ class CostEnumerationUtils(
         // Read creature-ness / haste from projected state so a Vehicle or animated permanent
         // that is currently a creature is gated. Lands keep the carve-out (basic-land mana
         // abilities are not restricted by summoning sickness).
-        if (!cardComponent.typeLine.isLand && state.projectedState.isCreature(entityId)) {
-            val hasSummoningSickness = container.has<SummoningSicknessComponent>()
-            val hasHaste = state.projectedState.hasKeyword(entityId, Keyword.HASTE)
-            if (hasSummoningSickness && !hasHaste) return false
-        }
+        if (!cardComponent.typeLine.isLand && state.projectedState.isCreature(entityId) &&
+            SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, state.projectedState)
+        ) return false
         return true
     }
 
@@ -520,11 +517,9 @@ class CostEnumerationUtils(
         if (attachedEntity.has<TappedComponent>()) return false
         // Read creature-ness / haste from projected state so a Vehicle or animated permanent
         // currently being a creature is gated.
-        if (state.projectedState.isCreature(attachedId)) {
-            val hasSummoningSickness = attachedEntity.has<SummoningSicknessComponent>()
-            val hasHaste = state.projectedState.hasKeyword(attachedId, Keyword.HASTE)
-            if (hasSummoningSickness && !hasHaste) return false
-        }
+        if (state.projectedState.isCreature(attachedId) &&
+            SummoningSicknessRules.blocksTapOrUntapCost(attachedId, attachedEntity, state.projectedState)
+        ) return false
         return true
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/SummoningSicknessRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/SummoningSicknessRules.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.mechanics
+
+import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * The **ability half** of summoning sickness (CR 302.6), in one place.
+ *
+ * CR 302.6 bundles two restrictions under one condition — "under its controller's control
+ * continuously since their most recent turn began":
+ *
+ *  1. a creature's activated ability with `{T}` or `{Q}` in its cost can't be activated, and
+ *  2. a creature can't attack.
+ *
+ * Haste (CR 702.10b/c) lifts both. [AbilityFlag.MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY] — the
+ * Thousand-Year Elixir / Shang-Chi permission, "you may activate abilities of creatures you control
+ * as though those creatures had haste" — lifts **only (1)**.
+ *
+ * That asymmetry is why this object exists and why it answers *only* question (1). Combat keeps its
+ * own check in `AttackRestrictionRules`, which reads [Keyword.HASTE] directly and never consults
+ * this object, so no as-though-hasty grant can leak into attack legality.
+ *
+ * Callers keep their own "is this a creature / is this a land" guard — the land carve-out differs
+ * between call sites (a `{T}` cost on the source itself exempts lands; a `TapAttachedCreature` cost
+ * does not) and folding it in here would silently change behaviour at half the sites. This answers
+ * exactly one question: *given that this permanent's `{T}`/`{Q}` cost is subject to CR 302.6, is it
+ * blocked right now?*
+ *
+ * Every `{T}`/`{Q}` activation gate in the engine routes through here;
+ * `SummoningSicknessGateEnforcementTest` fails the build if a new direct
+ * [SummoningSicknessComponent] read appears outside the allowlisted files.
+ */
+object SummoningSicknessRules {
+
+    /**
+     * Whether summoning sickness currently blocks [entityId] from paying a `{T}` or `{Q}`
+     * activation cost.
+     *
+     * [container] is [entityId]'s component container, which every call site already has in hand —
+     * the map lookup is skipped so this stays free in the mana-solver and enumerator hot paths. The
+     * as-though-hasty flag lookup is only reached for a permanent that is actually sick *and*
+     * hasteless, which is rare.
+     *
+     * **Caller invariant:** [container] must be [entityId]'s *own* container. The pair is not
+     * checked — passing a mismatched one reads the sickness marker off one permanent and haste off
+     * another, and mis-gates silently. Note that the `TapAttachedCreature` sites correctly pass the
+     * *attached creature's* id and container, not the Aura's.
+     */
+    fun blocksTapOrUntapCost(
+        entityId: EntityId,
+        container: ComponentContainer,
+        projected: ProjectedState
+    ): Boolean =
+        container.has<SummoningSicknessComponent>() &&
+            !projected.hasKeyword(entityId, Keyword.HASTE) &&
+            !projected.hasKeyword(entityId, AbilityFlag.MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY)
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
@@ -159,17 +159,22 @@ sealed interface SerializableModification {
     data class SetToughness(val toughness: Int) : SerializableModification
 
     /**
-     * Dynamic base power/toughness *setting* (characteristic-defining ability) — Layer 7b
-     * (SET_VALUES), evaluated per affected entity at projection time. Mirrors
-     * [Modification.SetPowerToughnessDynamic] for floating effects, so a one-shot animate
-     * (e.g. Titania's Song's "this effect continues until end of turn" linger) can set base
-     * P/T to a value computed from each animated permanent (its mana value, via
+     * Dynamic base power/toughness *setting* — Layer 7b (SET_VALUES), evaluated per affected entity
+     * at projection time. Mirrors [Modification.SetPowerToughnessDynamic] for floating effects, so
+     * a one-shot animate (e.g. Titania's Song's "this effect continues until end of turn" linger)
+     * can set base P/T to a value computed from each animated permanent (its mana value, via
      * `EntityProperty(EntityReference.AffectedEntity, EntityNumericProperty.ManaValue)`).
+     *
+     * Also the shape a `SetBaseStatsEffect(reevaluateContinuously = true)` resolves into, which is
+     * why [power] and [toughness] are independently nullable: "gains 'this creature's base *power*
+     * is equal to the number of cards in your hand'" sets power only and leaves toughness printed.
+     * The stat that is set keeps tracking the game state for the effect's whole duration, unlike the
+     * fixed [SetPower]/[SetToughness]/[SetPowerToughness] siblings, which freeze a number.
      */
     @Serializable
     data class SetPowerToughnessDynamic(
-        val power: DynamicAmount,
-        val toughness: DynamicAmount
+        val power: DynamicAmount?,
+        val toughness: DynamicAmount?
     ) : SerializableModification
 
     @Serializable

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -779,6 +779,10 @@ internal class AffectsFilterResolver {
         CardPredicate.ManaValueIsEven -> card.manaValue % 2 == 0
         CardPredicate.ManaValueIsOdd -> card.manaValue % 2 != 0
         CardPredicate.HasXInManaCost -> if (isFaceDown) false else card.manaCost.hasX
+        is CardPredicate.ColoredManaSymbolsAtLeast ->
+            // Printed cost's colored pips (CR 107.4e/f); face-down has no mana cost (CR 708.2).
+            if (isFaceDown) false
+            else card.manaCost.coloredSymbolCount(predicate.colors.toSet()) >= predicate.min
         is CardPredicate.NameEquals -> card.name == predicate.name
         // Room-name distinctness is a resolution-time search filter, not a continuous/static
         // affects-filter concern.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
@@ -57,13 +57,24 @@ internal class EffectApplicator(
                     values.toughness = mod.toughness
                 }
                 is Modification.SetPowerToughnessDynamic -> {
-                    // CDA (CR 604.3): the dynamic value *is* the base P/T, set at Layer 7b.
+                    // The dynamic value *is* the base P/T, recomputed on every projection pass:
+                    // either an effect-granted "base power is equal to …" (CR 613.4b, layer 7b) or
+                    // a star/star CDA (CR 604.3), which CR 613.4a actually puts in layer 7a but
+                    // which this engine lowers into SET_VALUES alongside the 7b sets — see the
+                    // KDoc on Modification.SetPowerToughnessDynamic.
                     // Fall back to the effect's captured controller when the source has left the
                     // battlefield (its ControllerComponent is gone) — Titania's Song's until-EOT
                     // linger keeps animating after the enchantment leaves.
                     val controllerId = projectedValues[effect.sourceId]?.controllerId
                         ?: state.getEntity(effect.sourceId)?.get<ControllerComponent>()?.playerId
                         ?: effect.controllerId
+                    // CR 208.3a: an effect setting the base P/T of a *noncreature* permanent is
+                    // still created, it just "doesn't do anything unless that permanent becomes a
+                    // creature". Layer 4 has already been applied into `values.types` by the time
+                    // we get here and the gate is re-asked on every pass, so a Vehicle crewed later
+                    // in the turn does pick the value up. Note the fixed SetPower / SetToughness /
+                    // SetPowerToughness branches below write unconditionally — this is the one
+                    // place the dynamic and fixed base-P/T sets genuinely diverge.
                     if (controllerId != null && "CREATURE" in values.types) {
                         val context = EffectContext(
                             sourceId = effect.sourceId,
@@ -71,8 +82,15 @@ internal class EffectApplicator(
                             affectedEntityId = entityId
                         )
                         val intermediateProjected = buildIntermediateProjectedState(state, projectedValues)
-                        values.power = dynamicAmountEvaluator.evaluate(state, mod.power, context, intermediateProjected)
-                        values.toughness = dynamicAmountEvaluator.evaluate(state, mod.toughness, context, intermediateProjected)
+                        // A null half means "leave that stat alone" — the same semantics as
+                        // SetBaseStatsEffect's null power/toughness, so "base power is equal to X"
+                        // does not silently zero the printed toughness.
+                        mod.power?.let {
+                            values.power = dynamicAmountEvaluator.evaluate(state, it, context, intermediateProjected)
+                        }
+                        mod.toughness?.let {
+                            values.toughness = dynamicAmountEvaluator.evaluate(state, it, context, intermediateProjected)
+                        }
                     }
                 }
                 is Modification.SetPower -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
@@ -622,15 +622,33 @@ sealed interface Modification {
     }
 
     /**
-     * Dynamic base power/toughness *setting* (characteristic-defining ability) — Layer 7b
-     * (SET_VALUES). The amounts are computed at projection time by evaluating the DynamicAmounts.
-     * Distinct from [ModifyPowerToughnessDynamic], which is a Layer 7c additive bonus. Used for
-     * star/star CDAs like Beau ("power and toughness each equal to the number of lands you control").
+     * Dynamic base power/toughness *setting* — Layer 7b (SET_VALUES). The amounts are computed at
+     * projection time by evaluating the DynamicAmounts, so the stat tracks the game state instead of
+     * freezing a number. Distinct from [ModifyPowerToughnessDynamic], which is a Layer 7c additive
+     * bonus.
+     *
+     * Two callers:
+     *  - a *resolved* effect that hands a creature a re-evaluated base-P/T set for a duration
+     *    (`SetBaseStatsEffect(reevaluateContinuously = true)` — Ms. Marvel, Kamala Khan). That one is
+     *    genuinely layer 7b: it is not a CDA (CR 604.3a criteria 2 and 4) and CR 613.4b puts
+     *    "effects that refer to the base power and/or toughness of a creature" in this layer.
+     *  - star/star CDAs like Beau ("power and toughness each equal to the number of lands you
+     *    control"), lowered from `SetBasePowerToughnessDynamicStatic`. Those belong in **layer 7a**
+     *    per CR 613.4a ("effects from characteristic-defining abilities that define power and/or
+     *    toughness"), not 7b; the engine lowers them into this same [Sublayer.SET_VALUES] as a
+     *    known simplification — [Sublayer.CHARACTERISTIC_DEFINING] exists but is currently
+     *    unreferenced. The two are therefore ordered against each other by timestamp, where CR says
+     *    a 7b set always wins over a 7a CDA. No shipped card needs that fight yet; whoever finds one
+     *    should split the sublayer rather than reorder here.
+     *
+     * A `null` [power] or [toughness] leaves that stat alone, mirroring
+     * `SetBaseStatsEffect`'s null semantics — that is how "base *power* is equal to …" sets power
+     * while toughness stays printed.
      */
     @Serializable
     data class SetPowerToughnessDynamic(
-        val power: DynamicAmount,
-        val toughness: DynamicAmount
+        val power: DynamicAmount?,
+        val toughness: DynamicAmount?
     ) : Modification {
         override val layer get() = Layer.POWER_TOUGHNESS
         override val sublayer get() = Sublayer.SET_VALUES

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -1215,6 +1215,8 @@ class CostCalculator(
             CardPredicate.ManaValueIsEven -> cardDef.manaCost.cmc % 2 == 0
             CardPredicate.ManaValueIsOdd -> cardDef.manaCost.cmc % 2 != 0
             CardPredicate.HasXInManaCost -> cardDef.manaCost.hasX
+            is CardPredicate.ColoredManaSymbolsAtLeast ->
+                cardDef.manaCost.coloredSymbolCount(predicate.colors.toSet()) >= predicate.min
 
             is CardPredicate.PowerEquals -> cardDef.creatureStats?.basePower == predicate.value
             // CostCalculator has no X context; predicate has no static answer here.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -25,6 +25,7 @@ import com.wingedsheep.sdk.core.ManaSymbol
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.engine.mechanics.SummoningSicknessRules
 import com.wingedsheep.engine.mechanics.cost.CostPaymentService
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.costs.CostAtom
@@ -979,9 +980,14 @@ class ManaSolver(
 
             // Creature and attack capability detection
             val isCreature = projected.isCreature(entityId)
+            // Attack legality reads plain haste (CR 302.6 / 702.10b): an "activate as though hasty"
+            // grant must NOT make this creature look like an attacker to the auto-tap heuristic.
             val hasSummoningSickness = container.has<SummoningSicknessComponent>()
             val hasHaste = projected.hasKeyword(entityId, Keyword.HASTE)
             val canAttack = isCreature && (!hasSummoningSickness || hasHaste)
+            // The {T}/{Q} half of CR 302.6, which "as though those creatures had haste" does lift.
+            val tapBlockedBySickness =
+                SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
 
             // Basic land detection
             val isBasicLand = card.typeLine.isBasicLand
@@ -1198,10 +1204,8 @@ class ManaSolver(
                 }
 
                 // Check summoning sickness for creatures (non-lands)
-                if (!card.typeLine.isLand && isCreature) {
-                    if (hasSummoningSickness && !hasHaste) {
-                        continue // Can't use this ability due to summoning sickness
-                    }
+                if (!card.typeLine.isLand && isCreature && tapBlockedBySickness) {
+                    continue // Can't use this ability due to summoning sickness
                 }
 
                 // Pain modeled as a self-damage side effect in the ability's effect chain
@@ -2417,9 +2421,7 @@ class ManaSolver(
         val projected = state.projectedState
         // Summoning sickness only bites non-land creatures (CR 302.6).
         if (!card.typeLine.isLand && projected.isCreature(entityId)) {
-            if (container.has<SummoningSicknessComponent>() &&
-                !projected.hasKeyword(entityId, Keyword.HASTE)
-            ) return false
+            if (SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)) return false
         }
         return true
     }
@@ -2473,13 +2475,12 @@ class ManaSolver(
             // Own abilities stripped by Humility / similar — skip the printed mana ability.
             if (projected.hasLostAllAbilities(entityId)) continue
 
-            // Summoning sickness applies to non-land creatures (Rule 302.1) — they can't tap unless they have haste.
+            // Summoning sickness applies to non-land creatures (CR 302.6) — they can't tap unless
+            // they have haste or an "activate as though hasty" grant.
             val isCreature = projected.isCreature(entityId)
-            if (!card.typeLine.isLand && isCreature) {
-                val hasSummoningSickness = container.has<SummoningSicknessComponent>()
-                val hasHaste = projected.hasKeyword(entityId, Keyword.HASTE)
-                if (hasSummoningSickness && !hasHaste) continue
-            }
+            if (!card.typeLine.isLand && isCreature &&
+                SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
+            ) continue
 
             for (ability in cardDef.script.activatedAbilities) {
                 if (!ability.isManaAbility) continue
@@ -2594,11 +2595,9 @@ class ManaSolver(
             if (projected.hasLostAllAbilities(entityId)) continue
 
             val isCreature = projected.isCreature(entityId)
-            if (!card.typeLine.isLand && isCreature) {
-                val hasSummoningSickness = container.has<SummoningSicknessComponent>()
-                val hasHaste = projected.hasKeyword(entityId, Keyword.HASTE)
-                if (hasSummoningSickness && !hasHaste) continue
-            }
+            if (!card.typeLine.isLand && isCreature &&
+                SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
+            ) continue
 
             for (ability in cardDef.script.activatedAbilities) {
                 if (!ability.isManaAbility) continue

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/SummoningSicknessGateEnforcementTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/SummoningSicknessGateEnforcementTest.kt
@@ -24,6 +24,9 @@ import java.io.File
  * [com.wingedsheep.sdk.scripting.ActivationRestriction.ControlledSinceYourMostRecentTurn]
  * restriction, and the client's display badge.
  *
+ * The scan matches both `has<…>` and `get<…>` spellings of the read, so `get<…>() != null` is not
+ * an escape hatch.
+ *
  * **Known limit, stated plainly:** the allowlist is per *file*, not per line, so a new open-coded
  * tap gate added inside **any** of the eight [ALLOWED_FILES] would not be caught — not just the two
  * biggest (`ManaSolver.kt`, `ActivateAbilityHandler.kt`) but `CastPermissionUtils.kt` and
@@ -45,9 +48,15 @@ class SummoningSicknessGateEnforcementTest : FunSpec({
 }) {
     companion object {
 
-        /** A direct read of the marker: `has<SummoningSicknessComponent>()`, qualified or not. */
+        /**
+         * A direct read of the marker: `has<SummoningSicknessComponent>()` or
+         * `get<SummoningSicknessComponent>()`, qualified or not. Both spellings, because
+         * `get<…>() != null` is the same gate written differently and matching only `has` would let
+         * it through in **any** file rather than just the allowlisted ones — a hole the per-file
+         * granularity documented above does not cover.
+         */
         private val DIRECT_READ_PATTERN =
-            Regex("""\.has<\s*(?:[\w.]+\.)?SummoningSicknessComponent\s*>""")
+            Regex("""\.(?:has|get)<\s*(?:[\w.]+\.)?SummoningSicknessComponent\s*>""")
 
         /**
          * Files permitted to read [com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent]

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/SummoningSicknessGateEnforcementTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/SummoningSicknessGateEnforcementTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.hygiene
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import java.io.File
+
+/**
+ * Guards the `{T}`/`{Q}` activation gate: every place that asks "is this creature's tap/untap cost
+ * blocked by summoning sickness?" must ask
+ * [com.wingedsheep.engine.mechanics.SummoningSicknessRules], not open-code
+ * `has<SummoningSicknessComponent>() && !hasKeyword(HASTE)`.
+ *
+ * The open-coded form was duplicated at fourteen sites across the mana solver, both ability
+ * enumerators, the cost helpers and the activation handler. Any permission that lifts the ability
+ * half of CR 302.6 without granting haste — currently
+ * [com.wingedsheep.sdk.core.AbilityFlag.MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY] (Thousand-Year
+ * Elixir, Shang-Chi) — has to be honoured at *all* of them or the enumerator and the authoritative
+ * re-check disagree and the ability is offered but rejected (or vice versa). Centralizing makes the
+ * next such permission a one-line change; this test makes a new bypass fail the build.
+ *
+ * [ALLOWED_FILES] lists the files that read the component directly, each for a reason that is *not*
+ * a tap/untap gate: the marker's own lifecycle, the attack half of CR 302.6 (which as-though-hasty
+ * deliberately does not lift), the separate
+ * [com.wingedsheep.sdk.scripting.ActivationRestriction.ControlledSinceYourMostRecentTurn]
+ * restriction, and the client's display badge.
+ *
+ * **Known limit, stated plainly:** the allowlist is per *file*, not per line, so a new open-coded
+ * tap gate added inside **any** of the eight [ALLOWED_FILES] would not be caught — not just the two
+ * biggest (`ManaSolver.kt`, `ActivateAbilityHandler.kt`) but `CastPermissionUtils.kt` and
+ * `SacrificeAndPayContinuationResumer.kt` equally. Every *other* file in
+ * `rules-engine/src/main/kotlin` is covered. The scan also does not cover `ai/`, `game-server/`,
+ * `gym/` or `mtg-sets/` at all; the reads there are attack-evaluation heuristics and scenario setup.
+ * A per-line allowlist (file → a regex the permitted line must match, e.g.
+ * `ControlledSinceYourMostRecentTurn` / `canAttack`) would close six of the eight without new
+ * machinery, and is the obvious next step if this ever catches nothing while a bypass ships.
+ */
+class SummoningSicknessGateEnforcementTest : FunSpec({
+
+    test("tap/untap summoning-sickness gates go through SummoningSicknessRules") {
+        val offenders = findDirectSicknessReads(sourceRoot())
+            .filterNot { it.relativePath in ALLOWED_FILES }
+
+        offenders.map { "${it.relativePath}:${it.lineNumber}: ${it.line.trim()}" }.shouldBeEmpty()
+    }
+}) {
+    companion object {
+
+        /** A direct read of the marker: `has<SummoningSicknessComponent>()`, qualified or not. */
+        private val DIRECT_READ_PATTERN =
+            Regex("""\.has<\s*(?:[\w.]+\.)?SummoningSicknessComponent\s*>""")
+
+        /**
+         * Files permitted to read [com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent]
+         * directly. None of these is a `{T}`/`{Q}` activation gate.
+         */
+        private val ALLOWED_FILES = setOf(
+            // The shared gate itself.
+            "com/wingedsheep/engine/mechanics/SummoningSicknessRules.kt",
+            // Marker lifecycle: the untap step clears it for the active player's permanents.
+            "com/wingedsheep/engine/core/BeginningPhaseManager.kt",
+            // Same lifecycle, for an effect that grants an extra untap/turn mid-resolution.
+            "com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt",
+            // The *attack* half of CR 302.6 (CR 702.10b). Reads plain haste on purpose — an
+            // "activate as though hasty" grant must never make a creature able to attack.
+            "com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt",
+            // Two non-gate reads: ManaSource.canAttack (an auto-tap preference that models
+            // attacking, so plain haste is correct) and ActivationRestriction
+            // .ControlledSinceYourMostRecentTurn. See the class KDoc's "known limit".
+            "com/wingedsheep/engine/mechanics/mana/ManaSolver.kt",
+            // ActivationRestriction.ControlledSinceYourMostRecentTurn — a printed activation
+            // restriction generalized beyond creatures; haste does not lift it (CR 702.10c covers
+            // only the tap/untap symbols). See the class KDoc's "known limit".
+            "com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt",
+            // Same restriction, evaluated during enumeration.
+            "com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt",
+            // The client's "summoning sick" badge, which reports attack-readiness.
+            "com/wingedsheep/engine/view/ClientStateTransformer.kt",
+        )
+
+        private data class DirectRead(
+            val relativePath: String,
+            val lineNumber: Int,
+            val line: String
+        )
+
+        /** Resolves `rules-engine/src/main/kotlin` from either the module root or the repo root. */
+        private fun sourceRoot(): File {
+            val candidates = listOf(
+                File("src/main/kotlin"),
+                File("rules-engine/src/main/kotlin")
+            )
+            return candidates.firstOrNull { it.isDirectory }
+                ?: error("Could not locate rules-engine/src/main/kotlin from ${File(".").absolutePath}")
+        }
+
+        private fun findDirectSicknessReads(sourceRoot: File): List<DirectRead> {
+            val rootPath = sourceRoot.absolutePath.replace('\\', '/')
+            val results = mutableListOf<DirectRead>()
+            sourceRoot.walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .forEach { file ->
+                    val relative = file.absolutePath.replace('\\', '/').removePrefix("$rootPath/")
+                    file.useLines { lines ->
+                        lines.forEachIndexed { idx, raw ->
+                            val code = stripLineComment(raw)
+                            if (code.trimStart().startsWith("*")) return@forEachIndexed
+                            if (DIRECT_READ_PATTERN.containsMatchIn(code)) {
+                                results += DirectRead(relative, idx + 1, raw)
+                            }
+                        }
+                    }
+                }
+            return results
+        }
+
+        /** Drops a trailing `// …` line comment so commented-out examples don't trip the scan. */
+        private fun stripLineComment(line: String): String {
+            val idx = line.indexOf("//")
+            return if (idx >= 0) line.substring(0, idx) else line
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtilsTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtilsTest.kt
@@ -8,13 +8,17 @@ import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
@@ -48,6 +52,20 @@ class CostEnumerationUtilsTest : FunSpec({
             predicateEvaluator = predicateEvaluator,
             cardRegistry = registry
         )
+    }
+
+    /** Grants the as-though-hasty permission to P1's creatures, for the `canPayTapCost` cases. */
+    val hasteElixir = card("Cost Utils Haste Elixir") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        oracleText = "You may activate abilities of creatures you control as though those " +
+            "creatures had haste."
+        staticAbility {
+            ability = GrantKeyword(
+                AbilityFlag.MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY.name,
+                GroupFilter.AllCreaturesYouControl,
+            )
+        }
     }
 
     /** Battlefield entity id for the P1 permanent matching [name]. */
@@ -272,6 +290,26 @@ class CostEnumerationUtilsTest : FunSpec({
         test("returns true for an untapped creature with no summoning sickness") {
             val driver = setupP1(battlefield = listOf("Grizzly Bears"))
             val bearsId = entityOnBattlefield(driver, "Grizzly Bears")
+
+            utils(driver).canPayTapCost(driver.game.state, bearsId) shouldBe true
+        }
+
+        test("returns true when an as-though-hasty permission covers the sick creature") {
+            // The `MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY` flag (Shang-Chi / Thousand-Year Elixir)
+            // lifts CR 302.6's ability half only. Pinned here, at the helper, as well as end-to-end:
+            // this is the exact pair of the "summoning sickness and no haste" case above.
+            val driver = setupP1(
+                battlefield = listOf("Grizzly Bears"),
+                extraSetCards = listOf(hasteElixir)
+            )
+            // The Elixir must go down through `putPermanentOnBattlefield`, not `setupP1`'s
+            // `battlefield =`: that helper moves cards zone-to-zone with raw state surgery, which
+            // bypasses `StaticAbilityHandler` — the permanent lands with no continuous-effect
+            // component and grants nothing.
+            driver.game.putPermanentOnBattlefield(driver.player1, "Cost Utils Haste Elixir")
+            val bearsId = entityOnBattlefield(driver, "Grizzly Bears")
+            val sick = driver.game.state.getEntity(bearsId)!!.with(SummoningSicknessComponent)
+            driver.game.replaceState(driver.game.state.withEntity(bearsId, sick))
 
             utils(driver).canPayTapCost(driver.game.state, bearsId) shouldBe true
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/ActivateAbilitiesAsThoughHastyTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/ActivateAbilitiesAsThoughHastyTest.kt
@@ -1,0 +1,328 @@
+package com.wingedsheep.engine.mechanics
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine coverage for [AbilityFlag.MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY] — the Thousand-Year
+ * Elixir / Shang-Chi permission, "you may activate abilities of creatures you control as though
+ * those creatures had haste".
+ *
+ * CR 302.6 gates two things on the same condition: a creature's activated ability whose cost
+ * includes the tap or untap symbol, **and** attacking. Haste (CR 702.10b/c) lifts both. This flag
+ * lifts only the first, so the interesting assertions are the *pair*: the `{T}` ability becomes
+ * legal while the attack stays illegal. Every positive tap-symbol assertion goes through
+ * `legalActions` — the enumerator is what the client is offered, and submitting the action directly
+ * would skip it entirely.
+ *
+ * Every board is built inside the turn it is tested in, never across an untap step — an untap step
+ * in between clears the sickness marker and makes the assertions vacuous. Main-phase tests build
+ * after advancing. The combat tests build first and then advance within the same turn, because the
+ * engine skips the declare-attackers step entirely when the active player has no *legal* attacker:
+ * with only a sick creature on board, `passPriorityUntil(DECLARE_ATTACKERS)` rolls forward to a
+ * later turn and the marker is gone by the time it arrives. Hence the printed-haste creature that
+ * opens combat in the sick-creature test.
+ */
+class ActivateAbilitiesAsThoughHastyTest : FunSpec({
+
+    // =========================================================================
+    // Test cards
+    // =========================================================================
+
+    /** The permission, isolated from Shang-Chi so this file tests the primitive, not the card. */
+    val elixir = card("Test Haste Elixir") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        oracleText = "You may activate abilities of creatures you control as though those " +
+            "creatures had haste."
+        staticAbility {
+            ability = GrantKeyword(
+                AbilityFlag.MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY.name,
+                GroupFilter.AllCreaturesYouControl,
+            )
+        }
+    }
+
+    /** A creature whose only ability costs `{T}` — the CR 302.6 tap-symbol case. */
+    val tapper = card("Test Tapper") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Monk"
+        power = 2
+        toughness = 2
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.GainLife(1)
+            description = "{T}: You gain 1 life."
+        }
+    }
+
+    /** A creature whose only ability costs `{Q}` — the untap symbol, gated by the same rule. */
+    val untapper = card("Test Untapper") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Monk"
+        power = 2
+        toughness = 2
+        activatedAbility {
+            cost = Costs.Untap
+            effect = Effects.GainLife(1)
+            description = "{Q}: You gain 1 life."
+        }
+    }
+
+    /** A creature whose ability has no tap/untap symbol — CR 302.6 never touches it. */
+    val bleeder = card("Test Bleeder") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Monk"
+        power = 2
+        toughness = 2
+        activatedAbility {
+            cost = Costs.PayLife(1)
+            effect = Effects.GainLife(2)
+            description = "Pay 1 life: You gain 2 life."
+        }
+    }
+
+    /** Same `{T}` ability, but the creature has printed haste — the control for the pair. */
+    val hastyTapper = card("Test Hasty Tapper") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Monk"
+        power = 2
+        toughness = 2
+        keywords(Keyword.HASTE)
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.GainLife(1)
+            description = "{T}: You gain 1 life."
+        }
+    }
+
+    val allTestCards = listOf(elixir, tapper, untapper, bleeder, hastyTapper)
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + allTestCards)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        return driver
+    }
+
+    /** Advance until [target] with player 1 the active player, cycling whole turns if needed. */
+    fun GameTestDriver.advanceToPlayer1(target: Step) {
+        passPriorityUntil(target)
+        var safety = 0
+        while (activePlayer != player1 && safety < 50) {
+            bothPass()
+            passPriorityUntil(target)
+            safety++
+        }
+        activePlayer shouldBe player1
+    }
+
+    fun List<LegalAction>.activationsOf(sourceId: EntityId): List<LegalAction> =
+        filter { (it.action as? ActivateAbility)?.sourceId == sourceId }
+
+    fun List<LegalAction>.offeredAttackers(): List<EntityId> =
+        firstOrNull { it.actionType == "DeclareAttackers" }?.validAttackers ?: emptyList()
+
+    fun GameTestDriver.abilityIdOf(cardName: String) =
+        cardRegistry.requireCard(cardName).script.activatedAbilities.single().id
+
+    // =========================================================================
+    // The tap-symbol half — lifted
+    // =========================================================================
+
+    test("a summoning-sick creature's {T} ability is not offered without the permission") {
+        val driver = createDriver()
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        val creature = driver.putCreatureOnBattlefield(driver.player1, "Test Tapper")
+
+        driver.legalActions(driver.player1).activationsOf(creature).size shouldBe 0
+    }
+
+    test("the permission makes a summoning-sick creature's {T} ability legal") {
+        val driver = createDriver()
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        val creature = driver.putCreatureOnBattlefield(driver.player1, "Test Tapper")
+        driver.putPermanentOnBattlefield(driver.player1, "Test Haste Elixir")
+
+        val offered = driver.legalActions(driver.player1).activationsOf(creature)
+        withClue("the {T} ability should be enumerated under the as-though-hasty permission") {
+            offered.size shouldBe 1
+        }
+
+        // And it actually resolves — the enumerator and the authoritative re-check agree.
+        val lifeBefore = driver.getLifeTotal(driver.player1)
+        driver.submitSuccess(offered.single().action)
+        driver.bothPass()
+        driver.getLifeTotal(driver.player1) shouldBe lifeBefore + 1
+    }
+
+    test("the permission does not reach a creature its controller does not control") {
+        val driver = createDriver()
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        // Player 2's Elixir says "creatures you control" — player 1's creature is not covered.
+        val creature = driver.putCreatureOnBattlefield(driver.player1, "Test Tapper")
+        driver.putPermanentOnBattlefield(driver.player2, "Test Haste Elixir")
+
+        driver.legalActions(driver.player1).activationsOf(creature).size shouldBe 0
+    }
+
+    // =========================================================================
+    // The attacking half — NOT lifted
+    // =========================================================================
+
+    test("the permission does not let a summoning-sick creature attack") {
+        val driver = createDriver()
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        val creature = driver.putCreatureOnBattlefield(driver.player1, "Test Tapper")
+        driver.putPermanentOnBattlefield(driver.player1, "Test Haste Elixir")
+        // The engine skips the declare-attackers step outright when the active player has no legal
+        // attacker, so a creature with *printed* haste has to open combat — otherwise priority
+        // passing rolls on to a later turn whose untap step clears the sickness marker and the test
+        // silently asserts nothing. It doubles as the in-list control: real haste is offered from
+        // the very same list that must not contain the sick creature.
+        val hasty = driver.putCreatureOnBattlefield(driver.player1, "Test Hasty Tapper")
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        val attackers = driver.legalActions(driver.player1).offeredAttackers()
+        withClue("as-though-hasty must not grant haste — attacking stays illegal (CR 302.6)") {
+            attackers.contains(creature) shouldBe false
+        }
+        withClue("...while printed haste is offered, from the same enumeration") {
+            attackers.contains(hasty) shouldBe true
+        }
+
+        // The authoritative handler must agree with the enumerator.
+        driver.submitExpectFailure(
+            DeclareAttackers(
+                playerId = driver.player1,
+                attackers = mapOf(creature to driver.player2)
+            )
+        )
+    }
+
+    test("printed haste lifts both halves — the control for the pair") {
+        val driver = createDriver()
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        val creature = driver.putCreatureOnBattlefield(driver.player1, "Test Hasty Tapper")
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        withClue("real haste still lets a freshly-arrived creature attack") {
+            driver.legalActions(driver.player1).offeredAttackers().contains(creature) shouldBe true
+        }
+    }
+
+    // =========================================================================
+    // Abilities the rule never gated
+    // =========================================================================
+
+    test("an ability with no tap or untap symbol is legal for a summoning-sick creature either way") {
+        val driver = createDriver()
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        val creature = driver.putCreatureOnBattlefield(driver.player1, "Test Bleeder")
+
+        withClue("CR 302.6 only gates the tap and untap symbols") {
+            driver.legalActions(driver.player1).activationsOf(creature).size shouldBe 1
+        }
+
+        driver.putPermanentOnBattlefield(driver.player1, "Test Haste Elixir")
+        driver.legalActions(driver.player1).activationsOf(creature).size shouldBe 1
+    }
+
+    // =========================================================================
+    // The untap symbol
+    // =========================================================================
+
+    // `{Q}` is gated in both places, like `{T}`: `ActivatedAbilityEnumerator` has an
+    // `AbilityCost.Untap` branch and `ActivateAbilityHandler` re-checks authoritatively. No shipped
+    // card uses `Costs.Untap`, so these tests are the only coverage the branch has — each asserts
+    // through `legalActions` *and* drives the handler, so a regression in either one goes red.
+    test("a summoning-sick creature's {Q} ability is rejected without the permission") {
+        val driver = createDriver()
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        val creature = driver.putCreatureOnBattlefield(driver.player1, "Test Untapper")
+        driver.tapPermanent(creature) // {Q} needs a tapped permanent to untap.
+
+        withClue("the enumerator must not offer a sick creature's {Q} ability") {
+            driver.legalActions(driver.player1).activationsOf(creature).size shouldBe 0
+        }
+
+        val result = driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = driver.player1,
+                sourceId = creature,
+                abilityId = driver.abilityIdOf("Test Untapper")
+            )
+        )
+        result.error shouldBe "This creature has summoning sickness"
+    }
+
+    test("the permission makes a summoning-sick creature's {Q} ability activatable") {
+        val driver = createDriver()
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        val creature = driver.putCreatureOnBattlefield(driver.player1, "Test Untapper")
+        driver.tapPermanent(creature)
+        driver.putPermanentOnBattlefield(driver.player1, "Test Haste Elixir")
+
+        val offered = driver.legalActions(driver.player1).activationsOf(creature)
+        withClue("the {Q} ability should be enumerated under the as-though-hasty permission") {
+            offered.size shouldBe 1
+        }
+
+        val lifeBefore = driver.getLifeTotal(driver.player1)
+        driver.submitSuccess(offered.single().action)
+        driver.bothPass()
+        driver.getLifeTotal(driver.player1) shouldBe lifeBefore + 1
+    }
+
+    test("an untapped creature's {Q} ability is never offered — the permission doesn't change that") {
+        val driver = createDriver()
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        // Left untapped on purpose: `{Q}` means "untap this permanent", so an untapped source can't
+        // pay it at all. This pins the enumerator's tapped-check, which is inverted relative to {T}.
+        val creature = driver.putCreatureOnBattlefield(driver.player1, "Test Untapper")
+        driver.putPermanentOnBattlefield(driver.player1, "Test Haste Elixir")
+
+        withClue("summoning sickness is lifted, but the untap symbol still needs a tapped permanent") {
+            driver.legalActions(driver.player1).activationsOf(creature).size shouldBe 0
+        }
+    }
+
+    // =========================================================================
+    // The permission leaving play
+    // =========================================================================
+
+    test("the {T} ability stops being offered when the permission leaves play mid-turn") {
+        val driver = createDriver()
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        val creature = driver.putCreatureOnBattlefield(driver.player1, "Test Tapper")
+        val elixirId = driver.putPermanentOnBattlefield(driver.player1, "Test Haste Elixir")
+
+        driver.legalActions(driver.player1).activationsOf(creature).size shouldBe 1
+
+        driver.moveToGraveyard(elixirId)
+
+        withClue("the grant is a continuous effect — it dies with its source") {
+            driver.legalActions(driver.player1).activationsOf(creature).size shouldBe 0
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/predicates/ColoredManaSymbolCountTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/predicates/ColoredManaSymbolCountTest.kt
@@ -4,7 +4,7 @@ import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
-import com.wingedsheep.engine.handlers.effects.permanent.stats.contextScopedReferenceIn
+import com.wingedsheep.sdk.scripting.values.contextScopedReferenceIn
 import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/predicates/ColoredManaSymbolCountTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/predicates/ColoredManaSymbolCountTest.kt
@@ -1,0 +1,241 @@
+package com.wingedsheep.engine.predicates
+
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.handlers.effects.permanent.stats.contextScopedReferenceIn
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.values.EntityReference
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine wiring for the two per-object coloured-pip primitives added for Namor the Sub-Mariner:
+ *
+ *  - [CardPredicate.ColoredManaSymbolsAtLeast] — "a spell with one or more blue mana symbols in
+ *    its mana cost", evaluated by [PredicateEvaluator].
+ *  - [com.wingedsheep.sdk.scripting.values.EntityNumericProperty.ColoredManaSymbolCount] — "that
+ *    many", evaluated by [DynamicAmountEvaluator].
+ *
+ * Both read the *printed* cost through the one shared
+ * [ManaCost.coloredSymbolCount] rule (hybrid and Phyrexian pips count for their colour(s),
+ * CR 107.4e/f — pinned down symbol by symbol in the SDK's `ManaCostColoredSymbolCountTest`). What
+ * this file pins down is the engine's side of it: that the two agree on the same object, that a
+ * face-down object has no mana cost (CR 708.2), that the predicate is a *cost* read rather than a
+ * colour read, and that the amount is classified correctly by the layer projector's
+ * context-scope guard.
+ */
+class ColoredManaSymbolCountTest : FunSpec({
+
+    val predicateEvaluator = PredicateEvaluator()
+    val amountEvaluator = DynamicAmountEvaluator()
+    val player = EntityId.generate()
+
+    /** A battlefield permanent whose only interesting characteristic is its printed cost. */
+    fun stateWith(costs: List<String>, faceDownIndices: Set<Int> = emptySet()): Pair<GameState, List<EntityId>> {
+        var state = GameState().withEntity(player, ComponentContainer())
+        val ids = costs.map { EntityId.generate() }
+        costs.forEachIndexed { index, cost ->
+            var container = ComponentContainer()
+                .with(
+                    CardComponent(
+                        cardDefinitionId = "Card$index",
+                        name = "Card$index",
+                        manaCost = ManaCost.parse(cost),
+                        typeLine = TypeLine(cardTypes = setOf(CardType.INSTANT)),
+                        ownerId = player
+                    )
+                )
+                .with(OwnerComponent(player))
+                .with(ControllerComponent(player))
+            if (index in faceDownIndices) container = container.with(FaceDownComponent)
+            state = state.withEntity(ids[index], container)
+                .addToZone(ZoneKey(player, Zone.BATTLEFIELD), ids[index])
+        }
+        return state to ids
+    }
+
+    fun pipFilter(vararg colors: Color, min: Int = 1) = GameObjectFilter(
+        cardPredicates = listOf(CardPredicate.ColoredManaSymbolsAtLeast(colors.toList(), min))
+    )
+
+    fun blueFilter(min: Int = 1) = pipFilter(Color.BLUE, min = min)
+
+    fun GameState.matches(id: EntityId, filter: GameObjectFilter) =
+        predicateEvaluator.matches(this, projectedState, id, filter, PredicateContext(controllerId = player))
+
+    // Read via EntityReference.Source so the object under test is named by sourceId alone —
+    // no ChosenTarget plumbing between the primitive and the assertion.
+    fun GameState.pips(id: EntityId?, vararg colors: Color) = amountEvaluator.evaluate(
+        this,
+        DynamicAmounts.coloredManaSymbolsOf(EntityReference.Source, *colors),
+        EffectContext(sourceId = id, controllerId = player)
+    )
+
+    fun GameState.bluePips(id: EntityId?) = pips(id, Color.BLUE)
+
+    test("the predicate matches exactly the costs that carry a blue pip") {
+        val costs = listOf("{1}{U}{U}", "{U}", "{2}{R}{G}", "{5}", "{X}", "", "{C}{C}")
+        val (state, ids) = stateWith(costs)
+        val expected = listOf(true, true, false, false, false, false, false)
+        costs.indices.forEach { i ->
+            withClue("'${costs[i]}' has a blue mana symbol?") {
+                state.matches(ids[i], blueFilter()) shouldBe expected[i]
+            }
+        }
+    }
+
+    test("hybrid and Phyrexian pips are blue mana symbols (CR 107.4e/f)") {
+        val costs = listOf("{U/R}", "{2/U}", "{U/P}", "{R/G}", "{2/B}", "{G/P}")
+        val (state, ids) = stateWith(costs)
+        val expected = listOf(true, true, true, false, false, false)
+        costs.indices.forEach { i ->
+            withClue("'${costs[i]}' has a blue mana symbol?") {
+                state.matches(ids[i], blueFilter()) shouldBe expected[i]
+            }
+        }
+    }
+
+    test("min raises the threshold — 'two or more blue mana symbols'") {
+        val costs = listOf("{U}", "{1}{U}{U}", "{U}{U}{U}")
+        val (state, ids) = stateWith(costs)
+        listOf(false, true, true).forEachIndexed { i, want ->
+            withClue("'${costs[i]}' has two or more blue pips?") {
+                state.matches(ids[i], blueFilter(min = 2)) shouldBe want
+            }
+        }
+    }
+
+    test("a two-colour request counts a pip of either, and a pip that is both only once") {
+        // The multi-colour rule is pinned symbol-by-symbol in the SDK; what this checks is that
+        // both engine wrappers really pass the whole colour list through (predicate.colors.toSet()
+        // / property.colors.toSet()) rather than only ever seeing one colour.
+        val costs = listOf("{U/R}", "{U}{R}", "{1}{R}", "{2}{G}")
+        val (state, ids) = stateWith(costs)
+        val expected = listOf(1, 2, 1, 0)
+        costs.indices.forEach { i ->
+            withClue("blue-or-red pips in '${costs[i]}'") {
+                state.pips(ids[i], Color.BLUE, Color.RED) shouldBe expected[i]
+            }
+            withClue("'${costs[i]}' has a blue or red mana symbol?") {
+                state.matches(ids[i], pipFilter(Color.BLUE, Color.RED)) shouldBe (expected[i] >= 1)
+            }
+        }
+    }
+
+    test("all five colours at min = 3 — Omnath, Locus of All's 'three or more colored mana symbols'") {
+        val allColors = Color.entries.toTypedArray()
+        // Omnath's own cost {W}{U}{B/P}{R}{G} is 5; a two-pip gold spell is not enough; a hybrid
+        // that is two of the requested colours is still one symbol, so {U/R}{U/R}{U/R} is exactly 3.
+        val costs = listOf("{W}{U}{B/P}{R}{G}", "{1}{W}{U}", "{U/R}{U/R}{U/R}", "{7}")
+        val (state, ids) = stateWith(costs)
+        val expected = listOf(5, 2, 3, 0)
+        costs.indices.forEach { i ->
+            withClue("colored pips in '${costs[i]}'") {
+                state.pips(ids[i], *allColors) shouldBe expected[i]
+            }
+            withClue("'${costs[i]}' has three or more colored mana symbols?") {
+                state.matches(ids[i], pipFilter(*allColors, min = 3)) shouldBe (expected[i] >= 3)
+            }
+        }
+    }
+
+    test("the degenerate predicate values are rejected at construction, not silently universal") {
+        // min <= 0 or no colours would make coloredSymbolCount's 0 satisfy the threshold, so the
+        // predicate would match every object including costless ones — never a caller's intent.
+        shouldThrow<IllegalArgumentException> {
+            CardPredicate.ColoredManaSymbolsAtLeast(emptyList())
+        }
+        shouldThrow<IllegalArgumentException> {
+            CardPredicate.ColoredManaSymbolsAtLeast(listOf(Color.BLUE), min = 0)
+        }
+    }
+
+    test("a face-down object has no mana cost, so it neither matches nor counts (CR 708.2a)") {
+        val (state, ids) = stateWith(listOf("{1}{U}{U}"), faceDownIndices = setOf(0))
+        state.matches(ids[0], blueFilter()) shouldBe false
+        state.bluePips(ids[0]) shouldBe 0
+    }
+
+    test("the amount counts the pips the predicate gated on, on the same object") {
+        val costs = listOf("{1}{U}{U}", "{U}", "{U/R}{U}", "{2/U}", "{U/P}", "{X}{X}{U}", "{5}", "")
+        val (state, ids) = stateWith(costs)
+        val expected = listOf(2, 1, 2, 1, 1, 1, 0, 0)
+        costs.indices.forEach { i ->
+            withClue("blue pips in '${costs[i]}'") {
+                state.bluePips(ids[i]) shouldBe expected[i]
+            }
+            withClue("predicate and amount agree on '${costs[i]}'") {
+                state.matches(ids[i], blueFilter()) shouldBe (expected[i] >= 1)
+            }
+        }
+    }
+
+    test("the amount is 0 for an entity that does not exist") {
+        val (state, _) = stateWith(emptyList())
+        state.bluePips(EntityId.generate()) shouldBe 0
+        state.bluePips(null) shouldBe 0
+    }
+
+    test("the predicate reads the printed cost, not the object's colour") {
+        // An object that is blue but has no blue pip (a colour indicator, devoid's inverse, a
+        // layer-5 recolour) must NOT match — this is the case a naive "is it blue" implementation
+        // gets wrong. Built by stamping the card's colour set apart from its printed cost.
+        val blueByColourOnly = EntityId.generate()
+        val state = GameState()
+            .withEntity(player, ComponentContainer())
+            .withEntity(
+                blueByColourOnly,
+                ComponentContainer()
+                    .with(
+                        CardComponent(
+                            cardDefinitionId = "Blue Without Pips",
+                            name = "Blue Without Pips",
+                            manaCost = ManaCost.parse("{2}{R}"),
+                            typeLine = TypeLine(cardTypes = setOf(CardType.INSTANT)),
+                            colors = setOf(Color.BLUE),
+                            ownerId = player
+                        )
+                    )
+                    .with(OwnerComponent(player))
+                    .with(ControllerComponent(player))
+            )
+            .addToZone(ZoneKey(player, Zone.BATTLEFIELD), blueByColourOnly)
+
+        withClue("blue with no blue mana symbol in its cost does not match") {
+            state.matches(blueByColourOnly, blueFilter()) shouldBe false
+            state.bluePips(blueByColourOnly) shouldBe 0
+        }
+    }
+
+    test("the amount is classified as context-scoped exactly when its entity reference is") {
+        // The layer projector rebuilds a bare EffectContext, so a triggering-scoped amount cannot
+        // be re-evaluated there; SetBaseStatsEffect(reevaluateContinuously = true) rejects it
+        // rather than reading 0 forever. Namor's token count is Triggering-scoped and lives in a
+        // resolution-time effect, which is fine; his *power* is a projector-safe count.
+        contextScopedReferenceIn(
+            DynamicAmounts.coloredManaSymbolsOf(EntityReference.Triggering, Color.BLUE)
+        ) shouldBe "Triggering"
+        contextScopedReferenceIn(
+            DynamicAmounts.coloredManaSymbolsOf(EntityReference.Source, Color.BLUE)
+        ) shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PayManaCostRepeatedlyTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PayManaCostRepeatedlyTest.kt
@@ -1,0 +1,346 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.PayManaCostRepeatedlyEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Engine-level tests for [PayManaCostRepeatedlyEffect] — "you may pay {1} up to three times"
+ * (Hawkeye, Master Marksman) and its uncapped "any number of times" sibling.
+ *
+ * These cover the *primitive*, not the card: the affordability-aware cap, the color-awareness of
+ * that cap, the decline paths (the wrapper's yes/no and an unaffordable cost), the count surviving
+ * the CR 603.12 reflexive stack round-trip, and the no-question shortcut when only one repetition
+ * is possible. Hawkeye's own modal payoff is covered in `HawkeyeMasterMarksmanScenarioTest`.
+ */
+class PayManaCostRepeatedlyTest : ScenarioTestBase() {
+
+    /**
+     * "When this enters, you may pay {1} up to three times. When you do, you gain that much life."
+     * Life is the readout: it equals the number of repetitions, and it is produced by the
+     * *reflexive* half, so a nonzero gain proves both the payment and the pipeline hand-off.
+     */
+    private val repeater = card("Repeating Ritualist") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Wizard"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = ReflexiveTriggerEffect(
+                action = Effects.PayRepeatedly("{1}", upTo = 3),
+                optional = true,
+                reflexiveEffect = Effects.GainLife(DynamicAmounts.timesPaid())
+            )
+            description = "When this enters, you may pay {1} up to three times. " +
+                "When you do, you gain that much life."
+        }
+    }
+
+    /**
+     * The same shape with a *colored* repetition unit — `{G}` three times is `{G}{G}{G}`. Its own
+     * cost is `{R}{R}` so casting it can only consume Mountains, leaving the Forest count on the
+     * battlefield the sole thing that can bound the repetitions.
+     */
+    private val greenRepeater = card("Verdant Ritualist") {
+        manaCost = "{R}{R}"
+        typeLine = "Creature — Elf Wizard"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = ReflexiveTriggerEffect(
+                action = Effects.PayRepeatedly("{G}", upTo = 3),
+                optional = true,
+                reflexiveEffect = Effects.GainLife(DynamicAmounts.timesPaid())
+            )
+            description = "When this enters, you may pay {G} up to three times. " +
+                "When you do, you gain that much life."
+        }
+    }
+
+    /**
+     * The `Gate.MayPay` wrapper instead of the reflexive one — "you may pay {1} up to three times.
+     * If you do, you gain that much life." The gate asks the yes/no, the effect asks the count, and
+     * `then` reads the count out of the pipeline the payment published to.
+     */
+    private val gatedRepeater = card("Bartering Ritualist") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Wizard"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = GatedEffect(
+                gate = Gate.MayPay(Effects.PayRepeatedly("{1}", upTo = 3)),
+                then = Effects.GainLife(DynamicAmounts.timesPaid())
+            )
+            description = "When this enters, you may pay {1} up to three times. " +
+                "If you do, you gain that much life."
+        }
+    }
+
+    /** The uncapped wording: "any number of times". */
+    private val uncappedRepeater = card("Unbounded Ritualist") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Wizard"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = ReflexiveTriggerEffect(
+                action = Effects.PayRepeatedly("{1}"),
+                optional = true,
+                reflexiveEffect = Effects.GainLife(DynamicAmounts.timesPaid())
+            )
+            description = "When this enters, you may pay {1} any number of times. " +
+                "When you do, you gain that much life."
+        }
+    }
+
+    /**
+     * Cast [name] with [lands] untapped lands of [landName] on the battlefield and stop on
+     * whatever the enters-trigger asks first. One land pays for the creature itself, so the
+     * repetitions have `lands - 1` mana behind them.
+     */
+    private fun castAndStopOnTrigger(name: String, landName: String, lands: Int): TestGame {
+        val game = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardInHand(1, name)
+            .withLandsOnBattlefield(1, landName, lands)
+            .withActivePlayer(1)
+            .withPriorityPlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+
+        game.castSpell(1, name).error shouldBe null
+        if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+        game.resolveStack()
+        return game
+    }
+
+    /** How many permanents named [name] are tapped right now. */
+    private fun tappedCount(game: TestGame, name: String): Int =
+        game.findPermanents(name).count {
+            game.state.getEntity(it)
+                ?.get<com.wingedsheep.engine.state.components.battlefield.TappedComponent>() != null
+        }
+
+    /** Say yes to the wrapper's "you may …" and return the repeat-count question. */
+    private fun acceptAndReadCountQuestion(game: TestGame): ChooseNumberDecision {
+        game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+        game.answerYesNo(true)
+        return game.getPendingDecision() as? ChooseNumberDecision
+            ?: error("expected the repeat-count question; got ${game.getPendingDecision()}")
+    }
+
+    init {
+        cardRegistry.register(repeater)
+        cardRegistry.register(greenRepeater)
+        cardRegistry.register(gatedRepeater)
+        cardRegistry.register(uncappedRepeater)
+
+        context("how many repetitions are offered") {
+
+            test("the cap is the printed maximum when mana is plentiful") {
+                val game = castAndStopOnTrigger("Repeating Ritualist", "Mountain", 6)
+                val question = acceptAndReadCountQuestion(game)
+
+                withClue("declining is the yes/no's job, so the count starts at one") {
+                    question.minValue shouldBe 1
+                }
+                question.maxValue shouldBe 3
+            }
+
+            test("the cap drops to what the payer can actually afford") {
+                // 3 lands: one pays for the creature, so only two repetitions are reachable.
+                val game = castAndStopOnTrigger("Repeating Ritualist", "Mountain", 3)
+                acceptAndReadCountQuestion(game).maxValue shouldBe 2
+            }
+
+            test("the cap is color-aware — {G} three times needs three green, and is paid in green") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Verdant Ritualist")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Verdant Ritualist").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the three Mountains left over can't pay a single {G} — only the Forests count") {
+                    acceptAndReadCountQuestion(game).maxValue shouldBe 2
+                }
+
+                game.chooseNumber(2)
+                game.resolveStack()
+
+                withClue("both repetitions were paid, so the reflexive half saw two") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+                withClue("{G}{G} came out of the Forests") {
+                    tappedCount(game, "Forest") shouldBe 2
+                }
+                withClue("only the two Mountains the creature's own {R}{R} used are tapped") {
+                    tappedCount(game, "Mountain") shouldBe 2
+                }
+            }
+
+            test("the cap counts only mana the auto-tapper will actually spend, not Treasures") {
+                // canPay() counts a Treasure's sacrifice-self ability toward affordability, but the
+                // auto-tap solver refuses to sacrifice permanents on the player's behalf — and the
+                // auto-tapper is what pays here. Capping with canPay would offer three repetitions
+                // and then error on the third. One Mountain goes to the creature itself.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Repeating Ritualist")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(1, "Treasure")
+                    .withCardOnBattlefield(1, "Treasure")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Repeating Ritualist").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("two untapped Mountains behind the payment; the two Treasures don't count") {
+                    acceptAndReadCountQuestion(game).maxValue shouldBe 2
+                }
+
+                game.chooseNumber(2)
+                game.resolveStack()
+
+                withClue("the offered count was payable — no mid-resolution failure") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+                withClue("and nothing was silently sacrificed to get there") {
+                    game.findPermanents("Treasure").size shouldBe 2
+                }
+            }
+
+            test("'any number of times' is bounded by the mana on hand, not by a printed cap") {
+                val game = castAndStopOnTrigger("Unbounded Ritualist", "Mountain", 5)
+                acceptAndReadCountQuestion(game).maxValue shouldBe 4
+            }
+
+            test("a single reachable repetition is paid with no question at all") {
+                // 2 lands: one for the creature, exactly one left — nothing to decide.
+                val game = castAndStopOnTrigger("Repeating Ritualist", "Mountain", 2)
+                game.answerYesNo(true)
+
+                withClue("no repeat-count prompt is raised") {
+                    (game.getPendingDecision() is ChooseNumberDecision) shouldBe false
+                }
+                game.resolveStack()
+                withClue("the one repetition was paid and the reflexive half saw it") {
+                    game.getLifeTotal(1) shouldBe 21
+                }
+            }
+        }
+
+        context("paying, declining, and what the reflexive half reads") {
+
+            test("the repetition count survives the reflexive stack round-trip") {
+                val game = castAndStopOnTrigger("Repeating Ritualist", "Mountain", 6)
+                acceptAndReadCountQuestion(game)
+                game.chooseNumber(2)
+                game.resolveStack()
+
+                withClue("'you gain that much life' reads the count the action stored") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+                withClue("one land paid for the creature, two paid for the repetitions") {
+                    game.state.getBattlefield()
+                        .mapNotNull { id -> game.state.getEntity(id) }
+                        .count { it.get<com.wingedsheep.engine.state.components.battlefield.TappedComponent>() != null }
+                        .shouldBe(3)
+                }
+            }
+
+            test("declining the wrapper's may-question pays nothing and fires no reflexive half") {
+                val game = castAndStopOnTrigger("Repeating Ritualist", "Mountain", 6)
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                game.getLifeTotal(1) shouldBe 20
+                withClue("nothing beyond the creature's own cost was tapped") {
+                    game.state.getBattlefield()
+                        .mapNotNull { id -> game.state.getEntity(id) }
+                        .count { it.get<com.wingedsheep.engine.state.components.battlefield.TappedComponent>() != null }
+                        .shouldBe(1)
+                }
+            }
+
+            test("Gate.MayPay wraps it too — 'if you do' reads the same count") {
+                val game = castAndStopOnTrigger("Bartering Ritualist", "Mountain", 6)
+                acceptAndReadCountQuestion(game)
+                game.chooseNumber(3)
+                game.resolveStack()
+
+                withClue("the gate's `then` reads the count the cost published") {
+                    game.getLifeTotal(1) shouldBe 23
+                }
+                withClue("one land for the creature, three for the repetitions") {
+                    tappedCount(game, "Mountain") shouldBe 4
+                }
+            }
+
+            test("Gate.MayPay offers no 'yes' when not even one repetition is affordable") {
+                // Exactly enough for the creature: the gate must fall through to `otherwise`
+                // rather than offering a payment whose cost then errors out.
+                val game = castAndStopOnTrigger("Bartering Ritualist", "Mountain", 1)
+
+                withClue("no impossible yes/no is raised") {
+                    (game.getPendingDecision() is YesNoDecision) shouldBe false
+                }
+                game.getLifeTotal(1) shouldBe 20
+            }
+
+            test("a payer who can't afford one repetition is never asked") {
+                // Exactly enough for the creature and nothing left over.
+                val game = castAndStopOnTrigger("Repeating Ritualist", "Mountain", 1)
+
+                withClue("the may-question is suppressed, not raised and refused") {
+                    (game.getPendingDecision() is YesNoDecision) shouldBe false
+                }
+                game.getLifeTotal(1) shouldBe 20
+            }
+        }
+
+        context("the SDK shape") {
+
+            test("the description reads as the printed wording") {
+                PayManaCostRepeatedlyEffect(
+                    com.wingedsheep.sdk.core.ManaCost.parse("{1}"), maxTimes = 3
+                ).description shouldBe "Pay {1} up to three times"
+
+                PayManaCostRepeatedlyEffect(
+                    com.wingedsheep.sdk.core.ManaCost.parse("{2}{R}")
+                ).description shouldBe "Pay {2}{R} any number of times"
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SetBaseStatsContinuousScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SetBaseStatsContinuousScenarioTest.kt
@@ -4,7 +4,7 @@ import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.SelectManaSourcesDecision
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.permanent.stats.SetBaseStatsExecutor
-import com.wingedsheep.engine.handlers.effects.permanent.stats.contextScopedReferenceIn
+import com.wingedsheep.sdk.scripting.values.contextScopedReferenceIn
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Counters
@@ -424,7 +424,7 @@ class SetBaseStatsContinuousScenarioTest : ScenarioTestBase() {
             }
         }
 
-        test("a context-scoped amount is rejected under re-evaluation, not silently read as 0") {
+        test("a context-scoped amount is rejected at construction, not silently read as 0") {
             // The projector rebuilds a bare EffectContext from the source, so a reference to the
             // triggering object — the exact shape Belligerent Yearling uses in snapshot mode —
             // has nothing to resolve against and would read 0 on every pass forever.
@@ -460,13 +460,31 @@ class SetBaseStatsContinuousScenarioTest : ScenarioTestBase() {
                 executor.execute(game.state, snapshot, context).error shouldBe null
             }
 
-            val reevaluated = Effects.SetBasePower(
-                EffectTarget.Self, triggeringPower, Duration.EndOfTurn, reevaluateContinuously = true
-            ) as SetBaseStatsEffect
+            // The rejection is in SetBaseStatsEffect's init, so it fires as the effect is *built* —
+            // i.e. while the cardDef is being constructed at load, not the first time some game
+            // happens to resolve it. Nothing reaches the executor at all.
             val thrown = shouldThrow<IllegalArgumentException> {
-                executor.execute(game.state, reevaluated, context)
+                Effects.SetBasePower(
+                    EffectTarget.Self, triggeringPower, Duration.EndOfTurn,
+                    reevaluateContinuously = true
+                )
             }
             thrown.message!! shouldContain "Triggering"
+
+            withClue("the check is on the flag, not the amount: a nested one is caught too") {
+                shouldThrow<IllegalArgumentException> {
+                    Effects.SetBasePowerAndToughness(
+                        power = DynamicAmount.Add(
+                            DynamicAmounts.cardsInYourHand(),
+                            DynamicAmount.Multiply(triggeringPower, 2),
+                        ),
+                        toughness = DynamicAmounts.cardsInYourHand(),
+                        target = EffectTarget.Self,
+                        duration = Duration.EndOfTurn,
+                        reevaluateContinuously = true,
+                    )
+                }.message!! shouldContain "Triggering"
+            }
         }
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SetBaseStatsContinuousScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SetBaseStatsContinuousScenarioTest.kt
@@ -1,0 +1,472 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.permanent.stats.SetBaseStatsExecutor
+import com.wingedsheep.engine.handlers.effects.permanent.stats.contextScopedReferenceIn
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.SetBaseStatsEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * `SetBaseStatsEffect(reevaluateContinuously = true)` — the layer 7b base-P/T *set* whose
+ * `DynamicAmount` is recomputed on every projection pass instead of snapshotted at resolution.
+ *
+ * This is what an effect that hands a creature a quoted static ability needs: Ms. Marvel, Kamala
+ * Khan's "Until end of turn, this creature gains 'This creature's base power is equal to the number
+ * of cards in your hand.'" Such a self-granted ability is **not** a characteristic-defining ability
+ * (CR 604.3a fails on criterion 2, "printed on the card it affects", and criterion 4, "not an
+ * ability that an object grants to itself"), so it applies in layer 7b — CR 613.4b, "effects that
+ * refer to the base power and/or toughness of a creature apply in this layer" — and not in 7a.
+ *
+ * The matrix below pins the whole contract of the flag:
+ *  - the value moves when the input moves, and the default (snapshot) does not;
+ *  - +1/+1 counters and pump effects — both layer 7c, which CR 613.4c defines as "effects **and
+ *    counters** that modify power and/or toughness" — apply *on top* of the re-evaluated base rather
+ *    than being overwritten by it;
+ *  - a `null` half leaves the other printed stat alone, in both the power-only and toughness-only
+ *    directions;
+ *  - the effect ends with its `Duration`;
+ *  - it keeps applying, and keeps re-evaluating, after the permanent that granted it has left
+ *    the battlefield (the projector falls back to the effect's captured controller);
+ *  - two competing layer 7b sets resolve in timestamp order, in both directions;
+ *  - and a `DynamicAmount` the projector could not evaluate is rejected at resolution rather than
+ *    silently read as 0 on every pass.
+ *
+ * The test cards below all say "target creature **you control**" deliberately: under
+ * `reevaluateContinuously = true` the projector rebuilds the context from the *source*, so "your
+ * hand" inside the quoted clause is the granting player's hand, not the affected creature's
+ * controller's. That is right for a self-grant and for a creature you control, and would be wrong
+ * for a grant to an opponent's creature — see the contract on `SetBaseStatsEffect`.
+ */
+class SetBaseStatsContinuousScenarioTest : ScenarioTestBase() {
+
+    private val continuousPower = card("Continuous Base Power Test") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        oracleText = "Until end of turn, target creature you control gains \"This creature's base " +
+            "power is equal to the number of cards in your hand.\""
+        spell {
+            val creature = target("creature", Targets.CreatureYouControl)
+            effect = Effects.SetBasePower(
+                creature,
+                DynamicAmounts.cardsInYourHand(),
+                Duration.EndOfTurn,
+                reevaluateContinuously = true,
+            )
+        }
+    }
+
+    private val snapshotPower = card("Snapshot Base Power Test") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        oracleText = "Target creature's base power becomes the number of cards in your hand " +
+            "until end of turn."
+        spell {
+            val creature = target("creature", Targets.Creature)
+            effect = Effects.SetBasePower(
+                creature,
+                DynamicAmounts.cardsInYourHand(),
+                Duration.EndOfTurn,
+            )
+        }
+    }
+
+    private val continuousToughness = card("Continuous Base Toughness Test") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        oracleText = "Until end of turn, target creature you control gains \"This creature's base " +
+            "toughness is equal to the number of cards in your hand.\""
+        spell {
+            val creature = target("creature", Targets.CreatureYouControl)
+            effect = Effects.SetBaseToughness(
+                creature,
+                DynamicAmounts.cardsInYourHand(),
+                Duration.EndOfTurn,
+                reevaluateContinuously = true,
+            )
+        }
+    }
+
+    private val drawTwo = card("Draw Two Test") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        oracleText = "Draw two cards."
+        spell {
+            effect = Effects.DrawCards(2)
+        }
+    }
+
+    private val addCounter = card("Add Counter Test") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        oracleText = "Put a +1/+1 counter on target creature."
+        spell {
+            val creature = target("creature", Targets.Creature)
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+        }
+    }
+
+    private val pump = card("Pump Test") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        oracleText = "Target creature gets +2/+2 until end of turn."
+        spell {
+            val creature = target("creature", Targets.Creature)
+            effect = Effects.ModifyStats(2, 2, creature)
+        }
+    }
+
+    /**
+     * The granter for the "source has left the battlefield" case: it sacrifices itself as the
+     * activation cost, so by the time the ability resolves the permanent that produced the
+     * continuous effect is already in the graveyard.
+     */
+    private val embiggenEngine = card("Embiggen Engine Test") {
+        manaCost = "{1}{U}"
+        typeLine = "Creature — Construct"
+        power = 1
+        toughness = 1
+        oracleText = "Sacrifice this creature: Until end of turn, target creature you control " +
+            "gains \"This creature's base power is equal to the number of cards in your hand.\""
+        activatedAbility {
+            cost = Costs.SacrificeSelf
+            val creature = target("creature", Targets.CreatureYouControl)
+            effect = Effects.SetBasePower(
+                creature,
+                DynamicAmounts.cardsInYourHand(),
+                Duration.EndOfTurn,
+                reevaluateContinuously = true,
+            )
+            description = "Sacrifice this creature: Until end of turn, target creature you " +
+                "control gains \"This creature's base power is equal to the number of cards in " +
+                "your hand.\""
+        }
+    }
+
+    init {
+        cardRegistry.register(
+            listOf(
+                continuousPower,
+                snapshotPower,
+                continuousToughness,
+                drawTwo,
+                addCounter,
+                pump,
+                embiggenEngine,
+            )
+        )
+
+        // Fixed board: a printed 2/2 to point the effects at, plenty of mana, and a library deep
+        // enough for the draw-two. Hand contents vary per test and are stated at each call site,
+        // because the number under test *is* the hand size.
+        fun build(vararg handCards: String) = scenario()
+            .withPlayers()
+            .withCardOnBattlefield(1, "Grizzly Bears") // printed 2/2
+            .withLandsOnBattlefield(1, "Island", 6)
+            .withCardInLibrary(1, "Hill Giant")
+            .withCardInLibrary(1, "Hill Giant")
+            .withCardInLibrary(1, "Hill Giant")
+            .let { builder -> handCards.fold(builder) { acc, name -> acc.withCardInHand(1, name) } }
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+
+        fun TestGame.castAndResolve(spellName: String, targetId: EntityId? = null) {
+            val result = castSpell(1, spellName, targetId)
+            withClue("casting $spellName should succeed: ${result.error}") { result.error shouldBe null }
+            if (getPendingDecision() is SelectManaSourcesDecision) submitManaSourcesAutoPay()
+            resolveStack()
+        }
+
+        test("re-evaluated base power tracks hand size as it changes mid-turn") {
+            // Hand: the two spells + 3 filler = 5.
+            val game = build(
+                "Continuous Base Power Test", "Draw Two Test",
+                "Hill Giant", "Hill Giant", "Hill Giant",
+            )
+            val bear = game.findPermanent("Grizzly Bears")!!
+            game.handSize(1) shouldBe 5
+
+            game.castAndResolve("Continuous Base Power Test", bear)
+
+            // The spell itself has left the hand: 4 cards, so base power is 4. Toughness untouched.
+            withClue("hand after the spell resolved") { game.handSize(1) shouldBe 4 }
+            game.state.projectedState.getPower(bear) shouldBe 4
+            game.state.projectedState.getToughness(bear) shouldBe 2
+
+            // Draw Two leaves the hand (-1) and then draws 2, so the hand ends at 5 — a different
+            // number from the one that was true when the effect resolved.
+            game.castAndResolve("Draw Two Test")
+            withClue("hand after drawing two") { game.handSize(1) shouldBe 5 }
+            withClue("base power must follow the new hand size, not the resolution-time snapshot") {
+                game.state.projectedState.getPower(bear) shouldBe 5
+            }
+            game.state.projectedState.getToughness(bear) shouldBe 2
+        }
+
+        test("the default (snapshot) mode freezes the value at resolution") {
+            val game = build(
+                "Snapshot Base Power Test", "Draw Two Test",
+                "Hill Giant", "Hill Giant", "Hill Giant",
+            )
+            val bear = game.findPermanent("Grizzly Bears")!!
+
+            game.castAndResolve("Snapshot Base Power Test", bear)
+            game.state.projectedState.getPower(bear) shouldBe 4
+
+            game.castAndResolve("Draw Two Test")
+            game.handSize(1) shouldBe 5
+            withClue("reevaluateContinuously = false must keep the number it saw at resolution") {
+                game.state.projectedState.getPower(bear) shouldBe 4
+            }
+        }
+
+        test("a re-evaluated base toughness set leaves power at its printed value") {
+            val game = build(
+                "Continuous Base Toughness Test", "Draw Two Test",
+                "Hill Giant", "Hill Giant", "Hill Giant",
+            )
+            val bear = game.findPermanent("Grizzly Bears")!!
+
+            game.castAndResolve("Continuous Base Toughness Test", bear)
+            game.state.projectedState.getPower(bear) shouldBe 2
+            game.state.projectedState.getToughness(bear) shouldBe 4
+
+            game.castAndResolve("Draw Two Test")
+            game.state.projectedState.getPower(bear) shouldBe 2
+            withClue("the toughness half re-evaluates the same way the power half does") {
+                game.state.projectedState.getToughness(bear) shouldBe 5
+            }
+        }
+
+        test("a +1/+1 counter applies on top of the re-evaluated base and rides the re-evaluation") {
+            val game = build(
+                "Add Counter Test", "Continuous Base Power Test", "Draw Two Test",
+                "Hill Giant", "Hill Giant", "Hill Giant",
+            )
+            val bear = game.findPermanent("Grizzly Bears")!!
+
+            // Counter first: 2/2 -> 3/3.
+            game.castAndResolve("Add Counter Test", bear)
+            game.state.projectedState.getPower(bear) shouldBe 3
+            game.state.projectedState.getToughness(bear) shouldBe 3
+
+            // Then the layer 7b set, with a 4-card hand. The counter is layer 7c (CR 613.4c,
+            // "effects **and counters** that modify power and/or toughness") and is applied *after*
+            // the set, so it is not overwritten: 4 (hand) + 1 = 5 power, 2 + 1 = 3 toughness.
+            game.castAndResolve("Continuous Base Power Test", bear)
+            game.handSize(1) shouldBe 4
+            withClue("the +1/+1 counter must stack on top of the layer 7b base, not be erased") {
+                game.state.projectedState.getPower(bear) shouldBe 5
+            }
+            game.state.projectedState.getToughness(bear) shouldBe 3
+
+            // Move the hand afterwards so the interaction is pinned *for the re-evaluated mode*:
+            // a snapshot executor would leave power at 5 here.
+            game.castAndResolve("Draw Two Test")
+            game.handSize(1) shouldBe 5
+            withClue("the counter keeps riding on top as the base re-evaluates") {
+                game.state.projectedState.getPower(bear) shouldBe 6
+            }
+            game.state.projectedState.getToughness(bear) shouldBe 3
+        }
+
+        test("a pump spell applies on top of the re-evaluated base") {
+            val game = build(
+                "Continuous Base Power Test", "Pump Test",
+                "Hill Giant", "Hill Giant", "Hill Giant",
+            )
+            val bear = game.findPermanent("Grizzly Bears")!!
+
+            game.castAndResolve("Continuous Base Power Test", bear)
+            game.state.projectedState.getPower(bear) shouldBe 4
+
+            // Pump leaves the hand, so the re-evaluated base drops to 3 and the +2/+2 rides on top.
+            game.castAndResolve("Pump Test", bear)
+            game.handSize(1) shouldBe 3
+            withClue("layer 7c pump applies after the re-evaluated layer 7b base") {
+                game.state.projectedState.getPower(bear) shouldBe 5
+            }
+            game.state.projectedState.getToughness(bear) shouldBe 4
+        }
+
+        test("the re-evaluated set ends with its duration") {
+            val game = build(
+                "Continuous Base Power Test", "Draw Two Test",
+                "Hill Giant", "Hill Giant", "Hill Giant",
+            )
+            val bear = game.findPermanent("Grizzly Bears")!!
+
+            game.castAndResolve("Continuous Base Power Test", bear)
+            game.state.projectedState.getPower(bear) shouldBe 4
+
+            // Prove the effect is live *in re-evaluated mode* before checking that it expires —
+            // otherwise a snapshot executor passes this test unchanged.
+            game.castAndResolve("Draw Two Test")
+            game.handSize(1) shouldBe 5
+            game.state.projectedState.getPower(bear) shouldBe 5
+
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN) // opponent's turn
+
+            withClue("the until-end-of-turn effect must be gone, printed 2/2 restored") {
+                game.state.projectedState.getPower(bear) shouldBe 2
+                game.state.projectedState.getToughness(bear) shouldBe 2
+            }
+        }
+
+        test("the effect survives its granter leaving the battlefield and keeps re-evaluating") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(1, "Embiggen Engine Test")
+                .withLandsOnBattlefield(1, "Island", 6)
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInHand(1, "Draw Two Test")
+                .withCardInHand(1, "Hill Giant")
+                .withCardInHand(1, "Hill Giant")
+                .withCardInHand(1, "Hill Giant")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bear = game.findPermanent("Grizzly Bears")!!
+            val engine = game.findPermanent("Embiggen Engine Test")!!
+            val abilityId = embiggenEngine.activatedAbilities.first().id
+
+            val activation = game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = engine,
+                    abilityId = abilityId,
+                    targets = listOf(ChosenTarget.Permanent(bear)),
+                )
+            )
+            withClue("activation should succeed: ${activation.error}") { activation.error shouldBe null }
+            if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+            game.resolveStack()
+
+            withClue("the granter sacrificed itself as the activation cost") {
+                game.isInGraveyard(1, "Embiggen Engine Test") shouldBe true
+            }
+            game.handSize(1) shouldBe 4
+            game.state.projectedState.getPower(bear) shouldBe 4
+            game.state.projectedState.getToughness(bear) shouldBe 2
+
+            game.castAndResolve("Draw Two Test")
+            game.handSize(1) shouldBe 5
+            withClue("still re-evaluating with the granting permanent in the graveyard") {
+                game.state.projectedState.getPower(bear) shouldBe 5
+            }
+        }
+
+        test("a later fixed layer 7b set overwrites an earlier re-evaluated one") {
+            val game = build(
+                "Continuous Base Power Test", "Snapshot Base Power Test", "Draw Two Test",
+                "Hill Giant", "Hill Giant", "Hill Giant",
+            )
+            val bear = game.findPermanent("Grizzly Bears")!!
+
+            game.castAndResolve("Continuous Base Power Test", bear)
+            game.state.projectedState.getPower(bear) shouldBe 5
+
+            // Same sublayer (SET_VALUES), so CR 613.7 timestamp order decides and the snapshot,
+            // being later, wins outright — the earlier re-evaluated set is fully overwritten.
+            game.castAndResolve("Snapshot Base Power Test", bear)
+            game.state.projectedState.getPower(bear) shouldBe 4
+
+            game.castAndResolve("Draw Two Test")
+            game.handSize(1) shouldBe 5
+            withClue("the later fixed 7b set wins, so the hand moving must not move power") {
+                game.state.projectedState.getPower(bear) shouldBe 4
+            }
+        }
+
+        test("a later re-evaluated layer 7b set overwrites an earlier fixed one and keeps tracking") {
+            val game = build(
+                "Snapshot Base Power Test", "Continuous Base Power Test", "Draw Two Test",
+                "Hill Giant", "Hill Giant", "Hill Giant",
+            )
+            val bear = game.findPermanent("Grizzly Bears")!!
+
+            game.castAndResolve("Snapshot Base Power Test", bear)
+            game.state.projectedState.getPower(bear) shouldBe 5
+
+            game.castAndResolve("Continuous Base Power Test", bear)
+            game.state.projectedState.getPower(bear) shouldBe 4
+
+            game.castAndResolve("Draw Two Test")
+            game.handSize(1) shouldBe 5
+            withClue("the later re-evaluated 7b set wins and goes on tracking the hand") {
+                game.state.projectedState.getPower(bear) shouldBe 5
+            }
+        }
+
+        test("a context-scoped amount is rejected under re-evaluation, not silently read as 0") {
+            // The projector rebuilds a bare EffectContext from the source, so a reference to the
+            // triggering object — the exact shape Belligerent Yearling uses in snapshot mode —
+            // has nothing to resolve against and would read 0 on every pass forever.
+            val triggeringPower = DynamicAmount.EntityProperty(
+                EntityReference.Triggering,
+                EntityNumericProperty.Power,
+            )
+
+            withClue("the scan finds a context-scoped reference at any depth, and only there") {
+                contextScopedReferenceIn(DynamicAmounts.cardsInYourHand()) shouldBe null
+                contextScopedReferenceIn(triggeringPower) shouldBe "Triggering"
+                contextScopedReferenceIn(DynamicAmount.XValue) shouldBe "XValue"
+                contextScopedReferenceIn(
+                    DynamicAmount.Add(DynamicAmounts.cardsInYourHand(), DynamicAmount.XValue)
+                ) shouldBe "XValue"
+                contextScopedReferenceIn(
+                    DynamicAmount.Add(
+                        DynamicAmounts.cardsInYourHand(),
+                        DynamicAmount.Multiply(triggeringPower, 2),
+                    )
+                ) shouldBe "Triggering"
+            }
+
+            val game = build("Hill Giant")
+            val bear = game.findPermanent("Grizzly Bears")!!
+            val context = EffectContext(sourceId = bear, controllerId = game.player1Id)
+            val executor = SetBaseStatsExecutor()
+
+            withClue("snapshot mode still accepts it — it is evaluated here, against a real context") {
+                val snapshot = Effects.SetBasePower(
+                    EffectTarget.Self, triggeringPower, Duration.EndOfTurn
+                ) as SetBaseStatsEffect
+                executor.execute(game.state, snapshot, context).error shouldBe null
+            }
+
+            val reevaluated = Effects.SetBasePower(
+                EffectTarget.Self, triggeringPower, Duration.EndOfTurn, reevaluateContinuously = true
+            ) as SetBaseStatsEffect
+            val thrown = shouldThrow<IllegalArgumentException> {
+                executor.execute(game.state, reevaluated, context)
+            }
+            thrown.message!! shouldContain "Triggering"
+        }
+    }
+}

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -354,6 +354,7 @@ export enum AbilityFlag {
   CANT_RECEIVE_COUNTERS = 'CANT_RECEIVE_COUNTERS',
   CANT_TRANSFORM = 'CANT_TRANSFORM',
   ASSIGNS_COMBAT_DAMAGE_AS_TOUGHNESS = 'ASSIGNS_COMBAT_DAMAGE_AS_TOUGHNESS',
+  MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY = 'MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY',
 }
 
 export const AbilityFlagDisplayNames: Record<AbilityFlag, string> = {
@@ -365,6 +366,10 @@ export const AbilityFlagDisplayNames: Record<AbilityFlag, string> = {
   [AbilityFlag.CANT_RECEIVE_COUNTERS]: "Can't have counters put on it",
   [AbilityFlag.CANT_TRANSFORM]: "Can't transform",
   [AbilityFlag.ASSIGNS_COMBAT_DAMAGE_AS_TOUGHNESS]: 'Assigns combat damage equal to its toughness rather than its power',
+  // Granted by Shang-Chi / Thousand-Year Elixir to a whole board of creatures at once, so it must be
+  // named here or every creature you control shows the raw enum identifier in its preview panel.
+  // Deliberately not in `displayableKeywords` — a battlefield icon on every creature is noise.
+  [AbilityFlag.MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY]: 'You may activate its abilities as though it had haste',
 }
 
 /**


### PR DESCRIPTION
Four Marvel Super Heroes cards, each paired with the minimum engine vocabulary it actually needed.
In every case that turned out to be an extension of an existing type rather than a new one — no new
`Effect`, no new `Modification`, no new `StaticAbility`.

MSH goes 262 → 266 of 276.

## The cards

| Card | Oracle line that needed engine work |
|---|---|
| **Ms. Marvel, Kamala Khan** `{2}{U}` | "Until end of turn, Ms. Marvel gains 'Ms. Marvel's base power is equal to the number of cards in your hand.'" |
| **Namor the Sub-Mariner** `{1}{U}{U}` | "Whenever you cast a noncreature spell with one or more blue mana symbols in its mana cost, create that many 1/1 blue Merfolk creature tokens." |
| **Shang-Chi, Master of Kung Fu** `{1}{G}` | "You may activate abilities of creatures you control as though those creatures had haste." |
| **Hawkeye, Master Marksman** `{1}{R}` | "…you may pay {1} up to three times. When you do, choose up to that many —" |

Everything else on all four cards was existing vocabulary.

## The four primitives

**1. `SetBaseStatsEffect(reevaluateContinuously = true)`** — a flag on the existing layer-7b atom
that carries the `DynamicAmount` into the projection instead of snapshotting it at resolution, so a
quoted "base power is equal to …" clause keeps tracking. It lowers onto the *existing*
`SetPowerToughnessDynamic` modification, whose `power`/`toughness` became independently nullable so
"base **power** is equal to …" leaves printed toughness alone.

That clause is **not** a CDA — CR 604.3a fails on criterion 2 (printed on the card it affects) and
criterion 4 (not an ability an object grants to itself) — so it belongs in layer 7b per CR 613.4b,
with the timestamp of the grant. Four limits of the flag are documented on the effect; the
projection-scope one is enforced at card load (below).

**2. `ManaCost.coloredSymbolCount(colors)`** — extracted from the devotion evaluator (deleting
`DynamicAmountEvaluator.manaSymbolColors`) and hung off a new `ManaSymbol.colors`, then shared by
both new per-object reads so they can never disagree:

- `CardPredicate.ColoredManaSymbolsAtLeast(colors, min)` — the trigger's "one or more blue mana
  symbols in its mana cost" gate, via `GameObjectFilter.coloredManaSymbolsAtLeast`. Also fits
  Omnath, Locus of All at `min = 3` over all five colours.
- `EntityNumericProperty.ColoredManaSymbolCount(colors)` — the "that many" count, via
  `DynamicAmounts.coloredManaSymbolsOf(entity, …)`.

Hybrid and Phyrexian pips count for their colour(s) (CR 107.4e/f); generic, `{C}` and `{X}` count
for none whatever X was announced (CR 107.4b). This reads the **printed** cost (CR 202.1/202.1a) —
additional costs, increases and reductions only build the spell's *total* cost (CR 601.2f), so none
of them move the count. Face-down objects have no mana cost (CR 708.2a) and never match. Wired into
all five object-evaluation sites: `PredicateEvaluator` (including the cast-record path, which
returns false — a record stores the resolved mana value, not the printed cost), `TriggerMatcher`,
`AffectsFilterResolver`, `CastZoneResolver`, `CostCalculator`.

**3. `SummoningSicknessRules.blocksTapOrUntapCost`** — CR 302.6's ability half, in one place. The
open-coded `has<SummoningSicknessComponent>() && !hasKeyword(HASTE)` was duplicated at fourteen
sites across the mana solver, both ability enumerators, the cost helpers and the activation handler.
CR 302.6 gates a creature's `{T}`/`{Q}` abilities *and* its ability to attack on one condition;
haste (CR 702.10b/c) lifts both, and Shang-Chi's
`AbilityFlag.MAY_ACTIVATE_ABILITIES_AS_THOUGH_HASTY` lifts **only the ability half** — so it is
deliberately not `Keyword.HASTE`, and combat's `AttackRestrictionRules` keeps its own plain-haste
check and never consults the shared rule. `SummoningSicknessGateEnforcementTest` fails the build if
a new open-coded gate (`has<…>` or `get<…>`) appears outside an allowlist of eight files, each
annotated with why it is not a tap gate. The handler's `{Q}` half was also brought in line with the
enumerator, bare and inside a `Composite`.

**4. `PayManaCostRepeatedlyEffect`** (`Effects.PayRepeatedly(cost, upTo)`) — "pay {1} up to three
times", read back with `DynamicAmounts.timesPaid()`. Two properties worth calling out:

- **The offered ceiling is affordability- and colour-aware**, tested as `cost * n` through the
  *same* auto-tap predicate the payment itself uses (new `canAutoPayManaCost`), deliberately **not**
  `ManaSolver.canPay`. `canPay` counts mana the auto-tapper refuses to spend on the player's behalf
  (sacrificing a Treasure, Springleaf Drum's sub-cost), so gating with it would offer a count the
  payment then errors on. Because both go through one predicate, the prompt can never offer a
  payment that fails mid-resolution.
- **The floor is one repetition, not zero.** Declining belongs to the wrapper —
  `ReflexiveTriggerEffect(optional = true)` for "you **may** pay … **when you do**" (CR 603.12), or
  `Gate.MayPay` for "if you do" — so the two questions stay one "do you want to?" and one "how
  many?". Per CR 603.12a the reflexive half triggers **once**, not once per repetition, which is why
  the repetitions are charged as a single `cost * n` payment. A cap of exactly 1 pays with no prompt.

The count is published to the resolution pipeline rather than as an X because an `EffectResult` has
no X channel — a sub-effect hands back collections, stored numbers and chosen values, and that is
the whole list.

## Tests

One test file per card, plus mechanic-level suites for the primitives:

- `HawkeyeMasterMarksmanScenarioTest` (8), `MsMarvelKamalaKhanScenarioTest` (6),
  `NamorTheSubMarinerScenarioTest` (16), `ShangChiMasterOfKungFuScenarioTest` (7)
- `PayManaCostRepeatedlyTest` (12) — the affordability cap, its colour-awareness, the Treasure
  exclusion, both decline paths, the count surviving the CR 603.12 round-trip, the no-prompt shortcut
- `SetBaseStatsContinuousScenarioTest` (10) — snapshot vs re-evaluated, counters and pump on top,
  duration expiry, the granter leaving play, two competing 7b sets in both timestamp orders
- `ActivateAbilitiesAsThoughHastyTest` (10) — both `{T}` and `{Q}`, the attack half staying shut,
  printed haste as the control, the permission leaving play mid-turn
- `ColoredManaSymbolCountTest` (11), `ManaCostColoredSymbolCountTest` (22),
  `CostEnumerationUtilsTest` (+3), `SummoningSicknessGateEnforcementTest` (1)

Every CR number cited in code, KDoc or docs was checked against the Comprehensive Rules. One
pre-existing citation was wrong and is fixed in passing: face-down objects having no mana cost is
CR 708.2a, not 711.4.

## Review round

This branch was reviewed and the findings applied in `Address review: …`:

- The projection-scope guard was a resolution-time `require()` in `SetBaseStatsExecutor` while its
  KDoc called it a load error. `contextScopedReferenceIn` and its deny list moved to
  `mtg-sdk/.../scripting/values/ProjectionScopedAmounts.kt`, and `SetBaseStatsEffect.init` now runs
  it, so an amount the projector cannot re-evaluate fails as the `cardDef` is built rather than
  mid-game. Gated on the flag, so the JSON scan costs nothing in the default snapshot mode.
- The hygiene test matched only `has<…>`, so the same gate written `get<…>() != null` bypassed it in
  any file. Both spellings now match.
- `ActivatedAbilityEnumerator` gated a bare `AbilityCost.Untap` but not one inside a `Composite`,
  so it could offer a `{Q}` activation the handler's re-check then rejected. Closed.
- Added a test pinning "up to that many" as a ceiling rather than a quota (pay twice, fire one
  arrow, decline the second) — the KDoc asserted this and nothing tested it.
- Documented a fourth limit of `reevaluateContinuously`: the clause is a layer-7b floating effect,
  not an ability the creature has, so `LoseAllAbilities` cannot strip it.

`docs/card-sdk-language-reference.md` is updated for every SDK addition and for the corrections
above.

## Verification

**12,702 tests, 0 failures, 0 errors** across `mtg-sdk`, `rules-engine`, `mtg-sets`, `game-server`
and all nine per-era scenario modules — run against the final tree. Per-module numbers are in the
review comment on this PR, along with what the gate does **not** cover: the `web-client` enum
addition is unverified by any TypeScript tool in this environment, and `just check-card-printing`
could not run because the `justfile` on `main` does not parse under `just` 1.36.0 (all four cards
are first printings with a single Scryfall printing each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
