### PR TITLE
Add every Assay-ready card in Phyrexia: All Will Be One

### DIFF
--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/PhyrexiaAllWillBeOneSet.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/PhyrexiaAllWillBeOneSet.kt
@@ -26,5 +26,9 @@ object PhyrexiaAllWillBeOneSet : MtgSet {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.one.cards"
 }

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/BasilicaSkullbomb.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/BasilicaSkullbomb.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Basilica Skullbomb
+ * {1}
+ * Artifact
+ *
+ * {1}, Sacrifice this artifact: Draw a card.
+ * {2}{W}, Sacrifice this artifact: Target creature you control gets +2/+2 and gains flying until end of turn. Draw a card. Activate only as a sorcery.
+ */
+val BasilicaSkullbomb = card("Basilica Skullbomb") {
+    manaCost = "{1}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "{1}, Sacrifice this artifact: Draw a card.\n" +
+        "{2}{W}, Sacrifice this artifact: Target creature you control gets +2/+2 and gains flying until end of turn. Draw a card. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{W}"), Costs.SacrificeSelf)
+        target = Targets.CreatureYouControl
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2, EffectTarget.ContextTarget(0)),
+            Effects.GrantKeyword(Keyword.FLYING, EffectTarget.ContextTarget(0)),
+            Effects.DrawCards(1)
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "224"
+        artist = "Gaboleps"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e2f0ae2-db68-4338-93f9-9d9268cec41e.jpg?1783917994"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/BiliousSkulldweller.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/BiliousSkulldweller.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Bilious Skulldweller
+ * {B}
+ * Creature — Phyrexian Insect
+ * 1/1
+ *
+ * Deathtouch
+ * Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)
+ */
+val BiliousSkulldweller = card("Bilious Skulldweller") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Insect"
+    power = 1
+    toughness = 1
+    oracleText = "Deathtouch\n" +
+        "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)"
+
+    keywords(Keyword.DEATHTOUCH)
+    keywordAbility(KeywordAbility.Numeric(Keyword.TOXIC, 1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "83"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/dfb81cb1-ac56-4803-a962-359854a447df.jpg?1783918051"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/BranchblightStalker.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/BranchblightStalker.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Branchblight Stalker
+ * {1}{G}
+ * Creature — Phyrexian Elf Scout
+ * 3/1
+ *
+ * Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)
+ */
+val BranchblightStalker = card("Branchblight Stalker") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Phyrexian Elf Scout"
+    power = 3
+    toughness = 1
+    oracleText = "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)"
+
+    keywordAbility(KeywordAbility.Numeric(Keyword.TOXIC, 2))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "160"
+        artist = "Krharts"
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e5290a4c-1f98-4e97-a407-f951e386b8b0.jpg?1783918019"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/CephalopodSentry.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/CephalopodSentry.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Cephalopod Sentry
+ * {2}{W}{U}
+ * Artifact Creature — Phyrexian Squid
+ * * / 5
+ *
+ * Flying
+ * Cephalopod Sentry's power is equal to the number of artifacts you control.
+ *
+ * The printed `*` power is a characteristic-defining ability: [dynamicPower] over
+ * [DynamicAmount.AggregateBattlefield] counting your artifacts, with no `power =` set. The
+ * Sentry counts itself — it is an artifact — so it is never smaller than 1/5 on the battlefield.
+ */
+val CephalopodSentry = card("Cephalopod Sentry") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Artifact Creature — Phyrexian Squid"
+    toughness = 5
+    oracleText = "Flying\n" +
+        "Cephalopod Sentry's power is equal to the number of artifacts you control."
+
+    keywords(Keyword.FLYING)
+    dynamicPower(DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Artifact))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "198"
+        artist = "Mathias Kollros"
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/30c22eb9-5056-4c0b-a5d8-41e09161eb40.jpg?1783918004"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/ChromeProwler.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/ChromeProwler.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chrome Prowler
+ * {2}{U}
+ * Artifact Creature — Phyrexian Cat
+ * 3/2
+ *
+ * Flash
+ * When this creature enters, tap target creature an opponent controls.
+ */
+val ChromeProwler = card("Chrome Prowler") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Phyrexian Cat"
+    power = 3
+    toughness = 2
+    oracleText = "Flash\n" +
+        "When this creature enters, tap target creature an opponent controls."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "45"
+        artist = "Maxime Minard"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a94378a2-cbde-4adf-b889-43e90fc6ba28.jpg?1783918069"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/DrossSkullbomb.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/DrossSkullbomb.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dross Skullbomb
+ * {1}
+ * Artifact
+ *
+ * {1}, Sacrifice this artifact: Draw a card.
+ * {2}{B}, Sacrifice this artifact: Return target creature card from your graveyard to your hand. Draw a card. Activate only as a sorcery.
+ */
+val DrossSkullbomb = card("Dross Skullbomb") {
+    manaCost = "{1}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "{1}, Sacrifice this artifact: Draw a card.\n" +
+        "{2}{B}, Sacrifice this artifact: Return target creature card from your graveyard to your hand. Draw a card. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}"), Costs.SacrificeSelf)
+        target = Targets.CreatureCardInYourGraveyard
+        effect = Effects.Composite(
+            Effects.ReturnToHand(EffectTarget.ContextTarget(0)),
+            Effects.DrawCards(1)
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "225"
+        artist = "Gaboleps"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/66270dd2-9139-4329-9621-852962836688.jpg?1783917994"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/DuneMover.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/DuneMover.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Dune Mover
+ * {2}
+ * Artifact Creature — Phyrexian Golem
+ * 2/1
+ *
+ * Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)
+ * When this creature enters, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.
+ */
+val DuneMover = card("Dune Mover") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Phyrexian Golem"
+    power = 2
+    toughness = 1
+    oracleText = "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\n" +
+        "When this creature enters, you may search your library for a basic land card, reveal it, then shuffle and put that card on top."
+
+    keywordAbility(KeywordAbility.Numeric(Keyword.TOXIC, 1))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            destination = SearchDestination.TOP_OF_LIBRARY,
+            reveal = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "226"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/29d2c689-af37-433a-a012-e8d384702811.jpg?1783917993"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/IchorspitBasilisk.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/IchorspitBasilisk.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Ichorspit Basilisk
+ * {2}{G}
+ * Creature — Phyrexian Basilisk
+ * 1/3
+ *
+ * Deathtouch
+ * Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)
+ */
+val IchorspitBasilisk = card("Ichorspit Basilisk") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Phyrexian Basilisk"
+    power = 1
+    toughness = 3
+    oracleText = "Deathtouch\n" +
+        "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)"
+
+    keywords(Keyword.DEATHTOUCH)
+    keywordAbility(KeywordAbility.Numeric(Keyword.TOXIC, 1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "170"
+        artist = "Joe Slucher"
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/0955b64f-6721-4fa6-b161-cae404cb5b9f.jpg?1783918014"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/JawboneDuelist.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/JawboneDuelist.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Jawbone Duelist
+ * {1}{W}
+ * Creature — Phyrexian Soldier
+ * 1/1
+ *
+ * Double strike
+ * Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)
+ */
+val JawboneDuelist = card("Jawbone Duelist") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Phyrexian Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "Double strike\n" +
+        "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)"
+
+    keywords(Keyword.DOUBLE_STRIKE)
+    keywordAbility(KeywordAbility.Numeric(Keyword.TOXIC, 1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "18"
+        artist = "Nino Vecia"
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b00ea7bb-705b-4669-bb2a-560bed04b14a.jpg?1783918078"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/MalcatorsWatcher.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/MalcatorsWatcher.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Malcator's Watcher
+ * {1}{U}
+ * Artifact Creature — Phyrexian Drone
+ * 1/1
+ *
+ * Flying, vigilance
+ * When this creature dies, draw a card.
+ */
+val MalcatorsWatcher = card("Malcator's Watcher") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Phyrexian Drone"
+    power = 1
+    toughness = 1
+    oracleText = "Flying, vigilance\n" +
+        "When this creature dies, draw a card."
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "58"
+        artist = "Jason A. Engle"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/95a7e5ff-ba81-4b45-933e-0ac747525ab8.jpg?1783918062"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/MandibleJusticiar.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/MandibleJusticiar.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mandible Justiciar
+ * {1}{W}
+ * Artifact Creature — Phyrexian Cleric
+ * 2/1
+ *
+ * Lifelink
+ * Whenever another artifact you control enters, this creature gets +1/+1 until end of turn.
+ *
+ * The word "another" is [TriggerBinding.OTHER]: the Justiciar entering does not pump itself.
+ */
+val MandibleJusticiar = card("Mandible Justiciar") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Phyrexian Cleric"
+    power = 2
+    toughness = 1
+    oracleText = "Lifelink\n" +
+        "Whenever another artifact you control enters, this creature gets +1/+1 until end of turn."
+
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact.youControl(),
+            binding = TriggerBinding.OTHER,
+        )
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "21"
+        artist = "Mike Franchina"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/544a707d-4090-4a74-91aa-60fbd8a4ae96.jpg?1783918079"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/MazeSkullbomb.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/MazeSkullbomb.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Maze Skullbomb
+ * {1}
+ * Artifact
+ *
+ * {1}, Sacrifice this artifact: Draw a card.
+ * {2}{G}, Sacrifice this artifact: Target creature you control gets +3/+3 and gains trample until end of turn. Draw a card. Activate only as a sorcery.
+ */
+val MazeSkullbomb = card("Maze Skullbomb") {
+    manaCost = "{1}"
+    colorIdentity = "G"
+    typeLine = "Artifact"
+    oracleText = "{1}, Sacrifice this artifact: Draw a card.\n" +
+        "{2}{G}, Sacrifice this artifact: Target creature you control gets +3/+3 and gains trample until end of turn. Draw a card. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{G}"), Costs.SacrificeSelf)
+        target = Targets.CreatureYouControl
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 3, EffectTarget.ContextTarget(0)),
+            Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.ContextTarget(0)),
+            Effects.DrawCards(1)
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "231"
+        artist = "Matt Forsyth"
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/1073aee2-aea6-473d-97c6-248778d79d80.jpg?1783917990"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/MyrConvert.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/MyrConvert.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Myr Convert
+ * {2}
+ * Artifact Creature — Phyrexian Myr
+ * 2/1
+ *
+ * Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)
+ * {T}, Pay 2 life: Add one mana of any color.
+ *
+ * The mana ability is Phyrexian Lens' shape with a bigger life payment: a composite
+ * [Costs.Tap] + [Costs.PayLife] cost feeding [Effects.AddAnyColorMana], flagged as a mana
+ * ability so it never uses the stack (CR 605.1a).
+ */
+val MyrConvert = card("Myr Convert") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Phyrexian Myr"
+    power = 2
+    toughness = 1
+    oracleText = "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\n" +
+        "{T}, Pay 2 life: Add one mana of any color."
+
+    keywordAbility(KeywordAbility.Numeric(Keyword.TOXIC, 1))
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(2))
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "234"
+        artist = "José Parodi"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9df0adcf-7ad0-4d70-8dcd-28f69471495b.jpg?1783917989"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/MyrKinsmith.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/MyrKinsmith.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Myr Kinsmith
+ * {4}
+ * Artifact Creature — Myr
+ * 3/1
+ *
+ * When this creature enters, you may search your library for a Myr card, reveal it, put it into your hand, then shuffle.
+ */
+val MyrKinsmith = card("Myr Kinsmith") {
+    manaCost = "{4}"
+    typeLine = "Artifact Creature — Myr"
+    power = 3
+    toughness = 1
+    oracleText = "When this creature enters, you may search your library for a Myr card, reveal it, put it into your hand, then shuffle."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype("Myr"),
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "236"
+        artist = "Cristi Balanescu"
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/6046e50a-f4c9-4029-a589-62a19371b734.jpg?1783917989"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/OrthodoxyEnforcer.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/OrthodoxyEnforcer.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Orthodoxy Enforcer
+ * {3}{W}
+ * Creature — Phyrexian Cleric
+ * 2/4
+ *
+ * Vigilance
+ * This creature gets +2/+0 as long as you control two or more artifacts.
+ *
+ * The conditional buff is a continuous static modification gated by
+ * [Conditions.YouControlAtLeast] over the artifact filter, recomputed at projection.
+ */
+val OrthodoxyEnforcer = card("Orthodoxy Enforcer") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Phyrexian Cleric"
+    power = 2
+    toughness = 4
+    oracleText = "Vigilance\n" +
+        "This creature gets +2/+0 as long as you control two or more artifacts."
+
+    keywords(Keyword.VIGILANCE)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 2, toughnessBonus = 0, filter = GroupFilter.source()),
+            condition = Conditions.YouControlAtLeast(2, GameObjectFilter.Artifact),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "Xavier Ribeiro"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8c938a0f-531c-4293-a89c-c7440d5acc5d.jpg?1783918076"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/PaladinOfPredation.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/PaladinOfPredation.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Paladin of Predation
+ * {5}{G}{G}
+ * Creature — Phyrexian Knight
+ * 6/7
+ *
+ * Toxic 6 (Players dealt combat damage by this creature also get six poison counters.)
+ * This creature can't be blocked by creatures with power 2 or less.
+ *
+ * Toxic must be a [KeywordAbility.Numeric] — the projector only emits the numbered toxic marker
+ * from the numeric form.
+ */
+val PaladinOfPredation = card("Paladin of Predation") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Phyrexian Knight"
+    power = 6
+    toughness = 7
+    oracleText = "Toxic 6 (Players dealt combat damage by this creature also get six poison counters.)\n" +
+        "This creature can't be blocked by creatures with power 2 or less."
+
+    keywordAbility(KeywordAbility.Numeric(Keyword.TOXIC, 6))
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.powerAtMost(2))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "178"
+        artist = "Lorenzo Mastroianni"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/758dbe61-6dc7-4b08-bdd6-7262257955fc.jpg?1783918012"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/PestilentSyphoner.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/PestilentSyphoner.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Pestilent Syphoner
+ * {1}{B}
+ * Creature — Phyrexian Insect
+ * 1/1
+ *
+ * Flying
+ * Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)
+ */
+val PestilentSyphoner = card("Pestilent Syphoner") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Insect"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)"
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.Numeric(Keyword.TOXIC, 1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/947a1e44-3485-4e24-a34d-6c318584743c.jpg?1783918043"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/PhyrexiaAllWillBeOneBasicLands.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/PhyrexiaAllWillBeOneBasicLands.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Phyrexia: All Will Be One Basic Lands
+ *
+ * ONE prints two booster basics per type — the standard art (262-266) and Mark Riddick's
+ * "compleated" art (267-271) — plus one non-booster full-art variant per type (272-276).
+ * The non-booster variants are kept defined for collection/display but excluded from the
+ * draft/sealed basic pool.
+ */
+
+// =============================================================================
+// Plains (Cards 262, 267, 272)
+// =============================================================================
+
+val OnePlains262 = basicLand("Plains") {
+    collectorNumber = "262"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/50958c6e-9555-42ad-9bb3-2da9faa5cb52.jpg?1783917978"
+}
+
+val OnePlains267 = basicLand("Plains") {
+    collectorNumber = "267"
+    artist = "Mark Riddick"
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/36ccde39-98bd-4a67-bfcf-a66d9fbd9417.jpg?1783917976"
+}
+
+val OnePlains272 = basicLand("Plains") {
+    collectorNumber = "272"
+    artist = "Sergey Glushakov"
+    imageUri = "https://cards.scryfall.io/normal/front/d/b/db14da86-6721-4e22-9b61-4a5680d4e5a3.jpg?1783917975"
+    inBooster = false
+}
+
+// =============================================================================
+// Island (Cards 263, 268, 273)
+// =============================================================================
+
+val OneIsland263 = basicLand("Island") {
+    collectorNumber = "263"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/5/c/5c6322d4-52bf-471a-a5b2-8329ef4be39a.jpg?1783917977"
+}
+
+val OneIsland268 = basicLand("Island") {
+    collectorNumber = "268"
+    artist = "Mark Riddick"
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/ac97baa8-5e57-45b6-9c64-cb9ce4806294.jpg?1783917975"
+}
+
+val OneIsland273 = basicLand("Island") {
+    collectorNumber = "273"
+    artist = "David Álvarez"
+    imageUri = "https://cards.scryfall.io/normal/front/f/a/fa641d46-d002-4903-af72-e96971f558bc.jpg?1783917974"
+    inBooster = false
+}
+
+// =============================================================================
+// Swamp (Cards 264, 269, 274)
+// =============================================================================
+
+val OneSwamp264 = basicLand("Swamp") {
+    collectorNumber = "264"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/7/3/736a0484-e091-4178-92c5-c517b0e92f3d.jpg?1783917977"
+}
+
+val OneSwamp269 = basicLand("Swamp") {
+    collectorNumber = "269"
+    artist = "Mark Riddick"
+    imageUri = "https://cards.scryfall.io/normal/front/1/8/187e9fa1-6a50-4697-8645-fea4524e8dde.jpg?1783917974"
+}
+
+val OneSwamp274 = basicLand("Swamp") {
+    collectorNumber = "274"
+    artist = "Julian Kok Joon Wen"
+    imageUri = "https://cards.scryfall.io/normal/front/d/4/d485c620-f1fb-4715-b7c5-d2d56588308d.jpg?1783917973"
+    inBooster = false
+}
+
+// =============================================================================
+// Mountain (Cards 265, 270, 275)
+// =============================================================================
+
+val OneMountain265 = basicLand("Mountain") {
+    collectorNumber = "265"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6d9e44c1-7b51-47cb-b564-608deb46cc44.jpg?1783917976"
+}
+
+val OneMountain270 = basicLand("Mountain") {
+    collectorNumber = "270"
+    artist = "Mark Riddick"
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/55c61b29-797f-4fda-acf1-039a807954c9.jpg?1783917974"
+}
+
+val OneMountain275 = basicLand("Mountain") {
+    collectorNumber = "275"
+    artist = "Muhammad Firdaus"
+    imageUri = "https://cards.scryfall.io/normal/front/c/d/cd95f833-27ce-447c-b505-02137daaba4c.jpg?1783917973"
+    inBooster = false
+}
+
+// =============================================================================
+// Forest (Cards 266, 271, 276)
+// =============================================================================
+
+val OneForest266 = basicLand("Forest") {
+    collectorNumber = "266"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/4/f/4fce7045-4572-4e9e-8853-2a5dcfc989ac.jpg?1783917975"
+}
+
+val OneForest271 = basicLand("Forest") {
+    collectorNumber = "271"
+    artist = "Mark Riddick"
+    imageUri = "https://cards.scryfall.io/normal/front/b/6/b6ec4ded-7c8d-416a-9a12-3e5d6c91ac93.jpg?1783917973"
+}
+
+val OneForest276 = basicLand("Forest") {
+    collectorNumber = "276"
+    artist = "Nadia Hurianova"
+    imageUri = "https://cards.scryfall.io/normal/front/9/f/9f9e911e-7e12-4d99-806c-5cfba19ea8f3.jpg?1783917974"
+    inBooster = false
+}
+
+/**
+ * All Phyrexia: All Will Be One basic land variants.
+ */
+val PhyrexiaAllWillBeOneBasicLands = listOf(
+    OnePlains262, OnePlains267, OnePlains272,
+    OneIsland263, OneIsland268, OneIsland273,
+    OneSwamp264, OneSwamp269, OneSwamp274,
+    OneMountain265, OneMountain270, OneMountain275,
+    OneForest266, OneForest271, OneForest276,
+)

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/PlatedOnslaught.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/PlatedOnslaught.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Plated Onslaught
+ * {3}{W}{W}
+ * Instant
+ *
+ * Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ * Creatures you control get +2/+1 until end of turn.
+ *
+ * Affinity is [KeywordAbility.Affinity] — its own cost-calculator branch, not a `ModifySpellCost`.
+ * The pump is a mass, non-targeted group effect over every creature you control.
+ */
+val PlatedOnslaught = card("Plated Onslaught") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n" +
+        "Creatures you control get +2/+1 until end of turn."
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+
+    spell {
+        effect = Patterns.Group.modifyStatsForAll(
+            power = 2,
+            toughness = 1,
+            filter = GroupFilter.AllCreaturesYouControl,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "29"
+        artist = "David Auden Nash"
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/472a635a-a581-4c00-89d6-464f30887944.jpg?1783918075"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/QuicksilverFisher.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/QuicksilverFisher.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Quicksilver Fisher
+ * {3}{U}{U}
+ * Creature — Phyrexian Drake
+ * 4/3
+ *
+ * Flying
+ * When this creature enters, draw a card, then discard a card.
+ */
+val QuicksilverFisher = card("Quicksilver Fisher") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Phyrexian Drake"
+    power = 4
+    toughness = 3
+    oracleText = "Flying\n" +
+        "When this creature enters, draw a card, then discard a card."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Hand.loot()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Filip Burburan"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/bad0e96a-b4cc-4439-aab9-731a1036145d.jpg?1783918058"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/ResistanceSkywarden.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/ResistanceSkywarden.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Resistance Skywarden
+ * {3}{R}{R}
+ * Creature — Ogre Rebel
+ * 5/5
+ *
+ * Reach (This creature can block creatures with flying.)
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ */
+val ResistanceSkywarden = card("Resistance Skywarden") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre Rebel"
+    power = 5
+    toughness = 5
+    oracleText = "Reach (This creature can block creatures with flying.)\n" +
+        "Menace (This creature can't be blocked except by two or more creatures.)"
+
+    keywords(Keyword.REACH, Keyword.MENACE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "146"
+        artist = "Jarel Threat"
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/6249aabe-8f21-4257-9e04-ceffd44d42a5.jpg?1783918024"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/Ribskiff.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/Ribskiff.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Ribskiff
+ * {4}
+ * Artifact — Vehicle
+ * 4/4
+ *
+ * Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)
+ * When this Vehicle enters, draw a card.
+ * Crew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)
+ *
+ * A Vehicle isn't a creature at rest, so the printed 4/4 sits on the card and only becomes
+ * live once crew turns it into an artifact creature; the toxic 2 rides along on that
+ * creature form. "When this Vehicle enters" is a plain SELF enters trigger.
+ */
+val Ribskiff = card("Ribskiff") {
+    manaCost = "{4}"
+    typeLine = "Artifact — Vehicle"
+    power = 4
+    toughness = 4
+    oracleText = "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)\n" +
+        "When this Vehicle enters, draw a card.\n" +
+        "Crew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)"
+
+    keywordAbility(KeywordAbility.Numeric(Keyword.TOXIC, 2))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    keywordAbility(KeywordAbility.crew(3))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "240"
+        artist = "José Parodi"
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1ec8f984-5ed4-4b34-8b2a-a113cbba001d.jpg?1783917986"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/SheoldredsHeadcleaver.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/SheoldredsHeadcleaver.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Sheoldred's Headcleaver
+ * {3}{B}
+ * Creature — Phyrexian Warrior
+ * 2/4
+ *
+ * Menace
+ * Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)
+ */
+val SheoldredsHeadcleaver = card("Sheoldred's Headcleaver") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Warrior"
+    power = 2
+    toughness = 4
+    oracleText = "Menace\n" +
+        "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)"
+
+    keywords(Keyword.MENACE)
+    keywordAbility(KeywordAbility.Numeric(Keyword.TOXIC, 2))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "109"
+        artist = "Andrey Kuzinskiy"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8c6b818f-6912-4ea1-a35a-c8cd7ee9aead.jpg?1783918040"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/SkyscytheEngulfer.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/SkyscytheEngulfer.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Skyscythe Engulfer
+ * {5}{G}
+ * Creature — Phyrexian Beast
+ * 6/5
+ *
+ * Reach, trample
+ * This creature can't be blocked by creatures with flying.
+ *
+ * The evasion clause is the standard [CantBeBlockedBy] restriction; its blocker filter is matched
+ * against projected keywords, so flying granted by a continuous effect counts.
+ */
+val SkyscytheEngulfer = card("Skyscythe Engulfer") {
+    manaCost = "{5}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Phyrexian Beast"
+    power = 6
+    toughness = 5
+    oracleText = "Reach, trample\n" +
+        "This creature can't be blocked by creatures with flying."
+
+    keywords(Keyword.REACH, Keyword.TRAMPLE)
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.withKeyword(Keyword.FLYING))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "183"
+        artist = "Helge C. Balzer"
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d7898399-3c52-402c-9cd7-baad2cb7f00e.jpg?1783918010"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/SurgicalSkullbomb.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/SurgicalSkullbomb.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Surgical Skullbomb
+ * {1}
+ * Artifact
+ *
+ * {1}, Sacrifice this artifact: Draw a card.
+ * {2}{U}, Sacrifice this artifact: Return target creature to its owner's hand. Draw a card. Activate only as a sorcery.
+ */
+val SurgicalSkullbomb = card("Surgical Skullbomb") {
+    manaCost = "{1}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "{1}, Sacrifice this artifact: Draw a card.\n" +
+        "{2}{U}, Sacrifice this artifact: Return target creature to its owner's hand. Draw a card. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{U}"), Costs.SacrificeSelf)
+        target = Targets.Creature
+        effect = Effects.Composite(
+            Effects.ReturnToHand(EffectTarget.ContextTarget(0)),
+            Effects.DrawCards(1)
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "243"
+        artist = "Gaboleps"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98c2b2af-739f-413c-8c36-da6f78df0acb.jpg?1783917986"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/SwoopingLookout.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/SwoopingLookout.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swooping Lookout
+ * {W}
+ * Artifact Creature — Phyrexian Construct
+ * 1/2
+ *
+ * Flying, vigilance
+ */
+val SwoopingLookout = card("Swooping Lookout") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Phyrexian Construct"
+    power = 1
+    toughness = 2
+    oracleText = "Flying, vigilance"
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "35"
+        artist = "Mike Franchina"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b62c740d-260d-4dfa-b6b3-9a1527538f89.jpg?1783918072"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TestamentBearer.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TestamentBearer.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Testament Bearer
+ * {3}{B}
+ * Creature — Phyrexian Warrior
+ * 4/1
+ *
+ * When this creature dies, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.
+ */
+val TestamentBearer = card("Testament Bearer") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Warrior"
+    power = 4
+    toughness = 1
+    oracleText = "When this creature dies, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Patterns.Library.lookAtTopAndKeep(
+            count = 3,
+            keepCount = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "Raluca Marinescu"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a5424859-628a-4c19-acd0-0c63c21c8338.jpg?1783918039"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TheAutonomousFurnace.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TheAutonomousFurnace.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * The Autonomous Furnace
+ * Land — Sphere
+ *
+ * This land enters tapped.
+ * {T}: Add {R}.
+ * {1}{R}, {T}, Sacrifice this land: Draw a card.
+ */
+val TheAutonomousFurnace = card("The Autonomous Furnace") {
+    colorIdentity = "R"
+    typeLine = "Land — Sphere"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {R}.\n" +
+        "{1}{R}, {T}, Sacrifice this land: Draw a card."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{R}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "247"
+        artist = "Muhammad Firdaus"
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c16f96f5-a2a6-4ac4-bdae-326cee92bf2e.jpg?1783917984"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TheDrossPits.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TheDrossPits.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * The Dross Pits
+ * Land — Sphere
+ *
+ * This land enters tapped.
+ * {T}: Add {B}.
+ * {1}{B}, {T}, Sacrifice this land: Draw a card.
+ */
+val TheDrossPits = card("The Dross Pits") {
+    colorIdentity = "B"
+    typeLine = "Land — Sphere"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {B}.\n" +
+        "{1}{B}, {T}, Sacrifice this land: Draw a card."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{B}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "251"
+        artist = "Martin de Diego Sádaba"
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/19d469f1-2219-4466-9f8a-769ee43e28db.jpg?1783917981"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TheFairBasilica.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TheFairBasilica.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * The Fair Basilica
+ * Land — Sphere
+ *
+ * This land enters tapped.
+ * {T}: Add {W}.
+ * {1}{W}, {T}, Sacrifice this land: Draw a card.
+ */
+val TheFairBasilica = card("The Fair Basilica") {
+    colorIdentity = "W"
+    typeLine = "Land — Sphere"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {W}.\n" +
+        "{1}{W}, {T}, Sacrifice this land: Draw a card."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "252"
+        artist = "Marc Simonetti"
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/01d6ba55-7bc0-41c6-84be-8cd528e46a05.jpg?1783917982"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TheHunterMaze.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TheHunterMaze.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * The Hunter Maze
+ * Land — Sphere
+ *
+ * This land enters tapped.
+ * {T}: Add {G}.
+ * {1}{G}, {T}, Sacrifice this land: Draw a card.
+ */
+val TheHunterMaze = card("The Hunter Maze") {
+    colorIdentity = "G"
+    typeLine = "Land — Sphere"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {G}.\n" +
+        "{1}{G}, {T}, Sacrifice this land: Draw a card."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{G}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "253"
+        artist = "Alayna Danner"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/6389c242-2139-4f12-af30-2b080a1c5e83.jpg?1783917981"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TheSurgicalBay.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TheSurgicalBay.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * The Surgical Bay
+ * Land — Sphere
+ *
+ * This land enters tapped.
+ * {T}: Add {U}.
+ * {1}{U}, {T}, Sacrifice this land: Draw a card.
+ */
+val TheSurgicalBay = card("The Surgical Bay") {
+    colorIdentity = "U"
+    typeLine = "Land — Sphere"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {U}.\n" +
+        "{1}{U}, {T}, Sacrifice this land: Draw a card."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "260"
+        artist = "Sarah Finnigan"
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b49ec35-2c4f-4144-85fe-226f7cb67266.jpg?1783917979"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TyrranaxAtrocity.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TyrranaxAtrocity.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Tyrranax Atrocity
+ * {3}{G}{G}
+ * Creature — Phyrexian Dinosaur
+ * 4/4
+ *
+ * Haste
+ * Toxic 3 (Players dealt combat damage by this creature also get three poison counters.)
+ */
+val TyrranaxAtrocity = card("Tyrranax Atrocity") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Phyrexian Dinosaur"
+    power = 4
+    toughness = 4
+    oracleText = "Haste\n" +
+        "Toxic 3 (Players dealt combat damage by this creature also get three poison counters.)"
+
+    keywords(Keyword.HASTE)
+    keywordAbility(KeywordAbility.Numeric(Keyword.TOXIC, 3))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "188"
+        artist = "Xavier Ribeiro"
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/157cf43c-f7f2-4362-bfc8-11682e94b747.jpg?1783918007"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TyrranaxRex.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/TyrranaxRex.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Tyrranax Rex
+ * {4}{G}{G}{G}
+ * Creature — Phyrexian Dinosaur
+ * 8/8
+ *
+ * This spell can't be countered.
+ * Trample, ward {4}, haste
+ * Toxic 4 (Players dealt combat damage by this creature also get four poison counters.)
+ *
+ * "This spell can't be countered" is a property of the spell on the stack, not a static
+ * ability of the permanent — it is the card-builder's [cantBeCountered] flag (Pearl Lake
+ * Ancient's shape).
+ */
+val TyrranaxRex = card("Tyrranax Rex") {
+    manaCost = "{4}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Phyrexian Dinosaur"
+    power = 8
+    toughness = 8
+    oracleText = "This spell can't be countered.\n" +
+        "Trample, ward {4}, haste\n" +
+        "Toxic 4 (Players dealt combat damage by this creature also get four poison counters.)"
+
+    cantBeCountered = true
+
+    keywords(Keyword.TRAMPLE, Keyword.HASTE)
+    keywordAbility(KeywordAbility.ward("{4}"))
+    keywordAbility(KeywordAbility.Numeric(Keyword.TOXIC, 4))
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "189"
+        artist = "Tuan Duong Chu"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0fb52b44-da5f-4f7a-a6c2-7924b855e051.jpg?1783918007"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/VanishIntoEternity.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/VanishIntoEternity.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Vanish into Eternity
+ * {2}{W}
+ * Instant
+ *
+ * This spell costs {3} more to cast if it targets a creature.
+ * Exile target nonland permanent.
+ *
+ * The cost clause is Dragon's Prey's shape: a **top-level** [ModifySpellCost] on
+ * [SpellCostTarget.SelfCast] whose condition lives inside the modification
+ * ([CostModification.IncreaseGenericIfAnyTargetMatches]). Wrapping it in a conditional
+ * static ability would hide it from cost calculation. The increase is locked in from the
+ * target chosen at cast time (CR 601.2f).
+ */
+val VanishIntoEternity = card("Vanish into Eternity") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "This spell costs {3} more to cast if it targets a creature.\n" +
+        "Exile target nonland permanent."
+
+    spell {
+        val permanent = target("target nonland permanent", Targets.NonlandPermanent)
+        effect = Effects.Move(permanent, Zone.EXILE)
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.IncreaseGenericIfAnyTargetMatches(
+                amount = 3,
+                filter = GameObjectFilter.Creature,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Magali Villeneuve"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8f0b3308-9c0b-4461-9094-38deec20e1bc.jpg?1783918072"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/VeilOfAssimilation.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/VeilOfAssimilation.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Veil of Assimilation
+ * {1}{W}
+ * Artifact
+ *
+ * Whenever this artifact or another artifact you control enters, target creature you control gets
+ * +1/+1 and gains vigilance until end of turn.
+ *
+ * "This artifact **or** another" includes the Veil itself, so the binding is
+ * [TriggerBinding.ANY] — not `OTHER`. The Veil entering triggers its own ability.
+ */
+val VeilOfAssimilation = card("Veil of Assimilation") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "Whenever this artifact or another artifact you control enters, target creature " +
+        "you control gets +1/+1 and gains vigilance until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 1, creature),
+            Effects.GrantKeyword(Keyword.VIGILANCE, creature),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "37"
+        artist = "Wayne Wu"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f9d8d87-e32f-4ad9-8d72-d1b88cd14510.jpg?1783918072"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ONE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONE.json
@@ -1,3 +1,138 @@
+// Basilica Skullbomb
+{
+    "name": "Basilica Skullbomb",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, Sacrifice this artifact: Draw a card.\n{2}{W}, Sacrifice this artifact: Target creature you control gets +2/+2 and gains flying until end of turn. Draw a card. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FLYING",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "artist": "Gaboleps",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8e2f0ae2-db68-4338-93f9-9d9268cec41e.jpg?1783917994"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Bilious Skulldweller
+{
+    "name": "Bilious Skulldweller",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Phyrexian Insect",
+    "oracleText": "Deathtouch\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEATHTOUCH",
+        "TOXIC"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "TOXIC",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "UNCOMMON",
+        "artist": "Svetlin Velinov",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/dfb81cb1-ac56-4803-a962-359854a447df.jpg?1783918051"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Blazing Crescendo
 {
     "name": "Blazing Crescendo",
@@ -153,6 +288,662 @@
     ]
 }
 
+// Branchblight Stalker
+{
+    "name": "Branchblight Stalker",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Phyrexian Elf Scout",
+    "oracleText": "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "TOXIC"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "TOXIC",
+            "n": 2
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "160",
+        "artist": "Krharts",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e5290a4c-1f98-4e97-a407-f951e386b8b0.jpg?1783918019"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Cephalopod Sentry
+{
+    "name": "Cephalopod Sentry",
+    "manaCost": "{2}{W}{U}",
+    "typeLine": "Artifact Creature — Phyrexian Squid",
+    "oracleText": "Flying\nCephalopod Sentry's power is equal to the number of artifacts you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "artifact"
+            }
+        },
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "198",
+        "rarity": "UNCOMMON",
+        "artist": "Mathias Kollros",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/30c22eb9-5056-4c0b-a5d8-41e09161eb40.jpg?1783918004"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
+// Chrome Prowler
+{
+    "name": "Chrome Prowler",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact Creature — Phyrexian Cat",
+    "oracleText": "Flash\nWhen this creature enters, tap target creature an opponent controls.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target creature an opponent controls"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "artist": "Maxime Minard",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a94378a2-cbde-4adf-b889-43e90fc6ba28.jpg?1783918069"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Dross Skullbomb
+{
+    "name": "Dross Skullbomb",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, Sacrifice this artifact: Draw a card.\n{2}{B}, Sacrifice this artifact: Return target creature card from your graveyard to your hand. Draw a card. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "destination": "Hand"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature own:you",
+                            "zone": "Graveyard"
+                        }
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "artist": "Gaboleps",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/66270dd2-9139-4329-9621-852962836688.jpg?1783917994"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Dune Mover
+{
+    "name": "Dune Mover",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Phyrexian Golem",
+    "oracleText": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nWhen this creature enters, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "TOXIC"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "TOXIC",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            "ShuffleLibrary",
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Library",
+                                    "placement": "Top"
+                                },
+                                "revealed": true
+                            },
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "artist": "Kev Walker",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/29d2c689-af37-433a-a012-e8d384702811.jpg?1783917993"
+    }
+}
+
+// Ichorspit Basilisk
+{
+    "name": "Ichorspit Basilisk",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Phyrexian Basilisk",
+    "oracleText": "Deathtouch\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEATHTOUCH",
+        "TOXIC"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "TOXIC",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "170",
+        "artist": "Joe Slucher",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/0955b64f-6721-4fa6-b161-cae404cb5b9f.jpg?1783918014"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Jawbone Duelist
+{
+    "name": "Jawbone Duelist",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Phyrexian Soldier",
+    "oracleText": "Double strike\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DOUBLE_STRIKE",
+        "TOXIC"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "TOXIC",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "18",
+        "rarity": "UNCOMMON",
+        "artist": "Nino Vecia",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b00ea7bb-705b-4669-bb2a-560bed04b14a.jpg?1783918078"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Malcator's Watcher
+{
+    "name": "Malcator's Watcher",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact Creature — Phyrexian Drone",
+    "oracleText": "Flying, vigilance\nWhen this creature dies, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "artist": "Jason A. Engle",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/95a7e5ff-ba81-4b45-933e-0ac747525ab8.jpg?1783918062"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Mandible Justiciar
+{
+    "name": "Mandible Justiciar",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact Creature — Phyrexian Cleric",
+    "oracleText": "Lifelink\nWhenever another artifact you control enters, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "artist": "Mike Franchina",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/544a707d-4090-4a74-91aa-60fbd8a4ae96.jpg?1783918079"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Maze Skullbomb
+{
+    "name": "Maze Skullbomb",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, Sacrifice this artifact: Draw a card.\n{2}{G}, Sacrifice this artifact: Target creature you control gets +3/+3 and gains trample until end of turn. Draw a card. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{G}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "TRAMPLE",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "artist": "Matt Forsyth",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/1073aee2-aea6-473d-97c6-248778d79d80.jpg?1783917990"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Myr Convert
+{
+    "name": "Myr Convert",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Phyrexian Myr",
+    "oracleText": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\n{T}, Pay 2 life: Add one mana of any color.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "TOXIC"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "TOXIC",
+            "n": 1
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "234",
+        "rarity": "UNCOMMON",
+        "artist": "José Parodi",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9df0adcf-7ad0-4d70-8dcd-28f69471495b.jpg?1783917989"
+    }
+}
+
+// Myr Kinsmith
+{
+    "name": "Myr Kinsmith",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Myr",
+    "oracleText": "When this creature enters, you may search your library for a Myr card, reveal it, put it into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "permanent Myr"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "artist": "Cristi Balanescu",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/6046e50a-f4c9-4029-a589-62a19371b734.jpg?1783917989"
+    }
+}
+
 // Offer Immortality
 {
     "name": "Offer Immortality",
@@ -199,6 +990,58 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Orthodoxy Enforcer
+{
+    "name": "Orthodoxy Enforcer",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Phyrexian Cleric",
+    "oracleText": "Vigilance\nThis creature gets +2/+0 as long as you control two or more artifacts.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "artist": "Xavier Ribeiro",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8c938a0f-531c-4293-a89c-c7440d5acc5d.jpg?1783918076"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -300,6 +1143,322 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Paladin of Predation
+{
+    "name": "Paladin of Predation",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Phyrexian Knight",
+    "oracleText": "Toxic 6 (Players dealt combat damage by this creature also get six poison counters.)\nThis creature can't be blocked by creatures with power 2 or less.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 7
+    },
+    "keywords": [
+        "TOXIC"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "TOXIC",
+            "n": 6
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "PowerAtMost",
+                            "max": 2
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "rarity": "UNCOMMON",
+        "artist": "Lorenzo Mastroianni",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/758dbe61-6dc7-4b08-bdd6-7262257955fc.jpg?1783918012"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Pestilent Syphoner
+{
+    "name": "Pestilent Syphoner",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Phyrexian Insect",
+    "oracleText": "Flying\nToxic 1 (Players dealt combat damage by this creature also get a poison counter.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "TOXIC"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "TOXIC",
+            "n": 1
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/947a1e44-3485-4e24-a34d-6c318584743c.jpg?1783918043"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Plated Onslaught
+{
+    "name": "Plated Onslaught",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nCreatures you control get +2/+1 until end of turn.",
+    "keywords": [
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "rarity": "UNCOMMON",
+        "artist": "David Auden Nash",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/472a635a-a581-4c00-89d6-464f30887944.jpg?1783918075"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Quicksilver Fisher
+{
+    "name": "Quicksilver Fisher",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Phyrexian Drake",
+    "oracleText": "Flying\nWhen this creature enters, draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "artist": "Filip Burburan",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/bad0e96a-b4cc-4439-aab9-731a1036145d.jpg?1783918058"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Resistance Skywarden
+{
+    "name": "Resistance Skywarden",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Ogre Rebel",
+    "oracleText": "Reach (This creature can block creatures with flying.)\nMenace (This creature can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "REACH",
+        "MENACE"
+    ],
+    "metadata": {
+        "collectorNumber": "146",
+        "rarity": "UNCOMMON",
+        "artist": "Jarel Threat",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/6249aabe-8f21-4257-9e04-ceffd44d42a5.jpg?1783918024"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ribskiff
+{
+    "name": "Ribskiff",
+    "manaCost": "{4}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Toxic 2 (Players dealt combat damage by this creature also get two poison counters.)\nWhen this Vehicle enters, draw a card.\nCrew 3 (Tap any number of creatures you control with total power 3 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "TOXIC",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "TOXIC",
+            "n": 2
+        },
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 3
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "240",
+        "rarity": "UNCOMMON",
+        "artist": "José Parodi",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1ec8f984-5ed4-4b34-8b2a-a113cbba001d.jpg?1783917986"
+    }
+}
+
+// Sheoldred's Headcleaver
+{
+    "name": "Sheoldred's Headcleaver",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Phyrexian Warrior",
+    "oracleText": "Menace\nToxic 2 (Players dealt combat damage by this creature also get two poison counters.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "MENACE",
+        "TOXIC"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "TOXIC",
+            "n": 2
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "109",
+        "artist": "Andrey Kuzinskiy",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8c6b818f-6912-4ea1-a35a-c8cd7ee9aead.jpg?1783918040"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -447,6 +1606,709 @@
         "rarity": "RARE",
         "artist": "Brian Valeza",
         "imageUri": "https://cards.scryfall.io/normal/front/6/0/60b565da-a49b-479c-b0c4-8ff3dd20cc0b.jpg?1675956933"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Skyscythe Engulfer
+{
+    "name": "Skyscythe Engulfer",
+    "manaCost": "{5}{G}",
+    "typeLine": "Creature — Phyrexian Beast",
+    "oracleText": "Reach, trample\nThis creature can't be blocked by creatures with flying.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywords": [
+        "REACH",
+        "TRAMPLE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasKeyword",
+                            "keyword": "FLYING"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "artist": "Helge C. Balzer",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d7898399-3c52-402c-9cd7-baad2cb7f00e.jpg?1783918010"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Surgical Skullbomb
+{
+    "name": "Surgical Skullbomb",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, Sacrifice this artifact: Draw a card.\n{2}{U}, Sacrifice this artifact: Return target creature to its owner's hand. Draw a card. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "destination": "Hand"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "243",
+        "artist": "Gaboleps",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/98c2b2af-739f-413c-8c36-da6f78df0acb.jpg?1783917986"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Swooping Lookout
+{
+    "name": "Swooping Lookout",
+    "manaCost": "{W}",
+    "typeLine": "Artifact Creature — Phyrexian Construct",
+    "oracleText": "Flying, vigilance",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "35",
+        "rarity": "UNCOMMON",
+        "artist": "Mike Franchina",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b62c740d-260d-4dfa-b6b3-9a1527538f89.jpg?1783918072"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Testament Bearer
+{
+    "name": "Testament Bearer",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Phyrexian Warrior",
+    "oracleText": "When this creature dies, look at the top three cards of your library. Put one of them into your hand and the rest into your graveyard.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Put in graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "artist": "Raluca Marinescu",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a5424859-628a-4c19-acd0-0c63c21c8338.jpg?1783918039"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// The Autonomous Furnace
+{
+    "name": "The Autonomous Furnace",
+    "manaCost": "",
+    "typeLine": "Land — Sphere",
+    "oracleText": "This land enters tapped.\n{T}: Add {R}.\n{1}{R}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "artist": "Muhammad Firdaus",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c16f96f5-a2a6-4ac4-bdae-326cee92bf2e.jpg?1783917984"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// The Dross Pits
+{
+    "name": "The Dross Pits",
+    "manaCost": "",
+    "typeLine": "Land — Sphere",
+    "oracleText": "This land enters tapped.\n{T}: Add {B}.\n{1}{B}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "251",
+        "artist": "Martin de Diego Sádaba",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/19d469f1-2219-4466-9f8a-769ee43e28db.jpg?1783917981"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// The Fair Basilica
+{
+    "name": "The Fair Basilica",
+    "manaCost": "",
+    "typeLine": "Land — Sphere",
+    "oracleText": "This land enters tapped.\n{T}: Add {W}.\n{1}{W}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "252",
+        "artist": "Marc Simonetti",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/01d6ba55-7bc0-41c6-84be-8cd528e46a05.jpg?1783917982"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// The Hunter Maze
+{
+    "name": "The Hunter Maze",
+    "manaCost": "",
+    "typeLine": "Land — Sphere",
+    "oracleText": "This land enters tapped.\n{T}: Add {G}.\n{1}{G}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "253",
+        "artist": "Alayna Danner",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/6389c242-2139-4f12-af30-2b080a1c5e83.jpg?1783917981"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// The Surgical Bay
+{
+    "name": "The Surgical Bay",
+    "manaCost": "",
+    "typeLine": "Land — Sphere",
+    "oracleText": "This land enters tapped.\n{T}: Add {U}.\n{1}{U}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "260",
+        "artist": "Sarah Finnigan",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b49ec35-2c4f-4144-85fe-226f7cb67266.jpg?1783917979"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Tyrranax Atrocity
+{
+    "name": "Tyrranax Atrocity",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Phyrexian Dinosaur",
+    "oracleText": "Haste\nToxic 3 (Players dealt combat damage by this creature also get three poison counters.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "HASTE",
+        "TOXIC"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "TOXIC",
+            "n": 3
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "188",
+        "artist": "Xavier Ribeiro",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/157cf43c-f7f2-4362-bfc8-11682e94b747.jpg?1783918007"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Tyrranax Rex
+{
+    "name": "Tyrranax Rex",
+    "manaCost": "{4}{G}{G}{G}",
+    "typeLine": "Creature — Phyrexian Dinosaur",
+    "oracleText": "This spell can't be countered.\nTrample, ward {4}, haste\nToxic 4 (Players dealt combat damage by this creature also get four poison counters.)",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "keywords": [
+        "TRAMPLE",
+        "HASTE",
+        "WARD",
+        "TOXIC"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{4}"
+            }
+        },
+        {
+            "type": "Numeric",
+            "keyword": "TOXIC",
+            "n": 4
+        }
+    ],
+    "script": {
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "189",
+        "rarity": "MYTHIC",
+        "artist": "Tuan Duong Chu",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0fb52b44-da5f-4f7a-a6c2-7924b855e051.jpg?1783918007"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Vanish into Eternity
+{
+    "name": "Vanish into Eternity",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {3} more to cast if it targets a creature.\nExile target nonland permanent.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target nonland permanent"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target nonland permanent"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "IncreaseGenericIfAnyTargetMatches",
+                    "amount": 3,
+                    "filter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Magali Villeneuve",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8f0b3308-9c0b-4461-9094-38deec20e1bc.jpg?1783918072"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Veil of Assimilation
+{
+    "name": "Veil of Assimilation",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever this artifact or another artifact you control enters, target creature you control gets +1/+1 and gains vigilance until end of turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "rarity": "UNCOMMON",
+        "artist": "Wayne Wu",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f9d8d87-e32f-4ad9-8d72-d1b88cd14510.jpg?1783918072"
     },
     "colorIdentityOverride": [
         "WHITE"


### PR DESCRIPTION
Every card Phyrexia: All Will Be One's Assay-ready list still had open — 35 new canonicals plus the
set's basic lands. ONE goes **15 → 55 of 266** implemented (6% → 21%).

"Assay-ready" = Assay verdict `whole` in `assay-verdicts.json` ∩ not yet implemented. The intersection
was 40 names: 35 needing authoring, 5 basic lands. **Nothing needed new SDK vocabulary** — every one of
the fifteen mechanics involved (toxic, affinity, crew, ward, can't-be-countered, printed-`*` CDA, the
targets-a-creature cost increase, enters-tapped lands, search-to-top, look-at-top-N, the artifact-ETB
trigger, both evasion filters, the conditional buff, sorcery-only sac abilities, the move facades) was
traced end-to-end first and confirmed live in `rules-engine`, so this is one batch PR rather than a
dozen.

Unlike MH3, no card left the batch.

### Cards

**The Skullbomb cycle** — `{1}` artifacts, `{1}, Sac: Draw a card` plus a coloured sorcery-speed mode
that also draws:
- **Basilica Skullbomb** — `{2}{W}` mode: target creature you control gets +2/+2 and gains flying.
- **Surgical Skullbomb** — `{2}{U}` mode: bounce target creature.
- **Dross Skullbomb** — `{2}{B}` mode: return a creature card from your graveyard to your hand.
- **Maze Skullbomb** — `{2}{G}` mode: target creature you control gets +3/+3 and gains trample.

**The "Sphere" land cycle** — `EntersTapped()` + a tap-for-mana ability + `{1}{C}, {T}, Sac: Draw a card`.
Structurally `Memorial to Genius` with different numbers. `Land — Sphere` needs no SDK subtype entry:
`TypeLine.parse` wraps subtype words free-form, and nothing here filters on it.
- **The Fair Basilica** (W), **The Surgical Bay** (U), **The Dross Pits** (B),
  **The Autonomous Furnace** (R), **The Hunter Maze** (G).

**Toxic creatures** — `KeywordAbility.Numeric(Keyword.TOXIC, n)` plus evergreen keywords, nothing else:
- **Bilious Skulldweller** (deathtouch, toxic 1), **Ichorspit Basilisk** (deathtouch, toxic 1),
  **Jawbone Duelist** (double strike, toxic 1), **Pestilent Syphoner** (flying, toxic 1),
  **Branchblight Stalker** (toxic 2), **Sheoldred's Headcleaver** (menace, toxic 2),
  **Tyrranax Atrocity** (haste, toxic 3).

**Keyword + static creatures**
- **Swooping Lookout** — flying, vigilance.
- **Resistance Skywarden** — reach, menace.
- **Skyscythe Engulfer** — reach, trample, `CantBeBlockedBy(Creature.withKeyword(FLYING))`.
- **Orthodoxy Enforcer** — vigilance, `ConditionalStaticAbility(ModifyStats(2, 0), YouControlAtLeast(2, Artifact))`.
- **Paladin of Predation** — toxic 6, `CantBeBlockedBy(Creature.powerAtMost(2))`.

**Enters / dies triggers**
- **Chrome Prowler** — flash; ETB taps a target creature an opponent controls.
- **Malcator's Watcher** — flying, vigilance; dies → draw.
- **Quicksilver Fisher** — flying; ETB → `Patterns.Hand.loot()`.
- **Testament Bearer** — dies → `Patterns.Library.lookAtTopAndKeep(3, keepCount = 1)`.
- **Myr Kinsmith** — optional ETB search for a Myr card to hand.
- **Dune Mover** — toxic 1; optional ETB search for a basic land to the **top** of the library.

**Artifact-matters**
- **Cephalopod Sentry** — flying; printed `*` power via `dynamicPower(AggregateBattlefield(You, Artifact))`.
- **Mandible Justiciar** — lifelink; "**another** artifact you control enters" (`TriggerBinding.OTHER`) → +1/+1 EOT.
- **Veil of Assimilation** — "**this artifact or** another artifact you control enters" — deliberately
  `TriggerBinding.ANY`, not `OTHER`, so it fires on its own ETB; targets a creature you control for
  +1/+1 and vigilance.
- **Plated Onslaught** — `KeywordAbility.Affinity(CardType.ARTIFACT)` (affinity is its own `CostCalculator`
  branch, not a `ModifySpellCost`); mass +2/+1.

**The rest**
- **Myr Convert** — toxic 1; `{T}, Pay 2 life: Add one mana of any color.`
- **Ribskiff** — Vehicle; toxic 2, ETB draw, `KeywordAbility.crew(3)`.
- **Tyrranax Rex** — `cantBeCountered = true` (the card-builder property, not a static), trample,
  ward `{4}`, haste, toxic 4.
- **Vanish into Eternity** — exile a nonland permanent, with a **top-level**
  `ModifySpellCost(SelfCast, IncreaseGenericIfAnyTargetMatches(3, Creature))`. Wrapping that in a
  `ConditionalStaticAbility` would hide it from cost calculation.

**Basic lands** — per-set `basicLand(...)` vals plus the `basicLands` override on the set object (they are
not `Printing` rows). Two booster arts per type (262–271) and one non-booster variant each (272–276),
the latter `inBooster = false` so they stay out of the limited basic pool.

### Verification

- `just build` — green after the expected `CardDefinitionSnapshotTest` diff; `just rebless-cards` moved
  **only `snapshots/cards/ONE.json`**, so no shared SDK behaviour shifted.
- `just assay-differential` — **13 divergences before, 13 after, the same 13 cards.** Scoped to the set:
  40 hand-written cards, 35 compared, **35 confirmed, 0 divergent** — every newly authored card
  round-trips against Assay's reading of its own Oracle text. Corpus-wide, compared went 3,096 → 3,130
  and confirmed 3,083 → 3,117, both +34; the 35th new card lands in "script slot not modelled yet".
- `just check-card-printing` — clean on all 35.
- Every metadata field and full oracle text was diffed back against the pre-fetched Scryfall brief,
  matching **inside** the `metadata { }` block only (a naive first-match regex hits `CreateToken`'s
  `imageUri` instead). All 35 match.

No scenario tests: every card composes existing primitives, so the snapshot, lint, facade-boundary and
differential nets cover them. There is no `backlog/sets/` file for ONE to tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
