### PR TITLE
Add the 43 Assay-ready March of the Machine cards

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/MonasteryMentor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/MonasteryMentor.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.frf.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Monastery Mentor
+ * {2}{W}
+ * Creature — Human Monk
+ * 2/2
+ * Prowess
+ * Whenever you cast a noncreature spell, create a 1/1 white Monk creature token with prowess.
+ *
+ * Canonical printing: Fate Reforged, the card's earliest real-expansion printing. Reprinted in MOM
+ * as a `Printing` row.
+ *
+ * The two abilities are independent triggers off the same event — `prowess()` lowers to the keyword
+ * plus its own +1/+1 trigger, and the token ability is a second `YouCastNoncreature` trigger, so
+ * casting one noncreature spell puts both on the stack (the printed ruling). The token carries the
+ * PROWESS keyword; `CreateTokenExecutor` grants the matching triggered ability from it, and per the
+ * ruling that token's own prowess does not see the spell that made it.
+ */
+val MonasteryMentor = card("Monastery Mentor") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Monk"
+    oracleText = "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until " +
+        "end of turn.)\n" +
+        "Whenever you cast a noncreature spell, create a 1/1 white Monk creature token with prowess."
+    power = 2
+    toughness = 2
+
+    prowess()
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Monk"),
+            keywords = setOf(Keyword.PROWESS),
+            imageUri = "https://cards.scryfall.io/normal/front/3/1/3142cb28-23cc-405f-9db5-7c4d168aab19.jpg?1783938663"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "20"
+        artist = "Magali Villeneuve"
+        flavorText = "\"Speak little. Do much.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abcd0e32-2e6b-419b-9e8a-af38f2b48a66.jpg?1783938710"
+        ruling(
+            "2014-11-24",
+            "Casting a noncreature spell will cause both prowess and Monastery Mentor's other " +
+                "ability to trigger. You can put these abilities on the stack in either order. " +
+                "Whichever ability is put on the stack last will resolve first."
+        )
+        ruling(
+            "2014-11-24",
+            "The spell that causes Monastery Mentor's second ability to trigger will not cause the " +
+                "prowess ability of the Monk token that's created to trigger."
+        )
+        ruling(
+            "2014-11-24",
+            "Any spell you cast that doesn't have the type creature will cause prowess to trigger. " +
+                "If a spell has multiple types, and one of those types is creature (such as an " +
+                "artifact creature), casting it won't cause prowess to trigger. Playing a land " +
+                "also won't cause prowess to trigger."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/InspiredCharge.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/InspiredCharge.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Inspired Charge
+ * {2}{W}{W}
+ * Instant
+ * Creatures you control get +2/+1 until end of turn.
+ *
+ * Canonical printing: Magic 2011, the card's earliest real-expansion printing. Reprinted in MOM
+ * (and elsewhere) as a `Printing` row.
+ */
+val InspiredCharge = card("Inspired Charge") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Creatures you control get +2/+1 until end of turn."
+
+    spell {
+        effect = Patterns.Group.modifyStatsForAll(
+            power = 2,
+            toughness = 1,
+            filter = GroupFilter.AllCreaturesYouControl
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Wayne Reynolds"
+        flavorText = "\"Impossible! How could they overwhelm us? We had barricades, war elephants, " +
+            ". . . and they were barely a tenth of our number!\"\n—General Avitora"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98151986-90de-4f76-9abd-507039e7c9ad.jpg?1783941834"
+        ruling(
+            "2016-09-20",
+            "The set of creatures affected by Inspired Charge is determined as the spell resolves. " +
+                "Creatures you begin to control later in the turn and noncreature permanents that " +
+                "become creatures later in the turn won't get +2/+1."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/StokeTheFlames.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/StokeTheFlames.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stoke the Flames
+ * {2}{R}{R}
+ * Instant
+ * Convoke
+ * Stoke the Flames deals 4 damage to any target.
+ *
+ * Canonical printing: Magic 2015, the card's earliest real-expansion printing. Reprinted in MOM
+ * as a `Printing` row.
+ */
+val StokeTheFlames = card("Stoke the Flames") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Stoke the Flames deals 4 damage to any target."
+
+    keywords(Keyword.CONVOKE)
+
+    spell {
+        val victim = target("any target", Targets.Any)
+        effect = Effects.DealDamage(4, victim)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "164"
+        artist = "Ryan Barger"
+        imageUri = "https://cards.scryfall.io/normal/front/1/d/1d94c000-52e0-4215-83af-6351dc43e636.jpg?1783939169"
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional " +
+                "costs, or anything else that increases or reduces the cost to cast the spell. " +
+                "Convoke applies after the total cost is calculated. Convoke doesn't change a " +
+                "spell's mana cost or mana value."
+        )
+        ruling(
+            "2024-01-12",
+            "Tapping an untapped creature that's attacking or blocking to convoke a spell won't " +
+                "cause that creature to stop attacking or blocking."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/VanquishTheWeak.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/VanquishTheWeak.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vanquish the Weak
+ * {2}{B}
+ * Instant
+ * Destroy target creature with power 3 or less.
+ *
+ * Canonical printing: Ixalan, the card's earliest real-expansion printing. Reprinted in MOM as a
+ * `Printing` row.
+ */
+val VanquishTheWeak = card("Vanquish the Weak") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature with power 3 or less."
+
+    spell {
+        val victim = target(
+            "target creature with power 3 or less",
+            Targets.CreatureWithPowerAtMost(3)
+        )
+        effect = Effects.Destroy(victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "127"
+        artist = "David Palumbo"
+        flavorText = "The clerics known as condemners punish those who do not recognize the " +
+            "righteous authority of the church."
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e599ed0b-4b3b-4341-b6ac-7fdfdc6799a3.jpg?1783935752"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/MarchOfTheMachineSet.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/MarchOfTheMachineSet.kt
@@ -23,6 +23,10 @@ object MarchOfTheMachineSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/AerialBoost.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/AerialBoost.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aerial Boost
+ * {1}{W}
+ * Instant
+ * Convoke
+ * Target creature gets +2/+2 and gains flying until end of turn.
+ *
+ * Convoke (CR 702.51) is a pure cost-payment keyword, so the spell body is the ordinary
+ * pump-and-grant pair over one named target.
+ */
+val AerialBoost = card("Aerial Boost") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Target creature gets +2/+2 and gains flying until end of turn."
+
+    keywords(Keyword.CONVOKE)
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(2, 2, creature) then
+            Effects.GrantKeyword(Keyword.FLYING, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "2"
+        artist = "Artur Nakhodkin"
+        flavorText = "\"Ha! You missed!\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7017afb-4c7c-4c8d-9c9d-3f056a55561e.jpg?1783917072"
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional " +
+                "costs, or anything else that increases or reduces the cost to cast the spell. " +
+                "Convoke applies after the total cost is calculated. Convoke doesn't change a " +
+                "spell's mana cost or mana value."
+        )
+        ruling(
+            "2024-01-12",
+            "Tapping an untapped creature that's attacking or blocking to convoke a spell won't " +
+                "cause that creature to stop attacking or blocking."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/AkkiScrapchomper.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/AkkiScrapchomper.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Akki Scrapchomper
+ * {R}
+ * Creature — Phyrexian Goblin
+ * 1/1
+ * {1}{R}, {T}, Sacrifice an artifact or land: Draw a card.
+ */
+val AkkiScrapchomper = card("Akki Scrapchomper") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Phyrexian Goblin"
+    oracleText = "{1}{R}, {T}, Sacrifice an artifact or land: Draw a card."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{R}"),
+            Costs.Tap,
+            Costs.Sacrifice(GameObjectFilter.ArtifactOrLand)
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Wisnu Tan"
+        flavorText = "The Furnace Host found great value in the chaotic ingenuity of Kamigawa's " +
+            "akki and allowed willing converts to \"experiment\" however they saw fit."
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0e02737-0193-46e4-a506-cec86a44dc99.jpg?1783916998"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/AlabasterHostSanctifier.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/AlabasterHostSanctifier.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alabaster Host Sanctifier
+ * {1}{W}
+ * Creature — Phyrexian Cleric
+ * 2/2
+ * Lifelink
+ */
+val AlabasterHostSanctifier = card("Alabaster Host Sanctifier") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Phyrexian Cleric"
+    oracleText = "Lifelink"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "4"
+        artist = "Konstantin Porubov"
+        flavorText = "\"Heliod shines his light on all things, excising the shadows of doubt. " +
+            "Rejoice, for beneath his purifying eyes, Theros is united as one!\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/efbd934a-39c4-4ce7-af2a-34ca226d7f23.jpg?1783917073"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/ArtisticRefusal.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/ArtisticRefusal.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Artistic Refusal
+ * {4}{U}{U}
+ * Instant
+ * Convoke
+ * Choose one or both —
+ * • Counter target spell.
+ * • Draw two cards, then discard a card.
+ *
+ * `modal(chooseCount = 2, minChooseCount = 1)` is the "choose one or both" shape (CR 700.2) — at
+ * least one mode, up to both, with the counter mode's target chosen as the spell is cast. If that
+ * target is illegal on resolution the whole spell is countered by game rules (CR 608.2b) and the
+ * draw mode does not happen either, which is what the printed ruling describes.
+ */
+val ArtisticRefusal = card("Artistic Refusal") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Choose one or both —\n" +
+        "• Counter target spell.\n" +
+        "• Draw two cards, then discard a card."
+
+    keywords(Keyword.CONVOKE)
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Counter target spell") {
+                target = Targets.Spell
+                effect = Effects.CounterSpell()
+            }
+            mode("Draw two cards, then discard a card") {
+                effect = Effects.DrawCards(2) then Effects.Discard(1, EffectTarget.Controller)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "46"
+        artist = "Olivier Bernard"
+        flavorText = "Errant wouldn't allow anything to stop her from decorating the streets of " +
+            "New Capenna."
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2bd05f97-ef8b-4cbe-a44b-6501aa5895b0.jpg?1783917045"
+        ruling(
+            "2023-04-14",
+            "If you choose both modes, and the target of the first mode is an illegal target at " +
+                "the time Artistic Refusal tries to resolve (probably because that spell has been " +
+                "countered by something else), Artistic Refusal won't resolve and none of its " +
+                "effects will happen. You won't draw or discard any cards."
+        )
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional " +
+                "costs, or anything else that increases or reduces the cost to cast the spell. " +
+                "Convoke applies after the total cost is calculated. Convoke doesn't change a " +
+                "spell's mana cost or mana value."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/AstralWingspan.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/AstralWingspan.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Astral Wingspan
+ * {4}{U}
+ * Enchantment — Aura
+ * Convoke
+ * Enchant creature
+ * When this Aura enters, draw a card.
+ * Enchanted creature gets +2/+2 and has flying.
+ */
+val AstralWingspan = card("Astral Wingspan") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Enchant creature\n" +
+        "When this Aura enters, draw a card.\n" +
+        "Enchanted creature gets +2/+2 and has flying."
+
+    keywords(Keyword.CONVOKE)
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "48"
+        artist = "Joseph Weston"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be2ef728-a2c7-45ee-8594-372ed135b482.jpg?1783917046"
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional " +
+                "costs, or anything else that increases or reduces the cost to cast the spell. " +
+                "Convoke applies after the total cost is calculated. Convoke doesn't change a " +
+                "spell's mana cost or mana value."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/CollectiveNightmare.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/CollectiveNightmare.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Collective Nightmare
+ * {2}{B}
+ * Instant
+ * Convoke
+ * Target creature gets -3/-3 until end of turn.
+ */
+val CollectiveNightmare = card("Collective Nightmare") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Target creature gets -3/-3 until end of turn."
+
+    keywords(Keyword.CONVOKE)
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-3, -3, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "95"
+        artist = "Rovina Cai"
+        flavorText = "Night fell all at once. Specifically, on the Phyrexian."
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/05864d3a-d8bb-4ddf-b721-883632050cb1.jpg?1783917017"
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional " +
+                "costs, or anything else that increases or reduces the cost to cast the spell. " +
+                "Convoke applies after the total cost is calculated. Convoke doesn't change a " +
+                "spell's mana cost or mana value."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/ComingInHot.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/ComingInHot.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Coming In Hot
+ * {R}
+ * Instant
+ * Target creature gets +1/+0 and gains first strike until end of turn. Scry 1.
+ */
+val ComingInHot = card("Coming In Hot") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1. " +
+        "(Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(1, 0, creature) then
+            Effects.GrantKeyword(Keyword.FIRST_STRIKE, creature) then
+            Patterns.Library.scry(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "136"
+        artist = "Cristi Balanescu"
+        flavorText = "\"I have a reckless idea,\" Koth offered. Chandra grinned and cracked her knuckles."
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f6eb966-67af-4b18-8899-4a99a5179aa3.jpg?1783916993"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/CopperHostCrusher.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/CopperHostCrusher.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Copper Host Crusher
+ * {6}{G}{G}
+ * Creature — Phyrexian Bear Rhino
+ * 8/8
+ * Trample
+ * Hexproof
+ */
+val CopperHostCrusher = card("Copper Host Crusher") {
+    manaCost = "{6}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Phyrexian Bear Rhino"
+    oracleText = "Trample\n" +
+        "Hexproof (This creature can't be the target of spells or abilities your opponents control.)"
+    power = 8
+    toughness = 8
+
+    keywords(Keyword.TRAMPLE, Keyword.HEXPROOF)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "181"
+        artist = "Nicholas Gregory"
+        flavorText = "Walls built to withstand assaults even from Ikoria's apex monsters were " +
+            "quickly deemed tactically irrelevant by Vorinclex's forces."
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/af527344-9d88-4641-8f6d-0263a6797df3.jpg?1783916973"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/DeadlyDerision.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/DeadlyDerision.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deadly Derision
+ * {2}{B}{B}
+ * Instant
+ * Destroy target creature or planeswalker. Create a Treasure token.
+ *
+ * Both clauses are one spell over one target: if the target is illegal on resolution the spell is
+ * countered by game rules (CR 608.2b) and no Treasure is made either — the printed ruling.
+ */
+val DeadlyDerision = card("Deadly Derision") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature or planeswalker. Create a Treasure token. (It's an " +
+        "artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+
+    spell {
+        val victim = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+        effect = Effects.Destroy(victim) then Effects.CreateTreasure(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "99"
+        artist = "Gaboleps"
+        flavorText = "Daretti looked down disdainfully. \"You call yourself machines? Where's the " +
+            "elegance? Nothing but ugly piles of scrap.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1ec1a02f-128c-44aa-b708-6fcda34b40c0.jpg?1783917014"
+        ruling(
+            "2023-04-14",
+            "If the target of Deadly Derision is illegal as the spell tries to resolve, it won't " +
+                "resolve and none of its effects will happen. You won't create a Treasure token."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/EpharasDispersal.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/EpharasDispersal.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Ephara's Dispersal
+ * {2}{U}
+ * Instant
+ * This spell costs {2} less to cast if it targets an attacking creature.
+ * Return target creature to its owner's hand. Surveil 2.
+ *
+ * The reduction is [CostReductionSource.FixedIfAnyTargetMatches] — a *generic* reduction gated on
+ * the spell's own chosen target, evaluated as the spell is cast. It touches only the total cost, so
+ * this card's mana value stays 3 (the printed ruling).
+ */
+val EpharasDispersal = card("Ephara's Dispersal") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "This spell costs {2} less to cast if it targets an attacking creature.\n" +
+        "Return target creature to its owner's hand. Surveil 2. (Look at the top two cards of " +
+        "your library, then put any number of them into your graveyard and the rest on top of " +
+        "your library in any order.)"
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfAnyTargetMatches(
+                    amount = 2,
+                    filter = GameObjectFilter.Creature.attacking()
+                )
+            )
+        )
+    }
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ReturnToHand(creature) then Patterns.Library.surveil(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "55"
+        artist = "Awanqi (Angela Wang)"
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0bcc71f-72ec-4a76-9393-ed3ea61eeeb6.jpg?1783917039"
+        ruling(
+            "2023-04-14",
+            "The cost reduction ability of Ephara's Dispersal doesn't affect its mana cost or mana " +
+                "value. It affects only the total cost you pay. Specifically, its mana value is always 3."
+        )
+        ruling(
+            "2024-01-12",
+            "You perform the actions stated on a card in sequence. For some spells and abilities, " +
+                "you'll surveil last. For others, you'll surveil and then perform other actions."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/FurnaceHostCharger.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/FurnaceHostCharger.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Furnace Host Charger
+ * {5}{R}
+ * Creature — Phyrexian Giant
+ * 5/5
+ * Haste
+ * Mountaincycling {2}
+ */
+val FurnaceHostCharger = card("Furnace Host Charger") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Phyrexian Giant"
+    oracleText = "Haste\n" +
+        "Mountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, " +
+        "reveal it, put it into your hand, then shuffle.)"
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.HASTE)
+    keywordAbility(KeywordAbility.typecycling("Mountain", ManaCost.parse("{2}")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "140"
+        artist = "Andreas Zafiratos"
+        flavorText = "With barely a moment's warning, a one-giant avalanche crashed into " +
+            "Kaldheim's defenders."
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d142ded-a2df-41b0-9c02-056b5f34abab.jpg?1783916991"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/FurtiveAnalyst.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/FurtiveAnalyst.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Furtive Analyst
+ * {2}{U}
+ * Creature — Human Wizard
+ * 1/4
+ * Vigilance
+ * {2}, {T}: Draw a card, then discard a card.
+ */
+val FurtiveAnalyst = card("Furtive Analyst") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "Vigilance\n{2}, {T}: Draw a card, then discard a card."
+    power = 1
+    toughness = 4
+
+    keywords(Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        effect = Effects.DrawCards(1) then Effects.Discard(1, EffectTarget.Controller)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "Marcela Bolívar"
+        flavorText = "Where had she first seen that symbol? She usually took such detailed notes, " +
+            "but her memory of it was like a fading nightmare."
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98c55aff-baed-4fb5-a490-abd59b8df5e7.jpg?1783917037"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/HaloHopper.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/HaloHopper.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Halo Hopper
+ * {3}
+ * Artifact Creature — Frog
+ * 3/2
+ * Convoke
+ */
+val HaloHopper = card("Halo Hopper") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Frog"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)"
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.CONVOKE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "260"
+        artist = "Daniel Ljunggren"
+        flavorText = "Folded by an imaginative child, animated by a mischievous kami, and blessed " +
+            "by an otherworldly angel."
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e07baeb1-c873-42c2-8f1e-757f13572079.jpg?1783916937"
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional " +
+                "costs, or anything else that increases or reduces the cost to cast the spell. " +
+                "Convoke applies after the total cost is calculated. Convoke doesn't change a " +
+                "spell's mana cost or mana value."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/InspiredChargeReprint.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/InspiredChargeReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inspired Charge reprint in MOM.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Magic 2011 (`m11`). This file
+ * contributes only the MOM-specific presentation row — set, collector number, art.
+ */
+val InspiredChargeReprint = Printing(
+    oracleId = "d465a3d6-5830-456c-8e7a-908b464db846",
+    name = "Inspired Charge",
+    setCode = "MOM",
+    collectorNumber = "19",
+    scryfallId = "9f17e624-219a-4e76-bfe0-f49c9ddd4a6d",
+    artist = "Vladimir Krisetskiy",
+    imageUri = "https://cards.scryfall.io/normal/front/9/f/9f17e624-219a-4e76-bfe0-f49c9ddd4a6d.jpg?1783917060",
+    releaseDate = "2023-04-21",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/InterdisciplinaryMascot.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/InterdisciplinaryMascot.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+
+/**
+ * Interdisciplinary Mascot
+ * {6}{U}{U}
+ * Creature — Elemental Fractal
+ * 5/5
+ * Convoke
+ * Ward {3}
+ * When this creature enters, look at the top four cards of your library. Put one of them into your
+ * hand and the rest on the bottom of your library in a random order.
+ *
+ * The entry ability is `Patterns.Library.lookAtTopAndKeep` with the bottom-of-library remainder in
+ * [CardOrder.Random] — "in a random order" is the remainder's ordering, not a shuffle.
+ */
+val InterdisciplinaryMascot = card("Interdisciplinary Mascot") {
+    manaCost = "{6}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental Fractal"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Ward {3}\n" +
+        "When this creature enters, look at the top four cards of your library. Put one of them " +
+        "into your hand and the rest on the bottom of your library in a random order."
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.CONVOKE)
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{3}")))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.lookAtTopAndKeep(
+            count = 4,
+            keepCount = 1,
+            keepDestination = CardDestination.ToZone(Zone.HAND),
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+            restOrder = CardOrder.Random
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "326"
+        artist = "Mathias Kollros"
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0eecdd9a-6c3f-43ee-8d9c-e3466bd7bf5e.jpg?1783916905"
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional " +
+                "costs, or anything else that increases or reduces the cost to cast the spell. " +
+                "Convoke applies after the total cost is calculated. Convoke doesn't change a " +
+                "spell's mana cost or mana value."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/IridescentBlademaster.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/IridescentBlademaster.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Iridescent Blademaster
+ * {1}{G}
+ * Creature — Elf Warrior
+ * 2/2
+ * {3}{G}: This creature gets +2/+2 until end of turn.
+ */
+val IridescentBlademaster = card("Iridescent Blademaster") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    oracleText = "{3}{G}: This creature gets +2/+2 until end of turn."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{G}")
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "195"
+        artist = "Livia Prima"
+        flavorText = "Her arm and spirit were weary, but as the Halo flowed across her blade, it " +
+            "became weightless, and new strength flooded through her. She would fight on."
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3fee189f-539f-48fa-b217-4b2599375364.jpg?1783916966"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/KitesailReprint.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/KitesailReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kitesail reprint in MOM.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Worldwake (`wwk`). This file
+ * contributes only the MOM-specific presentation row — set, collector number, art.
+ */
+val KitesailReprint = Printing(
+    oracleId = "b079f9db-974d-4525-a894-57b754ba9dcc",
+    name = "Kitesail",
+    setCode = "MOM",
+    collectorNumber = "261",
+    scryfallId = "fdc3bf6e-e011-4334-a142-c09941c6f213",
+    artist = "Ben Hill",
+    imageUri = "https://cards.scryfall.io/normal/front/f/d/fdc3bf6e-e011-4334-a142-c09941c6f213.jpg?1783916936",
+    releaseDate = "2023-04-21",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/KithkinBillyrider.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/KithkinBillyrider.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kithkin Billyrider
+ * {2}{W}
+ * Creature — Kithkin Knight
+ * 1/3
+ * Double strike
+ */
+val KithkinBillyrider = card("Kithkin Billyrider") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kithkin Knight"
+    oracleText = "Double strike"
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.DOUBLE_STRIKE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Zara Alfonso"
+        flavorText = "\"Brother, guide my right hand. Sister, my left. Rest well, my kin, but " +
+            "Lorwyn still needs me. I will not be joining you quite yet.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/0535b69f-247d-49c9-97e1-d988700578ab.jpg?1783917058"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/KnightOfTheNewCoalition.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/KnightOfTheNewCoalition.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Knight of the New Coalition
+ * {3}{W}
+ * Creature — Human Knight
+ * 2/2
+ * Vigilance
+ * When this creature enters, create a 2/2 white and blue Knight creature token with vigilance.
+ */
+val KnightOfTheNewCoalition = card("Knight of the New Coalition") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Vigilance\n" +
+        "When this creature enters, create a 2/2 white and blue Knight creature token with vigilance."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE, Color.BLUE),
+            creatureTypes = setOf("Knight"),
+            keywords = setOf(Keyword.VIGILANCE),
+            imageUri = "https://cards.scryfall.io/normal/front/8/8/88439bfc-8942-473b-9e4f-863017788476.jpg?1783916669"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "Jake Murray"
+        flavorText = "Raised in a long tradition of heroes, every Benalish knight knows the day " +
+            "might come when they will be called to face Phyrexia."
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/56a3108b-c33d-47c5-984b-01fa257fbd79.jpg?1783917059"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/KorHalberd.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/KorHalberd.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Kor Halberd
+ * {W}
+ * Artifact — Equipment
+ * Equipped creature gets +1/+1 and has vigilance.
+ * Equip {1}
+ */
+val KorHalberd = card("Kor Halberd") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1 and has vigilance.\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(1, 1, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE, Filters.EquippedCreature)
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "27"
+        artist = "Bastien L. Deharme"
+        flavorText = "An ancient weapon for a modern war."
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4705327-ada6-4575-82fc-351e183d060e.jpg?1783917057"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/MarchOfTheMachineBasicLands.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/MarchOfTheMachineBasicLands.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * March of the Machine Basic Lands
+ *
+ * MOM prints three art variants of each basic land type: one full-set cycle by Sam Burley
+ * (277-281), then two more variants per type (282-291).
+ */
+
+// =============================================================================
+// Plains (277, 282, 283)
+// =============================================================================
+
+val MarchOfTheMachinePlains277 = basicLand("Plains") {
+    collectorNumber = "277"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/0/0/00bf269d-aca3-494c-8777-de90ae903af2.jpg?1783916929"
+}
+
+val MarchOfTheMachinePlains282 = basicLand("Plains") {
+    collectorNumber = "282"
+    artist = "Jorge Jacinto"
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/ee7f525c-d777-4adf-8920-8adfc73bbc55.jpg?1783916926"
+}
+
+val MarchOfTheMachinePlains283 = basicLand("Plains") {
+    collectorNumber = "283"
+    artist = "Lucas Staniec"
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8a790328-70b3-477d-bf02-8718870367ae.jpg?1783916925"
+}
+
+// =============================================================================
+// Island (278, 284, 285)
+// =============================================================================
+
+val MarchOfTheMachineIsland278 = basicLand("Island") {
+    collectorNumber = "278"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/9/8/988bfa94-0c83-4057-a0c7-0ad885b8919c.jpg?1783916928"
+}
+
+val MarchOfTheMachineIsland284 = basicLand("Island") {
+    collectorNumber = "284"
+    artist = "Grady Frederick"
+    imageUri = "https://cards.scryfall.io/normal/front/2/0/2039d727-3bb6-4a76-89ca-159ecf10cad8.jpg?1783916925"
+}
+
+val MarchOfTheMachineIsland285 = basicLand("Island") {
+    collectorNumber = "285"
+    artist = "Henry Peters"
+    imageUri = "https://cards.scryfall.io/normal/front/5/6/560c7de9-0046-4a76-a41a-fa1c3ef92f04.jpg?1783916926"
+}
+
+// =============================================================================
+// Swamp (279, 286, 287)
+// =============================================================================
+
+val MarchOfTheMachineSwamp279 = basicLand("Swamp") {
+    collectorNumber = "279"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/888cdb76-d365-41df-8b6a-378ac58ca8b2.jpg?1783916927"
+}
+
+val MarchOfTheMachineSwamp286 = basicLand("Swamp") {
+    collectorNumber = "286"
+    artist = "Raymond Bonilla"
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e19e24a8-5a4f-4a2d-b8dd-eb92aac7be78.jpg?1783916920"
+}
+
+val MarchOfTheMachineSwamp287 = basicLand("Swamp") {
+    collectorNumber = "287"
+    artist = "Julian Kok Joon Wen"
+    imageUri = "https://cards.scryfall.io/normal/front/0/1/013612b4-fed9-4112-8018-9267ae608fd7.jpg?1783916921"
+}
+
+// =============================================================================
+// Mountain (280, 288, 289)
+// =============================================================================
+
+val MarchOfTheMachineMountain280 = basicLand("Mountain") {
+    collectorNumber = "280"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/2/1/21041ed6-8f13-4909-a2c3-fa4894a2d1e3.jpg?1783916928"
+}
+
+val MarchOfTheMachineMountain288 = basicLand("Mountain") {
+    collectorNumber = "288"
+    artist = "Jorge Jacinto"
+    imageUri = "https://cards.scryfall.io/normal/front/a/6/a6a57c6a-3603-466c-8a81-a9eb8de92aec.jpg?1783916920"
+}
+
+val MarchOfTheMachineMountain289 = basicLand("Mountain") {
+    collectorNumber = "289"
+    artist = "Lucas Staniec"
+    imageUri = "https://cards.scryfall.io/normal/front/7/e/7e19c7e1-1b4b-4c7e-b011-eff8ed7de0fd.jpg?1783916920"
+}
+
+// =============================================================================
+// Forest (281, 290, 291)
+// =============================================================================
+
+val MarchOfTheMachineForest281 = basicLand("Forest") {
+    collectorNumber = "281"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/80716ed1-8d0e-44e6-8b18-606e80d22181.jpg?1783916927"
+}
+
+val MarchOfTheMachineForest290 = basicLand("Forest") {
+    collectorNumber = "290"
+    artist = "Grady Frederick"
+    imageUri = "https://cards.scryfall.io/normal/front/7/e/7e6151d4-5129-4631-84a1-5cffc551c1e9.jpg?1783916919"
+}
+
+val MarchOfTheMachineForest291 = basicLand("Forest") {
+    collectorNumber = "291"
+    artist = "Henry Peters"
+    imageUri = "https://cards.scryfall.io/normal/front/e/0/e0ce5575-2d62-43c9-9c4b-fca4aff6ae4d.jpg?1783916919"
+}
+
+/**
+ * All March of the Machine basic land variants.
+ */
+val MarchOfTheMachineBasicLands = listOf(
+    MarchOfTheMachinePlains277, MarchOfTheMachinePlains282, MarchOfTheMachinePlains283,
+    MarchOfTheMachineIsland278, MarchOfTheMachineIsland284, MarchOfTheMachineIsland285,
+    MarchOfTheMachineSwamp279, MarchOfTheMachineSwamp286, MarchOfTheMachineSwamp287,
+    MarchOfTheMachineMountain280, MarchOfTheMachineMountain288, MarchOfTheMachineMountain289,
+    MarchOfTheMachineForest281, MarchOfTheMachineForest290, MarchOfTheMachineForest291
+)

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/MeetingOfMinds.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/MeetingOfMinds.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meeting of Minds
+ * {3}{U}
+ * Instant
+ * Convoke
+ * Draw two cards.
+ */
+val MeetingOfMinds = card("Meeting of Minds") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Draw two cards."
+
+    keywords(Keyword.CONVOKE)
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Milivoj Ćeran"
+        flavorText = "\"If something seems impossible, you probably haven't tried asking for help.\"\n" +
+            "—Niambi, cleric of Dominaria"
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/508b8650-c283-4e54-abdc-32ec2fb1ee34.jpg?1783917031"
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional " +
+                "costs, or anything else that increases or reduces the cost to cast the spell. " +
+                "Convoke applies after the total cost is calculated. Convoke doesn't change a " +
+                "spell's mana cost or mana value."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/MonasteryMentorReprint.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/MonasteryMentorReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Monastery Mentor reprint in MOM.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Fate Reforged (`frf`). This
+ * file contributes only the MOM-specific presentation row — set, collector number, art.
+ */
+val MonasteryMentorReprint = Printing(
+    oracleId = "3979067a-9c68-443d-a85f-d9f07be880b9",
+    name = "Monastery Mentor",
+    setCode = "MOM",
+    collectorNumber = "28",
+    scryfallId = "75665c2f-a100-4e3f-be8e-b5cc3c9a090b",
+    artist = "Brian Valeza",
+    imageUri = "https://cards.scryfall.io/normal/front/7/5/75665c2f-a100-4e3f-be8e-b5cc3c9a090b.jpg?1783917054",
+    releaseDate = "2023-04-21",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/NezumiInformant.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/NezumiInformant.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nezumi Informant
+ * {1}{B}
+ * Creature — Rat Rogue
+ * 1/1
+ * When this creature enters, each opponent discards a card.
+ */
+val NezumiInformant = card("Nezumi Informant") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Rat Rogue"
+    oracleText = "When this creature enters, each opponent discards a card."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Hand.eachOpponentDiscards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "120"
+        artist = "Steve Prescott"
+        flavorText = "\"Tell Boss Umezawa there's a new gang moving in on our territory. I'm " +
+            "forwarding their insignia. Watch for it elsewhere.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e36fbff8-471e-4cf8-8946-e1e5cdf598af.jpg?1783917003"
+        ruling(
+            "2023-04-14",
+            "To resolve Nezumi Informant's ability in a multiplayer game, the next opponent in " +
+                "turn order (or, if it's an opponent's turn, the opponent whose turn it is) " +
+                "chooses a card in hand and sets it aside without revealing it. Then each other " +
+                "opponent in turn order does the same. Finally, all chosen cards are revealed and " +
+                "discarded at the same time."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/PileOn.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/PileOn.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pile On
+ * {3}{B}
+ * Instant
+ * Convoke
+ * Destroy target creature or planeswalker. Surveil 2.
+ */
+val PileOn = card("Pile On") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Destroy target creature or planeswalker. Surveil 2. (Look at the top two cards of your " +
+        "library, then put any number of them into your graveyard and the rest on top of your " +
+        "library in any order.)"
+
+    keywords(Keyword.CONVOKE)
+
+    spell {
+        val victim = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+        effect = Effects.Destroy(victim) then Patterns.Library.surveil(2)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "122"
+        artist = "Javier Charro"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/492e9369-0ca3-4c31-b747-75d615daf6e4.jpg?1783917002"
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional " +
+                "costs, or anything else that increases or reduces the cost to cast the spell. " +
+                "Convoke applies after the total cost is calculated. Convoke doesn't change a " +
+                "spell's mana cost or mana value."
+        )
+        ruling(
+            "2024-01-12",
+            "You perform the actions stated on a card in sequence. For some spells and abilities, " +
+                "you'll surveil last. For others, you'll surveil and then perform other actions."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/PreeningChampion.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/PreeningChampion.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Preening Champion
+ * {2}{U}
+ * Creature — Bird Knight
+ * 2/2
+ * Flying
+ * When this creature enters, create a 1/1 blue and red Elemental creature token.
+ */
+val PreeningChampion = card("Preening Champion") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird Knight"
+    oracleText = "Flying\n" +
+        "When this creature enters, create a 1/1 blue and red Elemental creature token."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLUE, Color.RED),
+            creatureTypes = setOf("Elemental"),
+            imageUri = "https://cards.scryfall.io/normal/front/2/8/28a7a9b0-d823-4b34-829f-ade81fc141e0.jpg?1783916668"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "73"
+        artist = "Alix Branwyn"
+        flavorText = "On Kylem, the omens of impending invasion went largely unnoticed, drowned " +
+            "out by the everyday fanfare of Valor's Reach."
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/44178ece-af31-4a94-88bc-c9ce43bb4573.jpg?1783917028"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/RalsReinforcements.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/RalsReinforcements.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ral's Reinforcements
+ * {1}{R}
+ * Sorcery
+ * Create two 1/1 blue and red Elemental creature tokens.
+ */
+val RalsReinforcements = card("Ral's Reinforcements") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Create two 1/1 blue and red Elemental creature tokens."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLUE, Color.RED),
+            creatureTypes = setOf("Elemental"),
+            count = 2,
+            imageUri = "https://cards.scryfall.io/normal/front/2/8/28a7a9b0-d823-4b34-829f-ade81fc141e0.jpg?1783916668"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "158"
+        artist = "Nils Hamm"
+        flavorText = "\"Good thing maintenance never got around to decatalyzing the bithermic " +
+            "plasma displacement conduits!\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/74d0bb76-075c-49d7-9afb-e5bcf5b654f7.jpg?1783916984"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/RamosianGreatsword.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/RamosianGreatsword.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Ramosian Greatsword
+ * {4}{R}
+ * Artifact — Equipment
+ * Convoke
+ * Equipped creature gets +3/+1 and has trample.
+ * Equip {2}
+ */
+val RamosianGreatsword = card("Ramosian Greatsword") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Equipped creature gets +3/+1 and has trample.\n" +
+        "Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    keywords(Keyword.CONVOKE)
+
+    staticAbility {
+        ability = ModifyStats(3, 1, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE, Filters.EquippedCreature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "159"
+        artist = "Jason A. Engle"
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/efd6f04e-e83d-4580-ae3f-583ada848868.jpg?1783916985"
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional " +
+                "costs, or anything else that increases or reduces the cost to cast the spell. " +
+                "Convoke applies after the total cost is calculated. Convoke doesn't change a " +
+                "spell's mana cost or mana value."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/RavenousSailback.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/RavenousSailback.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ravenous Sailback
+ * {4}{G}
+ * Creature — Dinosaur
+ * 3/4
+ * When this creature enters, choose one —
+ * • This creature gains haste until end of turn.
+ * • Destroy target artifact or enchantment.
+ *
+ * A modal *triggered* ability (CR 700.2 / 603.3c): the mode is chosen as the trigger goes on the
+ * stack, so the destroy mode's target is picked then too. [TriggeredAbilityBuilder] has no `modal`
+ * shorthand, so the body is a [ModalEffect] directly.
+ */
+val RavenousSailback = card("Ravenous Sailback") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "When this creature enters, choose one —\n" +
+        "• This creature gains haste until end of turn.\n" +
+        "• Destroy target artifact or enchantment."
+    power = 3
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect(
+            modes = listOf(
+                Mode.noTarget(
+                    effect = Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self),
+                    description = "This creature gains haste until end of turn."
+                ),
+                Mode.withTarget(
+                    effect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+                    target = Targets.ArtifactOrEnchantment,
+                    description = "Destroy target artifact or enchantment."
+                )
+            ),
+            chooseCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "202"
+        artist = "Andrew Mar"
+        flavorText = "Converter beasts were sent to ensnare as many of Ixalan's dinosaurs as " +
+            "possible. Many of them were converted themselves—into snacks."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a225cb30-9f3e-4cfa-bdd6-a7c73c95ea2b.jpg?1783916962"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/RefereeSquad.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/RefereeSquad.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Referee Squad
+ * {2}{U}
+ * Creature — Homunculus
+ * 2/2
+ * Convoke
+ * Vigilance
+ * When this creature enters, tap target creature an opponent controls and put a stun counter on it.
+ *
+ * The target may already be tapped (printed ruling) — the tap simply does nothing and the stun
+ * counter still lands, so the requirement stays a plain "creature an opponent controls".
+ */
+val RefereeSquad = card("Referee Squad") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Homunculus"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Vigilance\n" +
+        "When this creature enters, tap target creature an opponent controls and put a stun " +
+        "counter on it. (If a permanent with a stun counter would become untapped, remove one " +
+        "from it instead.)"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.CONVOKE, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val victim = target(
+            "target creature an opponent controls",
+            TargetCreature(filter = TargetFilter.Creature.opponentControls())
+        )
+        effect = Effects.Tap(victim) then Effects.AddCounters(Counters.STUN, 1, victim)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "327"
+        artist = "Steven Belledin"
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/434515bf-de57-4c00-b0b4-c9579cc1b84c.jpg?1783916905"
+        ruling(
+            "2023-04-14",
+            "Referee Squad's enters-the-battlefield ability can target a creature that's already tapped."
+        )
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional " +
+                "costs, or anything else that increases or reduces the cost to cast the spell. " +
+                "Convoke applies after the total cost is calculated. Convoke doesn't change a " +
+                "spell's mana cost or mana value."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/RuinsRecluse.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/RuinsRecluse.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ruins Recluse
+ * {1}{G}
+ * Creature — Spider
+ * 1/1
+ * Reach, deathtouch
+ * {3}{G}: Put a +1/+1 counter on this creature.
+ */
+val RuinsRecluse = card("Ruins Recluse") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider"
+    oracleText = "Reach, deathtouch\n{3}{G}: Put a +1/+1 counter on this creature."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.REACH, Keyword.DEATHTOUCH)
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{G}")
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "336"
+        artist = "Lorenzo Mastroianni"
+        flavorText = "Desert horrors were its favorite treat, but it happily expanded its diet to " +
+            "include extraplanar horrors."
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c0c0fdf5-2f56-4480-9ccb-84471b3e5331.jpg?1783916899"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/ShivanBranchBurner.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/ShivanBranchBurner.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shivan Branch-Burner
+ * {5}{R}{R}
+ * Creature — Dragon
+ * 4/4
+ * Convoke
+ * Flying, haste
+ */
+val ShivanBranchBurner = card("Shivan Branch-Burner") {
+    manaCost = "{5}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Flying, haste"
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.CONVOKE, Keyword.FLYING, Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "165"
+        artist = "Aaron Miller"
+        flavorText = "The New Coalition gave Shiv time to prepare a warm welcome for the invaders."
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e585631c-bd41-4b48-aac4-4b6f5636ecd5.jpg?1783916980"
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional " +
+                "costs, or anything else that increases or reduces the cost to cast the spell. " +
+                "Convoke applies after the total cost is calculated. Convoke doesn't change a " +
+                "spell's mana cost or mana value."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/StokeTheFlamesReprint.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/StokeTheFlamesReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stoke the Flames reprint in MOM.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Magic 2015 (`m15`). This file
+ * contributes only the MOM-specific presentation row — set, collector number, art.
+ */
+val StokeTheFlamesReprint = Printing(
+    oracleId = "2249001c-08d5-4c0a-86f8-d97519a39f37",
+    name = "Stoke the Flames",
+    setCode = "MOM",
+    collectorNumber = "166",
+    scryfallId = "04113b3c-cc8f-4b15-9091-f82ea3df2e7c",
+    artist = "Liiga Smilshkalne",
+    imageUri = "https://cards.scryfall.io/normal/front/0/4/04113b3c-cc8f-4b15-9091-f82ea3df2e7c.jpg?1783916979",
+    releaseDate = "2023-04-21",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/ThunderheadSquadron.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/ThunderheadSquadron.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thunderhead Squadron
+ * {5}{U}
+ * Creature — Human Knight
+ * 3/4
+ * Convoke
+ * Flying
+ */
+val ThunderheadSquadron = card("Thunderhead Squadron") {
+    manaCost = "{5}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Flying"
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.CONVOKE, Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "81"
+        artist = "PINDURSKI"
+        flavorText = "Just as all seemed lost, the griffin riders of Zhalfir arrived with the " +
+            "force of a gathered storm."
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8eaa0946-591f-4136-9d8a-e56934151383.jpg?1783917023"
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional " +
+                "costs, or anything else that increases or reduces the cost to cast the spell. " +
+                "Convoke applies after the total cost is calculated. Convoke doesn't change a " +
+                "spell's mana cost or mana value."
+        )
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/TimberlandAncient.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/TimberlandAncient.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Timberland Ancient
+ * {4}{G}{G}
+ * Creature — Treefolk
+ * 6/5
+ * Reach, trample
+ * Forestcycling {2}
+ */
+val TimberlandAncient = card("Timberland Ancient") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Treefolk"
+    oracleText = "Reach, trample\n" +
+        "Forestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal " +
+        "it, put it into your hand, then shuffle.)"
+    power = 6
+    toughness = 5
+
+    keywords(Keyword.REACH, Keyword.TRAMPLE)
+    keywordAbility(KeywordAbility.typecycling("Forest", ManaCost.parse("{2}")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "210"
+        artist = "Pavel Kolomeyets"
+        flavorText = "Only the trees were old enough to remember what happened when Moag ignored " +
+            "warnings of Phyrexia millennia ago. They were determined not to repeat the mistake."
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f73cd60-cd89-4c7a-85a6-e0ae34ca101b.jpg?1783916960"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/UrnOfGodfire.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/UrnOfGodfire.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Urn of Godfire
+ * {1}
+ * Artifact
+ * {2}: Add one mana of any color.
+ * {6}, {T}, Sacrifice this artifact: Destroy target creature or enchantment.
+ */
+val UrnOfGodfire = card("Urn of Godfire") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{2}: Add one mana of any color.\n" +
+        "{6}, {T}, Sacrifice this artifact: Destroy target creature or enchantment."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{6}"), Costs.Tap, Costs.SacrificeSelf)
+        val victim = target("target creature or enchantment", Targets.CreatureOrEnchantment)
+        effect = Effects.Destroy(victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "266"
+        artist = "Ovidio Cartagena"
+        flavorText = "Ephara blessed the defenders of Theros with godfire, a Nyx-infused " +
+            "incendiary substance that burned without fuel."
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff5f302e-d884-4995-ba3c-8c22f9045318.jpg?1783916934"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/VanquishTheWeakReprint.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/VanquishTheWeakReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vanquish the Weak reprint in MOM.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Ixalan (`xln`). This file
+ * contributes only the MOM-specific presentation row — set, collector number, art.
+ */
+val VanquishTheWeakReprint = Printing(
+    oracleId = "4a3cc4f6-037f-461d-a3b7-9f9e24c4b8cf",
+    name = "Vanquish the Weak",
+    setCode = "MOM",
+    collectorNumber = "129",
+    scryfallId = "935cb9a2-11ba-45d9-ab38-dea23cecf521",
+    artist = "Gaboleps",
+    imageUri = "https://cards.scryfall.io/normal/front/9/3/935cb9a2-11ba-45d9-ab38-dea23cecf521.jpg?1783916998",
+    releaseDate = "2023-04-21",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/WrennsResolve.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/WrennsResolve.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+
+/**
+ * Wrenn's Resolve
+ * {1}{R}
+ * Sorcery
+ * Exile the top two cards of your library. Until the end of your next turn, you may play those cards.
+ */
+val WrennsResolve = card("Wrenn's Resolve") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Exile the top two cards of your library. Until the end of your next turn, you " +
+        "may play those cards."
+
+    spell {
+        effect = Patterns.Exile.impulse(2, MayPlayExpiry.UntilEndOfNextTurn)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "173"
+        artist = "Viko Menezes"
+        flavorText = "Even as she burned, Wrenn bent Realmbreaker to her will."
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9a47999c-12d5-4e1a-a9c1-40a1757007f1.jpg?1783916978"
+        ruling(
+            "2023-04-14",
+            "The cards you play from exile follow the usual timing restrictions, and you must pay " +
+                "any costs for spells you cast."
+        )
+        ruling("2023-04-14", "Any cards you don't play will remain in exile.")
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/ZhalfirinLancer.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/ZhalfirinLancer.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Zhalfirin Lancer
+ * {2}{W}
+ * Creature — Human Knight
+ * 3/3
+ * Whenever another Knight you control enters, this creature gets +1/+1 and gains vigilance until
+ * end of turn.
+ *
+ * "another **Knight** you control" is a bare tribal noun, so it names every *permanent* with the
+ * subtype rather than only creatures (a Knight artifact or Vehicle entering would trigger it) —
+ * `GameObjectFilter.Permanent.withSubtype(KNIGHT)`, not `Creature.withSubtype`. `TriggerBinding.OTHER`
+ * is the printed "another": the Lancer entering does not trigger itself.
+ */
+val ZhalfirinLancer = card("Zhalfirin Lancer") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Whenever another Knight you control enters, this creature gets +1/+1 and gains " +
+        "vigilance until end of turn."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.KNIGHT).youControl(),
+            binding = TriggerBinding.OTHER
+        )
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self) then
+            Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "45"
+        artist = "Nino Vecia"
+        flavorText = "The Phyrexians armored themselves against blades, fire, and every conjuration " +
+            "they could think of. She brought a war rhino."
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/277e5b49-c53f-4bf7-aac0-950d8708b957.jpg?1783917048"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FRF.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FRF.json
@@ -122,6 +122,100 @@
     ]
 }
 
+// Monastery Mentor
+{
+    "name": "Monastery Mentor",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Monk",
+    "oracleText": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nWhenever you cast a noncreature spell, create a 1/1 white Monk creature token with prowess.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "PROWESS"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Monk"
+                    ],
+                    "keywords": [
+                        "PROWESS"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/3/1/3142cb28-23cc-405f-9db5-7c4d168aab19.jpg?1783938663"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "rarity": "MYTHIC",
+        "artist": "Magali Villeneuve",
+        "flavorText": "\"Speak little. Do much.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/abcd0e32-2e6b-419b-9e8a-af38f2b48a66.jpg?1783938710",
+        "rulings": [
+            {
+                "date": "2014-11-24",
+                "text": "Casting a noncreature spell will cause both prowess and Monastery Mentor's other ability to trigger. You can put these abilities on the stack in either order. Whichever ability is put on the stack last will resolve first."
+            },
+            {
+                "date": "2014-11-24",
+                "text": "The spell that causes Monastery Mentor's second ability to trigger will not cause the prowess ability of the Monk token that's created to trigger."
+            },
+            {
+                "date": "2014-11-24",
+                "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Noxious Dragon
 {
     "name": "Noxious Dragon",

--- a/mtg-sets/src/test/resources/snapshots/cards/M11.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M11.json
@@ -366,6 +366,52 @@
     ]
 }
 
+// Inspired Charge
+{
+    "name": "Inspired Charge",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Creatures you control get +2/+1 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Wayne Reynolds",
+        "flavorText": "\"Impossible! How could they overwhelm us? We had barricades, war elephants, . . . and they were barely a tenth of our number!\"\n—General Avitora",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/98151986-90de-4f76-9abd-507039e7c9ad.jpg?1783941834",
+        "rulings": [
+            {
+                "date": "2016-09-20",
+                "text": "The set of creatures affected by Inspired Charge is determined as the spell resolves. Creatures you begin to control later in the turn and noncreature permanents that become creatures later in the turn won't get +2/+1."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Maritime Guard
 {
     "name": "Maritime Guard",

--- a/mtg-sets/src/test/resources/snapshots/cards/M15.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M15.json
@@ -134,6 +134,55 @@
     ]
 }
 
+// Stoke the Flames
+{
+    "name": "Stoke the Flames",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nStoke the Flames deals 4 damage to any target.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "any target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "any target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "rarity": "UNCOMMON",
+        "artist": "Ryan Barger",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/d/1d94c000-52e0-4215-83af-6351dc43e636.jpg?1783939169",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "Tapping an untapped creature that's attacking or blocking to convoke a spell won't cause that creature to stop attacking or blocking."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Triplicate Spirits
 {
     "name": "Triplicate Spirits",

--- a/mtg-sets/src/test/resources/snapshots/cards/MOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MOM.json
@@ -1,3 +1,314 @@
+// Aerial Boost
+{
+    "name": "Aerial Boost",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets +2/+2 and gains flying until end of turn.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "artist": "Artur Nakhodkin",
+        "flavorText": "\"Ha! You missed!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7017afb-4c7c-4c8d-9c9d-3f056a55561e.jpg?1783917072",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "Tapping an untapped creature that's attacking or blocking to convoke a spell won't cause that creature to stop attacking or blocking."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Akki Scrapchomper
+{
+    "name": "Akki Scrapchomper",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Phyrexian Goblin",
+    "oracleText": "{1}{R}, {T}, Sacrifice an artifact or land: Draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact|land"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "artist": "Wisnu Tan",
+        "flavorText": "The Furnace Host found great value in the chaotic ingenuity of Kamigawa's akki and allowed willing converts to \"experiment\" however they saw fit.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0e02737-0193-46e4-a506-cec86a44dc99.jpg?1783916998"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Alabaster Host Sanctifier
+{
+    "name": "Alabaster Host Sanctifier",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Phyrexian Cleric",
+    "oracleText": "Lifelink",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "4",
+        "artist": "Konstantin Porubov",
+        "flavorText": "\"Heliod shines his light on all things, excising the shadows of doubt. Rejoice, for beneath his purifying eyes, Theros is united as one!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/efbd934a-39c4-4ce7-af2a-34ca226d7f23.jpg?1783917073"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Artistic Refusal
+{
+    "name": "Artistic Refusal",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nChoose one or both —\n• Counter target spell.\n• Draw two cards, then discard a card.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": "Counter",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {},
+                                "zone": "Stack"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "description": "Draw two cards, then discard a card"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "UNCOMMON",
+        "artist": "Olivier Bernard",
+        "flavorText": "Errant wouldn't allow anything to stop her from decorating the streets of New Capenna.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2bd05f97-ef8b-4cbe-a44b-6501aa5895b0.jpg?1783917045",
+        "rulings": [
+            {
+                "date": "2023-04-14",
+                "text": "If you choose both modes, and the target of the first mode is an illegal target at the time Artistic Refusal tries to resolve (probably because that spell has been countered by something else), Artistic Refusal won't resolve and none of its effects will happen. You won't draw or discard any cards."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Astral Wingspan
+{
+    "name": "Astral Wingspan",
+    "manaCost": "{4}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nEnchant creature\nWhen this Aura enters, draw a card.\nEnchanted creature gets +2/+2 and has flying.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "rarity": "UNCOMMON",
+        "artist": "Joseph Weston",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/be2ef728-a2c7-45ee-8594-372ed135b482.jpg?1783917046",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Chrome Host Seedshark
 {
     "name": "Chrome Host Seedshark",
@@ -66,6 +377,145 @@
     ]
 }
 
+// Collective Nightmare
+{
+    "name": "Collective Nightmare",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets -3/-3 until end of turn.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": -3
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "rarity": "UNCOMMON",
+        "artist": "Rovina Cai",
+        "flavorText": "Night fell all at once. Specifically, on the Phyrexian.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/05864d3a-d8bb-4ddf-b721-883632050cb1.jpg?1783917017",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Coming In Hot
+{
+    "name": "Coming In Hot",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "artist": "Cristi Balanescu",
+        "flavorText": "\"I have a reckless idea,\" Koth offered. Chandra grinned and cracked her knuckles.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f6eb966-67af-4b18-8899-4a99a5179aa3.jpg?1783916993"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Copper Host Crusher
+{
+    "name": "Copper Host Crusher",
+    "manaCost": "{6}{G}{G}",
+    "typeLine": "Creature — Phyrexian Bear Rhino",
+    "oracleText": "Trample\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "keywords": [
+        "TRAMPLE",
+        "HEXPROOF"
+    ],
+    "metadata": {
+        "collectorNumber": "181",
+        "rarity": "UNCOMMON",
+        "artist": "Nicholas Gregory",
+        "flavorText": "Walls built to withstand assaults even from Ikoria's apex monsters were quickly deemed tactically irrelevant by Vorinclex's forces.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/af527344-9d88-4641-8f6d-0263a6797df3.jpg?1783916973"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Corrupted Conviction
 {
     "name": "Corrupted Conviction",
@@ -95,6 +545,55 @@
         "artist": "Joseph Weston",
         "flavorText": "\"For the good of all, those who stand against the harmony of Phyrexia must be cut down.\"\n—Ajani Goldmane",
         "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce133ad5-8748-4a3d-ae8c-7b2a5938927d.jpg?1682203658"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Deadly Derision
+{
+    "name": "Deadly Derision",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature or planeswalker. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or planeswalker"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target creature or planeswalker"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "artist": "Gaboleps",
+        "flavorText": "Daretti looked down disdainfully. \"You call yourself machines? Where's the elegance? Nothing but ugly piles of scrap.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1ec1a02f-128c-44aa-b708-6fcda34b40c0.jpg?1783917014",
+        "rulings": [
+            {
+                "date": "2023-04-14",
+                "text": "If the target of Deadly Derision is illegal as the spell tries to resolve, it won't resolve and none of its effects will happen. You won't create a Treasure token."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -163,6 +662,332 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Ephara's Dispersal
+{
+    "name": "Ephara's Dispersal",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {2} less to cast if it targets an attacking creature.\nReturn target creature to its owner's hand. Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "Surveil",
+                    "count": 2
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "FixedIfAnyTargetMatches",
+                        "amount": 2,
+                        "filter": "creature attacking"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "artist": "Awanqi (Angela Wang)",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0bcc71f-72ec-4a76-9393-ed3ea61eeeb6.jpg?1783917039",
+        "rulings": [
+            {
+                "date": "2023-04-14",
+                "text": "The cost reduction ability of Ephara's Dispersal doesn't affect its mana cost or mana value. It affects only the total cost you pay. Specifically, its mana value is always 3."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "You perform the actions stated on a card in sequence. For some spells and abilities, you'll surveil last. For others, you'll surveil and then perform other actions."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Furnace Host Charger
+{
+    "name": "Furnace Host Charger",
+    "manaCost": "{5}{R}",
+    "typeLine": "Creature — Phyrexian Giant",
+    "oracleText": "Haste\nMountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}",
+            "searchFilter": {
+                "cardPredicates": [
+                    {
+                        "type": "HasSubtype",
+                        "subtype": "Mountain"
+                    }
+                ]
+            },
+            "displayPrefix": "Mountaincycling"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "140",
+        "artist": "Andreas Zafiratos",
+        "flavorText": "With barely a moment's warning, a one-giant avalanche crashed into Kaldheim's defenders.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d142ded-a2df-41b0-9c02-056b5f34abab.jpg?1783916991"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Furtive Analyst
+{
+    "name": "Furtive Analyst",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Vigilance\n{2}, {T}: Draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "artist": "Marcela Bolívar",
+        "flavorText": "Where had she first seen that symbol? She usually took such detailed notes, but her memory of it was like a fading nightmare.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/98c55aff-baed-4fb5-a490-abd59b8df5e7.jpg?1783917037"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Halo Hopper
+{
+    "name": "Halo Hopper",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Frog",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "CONVOKE"
+    ],
+    "metadata": {
+        "collectorNumber": "260",
+        "artist": "Daniel Ljunggren",
+        "flavorText": "Folded by an imaginative child, animated by a mischievous kami, and blessed by an otherworldly angel.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e07baeb1-c873-42c2-8f1e-757f13572079.jpg?1783916937",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
+// Interdisciplinary Mascot
+{
+    "name": "Interdisciplinary Mascot",
+    "manaCost": "{6}{U}{U}",
+    "typeLine": "Creature — Elemental Fractal",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWard {3}\nWhen this creature enters, look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "CONVOKE",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{3}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Put on bottom"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "326",
+        "rarity": "RARE",
+        "artist": "Mathias Kollros",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0eecdd9a-6c3f-43ee-8d9c-e3466bd7bf5e.jpg?1783916905",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -348,6 +1173,870 @@
     ]
 }
 
+// Iridescent Blademaster
+{
+    "name": "Iridescent Blademaster",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "{3}{G}: This creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "artist": "Livia Prima",
+        "flavorText": "Her arm and spirit were weary, but as the Halo flowed across her blade, it became weightless, and new strength flooded through her. She would fight on.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3fee189f-539f-48fa-b217-4b2599375364.jpg?1783916966"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Kithkin Billyrider
+{
+    "name": "Kithkin Billyrider",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Kithkin Knight",
+    "oracleText": "Double strike",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "DOUBLE_STRIKE"
+    ],
+    "metadata": {
+        "collectorNumber": "24",
+        "artist": "Zara Alfonso",
+        "flavorText": "\"Brother, guide my right hand. Sister, my left. Rest well, my kin, but Lorwyn still needs me. I will not be joining you quite yet.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/0535b69f-247d-49c9-97e1-d988700578ab.jpg?1783917058"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Knight of the New Coalition
+{
+    "name": "Knight of the New Coalition",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Vigilance\nWhen this creature enters, create a 2/2 white and blue Knight creature token with vigilance.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE",
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Knight"
+                    ],
+                    "keywords": [
+                        "VIGILANCE"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/8/8/88439bfc-8942-473b-9e4f-863017788476.jpg?1783916669"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "artist": "Jake Murray",
+        "flavorText": "Raised in a long tradition of heroes, every Benalish knight knows the day might come when they will be called to face Phyrexia.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/56a3108b-c33d-47c5-984b-01fa257fbd79.jpg?1783917059"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Kor Halberd
+{
+    "name": "Kor Halberd",
+    "manaCost": "{W}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+1 and has vigilance.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "27",
+        "artist": "Bastien L. Deharme",
+        "flavorText": "An ancient weapon for a modern war.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a4705327-ada6-4575-82fc-351e183d060e.jpg?1783917057"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Meeting of Minds
+{
+    "name": "Meeting of Minds",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDraw two cards.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "artist": "Milivoj Ćeran",
+        "flavorText": "\"If something seems impossible, you probably haven't tried asking for help.\"\n—Niambi, cleric of Dominaria",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/508b8650-c283-4e54-abdc-32ec2fb1ee34.jpg?1783917031",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Nezumi Informant
+{
+    "name": "Nezumi Informant",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Rat Rogue",
+    "oracleText": "When this creature enters, each opponent discards a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "discarded"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "artist": "Steve Prescott",
+        "flavorText": "\"Tell Boss Umezawa there's a new gang moving in on our territory. I'm forwarding their insignia. Watch for it elsewhere.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e36fbff8-471e-4cf8-8946-e1e5cdf598af.jpg?1783917003",
+        "rulings": [
+            {
+                "date": "2023-04-14",
+                "text": "To resolve Nezumi Informant's ability in a multiplayer game, the next opponent in turn order (or, if it's an opponent's turn, the opponent whose turn it is) chooses a card in hand and sets it aside without revealing it. Then each other opponent in turn order does the same. Finally, all chosen cards are revealed and discarded at the same time."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Pile On
+{
+    "name": "Pile On",
+    "manaCost": "{3}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy target creature or planeswalker. Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or planeswalker"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "Surveil",
+                    "count": 2
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target creature or planeswalker"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "rarity": "RARE",
+        "artist": "Javier Charro",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/492e9369-0ca3-4c31-b747-75d615daf6e4.jpg?1783917002",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "You perform the actions stated on a card in sequence. For some spells and abilities, you'll surveil last. For others, you'll surveil and then perform other actions."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Preening Champion
+{
+    "name": "Preening Champion",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Bird Knight",
+    "oracleText": "Flying\nWhen this creature enters, create a 1/1 blue and red Elemental creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLUE",
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Elemental"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/2/8/28a7a9b0-d823-4b34-829f-ade81fc141e0.jpg?1783916668"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "artist": "Alix Branwyn",
+        "flavorText": "On Kylem, the omens of impending invasion went largely unnoticed, drowned out by the everyday fanfare of Valor's Reach.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/44178ece-af31-4a94-88bc-c9ce43bb4573.jpg?1783917028"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Ral's Reinforcements
+{
+    "name": "Ral's Reinforcements",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create two 1/1 blue and red Elemental creature tokens.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "BLUE",
+                "RED"
+            ],
+            "creatureTypes": [
+                "Elemental"
+            ],
+            "imageUri": "https://cards.scryfall.io/normal/front/2/8/28a7a9b0-d823-4b34-829f-ade81fc141e0.jpg?1783916668"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "artist": "Nils Hamm",
+        "flavorText": "\"Good thing maintenance never got around to decatalyzing the bithermic plasma displacement conduits!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/74d0bb76-075c-49d7-9afb-e5bcf5b654f7.jpg?1783916984"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ramosian Greatsword
+{
+    "name": "Ramosian Greatsword",
+    "manaCost": "{4}{R}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nEquipped creature gets +3/+1 and has trample.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "159",
+        "rarity": "UNCOMMON",
+        "artist": "Jason A. Engle",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/efd6f04e-e83d-4580-ae3f-583ada848868.jpg?1783916985",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ravenous Sailback
+{
+    "name": "Ravenous Sailback",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "When this creature enters, choose one —\n• This creature gains haste until end of turn.\n• Destroy target artifact or enchantment.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": "Self"
+                            },
+                            "description": "This creature gains haste until end of turn."
+                        },
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "artifact|enchantment"
+                                    }
+                                }
+                            ],
+                            "description": "Destroy target artifact or enchantment."
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "202",
+        "rarity": "UNCOMMON",
+        "artist": "Andrew Mar",
+        "flavorText": "Converter beasts were sent to ensnare as many of Ixalan's dinosaurs as possible. Many of them were converted themselves—into snacks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a225cb30-9f3e-4cfa-bdd6-a7c73c95ea2b.jpg?1783916962"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Referee Squad
+{
+    "name": "Referee Squad",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Homunculus",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nVigilance\nWhen this creature enters, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "CONVOKE",
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature an opponent controls"
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "stun",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature an opponent controls"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target creature an opponent controls"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "327",
+        "rarity": "UNCOMMON",
+        "artist": "Steven Belledin",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/434515bf-de57-4c00-b0b4-c9579cc1b84c.jpg?1783916905",
+        "rulings": [
+            {
+                "date": "2023-04-14",
+                "text": "Referee Squad's enters-the-battlefield ability can target a creature that's already tapped."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Ruins Recluse
+{
+    "name": "Ruins Recluse",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Reach, deathtouch\n{3}{G}: Put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "REACH",
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "336",
+        "rarity": "UNCOMMON",
+        "artist": "Lorenzo Mastroianni",
+        "flavorText": "Desert horrors were its favorite treat, but it happily expanded its diet to include extraplanar horrors.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c0c0fdf5-2f56-4480-9ccb-84471b3e5331.jpg?1783916899"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Shivan Branch-Burner
+{
+    "name": "Shivan Branch-Burner",
+    "manaCost": "{5}{R}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying, haste",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "CONVOKE",
+        "FLYING",
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "UNCOMMON",
+        "artist": "Aaron Miller",
+        "flavorText": "The New Coalition gave Shiv time to prepare a warm welcome for the invaders.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e585631c-bd41-4b48-aac4-4b6f5636ecd5.jpg?1783916980",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Thunderhead Squadron
+{
+    "name": "Thunderhead Squadron",
+    "manaCost": "{5}{U}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "CONVOKE",
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "81",
+        "artist": "PINDURSKI",
+        "flavorText": "Just as all seemed lost, the griffin riders of Zhalfir arrived with the force of a gathered storm.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8eaa0946-591f-4136-9d8a-e56934151383.jpg?1783917023",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Timberland Ancient
+{
+    "name": "Timberland Ancient",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Treefolk",
+    "oracleText": "Reach, trample\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywords": [
+        "REACH",
+        "TRAMPLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}",
+            "searchFilter": {
+                "cardPredicates": [
+                    {
+                        "type": "HasSubtype",
+                        "subtype": "Forest"
+                    }
+                ]
+            },
+            "displayPrefix": "Forestcycling"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "210",
+        "artist": "Pavel Kolomeyets",
+        "flavorText": "Only the trees were old enough to remember what happened when Moag ignored warnings of Phyrexia millennia ago. They were determined not to repeat the mistake.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f73cd60-cd89-4c7a-85a6-e0ae34ca101b.jpg?1783916960"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Urn of Godfire
+{
+    "name": "Urn of Godfire",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}: Add one mana of any color.\n{6}, {T}, Sacrifice this artifact: Destroy target creature or enchantment.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or enchantment"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature|enchantment"
+                        },
+                        "id": "target creature or enchantment"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "266",
+        "artist": "Ovidio Cartagena",
+        "flavorText": "Ephara blessed the defenders of Theros with godfire, a Nyx-infused incendiary substance that burned without fuel.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff5f302e-d884-4995-ba3c-8c22f9045318.jpg?1783916934"
+    },
+    "colorIdentityOverride": []
+}
+
 // Wary Thespian
 {
     "name": "Wary Thespian",
@@ -396,6 +2085,68 @@
     ]
 }
 
+// Wrenn's Resolve
+{
+    "name": "Wrenn's Resolve",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "storeAs": "impulseExiled"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "impulseExiled",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Exile"
+                    }
+                },
+                {
+                    "type": "GrantMayPlayFromExile",
+                    "from": "impulseExiled",
+                    "expiry": {
+                        "type": "UntilControllerStep",
+                        "step": "CLEANUP",
+                        "includeCurrentTurn": false
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "artist": "Viko Menezes",
+        "flavorText": "Even as she burned, Wrenn bent Realmbreaker to her will.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9a47999c-12d5-4e1a-a9c1-40a1757007f1.jpg?1783916978",
+        "rulings": [
+            {
+                "date": "2023-04-14",
+                "text": "The cards you play from exile follow the usual timing restrictions, and you must pay any costs for spells you cast."
+            },
+            {
+                "date": "2023-04-14",
+                "text": "Any cards you don't play will remain in exile."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Yargle and Multani
 {
     "name": "Yargle and Multani",
@@ -415,5 +2166,62 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Zhalfirin Lancer
+{
+    "name": "Zhalfirin Lancer",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Whenever another Knight you control enters, this creature gets +1/+1 and gains vigilance until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Knight ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "rarity": "UNCOMMON",
+        "artist": "Nino Vecia",
+        "flavorText": "The Phyrexians armored themselves against blades, fire, and every conjuration they could think of. She brought a war rhino.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/277e5b49-c53f-4bf7-aac0-950d8708b957.jpg?1783917048"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/XLN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/XLN.json
@@ -1711,3 +1711,40 @@
         "imageUri": "https://cards.scryfall.io/normal/front/c/0/c0f9c733-0818-4a03-8f0c-a163d09e0fff.jpg?1783935704"
     }
 }
+
+// Vanquish the Weak
+{
+    "name": "Vanquish the Weak",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature with power 3 or less.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature with power 3 or less"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature pow<=3"
+                },
+                "id": "target creature with power 3 or less"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "artist": "David Palumbo",
+        "flavorText": "The clerics known as condemners punish those who do not recognize the righteous authority of the church.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e599ed0b-4b3b-4341-b6ac-7fdfdc6799a3.jpg?1783935752"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}


### PR DESCRIPTION
Every card March of the Machine has that Argentum Assay reads whole and the corpus was missing — 43 of them, taking MOM from 20/281 to 60/281 (7% → 21%), plus 3/15 on the extras.

**Scope.** Assay verdict `whole` (`coverage/assay-verdicts.json`) ∩ not yet implemented in MOM = 43 names. They split three ways, and the split is most of the work:

- **33 authored here**, canonical printing is MOM itself.
- **5 already have a canonical elsewhere, or belong there** — Kitesail's canonical is Worldwake and MOM just needed the row; Inspired Charge, Monastery Mentor, Stoke the Flames and Vanquish the Weak had no canonical anywhere, so each was authored in its *earliest real-expansion printing* (M11, FRF, M15, XLN — all already scaffolded) with a `Printing(...)` row in MOM.
- **5 basic lands** → 15 `basicLand(...)` variants in MOM's own `cards/` package plus the `basicLands` override on the set object. Not `Printing` rows.

Everything composes existing `Effects.*` / `Patterns.*` / `Filters.*` — **no new SDK vocabulary**, so no card left the batch.

### Cards

| Card | What it does | Composed from |
|---|---|---|
| Aerial Boost | convoke; +2/+2 and flying | `ModifyStats` + `GrantKeyword` |
| Akki Scrapchomper | `{1}{R}`, `{T}`, sac an artifact or land: draw | `Costs.Composite` + `Costs.Sacrifice(ArtifactOrLand)` |
| Alabaster Host Sanctifier | lifelink | keyword only |
| Artistic Refusal | convoke; choose one or both — counter / draw 2 discard 1 | `modal(chooseCount = 2, minChooseCount = 1)` |
| Astral Wingspan | convoke Aura; ETB draw; +2/+2 and flying | `auraTarget` + `ModifyStats` + `GrantKeyword` |
| Collective Nightmare | convoke; −3/−3 | `ModifyStats` |
| Coming In Hot | +1/+0, first strike, scry 1 | `ModifyStats` + `GrantKeyword` + `Patterns.Library.scry` |
| Copper Host Crusher | trample, hexproof | keywords only |
| Deadly Derision | destroy creature or planeswalker, Treasure | `Destroy` + `CreateTreasure` |
| Ephara's Dispersal | costs `{2}` less if it targets an attacking creature; bounce + surveil 2 | `ModifySpellCost` + `CostReductionSource.FixedIfAnyTargetMatches` |
| Furnace Host Charger | haste, Mountaincycling `{2}` | `KeywordAbility.typecycling` |
| Furtive Analyst | vigilance; `{2}`, `{T}`: loot | `Costs.Composite` |
| Halo Hopper | convoke vanilla artifact creature | keyword only |
| Interdisciplinary Mascot | convoke, ward `{3}`; look at 4, keep 1, rest on bottom at random | `Patterns.Library.lookAtTopAndKeep(restOrder = CardOrder.Random)` |
| Iridescent Blademaster | `{3}{G}`: +2/+2 | `ModifyStats(EffectTarget.Self)` |
| Kithkin Billyrider | double strike | keyword only |
| Knight of the New Coalition | vigilance; ETB 2/2 W/U Knight token | `CreateToken` |
| Kor Halberd | +1/+1 and vigilance; equip `{1}` | `ModifyStats(EquippedCreature)` + `equipAbility` |
| Meeting of Minds | convoke; draw 2 | `DrawCards` |
| Nezumi Informant | ETB each opponent discards | `Patterns.Hand.eachOpponentDiscards` |
| Pile On | convoke; destroy creature or planeswalker, surveil 2 | `Destroy` + `Patterns.Library.surveil` |
| Preening Champion | flying; ETB 1/1 U/R Elemental | `CreateToken` |
| Ral's Reinforcements | two 1/1 U/R Elementals | `CreateToken(count = 2)` |
| Ramosian Greatsword | convoke Equipment; +3/+1 and trample, equip `{2}` | `ModifyStats` + `GrantKeyword` + `equipAbility` |
| Ravenous Sailback | ETB choose one — haste / destroy artifact or enchantment | `ModalEffect` inside a triggered ability |
| Referee Squad | convoke, vigilance; ETB tap + stun counter | `Tap` + `AddCounters(Counters.STUN)` |
| Ruins Recluse | reach, deathtouch; `{3}{G}`: +1/+1 counter | `AddCounters` |
| Shivan Branch-Burner | convoke; flying, haste | keywords only |
| Thunderhead Squadron | convoke; flying | keywords only |
| Timberland Ancient | reach, trample, Forestcycling `{2}` | `KeywordAbility.typecycling` |
| Urn of Godfire | `{2}`: any-color mana; `{6}`, `{T}`, sac: destroy creature or enchantment | `AddAnyColorMana` (`manaAbility`) + `Costs.SacrificeSelf` |
| Wrenn's Resolve | impulse 2 until end of your next turn | `Patterns.Exile.impulse(2, MayPlayExpiry.UntilEndOfNextTurn)` |
| Zhalfirin Lancer | whenever another Knight you control enters, +1/+1 and vigilance | `entersBattlefield(Permanent.withSubtype(KNIGHT), OTHER)` |
| **Inspired Charge** (M11) | creatures you control get +2/+1 | `Patterns.Group.modifyStatsForAll` |
| **Monastery Mentor** (FRF) | prowess; noncreature spell → 1/1 Monk with prowess | `prowess()` + `Triggers.YouCastNoncreature` + `CreateToken` |
| **Stoke the Flames** (M15) | convoke; 4 damage to any target | `DealDamage` |
| **Vanquish the Weak** (XLN) | destroy creature with power 3 or less | `Targets.CreatureWithPowerAtMost(3)` |

Two readings worth calling out:

- **Zhalfirin Lancer** — "another **Knight** you control" is a bare tribal noun, so it names every *permanent* with the subtype, not only creatures: `GameObjectFilter.Permanent.withSubtype(KNIGHT)`.
- **Ravenous Sailback** — `TriggeredAbilityBuilder` has no `modal { }` shorthand, so the modal ETB is a `ModalEffect` written out directly.

Every convoke, ward and typecycling keyword was checked against `rules-engine` before authoring — all three have live read paths (`AlternativePaymentHandler` / `CastSpellEnumerator`, `StateProjector` + `TriggerAbilityResolver`, `CyclingEnumerator` + `TypecycleCardHandler`), none is display-only.

### Verification

- `just build` — green.
- `just rebless-cards` — MOM, FRF, M11, M15 and XLN goldens moved; a before/after diff of the goldens confirms **33 / 1 / 1 / 1 / 1 cards added and zero existing cards changed or removed**.
- `just assay-differential` — **3,080 compared, 13 divergent**, and all 13 are the pre-existing set (Pearl of Wisdom, Ghalta, Wizard's Lightning/Retort, Mistmeadow Council, Arcane Epiphany, Goblin/Krosan Warchief, Grow Extra Arms, Tombstone, Venom's Hunger, Dragon's Prey, Bolt Bend). **Zero new divergences** — Assay's independent reading of all 37 new cards agrees with what was written, in `spellEffect`, `targetRequirements`, `staticAbilities`, `keywords` and the rest.
- `just check-card-printing` — clean for 35 of the 38 touched cards.

### Known, out of scope

`check-card-printing` flags three cards for **missing `Printing(...)` rows in *other* already-scaffolded sets** — Inspired Charge (m15, bfz, kld, m19, m20, jmp), Vanquish the Weak (znr), Kitesail (m13). These are real but belong to those sets, not to this change; the gate could not even see them before, because it exited "card not implemented". MOM's own rows are correct for all three.

No scenario tests: every card is built purely from existing primitives, which `CONTRIBUTING.md` covers by the snapshot and lint nets — and the differential gate is the stronger check here, since it re-derives each card from its Oracle text independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
