### PR TITLE
Add the 55 Assay-ready Dominaria United cards

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BoneSplinters.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BoneSplinters.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Bone Splinters
+ * {B}
+ * Sorcery
+ * As an additional cost to cast this spell, sacrifice a creature.
+ * Destroy target creature.
+ */
+val BoneSplinters = card("Bone Splinters") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature.\nDestroy target creature."
+
+    additionalCost(Costs.additional.SacrificePermanent(GameObjectFilter.Creature))
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "67"
+        artist = "Cole Eastburn"
+        flavorText = "Witches of the Split-Eye Coven speak of a future when Grixis will overflow with life energy. For now, they must harvest vis from the living to fuel their dark magics."
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d4a4b3a3-b7ae-4210-8037-098fdf5808d0.jpg?1783942568"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/GriffinProtector.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/GriffinProtector.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Griffin Protector
+ * {3}{W}
+ * Creature — Griffin
+ * 2/3
+ * Flying
+ * Whenever another creature you control enters, this creature gets +1/+1 until end of turn.
+ */
+val GriffinProtector = card("Griffin Protector") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Griffin"
+    oracleText = "Flying\nWhenever another creature you control enters, this creature gets +1/+1 until end of turn."
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "16"
+        artist = "Christopher Moeller"
+        flavorText = "The drums of war stir the hearts of all who fight for righteousness."
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/ddae4f7a-525c-4306-81b5-b0991840a11e.jpg?1783940518"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/Meteorite.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/Meteorite.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Meteorite
+ * {5}
+ * Artifact
+ * When this artifact enters, it deals 2 damage to any target.
+ * {T}: Add one mana of any color.
+ */
+val Meteorite = card("Meteorite") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, it deals 2 damage to any target.\n{T}: Add one mana of any color."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("any target", AnyTarget())
+        effect = Effects.DealDamage(2, t)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "221"
+        artist = "Scott Murphy"
+        flavorText = "\"And if I'm lying,\" he began . . ."
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d7a39c1a-7615-4ac8-8984-b8459d201cb2.jpg?1783939157"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/DominariaUnitedSet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/DominariaUnitedSet.kt
@@ -22,6 +22,10 @@ object DominariaUnitedSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ArgivianPhalanx.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ArgivianPhalanx.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Argivian Phalanx
+ * {5}{W}
+ * Creature — Human Kor Soldier
+ * 4/4
+ * Affinity for creatures (This spell costs {1} less to cast for each creature you control.)
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ */
+val ArgivianPhalanx = card("Argivian Phalanx") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Kor Soldier"
+    oracleText = "Affinity for creatures (This spell costs {1} less to cast for each creature you control.)\nVigilance (Attacking doesn't cause this creature to tap.)"
+    power = 4
+    toughness = 4
+
+    keywordAbility(KeywordAbility.Affinity(CardType.CREATURE))
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "5"
+        artist = "Josh Hass"
+        flavorText = "New Argive welcomed the kor people when they were displaced by the Rathi overlay. The kor repay that kindness with fierce loyalty."
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/afbadc37-1b4f-4237-a3c0-772bafb18aa0.jpg?1783921373"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/AutomaticLibrarian.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/AutomaticLibrarian.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Automatic Librarian
+ * {3}
+ * Artifact Creature — Construct
+ * 3/2
+ * When this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+ */
+val AutomaticLibrarian = card("Automatic Librarian") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    oracleText = "When this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)"
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Scry(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "229"
+        artist = "Alex Konstad"
+        flavorText = "Enforcing absolute quiet with extreme prejudice since 3285 AR."
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6c3d7ece-0f57-4213-a0ab-a9d7c1536ebb.jpg?1783921271"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/BattleRageBlessing.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/BattleRageBlessing.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Battle-Rage Blessing
+ * {1}{B}
+ * Instant
+ * Target creature gains deathtouch and indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.)
+ */
+val BattleRageBlessing = card("Battle-Rage Blessing") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gains deathtouch and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)"
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.GrantKeyword(Keyword.DEATHTOUCH, t),
+            Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "80"
+        artist = "Jarel Threat"
+        flavorText = "\"Since when is it cheating to give one side an unfair advantage?\"\n—Braids"
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7cfc631b-49d1-4f1c-adac-5b07a2ccd06f.jpg?1783921339"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/BattleflySwarm.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/BattleflySwarm.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Battlefly Swarm
+ * {B}
+ * Creature — Phyrexian Insect
+ * 1/1
+ * Flying
+ * {B}: This creature gains deathtouch until end of turn.
+ */
+val BattleflySwarm = card("Battlefly Swarm") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Insect"
+    oracleText = "Flying\n{B}: This creature gains deathtouch until end of turn."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "81"
+        artist = "Xavier Ribeiro"
+        flavorText = "Having encountered the bitter Phyrexian battleflies before, Squee knew not to bother eating them—or at least to stop after the fifth."
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c6b4a2d-0bc0-4a54-9c78-712b48ad6be1.jpg?1783921337"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/BoneSplintersReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/BoneSplintersReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bone Splinters reprint in DMU. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Shards of Alara's `cards/` package; this file contributes only presentation data.
+ */
+val BoneSplintersReprint = Printing(
+    oracleId = "0c936582-d4c0-4da8-bc7e-49da5a433939",
+    name = "Bone Splinters",
+    setCode = "DMU",
+    collectorNumber = "83",
+    scryfallId = "106b5c96-d1bd-433d-955e-ace0b60d3bc3",
+    artist = "Jeremy Wilson",
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/106b5c96-d1bd-433d-955e-ace0b60d3bc3.jpg?1783921336",
+    releaseDate = "2022-09-09",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/CharismaticVanguard.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/CharismaticVanguard.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Charismatic Vanguard
+ * {2}{W}
+ * Creature — Dwarf Soldier
+ * 3/2
+ * {4}{W}: Creatures you control get +1/+1 until end of turn.
+ */
+val CharismaticVanguard = card("Charismatic Vanguard") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dwarf Soldier"
+    oracleText = "{4}{W}: Creatures you control get +1/+1 until end of turn."
+    power = 3
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{W}")
+        effect = Patterns.Group.modifyStatsForAll(1, 1, GroupFilter.AllCreaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "David Palumbo"
+        flavorText = "\"This battlefield is an anvil, my mace a forging hammer . . . and you, Phyrexian scum, are the scrap metal that's about to be reshaped as I see fit.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a51764fe-0d75-4cfa-a699-0d9e7ffb7843.jpg?1783921370"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ClockworkDrawbridge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ClockworkDrawbridge.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Clockwork Drawbridge
+ * {W}
+ * Artifact Creature — Wall
+ * 0/3
+ * Defender
+ * {2}{W}, {T}: Tap target creature.
+ */
+val ClockworkDrawbridge = card("Clockwork Drawbridge") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Wall"
+    oracleText = "Defender\n{2}{W}, {T}: Tap target creature."
+    power = 0
+    toughness = 3
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{W}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "13"
+        artist = "Nadia Hurianova"
+        flavorText = "Argivia's clockwork fortifications are the stuff of legend, reminding all on Dominaria that ingenuity has saved them before and can do so again."
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/037cb79c-163d-4b36-bd93-954eca8fe26e.jpg?1783921369"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ContaminatedAquifer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ContaminatedAquifer.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Contaminated Aquifer
+ * Land — Island Swamp
+ * ({T}: Add {U} or {B}.)
+ * This land enters tapped.
+ *
+ * Mana abilities are intrinsic from the two basic land types (the reminder line is the whole mana text).
+ */
+val ContaminatedAquifer = card("Contaminated Aquifer") {
+    colorIdentity = "UB"
+    typeLine = "Land — Island Swamp"
+    oracleText = "({T}: Add {U} or {B}.)\nThis land enters tapped."
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "245"
+        artist = "Robin Olausson"
+        flavorText = "The caves stretch farther than anyone knows, and the terrible legacy of Yawgmoth lurks in every shadow."
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6bb570f4-de68-4d8c-a9f3-8a3294163aa8.jpg?1783921262"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/DeathbloomGardener.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/DeathbloomGardener.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Deathbloom Gardener
+ * {2}{G}
+ * Creature — Elf Druid
+ * 1/1
+ * Deathtouch
+ * {T}: Add one mana of any color.
+ */
+val DeathbloomGardener = card("Deathbloom Gardener") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid"
+    oracleText = "Deathtouch\n{T}: Add one mana of any color."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.DEATHTOUCH)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "159"
+        artist = "Marta Nael"
+        flavorText = "\"I can provide the Coalition with poisons that will break down Phyrexian machinery as easily as they stop the heart.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88dee3d1-0496-40ea-b208-7362a932f531.jpg?1783921304"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/DominariaUnitedBasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/DominariaUnitedBasicLands.kt
@@ -1,0 +1,162 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Dominaria United Basic Lands
+ *
+ * DMU prints four art variants of each basic land type: three regular ones
+ * (262-276) and one full-art Magali Villeneuve treatment (277-281).
+ */
+
+// =============================================================================
+// Plains (262, 263, 264, 277)
+// =============================================================================
+
+val DominariaUnitedPlains262 = basicLand("Plains") {
+    collectorNumber = "262"
+    artist = "Lorenzo Lanfranconi"
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/5822b027-369d-46da-b6dd-c31207e2f449.jpg?1783921255"
+}
+
+val DominariaUnitedPlains263 = basicLand("Plains") {
+    collectorNumber = "263"
+    artist = "Seb McKinnon"
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5b364f40-c3c0-4e3a-8556-73f6fcc19eec.jpg?1783921257"
+}
+
+val DominariaUnitedPlains264 = basicLand("Plains") {
+    collectorNumber = "264"
+    artist = "Johannes Voss"
+    imageUri = "https://cards.scryfall.io/normal/front/b/e/be849ad5-9f96-4605-a0dc-8b9588ac7dd6.jpg?1783921255"
+}
+
+val DominariaUnitedPlains277 = basicLand("Plains") {
+    collectorNumber = "277"
+    artist = "Magali Villeneuve"
+    imageUri = "https://cards.scryfall.io/normal/front/5/7/572eab93-7b1d-434b-ba92-844248e472d0.jpg?1783921247"
+}
+
+// =============================================================================
+// Island (265, 266, 267, 278)
+// =============================================================================
+
+val DominariaUnitedIsland265 = basicLand("Island") {
+    collectorNumber = "265"
+    artist = "Seb McKinnon"
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8bafc217-3d83-4551-b2e3-3494ec14b2f9.jpg?1783921253"
+}
+
+val DominariaUnitedIsland266 = basicLand("Island") {
+    collectorNumber = "266"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/34ec0f4f-e6f7-4a49-81a3-a1fbad102a9d.jpg?1783921253"
+}
+
+val DominariaUnitedIsland267 = basicLand("Island") {
+    collectorNumber = "267"
+    artist = "Johannes Voss"
+    imageUri = "https://cards.scryfall.io/normal/front/6/4/64e7580a-92bd-4b50-84fc-ee42e47c9014.jpg?1783921253"
+}
+
+val DominariaUnitedIsland278 = basicLand("Island") {
+    collectorNumber = "278"
+    artist = "Magali Villeneuve"
+    imageUri = "https://cards.scryfall.io/normal/front/e/6/e67477a4-6878-4356-8037-807f41590ad1.jpg?1783921245"
+}
+
+// =============================================================================
+// Swamp (268, 269, 270, 279)
+// =============================================================================
+
+val DominariaUnitedSwamp268 = basicLand("Swamp") {
+    collectorNumber = "268"
+    artist = "Seb McKinnon"
+    imageUri = "https://cards.scryfall.io/normal/front/5/a/5a846f00-ccb9-4ee2-8358-7c7722258601.jpg?1783921252"
+}
+
+val DominariaUnitedSwamp269 = basicLand("Swamp") {
+    collectorNumber = "269"
+    artist = "Mark Poole"
+    imageUri = "https://cards.scryfall.io/normal/front/0/0/00daa026-aba3-421e-9eaa-aa5649b36eb2.jpg?1783921251"
+}
+
+val DominariaUnitedSwamp270 = basicLand("Swamp") {
+    collectorNumber = "270"
+    artist = "Johannes Voss"
+    imageUri = "https://cards.scryfall.io/normal/front/0/3/0306607d-2a42-4008-ac84-8d3ed91fe3aa.jpg?1783921250"
+}
+
+val DominariaUnitedSwamp279 = basicLand("Swamp") {
+    collectorNumber = "279"
+    artist = "Magali Villeneuve"
+    imageUri = "https://cards.scryfall.io/normal/front/f/1/f1b8c9a6-62eb-436e-9277-e2b8075d482d.jpg?1783921245"
+}
+
+// =============================================================================
+// Mountain (271, 272, 273, 280)
+// =============================================================================
+
+val DominariaUnitedMountain271 = basicLand("Mountain") {
+    collectorNumber = "271"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/a/8/a82f782e-abc8-4b92-a193-17b2c383f765.jpg?1783921250"
+}
+
+val DominariaUnitedMountain272 = basicLand("Mountain") {
+    collectorNumber = "272"
+    artist = "Seb McKinnon"
+    imageUri = "https://cards.scryfall.io/normal/front/7/2/72776f25-48f5-4d7f-84a9-310928b9d7ad.jpg?1783921250"
+}
+
+val DominariaUnitedMountain273 = basicLand("Mountain") {
+    collectorNumber = "273"
+    artist = "Johannes Voss"
+    imageUri = "https://cards.scryfall.io/normal/front/4/0/40d07155-d45d-4fec-a15e-525df5010af3.jpg?1783921248"
+}
+
+val DominariaUnitedMountain280 = basicLand("Mountain") {
+    collectorNumber = "280"
+    artist = "Magali Villeneuve"
+    imageUri = "https://cards.scryfall.io/normal/front/0/a/0aaf15b9-1bf5-424a-a994-67beaae29d36.jpg?1783921246"
+}
+
+// =============================================================================
+// Forest (274, 275, 276, 281)
+// =============================================================================
+
+val DominariaUnitedForest274 = basicLand("Forest") {
+    collectorNumber = "274"
+    artist = "Seb McKinnon"
+    imageUri = "https://cards.scryfall.io/normal/front/5/2/52097f6a-58d3-4176-b3bf-dc94f44adf30.jpg?1783921251"
+}
+
+val DominariaUnitedForest275 = basicLand("Forest") {
+    collectorNumber = "275"
+    artist = "Johannes Voss"
+    imageUri = "https://cards.scryfall.io/normal/front/1/a/1a1b6004-6dda-4495-85f7-eb8fa29873e9.jpg?1783921248"
+}
+
+val DominariaUnitedForest276 = basicLand("Forest") {
+    collectorNumber = "276"
+    artist = "Darek Zabrocki"
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/279ebd05-229a-4a4a-a1c0-c5f24d16dee3.jpg?1783921247"
+}
+
+val DominariaUnitedForest281 = basicLand("Forest") {
+    collectorNumber = "281"
+    artist = "Magali Villeneuve"
+    imageUri = "https://cards.scryfall.io/normal/front/e/8/e8e9959a-b422-4906-8d35-8b05c5dd6de1.jpg?1783921246"
+}
+
+
+/**
+ * All Dominaria United basic land variants.
+ */
+val DominariaUnitedBasicLands = listOf(
+    DominariaUnitedPlains262, DominariaUnitedPlains263, DominariaUnitedPlains264, DominariaUnitedPlains277,
+    DominariaUnitedIsland265, DominariaUnitedIsland266, DominariaUnitedIsland267, DominariaUnitedIsland278,
+    DominariaUnitedSwamp268, DominariaUnitedSwamp269, DominariaUnitedSwamp270, DominariaUnitedSwamp279,
+    DominariaUnitedMountain271, DominariaUnitedMountain272, DominariaUnitedMountain273, DominariaUnitedMountain280,
+    DominariaUnitedForest274, DominariaUnitedForest275, DominariaUnitedForest276, DominariaUnitedForest281
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ElectrostaticInfantry.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ElectrostaticInfantry.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Electrostatic Infantry
+ * {1}{R}
+ * Creature — Dwarf Wizard
+ * 1/2
+ * Trample
+ * Whenever you cast an instant or sorcery spell, put a +1/+1 counter on this creature.
+ */
+val ElectrostaticInfantry = card("Electrostatic Infantry") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dwarf Wizard"
+    oracleText = "Trample\nWhenever you cast an instant or sorcery spell, put a +1/+1 counter on this creature."
+    power = 1
+    toughness = 2
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "122"
+        artist = "Kekai Kotaki"
+        flavorText = "\"That's not exactly what I had in mind when I said 'charge,' but I like your enthusiasm!\"\n—Balmor, battlemage captain"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5ed2d72f-f1cf-45a7-adf7-969f531721ce.jpg?1783921319"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ElfhameWurm.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ElfhameWurm.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elfhame Wurm
+ * {4}{G}
+ * Creature — Wurm
+ * 5/4
+ * Vigilance, trample
+ */
+val ElfhameWurm = card("Elfhame Wurm") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    oracleText = "Vigilance, trample"
+    power = 5
+    toughness = 4
+
+    keywords(Keyword.VIGILANCE, Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "161"
+        artist = "Victor Adame Minguez"
+        flavorText = "The wurms consume everything in their path, so the elves make sure that their path goes through as many Phyrexians as possible."
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/ef2dc99b-083d-473e-b352-e8264353e85b.jpg?1783921301"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/FloriferousVinewall.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/FloriferousVinewall.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Floriferous Vinewall
+ * {1}{G}
+ * Creature — Plant Wall
+ * 0/2
+ * Defender
+ * When this creature enters, look at the top six cards of your library. You may reveal a land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
+ */
+val FloriferousVinewall = card("Floriferous Vinewall") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Wall"
+    oracleText = "Defender\nWhen this creature enters, look at the top six cards of your library. You may reveal a land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order."
+    power = 0
+    toughness = 2
+
+    keywords(Keyword.DEFENDER)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.lookAtTopRevealMatchingToHand(
+            count = DynamicAmount.Fixed(6),
+            filter = GameObjectFilter.Land,
+            prompt = "You may reveal a land card from among them and put it into your hand"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "163"
+        artist = "Jakub Kasper"
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/8382b7c7-762e-43f6-b285-e0cebe749fab.jpg?1783921303"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/FlowstoneInfusion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/FlowstoneInfusion.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flowstone Infusion
+ * {R}
+ * Instant
+ * Target creature gets +2/-2 until end of turn.
+ */
+val FlowstoneInfusion = card("Flowstone Infusion") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/-2 until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(2, -2, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "124"
+        artist = "Allen Williams"
+        flavorText = "The rumor that contact with flowstone would reveal Phyrexian sleeper agents was spread mostly by Phyrexian sleeper agents."
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b57c3674-9a31-4418-b306-e6b0a2514d8f.jpg?1783921318"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/FlowstoneKavu.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/FlowstoneKavu.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Flowstone Kavu
+ * {2}{R}
+ * Creature — Kavu
+ * 2/3
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ * {R}: This creature gets +1/-1 until end of turn.
+ */
+val FlowstoneKavu = card("Flowstone Kavu") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kavu"
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n{R}: This creature gets +1/-1 until end of turn."
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.MENACE)
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, -1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "125"
+        artist = "Simon Dominic"
+        flavorText = "The kavu adjusted easily to the Rathi overlay, incorporating the invasive flowstone into their own adaptable forms."
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73e40916-3502-448a-a509-f6a6ff3cd73d.jpg?1783921317"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/FrostfistStrider.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/FrostfistStrider.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Frostfist Strider
+ * {3}{U}{U}
+ * Creature — Elemental Giant
+ * 4/4
+ * Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)
+ * When this creature enters, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)
+ */
+val FrostfistStrider = card("Frostfist Strider") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental Giant"
+    oracleText = "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen this creature enters, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)"
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.WARD)
+    keywordAbility(KeywordAbility.ward("{2}"))
+
+    // A stun counter replaces the permanent's next untap, so the tap sticks for a turn cycle.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.opponentControls()))
+        effect = Effects.Composite(
+            Effects.Tap(t),
+            Effects.AddCounters(Counters.STUN, 1, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "51"
+        artist = "Francisco Miyara"
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40141353-c0d6-4529-b26a-34dfccbcf231.jpg?1783921351"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/FuriousBellow.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/FuriousBellow.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Furious Bellow
+ * {1}{R}
+ * Instant
+ * Target creature gets +3/+0 and gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ */
+val FuriousBellow = card("Furious Bellow") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+0 and gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.Composite(
+                Effects.ModifyStats(3, 0, t),
+                Effects.GrantKeyword(Keyword.FIRST_STRIKE, t)
+            ),
+            Effects.Scry(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "126"
+        artist = "Joshua Raphael"
+        flavorText = "Minotaurs sometimes pretend to be lost in a battle rage, leading their opponents to underestimate their cleverness."
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63d05659-bfff-4b73-80f7-a9f31a7ef957.jpg?1783921317"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/GeothermalBog.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/GeothermalBog.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Geothermal Bog
+ * Land — Swamp Mountain
+ * ({T}: Add {B} or {R}.)
+ * This land enters tapped.
+ *
+ * Mana abilities are intrinsic from the two basic land types (the reminder line is the whole mana text).
+ */
+val GeothermalBog = card("Geothermal Bog") {
+    colorIdentity = "BR"
+    typeLine = "Land — Swamp Mountain"
+    oracleText = "({T}: Add {B} or {R}.)\nThis land enters tapped."
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "247"
+        artist = "Gabor Szikszai"
+        flavorText = "There are still a few places where the natural dangers outweigh even those posed by Phyrexian sleeper agents."
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1e62fe57-4fa4-4bfd-8e31-9f6db774d7e2.jpg?1783921261"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/GibberingBarricade.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/GibberingBarricade.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Gibbering Barricade
+ * {2}{B}
+ * Creature — Nightmare Wall
+ * 2/4
+ * Defender
+ * {2}{B}, Sacrifice a creature: You gain 1 life and draw a card.
+ */
+val GibberingBarricade = card("Gibbering Barricade") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Nightmare Wall"
+    oracleText = "Defender\n{2}{B}, Sacrifice a creature: You gain 1 life and draw a card."
+    power = 2
+    toughness = 4
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}"), Costs.Sacrifice(GameObjectFilter.Creature))
+        effect = Effects.Composite(
+            Effects.GainLife(1),
+            Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "Drew Tucker"
+        flavorText = "\"Who needs stone walls when you can hide behind an impenetrable barrier of screaming nightmares?\"\n—Braids"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/0674b340-420d-4864-92fe-7b268fe0874c.jpg?1783921331"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/GoblinPicker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/GoblinPicker.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Picker
+ * {1}{R}
+ * Creature — Goblin
+ * 2/2
+ * {R}, {T}, Discard a card: Draw a card.
+ */
+val GoblinPicker = card("Goblin Picker") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin"
+    oracleText = "{R}, {T}, Discard a card: Draw a card."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Tap, Costs.DiscardCard)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "128"
+        artist = "Vladimir Krisetskiy"
+        flavorText = "Countless generations of Shivan goblins have worked on the Mana Rig, giving them an unparalleled eye for useful relics."
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6d8f1f06-dde5-41f2-923c-67d1d4d13fab.jpg?1783921317"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/GriffinProtectorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/GriffinProtectorReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Griffin Protector reprint in DMU. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Magic 2013's `cards/` package; this file contributes only presentation data.
+ */
+val GriffinProtectorReprint = Printing(
+    oracleId = "2d91cf05-fc39-4d76-8c95-62738b57e0a0",
+    name = "Griffin Protector",
+    setCode = "DMU",
+    collectorNumber = "18",
+    scryfallId = "10d1d701-841c-4bf3-9122-b01842a22ac6",
+    artist = "Omar Rayyan",
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/10d1d701-841c-4bf3-9122-b01842a22ac6.jpg?1783921366",
+    releaseDate = "2022-09-09",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/HauntedMire.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/HauntedMire.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Haunted Mire
+ * Land — Swamp Forest
+ * ({T}: Add {B} or {G}.)
+ * This land enters tapped.
+ *
+ * Mana abilities are intrinsic from the two basic land types (the reminder line is the whole mana text).
+ */
+val HauntedMire = card("Haunted Mire") {
+    colorIdentity = "BG"
+    typeLine = "Land — Swamp Forest"
+    oracleText = "({T}: Add {B} or {G}.)\nThis land enters tapped."
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "248"
+        artist = "Bruce Brenneise"
+        flavorText = "Some of the nature spirits and wraiths that haunt Urborg take offense at the term \"ghost town.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/16f5e958-56e6-4666-a534-24deba6f652d.jpg?1783921260"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/HurlerCyclops.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/HurlerCyclops.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Hurler Cyclops
+ * {3}{R}{R}
+ * Creature — Cyclops
+ * 5/4
+ * {1}, Sacrifice another creature: This creature deals 1 damage to any target.
+ */
+val HurlerCyclops = card("Hurler Cyclops") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Cyclops"
+    oracleText = "{1}, Sacrifice another creature: This creature deals 1 damage to any target."
+    power = 5
+    toughness = 4
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.SacrificeAnother(GameObjectFilter.Creature)
+        )
+        val t = target("any target", AnyTarget())
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "130"
+        artist = "Xavier Ribeiro"
+        flavorText = "\"It's my fault, really. I told him to throw anything he could find at the enemy.\"\n—Throppel, auxiliary commander"
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b16f2cf2-5908-4f49-9c5c-6c9e22a65a4d.jpg?1783921316"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/IdyllicBeachfront.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/IdyllicBeachfront.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Idyllic Beachfront
+ * Land — Plains Island
+ * ({T}: Add {W} or {U}.)
+ * This land enters tapped.
+ *
+ * Mana abilities are intrinsic from the two basic land types (the reminder line is the whole mana text).
+ */
+val IdyllicBeachfront = card("Idyllic Beachfront") {
+    colorIdentity = "WU"
+    typeLine = "Land — Plains Island"
+    oracleText = "({T}: Add {W} or {U}.)\nThis land enters tapped."
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "249"
+        artist = "Robin Olausson"
+        flavorText = "In the tradition of the original Tolarian Academy, every Tolarian campus is built near a body of water."
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c50ec22c-decb-419f-ae52-78ea1706eb11.jpg?1783921261"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/JayasFirenado.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/JayasFirenado.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jaya's Firenado
+ * {4}{R}
+ * Sorcery
+ * Jaya's Firenado deals 5 damage to target creature or planeswalker. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ */
+val JayasFirenado = card("Jaya's Firenado") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Jaya's Firenado deals 5 damage to target creature or planeswalker. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        val t = target("target", Targets.CreatureOrPlaneswalker)
+        effect = Effects.Composite(
+            Effects.DealDamage(5, t),
+            Effects.Scry(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "134"
+        artist = "Jeremy Wilson"
+        flavorText = "\"For all their supposed advances, the Phyrexians still aren't fireproof.\"\n—Jaya Ballard"
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b78eaab-819c-4f06-b3b1-a25c17ab2235.jpg?1783921314"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/LeafCrownedVisionary.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/LeafCrownedVisionary.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Leaf-Crowned Visionary
+ * {G}{G}
+ * Creature — Elf Druid
+ * 1/1
+ * Other Elves you control get +1/+1.
+ * Whenever you cast an Elf spell, you may pay {G}. If you do, draw a card.
+ */
+val LeafCrownedVisionary = card("Leaf-Crowned Visionary") {
+    manaCost = "{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid"
+    oracleText = "Other Elves you control get +1/+1.\nWhenever you cast an Elf spell, you may pay {G}. If you do, draw a card."
+    power = 1
+    toughness = 1
+
+    // "Other Elves you control" is every Elf *permanent* you control — a kindred
+    // enchantment counts — minus this creature.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype("Elf").youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCastSubtype(Subtype("Elf"))
+        effect = MayPayManaEffect(ManaCost.parse("{G}"), Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "167"
+        artist = "Anna Steinbauer"
+        flavorText = "\"The seedling you save today may be the sheltering boughs of generations to come.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aa7bd814-9f88-4e01-932d-07ac1abc060e.jpg?1783921299"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/LlanowarStalker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/LlanowarStalker.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Llanowar Stalker
+ * {G}
+ * Creature — Elf Warrior
+ * 1/1
+ * Whenever another creature you control enters, this creature gets +1/+0 until end of turn.
+ */
+val LlanowarStalker = card("Llanowar Stalker") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    oracleText = "Whenever another creature you control enters, this creature gets +1/+0 until end of turn."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "171"
+        artist = "Fariba Khamseh"
+        flavorText = "If you spot one elf in Llanowar, it's likely there's another with a knife at your back."
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2d714d8-0e9b-4761-a0ef-3429b4e2f5b7.jpg?1783921297"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/MeriaScholarOfAntiquity.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/MeriaScholarOfAntiquity.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Meria, Scholar of Antiquity
+ * {1}{R}{G}
+ * Legendary Creature — Elf Artificer
+ * 3/3
+ * Tap an untapped nontoken artifact you control: Add {G}.
+ * Tap two untapped nontoken artifacts you control: Exile the top card of your library. You may play it this turn.
+ */
+val MeriaScholarOfAntiquity = card("Meria, Scholar of Antiquity") {
+    manaCost = "{1}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Creature — Elf Artificer"
+    oracleText = "Tap an untapped nontoken artifact you control: Add {G}.\nTap two untapped nontoken artifacts you control: Exile the top card of your library. You may play it this turn."
+    power = 3
+    toughness = 3
+
+    // Both costs tap *nontoken* artifacts; `TapPermanents` already restricts the
+    // candidates to untapped permanents their controller controls.
+    activatedAbility {
+        cost = Costs.TapPermanents(1, GameObjectFilter.Artifact.nontoken())
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.TapPermanents(2, GameObjectFilter.Artifact.nontoken())
+        effect = Patterns.Exile.impulse(count = 1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "206"
+        artist = "Aurore Folny"
+        flavorText = "\"Why fear artifice? Is it not also of this world?\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3eedd979-783d-4721-92de-965b77c20576.jpg?1783921281"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/MesaCavalier.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/MesaCavalier.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mesa Cavalier
+ * {2}{W}
+ * Creature — Human Knight
+ * 2/1
+ * Flying
+ * When this creature enters, you gain 2 life.
+ */
+val MesaCavalier = card("Mesa Cavalier") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Flying\nWhen this creature enters, you gain 2 life."
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "26"
+        artist = "David Palumbo"
+        flavorText = "In the fight to defeat Phyrexia, the courage of Benalish knights is matched only by that of their pegasus steeds."
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/feeec740-7ffc-4f57-b52c-92209da91d69.jpg?1783921362"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/MeteoriteReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/MeteoriteReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meteorite reprint in DMU. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Magic 2015's `cards/` package; this file contributes only presentation data.
+ */
+val MeteoriteReprint = Printing(
+    oracleId = "0c3c3bcc-d485-4a01-92fe-8bf29c0fc926",
+    name = "Meteorite",
+    setCode = "DMU",
+    collectorNumber = "235",
+    scryfallId = "33eb2032-50af-4fd6-bdc7-7cae2211956c",
+    artist = "Olena Richards",
+    imageUri = "https://cards.scryfall.io/normal/front/3/3/33eb2032-50af-4fd6-bdc7-7cae2211956c.jpg?1783921269",
+    releaseDate = "2022-09-09",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/MoltenMonstrosity.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/MoltenMonstrosity.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+
+/**
+ * Molten Monstrosity
+ * {7}{R}
+ * Creature — Hellion
+ * 5/5
+ * This spell costs {X} less to cast, where X is the greatest power among creatures you control.
+ * Trample
+ */
+val MoltenMonstrosity = card("Molten Monstrosity") {
+    manaCost = "{7}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Hellion"
+    oracleText = "This spell costs {X} less to cast, where X is the greatest power among creatures you control.\nTrample"
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.TRAMPLE)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.GreatestPropertyAmongPermanentsYouControl(
+                    EntityNumericProperty.Power,
+                    GameObjectFilter.Creature
+                )
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "139"
+        artist = "Manuel Castañón"
+        flavorText = "The cold snap killed off most of the heat-loving hellions . . . leaving only the strongest alive to breed."
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/240957e5-ab0a-443f-92de-ae999b08c44f.jpg?1783921312"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/MoltenTributary.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/MoltenTributary.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Molten Tributary
+ * Land — Island Mountain
+ * ({T}: Add {U} or {R}.)
+ * This land enters tapped.
+ *
+ * Mana abilities are intrinsic from the two basic land types (the reminder line is the whole mana text).
+ */
+val MoltenTributary = card("Molten Tributary") {
+    colorIdentity = "UR"
+    typeLine = "Land — Island Mountain"
+    oracleText = "({T}: Add {U} or {R}.)\nThis land enters tapped."
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "251"
+        artist = "Yeong-Hao Han"
+        flavorText = "Though dangerous, Shiv teems with both life and mana, making it a tempting destination for ambitious mages."
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/20aff4af-5128-432f-a8c8-65b6909d31ac.jpg?1783921259"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/MossbeardAncient.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/MossbeardAncient.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mossbeard Ancient
+ * {5}{G}{G}
+ * Creature — Treefolk
+ * 7/7
+ * Trample
+ * When this creature enters, you gain 5 life.
+ */
+val MossbeardAncient = card("Mossbeard Ancient") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Treefolk"
+    oracleText = "Trample\nWhen this creature enters, you gain 5 life."
+    power = 7
+    toughness = 7
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(5)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "173"
+        artist = "Alexandre Honoré"
+        flavorText = "Older than the mountains, the dragons, and the wars of humans and machines."
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e528d36-cea6-4013-83d5-ba837d570713.jpg?1783921298"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/NishobaBrawler.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/NishobaBrawler.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nishoba Brawler
+ * {1}{G}
+ * Creature — Cat Warrior
+ * * / 3
+ * Trample
+ * Domain — Nishoba Brawler's power is equal to the number of basic land types among lands you control.
+ */
+val NishobaBrawler = card("Nishoba Brawler") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat Warrior"
+    oracleText = "Trample\nDomain — Nishoba Brawler's power is equal to the number of basic land types among lands you control."
+
+    // Domain is an ability word (CR 207.2c) — no rules meaning of its own. The
+    // value is the number of basic land types among lands you control, capped at five.
+    dynamicPower(DynamicAmounts.domain())
+    toughness = 3
+
+    keywords(Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "174"
+        artist = "Valera Lutfullina"
+        flavorText = "Though native to cold climates, the nishoba have adapted to more temperate environments since the Ice Age ended."
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2ef6cb5f-0ab3-4652-9b39-c2cbf6d693d5.jpg?1783921297"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/RadiantGrove.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/RadiantGrove.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Radiant Grove
+ * Land — Forest Plains
+ * ({T}: Add {G} or {W}.)
+ * This land enters tapped.
+ *
+ * Mana abilities are intrinsic from the two basic land types (the reminder line is the whole mana text).
+ */
+val RadiantGrove = card("Radiant Grove") {
+    colorIdentity = "WG"
+    typeLine = "Land — Forest Plains"
+    oracleText = "({T}: Add {G} or {W}.)\nThis land enters tapped."
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "253"
+        artist = "Lorenzo Lanfranconi"
+        flavorText = "Yavimaya's inhabitants are dedicated to protecting its unspoiled jungle from the scourge of artifice."
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0f9dca6-e5ae-4714-8a59-2ef1d8f1e82d.jpg?1783921259"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/SacredPeaks.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/SacredPeaks.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Sacred Peaks
+ * Land — Mountain Plains
+ * ({T}: Add {R} or {W}.)
+ * This land enters tapped.
+ *
+ * Mana abilities are intrinsic from the two basic land types (the reminder line is the whole mana text).
+ */
+val SacredPeaks = card("Sacred Peaks") {
+    colorIdentity = "WR"
+    typeLine = "Land — Mountain Plains"
+    oracleText = "({T}: Add {R} or {W}.)\nThis land enters tapped."
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "254"
+        artist = "Kamila Szutenberg"
+        flavorText = "Everyone is welcome in the floating Serran cities, though few but the most faithful attempt the ascent."
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/24957d64-ad17-4d4f-8a00-3cdd83e1ce88.jpg?1783921260"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/SalvagedManaworker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/SalvagedManaworker.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Salvaged Manaworker
+ * {2}
+ * Artifact Creature — Construct
+ * 1/3
+ * {1}: Add one mana of any color. Activate only once each turn.
+ */
+val SalvagedManaworker = card("Salvaged Manaworker") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    oracleText = "{1}: Add one mana of any color. Activate only once each turn."
+    power = 1
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "237"
+        artist = "Julian Kok Joon Wen"
+        flavorText = "\"When weapons of war are repurposed for peaceful ends, you know society has advanced.\"\n—Jodah"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5fc22ecb-5d87-464e-8c7d-5d40a52e1e4f.jpg?1783921267"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ShadowRitePriest.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ShadowRitePriest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Shadow-Rite Priest
+ * {1}{B}
+ * Creature — Human Cleric
+ * 2/2
+ * Other Clerics you control get +1/+1.
+ * {3}{B}{B}, {T}, Sacrifice another Cleric: Search your library for a black creature card, put it onto the battlefield, then shuffle.
+ */
+val ShadowRitePriest = card("Shadow-Rite Priest") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Cleric"
+    oracleText = "Other Clerics you control get +1/+1.\n{3}{B}{B}, {T}, Sacrifice another Cleric: Search your library for a black creature card, put it onto the battlefield, then shuffle."
+    power = 2
+    toughness = 2
+
+    // "Other Clerics you control" is every Cleric *permanent* you control minus this creature.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype("Cleric").youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{3}{B}{B}"),
+            Costs.Tap,
+            Costs.SacrificeAnother(GameObjectFilter.Permanent.withSubtype("Cleric"))
+        )
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Creature.withColor(Color.BLACK),
+            count = 1,
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "106"
+        artist = "Michael C. Hayes"
+        flavorText = "Backstabbing is common within demonic cults. So are front- and side-stabbing."
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c9e43116-a489-4557-a47f-623d915a2b79.jpg?1783921326"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/SoaringDrake.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/SoaringDrake.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soaring Drake
+ * {2}{U}
+ * Creature — Drake
+ * 2/3
+ * Flying
+ */
+val SoaringDrake = card("Soaring Drake") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    oracleText = "Flying"
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Jason Kang"
+        flavorText = "The already spectacular views from the towers of the College at Lat-Nam are sometimes enhanced by glimpses of drakes diving into the ocean to devour small sharks."
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b0979f9-aae3-4fc7-beae-c8c6637ae596.jpg?1783921344"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/SplatterGoblin.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/SplatterGoblin.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Splatter Goblin
+ * {1}{B}
+ * Creature — Phyrexian Goblin
+ * 2/1
+ * When this creature dies, target creature an opponent controls gets -1/-1 until end of turn.
+ */
+val SplatterGoblin = card("Splatter Goblin") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Goblin"
+    oracleText = "When this creature dies, target creature an opponent controls gets -1/-1 until end of turn."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.opponentControls()))
+        effect = Effects.ModifyStats(-1, -1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "109"
+        artist = "Lars Grant-West"
+        flavorText = "\"For some, perfection is but a single moment when form and purpose converge.\"\n—Rona"
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/5045027d-0ff4-484c-b4cb-e0b61885d428.jpg?1783921326"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/SunlitMarsh.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/SunlitMarsh.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Sunlit Marsh
+ * Land — Plains Swamp
+ * ({T}: Add {W} or {B}.)
+ * This land enters tapped.
+ *
+ * Mana abilities are intrinsic from the two basic land types (the reminder line is the whole mana text).
+ */
+val SunlitMarsh = card("Sunlit Marsh") {
+    colorIdentity = "WB"
+    typeLine = "Land — Plains Swamp"
+    oracleText = "({T}: Add {W} or {B}.)\nThis land enters tapped."
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "257"
+        artist = "Marc Simonetti"
+        flavorText = "Even the poisoned land around the Stronghold blossomed with new life in the wake of the Great Mending."
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f0588fbf-3c05-452a-b3f7-67604c1f921d.jpg?1783921257"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/TalasLookout.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/TalasLookout.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Talas Lookout
+ * {2}{U}{U}
+ * Creature — Human Pirate
+ * 3/2
+ * Flying
+ * When this creature dies, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.
+ *
+ * The kept card goes to hand and the remainder to the graveyard — the
+ * `lookAtTopAndKeep` defaults, so only the two counts are spelled here.
+ */
+val TalasLookout = card("Talas Lookout") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Pirate"
+    oracleText = "Flying\nWhen this creature dies, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard."
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Patterns.Library.lookAtTopAndKeep(count = 2, keepCount = 1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "68"
+        artist = "Julia Metzger"
+        flavorText = "\"The Talas pirates are motivated by money, so we paid them twice what they could steal from us to spy for us instead.\"\n—Jhoira"
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0a4b9afe-aeb7-4c56-8a22-96e19a7a938c.jpg?1783921343"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/TangledIslet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/TangledIslet.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Tangled Islet
+ * Land — Forest Island
+ * ({T}: Add {G} or {U}.)
+ * This land enters tapped.
+ *
+ * Mana abilities are intrinsic from the two basic land types (the reminder line is the whole mana text).
+ */
+val TangledIslet = card("Tangled Islet") {
+    colorIdentity = "UG"
+    typeLine = "Land — Forest Island"
+    oracleText = "({T}: Add {G} or {U}.)\nThis land enters tapped."
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "258"
+        artist = "Randy Gallegos"
+        flavorText = "Many of Terisiare's islands are merely extensions of the root system of the Yavimaya magnigoth forests."
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4a325fb4-fe71-47f1-9a2f-05b8cfe88fe6.jpg?1783921256"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/TatteredApparition.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/TatteredApparition.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tattered Apparition
+ * {3}{B}
+ * Creature — Shade
+ * 2/2
+ * Flying
+ * {1}{B}: This creature gets +1/+1 until end of turn.
+ */
+val TatteredApparition = card("Tattered Apparition") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Shade"
+    oracleText = "Flying\n{1}{B}: This creature gets +1/+1 until end of turn."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{B}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "Jason A. Engle"
+        flavorText = "\"Ah yes, I remember that one. I turned him inside out and cast his soul into an endless nightmare a few centuries ago.\"\n—Braids"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/0368e91c-31ee-4b81-a361-30a4555b1a42.jpg?1783921324"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/TerritorialMaro.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/TerritorialMaro.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Territorial Maro
+ * {4}{G}
+ * Creature — Elemental
+ * * / *
+ * Domain — Territorial Maro's power and toughness are each equal to twice the number of basic land types among lands you control.
+ */
+val TerritorialMaro = card("Territorial Maro") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental"
+    oracleText = "Domain — Territorial Maro's power and toughness are each equal to twice the number of basic land types among lands you control."
+
+    // Twice the domain count, in both halves of the printed `*`/`*`.
+    dynamicPower(DynamicAmount.Multiply(DynamicAmounts.domain(), 2))
+    dynamicToughness(DynamicAmount.Multiply(DynamicAmounts.domain(), 2))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "184"
+        artist = "Simon Dominic"
+        flavorText = "The Coalition was more than just treaties and alliances: it was the soul of a world rising up against the invading tide."
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/853ddf31-826b-411e-9b6d-75d53cdd1b84.jpg?1783921293"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/TidepoolTurtle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/TidepoolTurtle.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tidepool Turtle
+ * {3}{U}
+ * Creature — Turtle
+ * 2/5
+ * {2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ */
+val TidepoolTurtle = card("Tidepool Turtle") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Turtle"
+    oracleText = "{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+    power = 2
+    toughness = 5
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{U}")
+        effect = Effects.Scry(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "69"
+        artist = "Andrew Mar"
+        flavorText = "Prized by wizards as a mobile scrying pool, it bears visions drawn from the depths of the sea."
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d397fb84-8573-4b2c-be2c-f8fd820342f0.jpg?1783921342"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ToxicAbomination.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ToxicAbomination.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Toxic Abomination
+ * {1}{B}
+ * Creature — Phyrexian Zombie
+ * 3/2
+ * When this creature enters, you lose 2 life.
+ */
+val ToxicAbomination = card("Toxic Abomination") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Zombie"
+    oracleText = "When this creature enters, you lose 2 life."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.LoseLife(2, EffectTarget.Controller)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "112"
+        artist = "Igor Kieryluk"
+        flavorText = "Deep in the forgotten reaches of Urborg, ancient Phyrexian monstrosities shamble endlessly, putrid ichor leaking from their rusted forms."
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f435329e-6de7-4b05-ba70-cb63d121116e.jpg?1783921324"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/TuraKennerudSkyknight.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/TuraKennerudSkyknight.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tura Kennerüd, Skyknight
+ * {2}{W}{U}{U}
+ * Legendary Creature — Human Knight
+ * 3/3
+ * Flying
+ * Whenever you cast an instant or sorcery spell, create a 1/1 white Soldier creature token.
+ */
+val TuraKennerudSkyknight = card("Tura Kennerüd, Skyknight") {
+    manaCost = "{2}{W}{U}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Human Knight"
+    oracleText = "Flying\nWhenever you cast an instant or sorcery spell, create a 1/1 white Soldier creature token."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Soldier")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "224"
+        artist = "Donato Giancola"
+        flavorText = "\"The sky is my birthright. I dare you to try and take it from me.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c839d302-bf85-4a30-a49a-dbbd48695b5c.jpg?1783921274"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/UurgSpawnOfTurg.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/UurgSpawnOfTurg.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Uurg, Spawn of Turg
+ * {B}{B}{G}
+ * Legendary Creature — Frog Beast
+ * * / 5
+ * Uurg's power is equal to the number of land cards in your graveyard.
+ * At the beginning of your upkeep, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)
+ * {B}{G}, Sacrifice a land: You gain 2 life.
+ */
+val UurgSpawnOfTurg = card("Uurg, Spawn of Turg") {
+    manaCost = "{B}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Frog Beast"
+    oracleText = "Uurg's power is equal to the number of land cards in your graveyard.\nAt the beginning of your upkeep, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)\n{B}{G}, Sacrifice a land: You gain 2 life."
+
+    // Characteristic-defining ability (CR 604.3) — functions in every zone.
+    dynamicPower(
+        DynamicAmount.Count(
+            player = Player.You,
+            zone = Zone.GRAVEYARD,
+            filter = GameObjectFilter.Land
+        )
+    )
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Surveil(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}{G}"), Costs.Sacrifice(GameObjectFilter.Land))
+        effect = Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "225"
+        artist = "Nicholas Gregory"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd3fc36c-682b-4352-a66f-eddd2baf0bf6.jpg?1783921273"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/VanquishersAxe.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/VanquishersAxe.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Vanquisher's Axe
+ * {1}
+ * Artifact — Equipment
+ * Equipped creature gets +2/+0.
+ * Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)
+ */
+val VanquishersAxe = card("Vanquisher's Axe") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(+2, +0, Filters.EquippedCreature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "240"
+        artist = "Joe Slucher"
+        flavorText = "When a Keldon takes a trophy from an enemy, it's usually something they can use to kill more enemies."
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/aef37244-deb9-464e-ab8c-4308369ae09b.jpg?1783921266"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/WrithingNecromass.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/WrithingNecromass.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Writhing Necromass
+ * {6}{B}
+ * Creature — Zombie Giant
+ * 5/5
+ * This spell costs {1} less to cast for each creature card in your graveyard.
+ * Deathtouch
+ */
+val WrithingNecromass = card("Writhing Necromass") {
+    manaCost = "{6}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Giant"
+    oracleText = "This spell costs {1} less to cast for each creature card in your graveyard.\nDeathtouch"
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.DEATHTOUCH)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.CardsInGraveyardMatchingFilter(
+                    filter = GameObjectFilter.Creature,
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "Campbell White"
+        flavorText = "\"We sent three of our best legions! You're telling me no one came back?\"\n—Tori D'Avenant"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a166abef-f068-47e9-8a65-43ebf4b015bd.jpg?1783921322"
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NishobaBrawlerScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NishobaBrawlerScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Nishoba Brawler (DMU #174) — {1}{G} Cat Warrior, power * / toughness 3, Trample.
+ *
+ * "Domain — Nishoba Brawler's power is equal to the number of basic land types among lands
+ * you control."
+ *
+ * Domain is the first characteristic-defining ability (CR 604.3) in the corpus to read
+ * `DynamicAmounts.domain()`, so this test pins the three things that make it different from a
+ * plain count: it counts *types* rather than lands, a dual land contributes both of its types,
+ * and only lands their controller controls are looked at.
+ */
+class NishobaBrawlerScenarioTest : ScenarioTestBase() {
+
+    private fun brawlerId(game: TestGame): EntityId =
+        game.state.getBattlefield().first { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name == "Nishoba Brawler"
+        }
+
+    init {
+        context("Nishoba Brawler — power = basic land types among lands you control") {
+
+            test("counts distinct types, not lands; toughness stays 3") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Nishoba Brawler")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .build()
+
+                val id = brawlerId(game)
+
+                withClue("four lands but only two basic land types → power 2") {
+                    game.state.projectedState.getPower(id) shouldBe 2
+                }
+                withClue("toughness is fixed at 3") {
+                    game.state.projectedState.getToughness(id) shouldBe 3
+                }
+            }
+
+            test("a dual land contributes both of its basic land types") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Nishoba Brawler")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardOnBattlefield(1, "Contaminated Aquifer") // Land — Island Swamp
+                    .withActivePlayer(1)
+                    .build()
+
+                val id = brawlerId(game)
+
+                withClue("Forest + Island + Swamp → power 3") {
+                    game.state.projectedState.getPower(id) shouldBe 3
+                }
+            }
+
+            test("lands an opponent controls do not count") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Nishoba Brawler")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(2, "Island", 1)
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .build()
+
+                val id = brawlerId(game)
+
+                withClue("only the controller's Swamp counts → power 1") {
+                    game.state.projectedState.getPower(id) shouldBe 1
+                }
+            }
+
+            test("power is 0 with no lands") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Nishoba Brawler")
+                    .withActivePlayer(1)
+                    .build()
+
+                val id = brawlerId(game)
+
+                game.state.projectedState.getPower(id) shouldBe 0
+                game.state.projectedState.getToughness(id) shouldBe 3
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TerritorialMaroScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TerritorialMaroScenarioTest.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Territorial Maro (DMU #184) — {4}{G} Elemental, power * / toughness *.
+ *
+ * "Domain — Territorial Maro's power and toughness are each equal to twice the number of basic
+ * land types among lands you control."
+ *
+ * Both halves of the printed `*`/`*` are the *same* doubled domain count, so this test pins the
+ * multiplier on each half independently — a card that doubled only power would still look right
+ * on the board.
+ */
+class TerritorialMaroScenarioTest : ScenarioTestBase() {
+
+    private fun maroId(game: TestGame): EntityId =
+        game.state.getBattlefield().first { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name == "Territorial Maro"
+        }
+
+    init {
+        context("Territorial Maro — power and toughness are each twice your domain") {
+
+            test("one basic land type → 2/2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Territorial Maro")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .build()
+
+                val id = maroId(game)
+
+                withClue("four Forests are still one basic land type → 2/2") {
+                    game.state.projectedState.getPower(id) shouldBe 2
+                    game.state.projectedState.getToughness(id) shouldBe 2
+                }
+            }
+
+            test("all five basic land types → 10/10") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Territorial Maro")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .build()
+
+                val id = maroId(game)
+
+                withClue("domain caps at five types → 10/10") {
+                    game.state.projectedState.getPower(id) shouldBe 10
+                    game.state.projectedState.getToughness(id) shouldBe 10
+                }
+            }
+
+            test("lands an opponent controls do not count") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Territorial Maro")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(2, "Plains", 1)
+                    .withLandsOnBattlefield(2, "Island", 1)
+                    .withActivePlayer(1)
+                    .build()
+
+                val id = maroId(game)
+
+                withClue("only the controller's Mountain counts → 2/2") {
+                    game.state.projectedState.getPower(id) shouldBe 2
+                    game.state.projectedState.getToughness(id) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ALA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ALA.json
@@ -1,3 +1,49 @@
+// Bone Splinters
+{
+    "name": "Bone Splinters",
+    "manaCost": "{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a creature.\nDestroy target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "67",
+        "artist": "Cole Eastburn",
+        "flavorText": "Witches of the Split-Eye Coven speak of a future when Grixis will overflow with life energy. For now, they must harvest vis from the living to fuel their dark magics.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d4a4b3a3-b7ae-4210-8037-098fdf5808d0.jpg?1783942568"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Cylian Elf
 {
     "name": "Cylian Elf",

--- a/mtg-sets/src/test/resources/snapshots/cards/DMU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DMU.json
@@ -1,3 +1,68 @@
+// Argivian Phalanx
+{
+    "name": "Argivian Phalanx",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Human Kor Soldier",
+    "oracleText": "Affinity for creatures (This spell costs {1} less to cast for each creature you control.)\nVigilance (Attacking doesn't cause this creature to tap.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE",
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "CREATURE"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "5",
+        "artist": "Josh Hass",
+        "flavorText": "New Argive welcomed the kor people when they were displaced by the Rathi overlay. The kor repay that kindness with fierce loyalty.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/afbadc37-1b4f-4237-a3c0-772bafb18aa0.jpg?1783921373"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Automatic Librarian
+{
+    "name": "Automatic Librarian",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "When this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "229",
+        "artist": "Alex Konstad",
+        "flavorText": "Enforcing absolute quiet with extreme prejudice since 3285 AR.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6c3d7ece-0f57-4213-a0ab-a9d7c1536ebb.jpg?1783921271"
+    },
+    "colorIdentityOverride": []
+}
+
 // Balmor, Battlemage Captain
 {
     "name": "Balmor, Battlemage Captain",
@@ -77,6 +142,98 @@
     ]
 }
 
+// Battle-Rage Blessing
+{
+    "name": "Battle-Rage Blessing",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gains deathtouch and indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "artist": "Jarel Threat",
+        "flavorText": "\"Since when is it cheating to give one side an unfair advantage?\"\n—Braids",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7cfc631b-49d1-4f1c-adac-5b07a2ccd06f.jpg?1783921339"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Battlefly Swarm
+{
+    "name": "Battlefly Swarm",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Phyrexian Insect",
+    "oracleText": "Flying\n{B}: This creature gains deathtouch until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "artist": "Xavier Ribeiro",
+        "flavorText": "Having encountered the bitter Phyrexian battleflies before, Squee knew not to bother eating them—or at least to stop after the fifth.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3c6b4a2d-0bc0-4a54-9c78-712b48ad6be1.jpg?1783921337"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Bite Down
 {
     "name": "Bite Down",
@@ -125,6 +282,122 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Charismatic Vanguard
+{
+    "name": "Charismatic Vanguard",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Dwarf Soldier",
+    "oracleText": "{4}{W}: Creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "artist": "David Palumbo",
+        "flavorText": "\"This battlefield is an anvil, my mace a forging hammer . . . and you, Phyrexian scum, are the scrap metal that's about to be reshaped as I see fit.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a51764fe-0d75-4cfa-a699-0d9e7ffb7843.jpg?1783921370"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Clockwork Drawbridge
+{
+    "name": "Clockwork Drawbridge",
+    "manaCost": "{W}",
+    "typeLine": "Artifact Creature — Wall",
+    "oracleText": "Defender\n{2}{W}, {T}: Tap target creature.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "artist": "Nadia Hurianova",
+        "flavorText": "Argivia's clockwork fortifications are the stuff of legend, reminding all on Dominaria that ingenuity has saved them before and can do so again.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/037cb79c-163d-4b36-bd93-954eca8fe26e.jpg?1783921369"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -193,6 +466,29 @@
     ]
 }
 
+// Contaminated Aquifer
+{
+    "name": "Contaminated Aquifer",
+    "manaCost": "",
+    "typeLine": "Land — Island Swamp",
+    "oracleText": "({T}: Add {U} or {B}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "245",
+        "artist": "Robin Olausson",
+        "flavorText": "The caves stretch farther than anyone knows, and the terrible legacy of Yawgmoth lurks in every shadow.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6bb570f4-de68-4d8c-a9f3-8a3294163aa8.jpg?1783921262"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Crystal Grotto
 {
     "name": "Crystal Grotto",
@@ -254,6 +550,434 @@
         "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd250c9d-c65f-4293-a6b0-007fac634d3d.jpg?1783921264"
     },
     "colorIdentityOverride": []
+}
+
+// Deathbloom Gardener
+{
+    "name": "Deathbloom Gardener",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "Deathtouch\n{T}: Add one mana of any color.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "159",
+        "artist": "Marta Nael",
+        "flavorText": "\"I can provide the Coalition with poisons that will break down Phyrexian machinery as easily as they stop the heart.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88dee3d1-0496-40ea-b208-7362a932f531.jpg?1783921304"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Electrostatic Infantry
+{
+    "name": "Electrostatic Infantry",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Dwarf Wizard",
+    "oracleText": "Trample\nWhenever you cast an instant or sorcery spell, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "rarity": "UNCOMMON",
+        "artist": "Kekai Kotaki",
+        "flavorText": "\"That's not exactly what I had in mind when I said 'charge,' but I like your enthusiasm!\"\n—Balmor, battlemage captain",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5ed2d72f-f1cf-45a7-adf7-969f531721ce.jpg?1783921319"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Elfhame Wurm
+{
+    "name": "Elfhame Wurm",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Wurm",
+    "oracleText": "Vigilance, trample",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE",
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "161",
+        "artist": "Victor Adame Minguez",
+        "flavorText": "The wurms consume everything in their path, so the elves make sure that their path goes through as many Phyrexians as possible.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/ef2dc99b-083d-473e-b352-e8264353e85b.jpg?1783921301"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Floriferous Vinewall
+{
+    "name": "Floriferous Vinewall",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Plant Wall",
+    "oracleText": "Defender\nWhen this creature enters, look at the top six cards of your library. You may reveal a land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 6
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "land",
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "prompt": "You may reveal a land card from among them and put it into your hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "artist": "Jakub Kasper",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/8382b7c7-762e-43f6-b285-e0cebe749fab.jpg?1783921303"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Flowstone Infusion
+{
+    "name": "Flowstone Infusion",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/-2 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -2
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "artist": "Allen Williams",
+        "flavorText": "The rumor that contact with flowstone would reveal Phyrexian sleeper agents was spread mostly by Phyrexian sleeper agents.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b57c3674-9a31-4418-b306-e6b0a2514d8f.jpg?1783921318"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Flowstone Kavu
+{
+    "name": "Flowstone Kavu",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Kavu",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\n{R}: This creature gets +1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "artist": "Simon Dominic",
+        "flavorText": "The kavu adjusted easily to the Rathi overlay, incorporating the invasive flowstone into their own adaptable forms.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73e40916-3502-448a-a509-f6a6ff3cd73d.jpg?1783921317"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Frostfist Strider
+{
+    "name": "Frostfist Strider",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Elemental Giant",
+    "oracleText": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)\nWhen this creature enters, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "stun",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "UNCOMMON",
+        "artist": "Francisco Miyara",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/40141353-c0d6-4529-b26a-34dfccbcf231.jpg?1783921351"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Furious Bellow
+{
+    "name": "Furious Bellow",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+0 and gains first strike until end of turn. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FIRST_STRIKE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "126",
+        "artist": "Joshua Raphael",
+        "flavorText": "Minotaurs sometimes pretend to be lost in a battle rage, leading their opponents to underestimate their cleverness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/63d05659-bfff-4b73-80f7-a9f31a7ef957.jpg?1783921317"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
 }
 
 // Garna, Bloodfist of Keld
@@ -322,6 +1046,150 @@
     ]
 }
 
+// Geothermal Bog
+{
+    "name": "Geothermal Bog",
+    "manaCost": "",
+    "typeLine": "Land — Swamp Mountain",
+    "oracleText": "({T}: Add {B} or {R}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "artist": "Gabor Szikszai",
+        "flavorText": "There are still a few places where the natural dangers outweigh even those posed by Phyrexian sleeper agents.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e62fe57-4fa4-4bfd-8e31-9f6db774d7e2.jpg?1783921261"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Gibbering Barricade
+{
+    "name": "Gibbering Barricade",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Nightmare Wall",
+    "oracleText": "Defender\n{2}{B}, Sacrifice a creature: You gain 1 life and draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "artist": "Drew Tucker",
+        "flavorText": "\"Who needs stone walls when you can hide behind an impenetrable barrier of screaming nightmares?\"\n—Braids",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/0674b340-420d-4864-92fe-7b268fe0874c.jpg?1783921331"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Goblin Picker
+{
+    "name": "Goblin Picker",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin",
+    "oracleText": "{R}, {T}, Discard a card: Draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "artist": "Vladimir Krisetskiy",
+        "flavorText": "Countless generations of Shivan goblins have worked on the Mana Rig, giving them an unparalleled eye for useful relics.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6d8f1f06-dde5-41f2-923c-67d1d4d13fab.jpg?1783921317"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Haughty Djinn
 {
     "name": "Haughty Djinn",
@@ -376,6 +1244,118 @@
         ]
     },
     "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Haunted Mire
+{
+    "name": "Haunted Mire",
+    "manaCost": "",
+    "typeLine": "Land — Swamp Forest",
+    "oracleText": "({T}: Add {B} or {G}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "248",
+        "artist": "Bruce Brenneise",
+        "flavorText": "Some of the nature spirits and wraiths that haunt Urborg take offense at the term \"ghost town.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/16f5e958-56e6-4666-a534-24deba6f652d.jpg?1783921260"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Hurler Cyclops
+{
+    "name": "Hurler Cyclops",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Cyclops",
+    "oracleText": "{1}, Sacrifice another creature: This creature deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "rarity": "UNCOMMON",
+        "artist": "Xavier Ribeiro",
+        "flavorText": "\"It's my fault, really. I told him to throw anything he could find at the enemy.\"\n—Throppel, auxiliary commander",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b16f2cf2-5908-4f49-9c5c-6c9e22a65a4d.jpg?1783921316"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Idyllic Beachfront
+{
+    "name": "Idyllic Beachfront",
+    "manaCost": "",
+    "typeLine": "Land — Plains Island",
+    "oracleText": "({T}: Add {W} or {U}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "249",
+        "artist": "Robin Olausson",
+        "flavorText": "In the tradition of the original Tolarian Academy, every Tolarian campus is built near a body of water.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c50ec22c-decb-419f-ae52-78ea1706eb11.jpg?1783921261"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
         "BLUE"
     ]
 }
@@ -445,6 +1425,120 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Jaya's Firenado
+{
+    "name": "Jaya's Firenado",
+    "manaCost": "{4}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Jaya's Firenado deals 5 damage to target creature or planeswalker. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "artist": "Jeremy Wilson",
+        "flavorText": "\"For all their supposed advances, the Phyrexians still aren't fireproof.\"\n—Jaya Ballard",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b78eaab-819c-4f06-b3b1-a25c17ab2235.jpg?1783921314"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Leaf-Crowned Visionary
+{
+    "name": "Leaf-Crowned Visionary",
+    "manaCost": "{G}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "Other Elves you control get +1/+1.\nWhenever you cast an Elf spell, you may pay {G}. If you do, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasSubtype",
+                                "subtype": "Elf"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{G}"
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "permanent Elf ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "rarity": "RARE",
+        "artist": "Anna Steinbauer",
+        "flavorText": "\"The seedling you save today may be the sheltering boughs of generations to come.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aa7bd814-9f88-4e01-932d-07ac1abc060e.jpg?1783921299"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -523,6 +1617,52 @@
     ]
 }
 
+// Llanowar Stalker
+{
+    "name": "Llanowar Stalker",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "Whenever another creature you control enters, this creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "artist": "Fariba Khamseh",
+        "flavorText": "If you spot one elf in Llanowar, it's likely there's another with a knife at your back.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2d714d8-0e9b-4761-a0ef-3429b4e2f5b7.jpg?1783921297"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Magnigoth Sentry
 {
     "name": "Magnigoth Sentry",
@@ -544,6 +1684,130 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Meria, Scholar of Antiquity
+{
+    "name": "Meria, Scholar of Antiquity",
+    "manaCost": "{1}{R}{G}",
+    "typeLine": "Legendary Creature — Elf Artificer",
+    "oracleText": "Tap an untapped nontoken artifact you control: Add {G}.\nTap two untapped nontoken artifacts you control: Exile the top card of your library. You may play it this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "artifact nontoken"
+                    }
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "artifact nontoken"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "impulseExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "impulseExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "impulseExiled"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "206",
+        "rarity": "RARE",
+        "artist": "Aurore Folny",
+        "flavorText": "\"Why fear artifice? Is it not also of this world?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3eedd979-783d-4721-92de-965b77c20576.jpg?1783921281"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
+// Mesa Cavalier
+{
+    "name": "Mesa Cavalier",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Flying\nWhen this creature enters, you gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "artist": "David Palumbo",
+        "flavorText": "In the fight to defeat Phyrexia, the courage of Benalish knights is matched only by that of their pegasus steeds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/e/feeec740-7ffc-4f57-b52c-92209da91d69.jpg?1783921362"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -618,6 +1882,145 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Molten Monstrosity
+{
+    "name": "Molten Monstrosity",
+    "manaCost": "{7}{R}",
+    "typeLine": "Creature — Hellion",
+    "oracleText": "This spell costs {X} less to cast, where X is the greatest power among creatures you control.\nTrample",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "GreatestPropertyAmongPermanentsYouControl",
+                        "property": "Power",
+                        "filter": "creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "artist": "Manuel Castañón",
+        "flavorText": "The cold snap killed off most of the heat-loving hellions . . . leaving only the strongest alive to breed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/240957e5-ab0a-443f-92de-ae999b08c44f.jpg?1783921312"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Molten Tributary
+{
+    "name": "Molten Tributary",
+    "manaCost": "",
+    "typeLine": "Land — Island Mountain",
+    "oracleText": "({T}: Add {U} or {R}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "251",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "Though dangerous, Shiv teems with both life and mana, making it a tempting destination for ambitious mages.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/20aff4af-5128-432f-a8c8-65b6909d31ac.jpg?1783921259"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
+// Mossbeard Ancient
+{
+    "name": "Mossbeard Ancient",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Treefolk",
+    "oracleText": "Trample\nWhen this creature enters, you gain 5 life.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "rarity": "UNCOMMON",
+        "artist": "Alexandre Honoré",
+        "flavorText": "Older than the mountains, the dragons, and the wars of humans and machines.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e528d36-cea6-4013-83d5-ba837d570713.jpg?1783921298"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Nishoba Brawler
+{
+    "name": "Nishoba Brawler",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Cat Warrior",
+    "oracleText": "Trample\nDomain — Nishoba Brawler's power is equal to the number of basic land types among lands you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land",
+                "aggregation": "DISTINCT_BASIC_LAND_SUBTYPES"
+            }
+        },
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "UNCOMMON",
+        "artist": "Valera Lutfullina",
+        "flavorText": "Though native to cold climates, the nishoba have adapted to more temperate environments since the Ice Age ended.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2ef6cb5f-0ab3-4652-9b39-c2cbf6d693d5.jpg?1783921297"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -785,6 +2188,29 @@
     ]
 }
 
+// Radiant Grove
+{
+    "name": "Radiant Grove",
+    "manaCost": "",
+    "typeLine": "Land — Forest Plains",
+    "oracleText": "({T}: Add {G} or {W}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "253",
+        "artist": "Lorenzo Lanfranconi",
+        "flavorText": "Yavimaya's inhabitants are dedicated to protecting its unspoiled jungle from the scourge of artifice.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0f9dca6-e5ae-4714-8a59-2ef1d8f1e82d.jpg?1783921259"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
 // Resolute Reinforcements
 {
     "name": "Resolute Reinforcements",
@@ -829,6 +2255,267 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Sacred Peaks
+{
+    "name": "Sacred Peaks",
+    "manaCost": "",
+    "typeLine": "Land — Mountain Plains",
+    "oracleText": "({T}: Add {R} or {W}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "254",
+        "artist": "Kamila Szutenberg",
+        "flavorText": "Everyone is welcome in the floating Serran cities, though few but the most faithful attempt the ascent.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/24957d64-ad17-4d4f-8a00-3cdd83e1ce88.jpg?1783921260"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "RED"
+    ]
+}
+
+// Salvaged Manaworker
+{
+    "name": "Salvaged Manaworker",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "{1}: Add one mana of any color. Activate only once each turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "restrictions": [
+                    "OncePerTurn"
+                ],
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "artist": "Julian Kok Joon Wen",
+        "flavorText": "\"When weapons of war are repurposed for peaceful ends, you know society has advanced.\"\n—Jodah",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5fc22ecb-5d87-464e-8c7d-5d40a52e1e4f.jpg?1783921267"
+    },
+    "colorIdentityOverride": []
+}
+
+// Shadow-Rite Priest
+{
+    "name": "Shadow-Rite Priest",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Other Clerics you control get +1/+1.\n{3}{B}{B}, {T}, Sacrifice another Cleric: Search your library for a black creature card, put it onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{B}{B}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "permanent Cleric",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "creature black"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "permanent Cleric ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "rarity": "RARE",
+        "artist": "Michael C. Hayes",
+        "flavorText": "Backstabbing is common within demonic cults. So are front- and side-stabbing.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c9e43116-a489-4557-a47f-623d915a2b79.jpg?1783921326"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Soaring Drake
+{
+    "name": "Soaring Drake",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "66",
+        "artist": "Jason Kang",
+        "flavorText": "The already spectacular views from the towers of the College at Lat-Nam are sometimes enhanced by glimpses of drakes diving into the ocean to devour small sharks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b0979f9-aae3-4fc7-beae-c8c6637ae596.jpg?1783921344"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Splatter Goblin
+{
+    "name": "Splatter Goblin",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Phyrexian Goblin",
+    "oracleText": "When this creature dies, target creature an opponent controls gets -1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "artist": "Lars Grant-West",
+        "flavorText": "\"For some, perfection is but a single moment when form and purpose converge.\"\n—Rona",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/5045027d-0ff4-484c-b4cb-e0b61885d428.jpg?1783921326"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Sunlit Marsh
+{
+    "name": "Sunlit Marsh",
+    "manaCost": "",
+    "typeLine": "Land — Plains Swamp",
+    "oracleText": "({T}: Add {W} or {B}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "257",
+        "artist": "Marc Simonetti",
+        "flavorText": "Even the poisoned land around the Stronghold blossomed with new life in the wake of the Great Mending.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f0588fbf-3c05-452a-b3f7-67604c1f921d.jpg?1783921257"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
     ]
 }
 
@@ -890,6 +2577,247 @@
     ]
 }
 
+// Talas Lookout
+{
+    "name": "Talas Lookout",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Human Pirate",
+    "oracleText": "Flying\nWhen this creature dies, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Put in graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "artist": "Julia Metzger",
+        "flavorText": "\"The Talas pirates are motivated by money, so we paid them twice what they could steal from us to spy for us instead.\"\n—Jhoira",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0a4b9afe-aeb7-4c56-8a22-96e19a7a938c.jpg?1783921343"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Tangled Islet
+{
+    "name": "Tangled Islet",
+    "manaCost": "",
+    "typeLine": "Land — Forest Island",
+    "oracleText": "({T}: Add {G} or {U}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "258",
+        "artist": "Randy Gallegos",
+        "flavorText": "Many of Terisiare's islands are merely extensions of the root system of the Yavimaya magnigoth forests.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4a325fb4-fe71-47f1-9a2f-05b8cfe88fe6.jpg?1783921256"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "GREEN"
+    ]
+}
+
+// Tattered Apparition
+{
+    "name": "Tattered Apparition",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Shade",
+    "oracleText": "Flying\n{1}{B}: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "artist": "Jason A. Engle",
+        "flavorText": "\"Ah yes, I remember that one. I turned him inside out and cast his soul into an endless nightmare a few centuries ago.\"\n—Braids",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/0368e91c-31ee-4b81-a361-30a4555b1a42.jpg?1783921324"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Territorial Maro
+{
+    "name": "Territorial Maro",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Domain — Territorial Maro's power and toughness are each equal to twice the number of basic land types among lands you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Multiply",
+                "amount": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "land",
+                    "aggregation": "DISTINCT_BASIC_LAND_SUBTYPES"
+                },
+                "multiplier": 2
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Multiply",
+                "amount": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "land",
+                    "aggregation": "DISTINCT_BASIC_LAND_SUBTYPES"
+                },
+                "multiplier": 2
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "rarity": "UNCOMMON",
+        "artist": "Simon Dominic",
+        "flavorText": "The Coalition was more than just treaties and alliances: it was the soul of a world rising up against the invading tide.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/853ddf31-826b-411e-9b6d-75d53cdd1b84.jpg?1783921293"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Tidepool Turtle
+{
+    "name": "Tidepool Turtle",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Turtle",
+    "oracleText": "{2}{U}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "artist": "Andrew Mar",
+        "flavorText": "Prized by wizards as a mobile scrying pool, it bears visions drawn from the depths of the sea.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d397fb84-8573-4b2c-be2c-f8fd820342f0.jpg?1783921342"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Tolarian Terror
 {
     "name": "Tolarian Terror",
@@ -938,6 +2866,237 @@
     ]
 }
 
+// Toxic Abomination
+{
+    "name": "Toxic Abomination",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Phyrexian Zombie",
+    "oracleText": "When this creature enters, you lose 2 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Controller"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "artist": "Igor Kieryluk",
+        "flavorText": "Deep in the forgotten reaches of Urborg, ancient Phyrexian monstrosities shamble endlessly, putrid ichor leaking from their rusted forms.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f435329e-6de7-4b05-ba70-cb63d121116e.jpg?1783921324"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Tura Kennerüd, Skyknight
+{
+    "name": "Tura Kennerüd, Skyknight",
+    "manaCost": "{2}{W}{U}{U}",
+    "typeLine": "Legendary Creature — Human Knight",
+    "oracleText": "Flying\nWhenever you cast an instant or sorcery spell, create a 1/1 white Soldier creature token.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Soldier"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "rarity": "UNCOMMON",
+        "artist": "Donato Giancola",
+        "flavorText": "\"The sky is my birthright. I dare you to try and take it from me.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c839d302-bf85-4a30-a49a-dbbd48695b5c.jpg?1783921274"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
+// Uurg, Spawn of Turg
+{
+    "name": "Uurg, Spawn of Turg",
+    "manaCost": "{B}{B}{G}",
+    "typeLine": "Legendary Creature — Frog Beast",
+    "oracleText": "Uurg's power is equal to the number of land cards in your graveyard.\nAt the beginning of your upkeep, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)\n{B}{G}, Sacrifice a land: You gain 2 life.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Count",
+                "player": "You",
+                "zone": "Graveyard",
+                "filter": "land"
+            }
+        },
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Surveil",
+                    "count": 1
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}{G}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "land"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "rarity": "UNCOMMON",
+        "artist": "Nicholas Gregory",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd3fc36c-682b-4352-a66f-eddd2baf0bf6.jpg?1783921273"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Vanquisher's Axe
+{
+    "name": "Vanquisher's Axe",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 0
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "240",
+        "artist": "Joe Slucher",
+        "flavorText": "When a Keldon takes a trophy from an enemy, it's usually something they can use to kill more enemies.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/aef37244-deb9-464e-ab8c-4308369ae09b.jpg?1783921266"
+    },
+    "colorIdentityOverride": []
+}
+
 // Wooded Ridgeline
 {
     "name": "Wooded Ridgeline",
@@ -958,5 +3117,44 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Writhing Necromass
+{
+    "name": "Writhing Necromass",
+    "manaCost": "{6}{B}",
+    "typeLine": "Creature — Zombie Giant",
+    "oracleText": "This spell costs {1} less to cast for each creature card in your graveyard.\nDeathtouch",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "CardsInGraveyardMatchingFilter",
+                        "filter": "creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "Campbell White",
+        "flavorText": "\"We sent three of our best legions! You're telling me no one came back?\"\n—Tori D'Avenant",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a166abef-f068-47e9-8a65-43ebf4b015bd.jpg?1783921322"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/M13.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M13.json
@@ -193,6 +193,55 @@
     ]
 }
 
+// Griffin Protector
+{
+    "name": "Griffin Protector",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Griffin",
+    "oracleText": "Flying\nWhenever another creature you control enters, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "artist": "Christopher Moeller",
+        "flavorText": "The drums of war stir the hearts of all who fight for righteousness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/ddae4f7a-525c-4306-81b5-b0991840a11e.jpg?1783940518"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Krenko, Mob Boss
 {
     "name": "Krenko, Mob Boss",

--- a/mtg-sets/src/test/resources/snapshots/cards/M15.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M15.json
@@ -81,6 +81,57 @@
     ]
 }
 
+// Meteorite
+{
+    "name": "Meteorite",
+    "manaCost": "{5}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, it deals 2 damage to any target.\n{T}: Add one mana of any color.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "221",
+        "rarity": "UNCOMMON",
+        "artist": "Scott Murphy",
+        "flavorText": "\"And if I'm lying,\" he began . . .",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d7a39c1a-7615-4ac8-8984-b8459d201cb2.jpg?1783939157"
+    },
+    "colorIdentityOverride": []
+}
+
 // Reclamation Sage
 {
     "name": "Reclamation Sage",


### PR DESCRIPTION
Every Dominaria United card the Set Completion view badges **Assay-ready** — Assay verdict `whole` and not yet implemented — is now in the corpus. **DMU 31/266 (12%) → 86/266 (32%)**, and the Assay-ready-and-missing list for the set is now empty.

## The split

The sweep's own note says to compute the split before planning, because it changes the job. DMU's 55 land four ways:

| | count |
|---|---|
| basic land names (21 printings) | 5 |
| dual "enters tapped" lands | 9 |
| canonical belongs to an earlier scaffolded set | 3 |
| new canonical in DMU | 38 |

Nothing needed new SDK vocabulary — that is what "Assay reads it whole" means, and it held for all 50 non-basic cards.

- **Canonicals in their earliest scaffolded set, with a `Printing(...)` row in DMU:** Bone Splinters → ALA, Griffin Protector → M13, Meteorite → M15.
- **Basic lands** are per-set `basicLand(...)` vals plus the `basicLands` override on `DominariaUnitedSet`, never `Printing` rows.
- Each card was written against the model `assay compile <name>` produces for it, so the differential *compares* them instead of bucketing them.

## Verification

- `just build` — green.
- `just assay-differential` — compared **3132 → 3181**; `DIVERGENT` unchanged at the **same 13 pre-existing cards** (Pearl of Wisdom, Ghalta, Wizard's Lightning, Wizard's Retort, Mistmeadow Council, Arcane Epiphany, Goblin Warchief, Krosan Warchief, Grow Extra Arms, Tombstone, Venom's Hunger, Dragon's Prey, Bolt Bend — none touched here). Per set touched: **DMU 53/53, ALA 9/9, M13 6/6, M15 8/8 — 1000.0‰ confirmed, 0 divergent.**
- `just rebless-cards` — DMU +47 card blocks, ALA/M13/M15 +1 each; **no existing card block changed or was removed** (verified by diffing the golden files block-by-block, since interleaving new names makes the raw diff look like deletions).
- `just check-card-printing` on the three reprints confirms the canonical lands in ALA / M13 / M15 and the DMU row reads `reprint`.

## Scenario tests

Domain as a **characteristic-defining ability** (CR 604.3) is the one shape here with no prior instance in the corpus — `DynamicAmounts.domain()` existed, but never in a `creatureStats` slot. Two tests, one card each:

- `NishobaBrawlerScenarioTest` — counts *types* not lands, a dual contributes both of its types, opponents' lands don't count, 0 with no lands.
- `TerritorialMaroScenarioTest` — both halves of the printed `*`/`*` are doubled independently, so a card that doubled only power would fail.

## Known, out of scope

`just check-card-printing` also reports missing `Printing(...)` rows for these three cards in *other* scaffolded sets (Bone Splinters: avr/bfz/m20/jmp; Griffin Protector: m20; Meteorite: ori/m21/tle). That is real drift but a separate change — the gate could not see it before, because it used to exit early on "card not implemented".

🤖 Generated with [Claude Code](https://claude.com/claude-code)