### PR TITLE
Add The Brothers' War's whole Assay-ready list: 36 cards, 20/275 -> 56/275

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/FaunaShaman.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/FaunaShaman.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Fauna Shaman
+ * {1}{G}
+ * Creature — Elf Shaman
+ * 2/2
+ * {G}, {T}, Discard a creature card: Search your library for a creature card, reveal it, put it into
+ * your hand, then shuffle.
+ */
+val FaunaShaman = card("Fauna Shaman") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "{G}, {T}, Discard a creature card: Search your library for a creature card, " +
+        "reveal it, put it into your hand, then shuffle."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{G}"),
+            Costs.Tap,
+            Costs.Discard(GameObjectFilter.Creature),
+        )
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Creature,
+            destination = SearchDestination.HAND,
+            reveal = true,
+        )
+        description = "Search your library for a creature card, reveal it, put it into your hand, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "172"
+        artist = "Steve Prescott"
+        flavorText = "She wears the talismans of every creature she can evoke."
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c685e4c3-eb7b-4b9e-9676-395d69d80974.jpg?1783941798"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/Disfigure.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/Disfigure.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Disfigure
+ * {B}
+ * Instant
+ * Target creature gets -2/-2 until end of turn.
+ */
+val Disfigure = card("Disfigure") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -2/-2 until end of turn."
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.ModifyStats(-2, -2, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Justin Sweet"
+        flavorText = "\"Brave scar or unfortunate tale? It all depends on your pain threshold.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3842ad2-a449-4963-8c96-276554125757.jpg?1783942155"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/BrothersWarSet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/BrothersWarSet.kt
@@ -22,6 +22,10 @@ object BrothersWarSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/AeronautsWings.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/AeronautsWings.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Aeronaut's Wings
+ * {2}
+ * Artifact — Equipment
+ * Equipped creature gets +1/+0 and has flying.
+ * Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)
+ *
+ * The plain Equipment shape: two static abilities scoped to [Filters.EquippedCreature] plus
+ * `equipAbility`, which sets `equipCost` and lowers the sorcery-speed equip activated ability in
+ * one place.
+ */
+val AeronautsWings = card("Aeronaut's Wings") {
+    manaCost = "{2}"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+0 and has flying.\n" +
+        "Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(1, 0, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING, Filters.EquippedCreature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "231"
+        artist = "Leon Tukker"
+        flavorText = "Volunteers rarely questioned why the airborne battalion always seemed to be recruiting."
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fcc65821-e4e7-471c-941c-9d3e25ae8bb9.jpg?1783920019"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/AirMarshal.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/AirMarshal.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Air Marshal
+ * {1}{U}
+ * Creature — Human Soldier
+ * 2/1
+ * {3}: Target Soldier gains flying until end of turn.
+ *
+ * "Soldier" is a **bare tribal noun**, so it names every *permanent* with the subtype rather than
+ * only a creature — [TargetFilter.Permanent] with the subtype, not `TargetFilter.Creature`.
+ */
+val AirMarshal = card("Air Marshal") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 1
+    oracleText = "{3}: Target Soldier gains flying until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{3}")
+        val t = target("target", TargetPermanent(filter = TargetFilter.Permanent.withSubtype("Soldier")))
+        effect = Effects.GrantKeyword(Keyword.FLYING, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "43"
+        artist = "Johan Grenier"
+        flavorText = "\"Today our blades remember Kroog! May the seven brass gods be with us!\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/991e1a6c-914b-45c8-9170-c09e72696117.jpg?1783920115"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/AmbushParatrooper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/AmbushParatrooper.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ambush Paratrooper
+ * {1}{W}
+ * Creature — Human Soldier
+ * 1/2
+ * Flash
+ * Flying
+ * {5}: Creatures you control get +1/+1 until end of turn.
+ */
+val AmbushParatrooper = card("Ambush Paratrooper") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 2
+    oracleText = "Flash\nFlying\n{5}: Creatures you control get +1/+1 until end of turn."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{5}")
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.ModifyStats(1, 1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "3"
+        artist = "Vladimir Krisetskiy"
+        flavorText = "\"It would be folly to fight a dragon engine head-on. Let's hit it from above.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cfa00c0e-163d-4f59-b8b9-3ee9143d27bb.jpg?1783920135"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/ArgothianSprite.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/ArgothianSprite.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Argothian Sprite
+ * {1}{G}
+ * Creature — Faerie
+ * 2/2
+ * This creature can't be blocked by artifact creatures.
+ * {7}: Put two +1/+1 counters on this creature.
+ *
+ * The blocking restriction is the same [CantBeBlockedBy] over [GameObjectFilter.ArtifactCreature]
+ * that Argothian Pixies (ATQ) prints.
+ */
+val ArgothianSprite = card("Argothian Sprite") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Faerie"
+    power = 2
+    toughness = 2
+    oracleText = "This creature can't be blocked by artifact creatures.\n" +
+        "{7}: Put two +1/+1 counters on this creature."
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.ArtifactCreature)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{7}")
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Rudy Siswanto"
+        flavorText = "\"Make the exhaust vents smaller next time!\"\n—Urza, notes to his engineers"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5dbc383-7e08-4701-8d4a-6b99b74fe358.jpg?1783920053"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/BrothersWarBasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/BrothersWarBasicLands.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * The Brothers' War Basic Lands
+ *
+ * BRO prints 4 art variants of each basic land type, all booster-eligible: two normal-frame
+ * (268-277) and two full-art (278-287).
+ */
+
+// =============================================================================
+// Plains (Cards 268, 269, 278, 279)
+// =============================================================================
+
+val BroPlains268 = basicLand("Plains") {
+    collectorNumber = "268"
+    artist = "Raymond Bonilla"
+    imageUri = "https://cards.scryfall.io/normal/front/2/2/22de1edc-ec67-4694-ab88-2a679c8a450f.jpg?1783920004"
+}
+
+val BroPlains269 = basicLand("Plains") {
+    collectorNumber = "269"
+    artist = "Jorge Jacinto"
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3cd136b1-c276-41f9-98ee-3e07eb87bacb.jpg?1783920004"
+}
+
+val BroPlains278 = basicLand("Plains") {
+    collectorNumber = "278"
+    artist = "Sergey Glushakov"
+    imageUri = "https://cards.scryfall.io/normal/front/7/e/7e134268-9ce9-4192-b548-90bedbfe654e.jpg?1783920000"
+}
+
+val BroPlains279 = basicLand("Plains") {
+    collectorNumber = "279"
+    artist = "Robin Olausson"
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/80b6636d-a342-4d49-9d1a-ab15b3d837c5.jpg?1783920000"
+}
+
+// =============================================================================
+// Island (Cards 270, 271, 280, 281)
+// =============================================================================
+
+val BroIsland270 = basicLand("Island") {
+    collectorNumber = "270"
+    artist = "Eddie Mendoza"
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/eee75629-86b4-40b0-884a-22646ebf6e27.jpg?1783920004"
+}
+
+val BroIsland271 = basicLand("Island") {
+    collectorNumber = "271"
+    artist = "Lucas Staniec"
+    imageUri = "https://cards.scryfall.io/normal/front/b/f/bf35ed4f-fa34-4fd6-b7d8-3c4aeda1e9ea.jpg?1783920003"
+}
+
+val BroIsland280 = basicLand("Island") {
+    collectorNumber = "280"
+    artist = "Robin Olausson"
+    imageUri = "https://cards.scryfall.io/normal/front/f/e/fe9d36d3-9373-407c-91fd-975d8ee9e4fe.jpg?1783919998"
+}
+
+val BroIsland281 = basicLand("Island") {
+    collectorNumber = "281"
+    artist = "Lucas Staniec"
+    imageUri = "https://cards.scryfall.io/normal/front/d/2/d20af588-2ce3-4e5a-9ab3-949401ead071.jpg?1783919998"
+}
+
+// =============================================================================
+// Swamp (Cards 272, 273, 282, 283)
+// =============================================================================
+
+val BroSwamp272 = basicLand("Swamp") {
+    collectorNumber = "272"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/1/c/1c90f777-2f98-4010-80a3-5fe395747e5f.jpg?1783920002"
+}
+
+val BroSwamp273 = basicLand("Swamp") {
+    collectorNumber = "273"
+    artist = "Robin Olausson"
+    imageUri = "https://cards.scryfall.io/normal/front/2/5/25bcf9b0-ee35-4911-b515-7182e703beba.jpg?1783920001"
+}
+
+val BroSwamp282 = basicLand("Swamp") {
+    collectorNumber = "282"
+    artist = "Sergey Glushakov"
+    imageUri = "https://cards.scryfall.io/normal/front/c/a/cabe866d-01c3-4ec5-9d41-70305208c2b1.jpg?1783919998"
+}
+
+val BroSwamp283 = basicLand("Swamp") {
+    collectorNumber = "283"
+    artist = "Robin Olausson"
+    imageUri = "https://cards.scryfall.io/normal/front/7/2/7232adef-c8eb-461f-b563-cb54cdeb22d5.jpg?1783919998"
+}
+
+// =============================================================================
+// Mountain (Cards 274, 275, 284, 285)
+// =============================================================================
+
+val BroMountain274 = basicLand("Mountain") {
+    collectorNumber = "274"
+    artist = "Bruce Brenneise"
+    imageUri = "https://cards.scryfall.io/normal/front/9/5/95083e1d-faf5-40e4-9be5-909cd01cc2b5.jpg?1783920000"
+}
+
+val BroMountain275 = basicLand("Mountain") {
+    collectorNumber = "275"
+    artist = "Victor Harmatiuk"
+    imageUri = "https://cards.scryfall.io/normal/front/a/b/abf2ec64-a850-47e3-91a8-7323e04a5f4a.jpg?1783920000"
+}
+
+val BroMountain284 = basicLand("Mountain") {
+    collectorNumber = "284"
+    artist = "Sergey Glushakov"
+    imageUri = "https://cards.scryfall.io/normal/front/c/4/c464b81a-3d91-4d07-bc9d-6756780417e3.jpg?1783919997"
+}
+
+val BroMountain285 = basicLand("Mountain") {
+    collectorNumber = "285"
+    artist = "Victor Harmatiuk"
+    imageUri = "https://cards.scryfall.io/normal/front/c/d/cd757142-45b7-40db-80f2-fe161379aa4e.jpg?1783919996"
+}
+
+// =============================================================================
+// Forest (Cards 276, 277, 286, 287)
+// =============================================================================
+
+val BroForest276 = basicLand("Forest") {
+    collectorNumber = "276"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/a/6/a63eab07-46e5-4b75-954f-b5a9f1f451cd.jpg?1783920000"
+}
+
+val BroForest277 = basicLand("Forest") {
+    collectorNumber = "277"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8a73d19b-72e3-4944-ac20-5b4c7b54c2aa.jpg?1783920000"
+}
+
+val BroForest286 = basicLand("Forest") {
+    collectorNumber = "286"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/1/a/1a1b7277-0c09-42ab-aa6b-542a1e402580.jpg?1783919997"
+}
+
+val BroForest287 = basicLand("Forest") {
+    collectorNumber = "287"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c1c2a41c-e974-4c14-8d01-d278ecdb31bc.jpg?1783919996"
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/CoastalBulwark.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/CoastalBulwark.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Coastal Bulwark
+ * {2}
+ * Artifact Creature — Wall
+ * 1/3
+ * Defender
+ * This creature gets +2/+0 as long as you control an Island.
+ * {2}, {T}: Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)
+ */
+val CoastalBulwark = card("Coastal Bulwark") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Wall"
+    power = 1
+    toughness = 3
+    oracleText = "Defender\nThis creature gets +2/+0 as long as you control an Island.\n" +
+        "{2}, {T}: Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)"
+
+    keywords(Keyword.DEFENDER)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(2, 0, Filters.Self),
+            condition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Island")),
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        effect = Patterns.Library.surveil(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "76"
+        artist = "Artur Nakhodkin"
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e24567f8-d195-4547-bba4-7a8131dc7889.jpg?1783920100"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/DeathbloomRitualist.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/DeathbloomRitualist.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deathbloom Ritualist
+ * {3}{B}{G}
+ * Creature — Elf Warlock
+ * 3/5
+ * {T}: Add X mana of any one color, where X is the number of creature cards in your graveyard.
+ *
+ * "Any one color" is [Effects.AddAnyColorMana] — one color chosen for the whole batch, not one
+ * per mana — taking the dynamic [DynamicAmounts.creatureCardsInYourGraveyard] count as X.
+ * `manaAbility = true` is the only switch: the builder derives both `isManaAbility` and the
+ * `ManaAbility` timing rule from it, so neither is hand-set.
+ */
+val DeathbloomRitualist = card("Deathbloom Ritualist") {
+    manaCost = "{3}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Elf Warlock"
+    power = 3
+    toughness = 5
+    oracleText = "{T}: Add X mana of any one color, where X is the number of creature cards in your graveyard."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(DynamicAmounts.creatureCardsInYourGraveyard())
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "208"
+        artist = "Taras Susak"
+        flavorText = "Each fallen friend was a seed of regret, eager to blossom again in Gaea's name."
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/45ff816d-1eb7-4985-90ec-f44802a696fc.jpg?1783920033"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/DisfigureReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/DisfigureReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Disfigure reprint in BRO. Canonical CardDefinition lives in its earliest set (ZEN).
+ */
+val DisfigureReprint = Printing(
+    oracleId = "77eafe49-b9c5-461d-89c5-cec217dd2974",
+    name = "Disfigure",
+    setCode = "BRO",
+    collectorNumber = "91",
+    scryfallId = "aaa9c6f1-3938-448b-bdc3-22420c5984d3",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/a/a/aaa9c6f1-3938-448b-bdc3-22420c5984d3.jpg?1783920093",
+    releaseDate = "2022-11-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/DwarvenForgeChanter.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/DwarvenForgeChanter.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Dwarven Forge-Chanter
+ * {1}{R}
+ * Creature — Dwarf Wizard
+ * 1/3
+ * Ward—Pay 2 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 2 life.)
+ * Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)
+ */
+val DwarvenForgeChanter = card("Dwarven Forge-Chanter") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dwarf Wizard"
+    power = 1
+    toughness = 3
+    oracleText = "Ward—Pay 2 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 2 life.)\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)"
+
+    // Ward—Pay 2 life (CR 702.21a). The bare `Keyword.WARD` marker is derived from this ability by
+    // the builder, so it is not restated here.
+    keywordAbility(KeywordAbility.wardLife(2))
+    prowess()
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "131"
+        artist = "Bartłomiej Gaweł"
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bbd6a95a-11b9-43aa-b293-20a3102bae71.jpg?1783920070"
+        ruling("2022-10-14", "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger.")
+        ruling("2022-10-14", "Prowess goes on the stack on top of the spell that caused it to trigger. It will resolve before that spell.")
+        ruling("2022-10-14", "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/EnergyRefractor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/EnergyRefractor.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Energy Refractor
+ * {2}
+ * Artifact
+ * When this artifact enters, draw a card.
+ * {2}: Add one mana of any color.
+ *
+ * The mana ability costs mana only — there is no tap symbol in the printed cost, so the artifact
+ * can be activated repeatedly. `manaAbility = true` derives the mana-ability timing rule.
+ */
+val EnergyRefractor = card("Energy Refractor") {
+    manaCost = "{2}"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, draw a card.\n" +
+        "{2}: Add one mana of any color."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "234"
+        artist = "Maria Poliakova"
+        flavorText = "\"Raw energy contains infinite possibility.\"\n—Urza"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc2a81fb-5045-4b7b-8cfb-b90c4f4a1f51.jpg?1783920019"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/FallajiChaindancer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/FallajiChaindancer.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fallaji Chaindancer
+ * {3}{R}
+ * Creature — Human Soldier
+ * 2/4
+ * {2}: This creature gains double strike until end of turn.
+ */
+val FallajiChaindancer = card("Fallaji Chaindancer") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 4
+    oracleText = "{2}: This creature gains double strike until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "134"
+        artist = "Filipe Pagliuso"
+        flavorText = "She was eager to show the invading Yotians how she earned her nickname, \"The Sandstorm of Tomakul.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4dc2da75-160d-47f9-b978-e153262ec1fc.jpg?1783920073"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/FallajiVanguard.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/FallajiVanguard.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Fallaji Vanguard
+ * {2}{R}{W}
+ * Creature — Human Soldier
+ * 2/3
+ * First strike
+ * Whenever this creature or another creature you control enters, target creature gets +2/+0 until end of turn.
+ *
+ * The inclusive "this creature or another creature you control enters" shape is
+ * [Triggers.entersBattlefield] over `Creature.youControl()` with [TriggerBinding.ANY] — the same
+ * construct Elrond, Lord of Rivendell uses. `ANY` is what lets the source itself entering fire it.
+ */
+val FallajiVanguard = card("Fallaji Vanguard") {
+    manaCost = "{2}{R}{W}"
+    colorIdentity = "WR"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 3
+    oracleText = "First strike\n" +
+        "Whenever this creature or another creature you control enters, target creature gets +2/+0 until end of turn."
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(2, 0, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "210"
+        artist = "Joshua Cairos"
+        flavorText = "\"The Burnished Banner will show the Warlord that the Suwwardi Marches belong to the Fallaji!\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ffe9ee1c-5eb3-4d63-a641-0ec5adf7b058.jpg?1783920030"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/FaunaShamanReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/FaunaShamanReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fauna Shaman reprint in BRO. Canonical CardDefinition lives in its earliest set (M11).
+ */
+val FaunaShamanReprint = Printing(
+    oracleId = "35b8fa77-4e85-418b-b335-cd1af127075c",
+    name = "Fauna Shaman",
+    setCode = "BRO",
+    collectorNumber = "179",
+    scryfallId = "b8b906eb-3223-474c-9b74-eda2c280f9c5",
+    artist = "Nicholas Elias",
+    imageUri = "https://cards.scryfall.io/normal/front/b/8/b8b906eb-3223-474c-9b74-eda2c280f9c5.jpg?1783920047",
+    releaseDate = "2022-11-18",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/GnarlrootPallbearer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/GnarlrootPallbearer.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gnarlroot Pallbearer
+ * {4}{G}{G}
+ * Creature — Treefolk Druid
+ * 5/5
+ * Trample
+ * When this creature enters, target creature gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.
+ *
+ * The Ghoultree count in a pump slot: [DynamicAmounts.creatureCardsInYourGraveyard] fills both
+ * modifiers of [Effects.ModifyStats], which is until end of turn by default.
+ */
+val GnarlrootPallbearer = card("Gnarlroot Pallbearer") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Treefolk Druid"
+    power = 5
+    toughness = 5
+    oracleText = "Trample\n" +
+        "When this creature enters, target creature gets +X/+X until end of turn, where X is the " +
+        "number of creature cards in your graveyard."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(
+            DynamicAmounts.creatureCardsInYourGraveyard(),
+            DynamicAmounts.creatureCardsInYourGraveyard(),
+            creature,
+        )
+        description = "When this creature enters, target creature gets +X/+X until end of turn, " +
+            "where X is the number of creature cards in your graveyard."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "184"
+        artist = "Nino Is"
+        flavorText = "The flames of war consumed most of Argoth's treefolk. Vengeance consumed the rest."
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b7382154-ac8f-40ca-94e4-2f0533c0cf20.jpg?1783920043"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/MachineOverMatter.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/MachineOverMatter.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Machine Over Matter
+ * {1}{U}
+ * Instant
+ * This spell costs {1} less to cast if you control an artifact creature.
+ * Return target nonland permanent to its owner's hand.
+ */
+val MachineOverMatter = card("Machine Over Matter") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "This spell costs {1} less to cast if you control an artifact creature.\n" +
+        "Return target nonland permanent to its owner's hand."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(1),
+            gating = CostGating.OnlyIf(Conditions.YouControl(GameObjectFilter.ArtifactCreature))
+        )
+    }
+
+    spell {
+        val t = target("target", Targets.NonlandPermanent)
+        effect = Effects.ReturnToHand(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "57"
+        artist = "Tuan Duong Chu"
+        flavorText = "The Warlord decreed that only someone who could move the statue would be strong enough to marry the princess. So Urza moved it."
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d08eadf5-a86d-4e8d-b65d-79b4f88477b9.jpg?1783920109"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/OverwhelmingRemorse.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/OverwhelmingRemorse.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Overwhelming Remorse
+ * {4}{B}
+ * Instant
+ * This spell costs {1} less to cast for each creature card in your graveyard.
+ * Exile target creature or planeswalker.
+ *
+ * The Ghoultree cost line on an instant: a self-cast [ModifySpellCost] reducing generic mana by
+ * [CostReductionSource.CardsInGraveyardMatchingFilter] over creature cards. The reduction only ever
+ * eats generic, so the coloured {B} floor the rulings call out falls out of the modification itself
+ * and the printed mana value stays 5.
+ */
+val OverwhelmingRemorse = card("Overwhelming Remorse") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "This spell costs {1} less to cast for each creature card in your graveyard.\n" +
+        "Exile target creature or planeswalker."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.CardsInGraveyardMatchingFilter(GameObjectFilter.Creature)
+            )
+        )
+    }
+
+    spell {
+        val victim = target("target", Targets.CreatureOrPlaneswalker)
+        effect = Effects.Exile(victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "110"
+        artist = "Ryan Valle"
+        flavorText = "Tocasia's face haunted his vision. The explosion still rung in his ears. Mishra kept running and never once looked back."
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/202cbfa4-3b3d-47fd-84a6-892692c906d6.jpg?1783920082"
+        ruling("2022-10-14", "Overwhelming Remorse's first ability doesn't change its mana cost or mana value. It just reduces the cost to cast the spell.")
+        ruling("2022-10-14", "Overwhelming Remorse's first ability can't reduce its cost to less than {B}.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/PerimeterPatrol.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/PerimeterPatrol.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Perimeter Patrol
+ * {2}{G}
+ * Creature — Human Soldier
+ * 3/3
+ * Whenever an artifact you control enters, this creature gets +1/+0 until end of turn.
+ *
+ * The Weldfast Wingsmith trigger shape — [Triggers.entersBattlefield] over
+ * `Artifact.youControl()` with [TriggerBinding.ANY] — feeding a self-targeted
+ * [Effects.ModifyStats] (default `Duration.EndOfTurn`).
+ */
+val PerimeterPatrol = card("Perimeter Patrol") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever an artifact you control enters, this creature gets +1/+0 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "This creature gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "188"
+        artist = "Edgar Sánchez Hidalgo"
+        flavorText = "The Fallaji quickly learned that the Kher Ridges held too many caves and valleys to be surveyed from the air alone."
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d4719bc1-4c27-45d8-89f7-8c76ccf946d2.jpg?1783920042"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/PhalanxVanguard.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/PhalanxVanguard.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Phalanx Vanguard
+ * {1}{W}
+ * Creature — Human Soldier
+ * 2/2
+ * Vigilance
+ * Whenever an artifact you control enters, this creature gets +1/+0 until end of turn.
+ *
+ * Perimeter Patrol's trigger in white with vigilance printed above it — the shared BRO
+ * "artifact you control enters" shape: [Triggers.entersBattlefield] over `Artifact.youControl()`
+ * with [TriggerBinding.ANY], feeding a self-targeted [Effects.ModifyStats].
+ */
+val PhalanxVanguard = card("Phalanx Vanguard") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Vigilance\nWhenever an artifact you control enters, this creature gets +1/+0 until end of turn."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "This creature gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Izzy"
+        flavorText = "The cool, sleek automatons beside her mirrored her own iron resolve."
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2abe2af7-deba-4569-822a-2d9309aeaadd.jpg?1783920125"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/RetrievalAgent.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/RetrievalAgent.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Retrieval Agent
+ * {3}{U}
+ * Creature — Human Soldier
+ * 2/5
+ * {2}: This creature gets +1/-1 until end of turn.
+ */
+val RetrievalAgent = card("Retrieval Agent") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 5
+    oracleText = "{2}: This creature gets +1/-1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        effect = Effects.ModifyStats(1, -1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Vladimir Krisetskiy"
+        flavorText = "The humming tome burned his leather glove, nearly taking his hand along with it. Then a strange power coursed through him."
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f333a7b1-936e-42f3-ba22-2c76dd2f1c9a.jpg?1783920107"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/RocHunter.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/RocHunter.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Roc Hunter
+ * {1}{R}
+ * Creature — Human Soldier
+ * 3/1
+ * Reach
+ */
+val RocHunter = card("Roc Hunter") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 1
+    oracleText = "Reach"
+
+    keywords(Keyword.REACH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "150"
+        artist = "Ina Wong"
+        flavorText = "\"Never track the roc itself with your eyes, for it will swoop with the sun at its back and blind you. Instead, track its shadow and, when it's almost upon you, heave your javelin upward with all your might.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5c8b2f2b-6f19-47f7-bb65-00665989bc30.jpg?1783920060"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/SupplyDrop.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/SupplyDrop.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Supply Drop
+ * {3}
+ * Artifact
+ * Flash
+ * When this artifact enters, target creature you control gets +2/+2 until end of turn.
+ * {4}, {T}, Sacrifice this artifact: Draw a card.
+ */
+val SupplyDrop = card("Supply Drop") {
+    manaCost = "{3}"
+    typeLine = "Artifact"
+    oracleText = "Flash\n" +
+        "When this artifact enters, target creature you control gets +2/+2 until end of turn.\n" +
+        "{4}, {T}, Sacrifice this artifact: Draw a card."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.CreatureYouControl))
+        effect = Effects.ModifyStats(2, 2, t)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "250"
+        artist = "Brian Valeza"
+        flavorText = "New armaments, fresh provisions, and best of all, dry socks."
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/82a5d3e9-bada-448b-894d-9d4e7e0463c7.jpg?1783920011"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/ThirdPathSavant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/ThirdPathSavant.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Third Path Savant
+ * {2}{U}
+ * Creature — Human Wizard
+ * 2/3
+ * {7}: Draw two cards.
+ */
+val ThirdPathSavant = card("Third Path Savant") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 3
+    oracleText = "{7}: Draw two cards."
+
+    activatedAbility {
+        cost = Costs.Mana("{7}")
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "67"
+        artist = "Artur Treffner"
+        flavorText = "As Mishra's army bore down on Terisia City, Corlo felt his focus, his patience, and his willpower twine together. With a deep breath, he plucked answers from the air."
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/793a51ab-59fb-424f-a315-3f63e8990322.jpg?1783920104"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/ThopterArchitect.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/ThopterArchitect.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Thopter Architect
+ * {3}{W}
+ * Creature — Human Artificer
+ * 2/3
+ * Whenever an artifact you control enters, target creature gains flying until end of turn.
+ *
+ * Weldfast Wingsmith's trigger and effect, but the flying lands on a chosen creature rather than
+ * on the source — so the ability declares a target slot and [Effects.GrantKeyword] points at it.
+ */
+val ThopterArchitect = card("Thopter Architect") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Artificer"
+    power = 2
+    toughness = 3
+    oracleText = "Whenever an artifact you control enters, target creature gains flying until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        val creature = target("creature", TargetCreature())
+        effect = Effects.GrantKeyword(Keyword.FLYING, creature)
+        description = "Target creature gains flying until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "29"
+        artist = "Michal Ivan"
+        flavorText = "\"She'll only fly once. Make it count!\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61017325-cec0-46ac-aa32-5855e5904888.jpg?1783920121"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/TocasiasDigSite.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/TocasiasDigSite.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tocasia's Dig Site
+ * Land
+ * {T}: Add {C}.
+ * {3}, {T}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)
+ */
+val TocasiasDigSite = card("Tocasia's Dig Site") {
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{3}, {T}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)"
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        effect = Patterns.Library.surveil(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "266"
+        artist = "Nadia Hurianova"
+        flavorText = "Sent by their noble parents to toughen up and learn something of the world's past, Urza and Mishra instead uncovered Terisiare's future."
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/23d4b90c-95b1-4828-bc08-7067da0d5364.jpg?1783920004"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/TomakulHonorGuard.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/TomakulHonorGuard.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Tomakul Honor Guard
+ * {1}{G}
+ * Creature — Human Soldier
+ * 3/1
+ * Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)
+ */
+val TomakulHonorGuard = card("Tomakul Honor Guard") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 1
+    oracleText = "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)"
+
+    // Ward {2} (CR 702.21a). The bare `Keyword.WARD` marker is derived from this ability by the
+    // builder, so it is not restated here.
+    keywordAbility(KeywordAbility.ward("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "195"
+        artist = "Francisco Miyara"
+        flavorText = "In the Great Desert, one law is enforced over all others: water belongs to all."
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c7745439-f40b-4647-8bff-53751d511bbd.jpg?1783920037"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/TyrantOfKherRidges.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/TyrantOfKherRidges.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tyrant of Kher Ridges
+ * {4}{R}{R}
+ * Creature — Dragon
+ * 4/5
+ * Flying
+ * When this creature enters, it deals 4 damage to any target.
+ * {R}: This creature gets +1/+0 until end of turn.
+ *
+ * "It deals" is the trigger's own source, which is [Effects.DealDamage]'s default — no explicit
+ * `damageSource` needed.
+ */
+val TyrantOfKherRidges = card("Tyrant of Kher Ridges") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 5
+    oracleText = "Flying\n" +
+        "When this creature enters, it deals 4 damage to any target.\n" +
+        "{R}: This creature gets +1/+0 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val anyTarget = target("any target", Targets.Any)
+        effect = Effects.DealDamage(4, anyTarget)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "154"
+        artist = "Karl Kopinski"
+        flavorText = "In war, dragons don't see sides, just side dishes."
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72a271b1-b757-4373-8e6d-e9698ae96bed.jpg?1783920058"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/UrzasRebuff.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/UrzasRebuff.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Urza's Rebuff
+ * {1}{U}{U}
+ * Instant
+ * Choose one —
+ * • Counter target spell.
+ * • Tap up to two target creatures.
+ */
+val UrzasRebuff = card("Urza's Rebuff") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n• Counter target spell.\n• Tap up to two target creatures."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Counter target spell") {
+                target("target", Targets.Spell)
+                effect = Effects.CounterSpell()
+            }
+            mode("Tap up to two target creatures") {
+                target("target", TargetCreature(count = 2, optional = true))
+                effect = Effects.TapEachTarget()
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "71"
+        artist = "Josu Hernaiz"
+        flavorText = "\"As usual, my brother's maneuvers are brash and impulsive.\"\n—Urza"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8a6f90b3-450c-490a-b6d0-2393c4646c85.jpg?1783920103"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/WhirlingStrike.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/WhirlingStrike.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Whirling Strike
+ * {1}{R}
+ * Instant
+ * Target creature gets +2/+0 and gains first strike and trample until end of turn.
+ */
+val WhirlingStrike = card("Whirling Strike") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+0 and gains first strike and trample until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 0, t),
+            Effects.GrantKeyword(Keyword.FIRST_STRIKE, t),
+            Effects.GrantKeyword(Keyword.TRAMPLE, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "157"
+        artist = "Aaron J. Riley"
+        flavorText = "\"I will trust desert steel in Fallaji hands over a soulless machine any day.\"\n—Hajar, Mishra's bodyguard"
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b17950ae-43aa-4d03-a41e-726ca96eb1ba.jpg?1783920058"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/WingCommando.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/WingCommando.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wing Commando
+ * {2}{U}
+ * Creature — Human Soldier
+ * 2/2
+ * Flying
+ * Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)
+ */
+val WingCommando = card("Wing Commando") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)"
+
+    keywords(Keyword.FLYING)
+    prowess()
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "73"
+        artist = "David Auden Nash"
+        flavorText = "\"The welds are weaker at the top.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/43e640c3-02bb-453c-a609-05d8214e2e2e.jpg?1783920103"
+        ruling("2022-10-14", "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger.")
+        ruling("2022-10-14", "Prowess goes on the stack on top of the spell that caused it to trigger. It will resolve before that spell.")
+        ruling("2022-10-14", "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/YotianDissident.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/YotianDissident.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Yotian Dissident
+ * {G}{W}
+ * Creature — Human Artificer
+ * 1/1
+ * Whenever an artifact you control enters, put a +1/+1 counter on target creature you control.
+ *
+ * The shared BRO "artifact you control enters" trigger — [Triggers.entersBattlefield] over
+ * `Artifact.youControl()` with [TriggerBinding.ANY] — feeding [Effects.AddCounters] on a
+ * declared target slot restricted to creatures you control.
+ */
+val YotianDissident = card("Yotian Dissident") {
+    manaCost = "{G}{W}"
+    colorIdentity = "WG"
+    typeLine = "Creature — Human Artificer"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever an artifact you control enters, put a +1/+1 counter on target creature you control."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        val creature = target("creature you control", TargetCreature(filter = TargetFilter.CreatureYouControl))
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+        description = "Put a +1/+1 counter on target creature you control."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "227"
+        artist = "Steve Prescott"
+        flavorText = "\"I joined this war to protect my homeland, not to destroy someone else's.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1eb02f00-c188-4193-a049-d26f7643e5da.jpg?1783920022"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/YotianMedic.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/YotianMedic.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Yotian Medic
+ * {2}{W}
+ * Creature — Human Cleric Soldier
+ * 1/4
+ * Lifelink
+ */
+val YotianMedic = card("Yotian Medic") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric Soldier"
+    power = 1
+    toughness = 4
+    oracleText = "Lifelink"
+
+    keywords(Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "33"
+        artist = "Aaron J. Riley"
+        flavorText = "\"Go, save as many as you can! The city walls may be rubble, but Kroog will live on in its people.\"\n—Queen Kayla bin-Kroog"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f21b9c48-6eca-4677-961b-614f5ec594ce.jpg?1783920120"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/YotianTactician.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/YotianTactician.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Yotian Tactician
+ * {2}{W}{U}
+ * Creature — Human Soldier
+ * 3/4
+ * Other Soldiers you control get +1/+1.
+ *
+ * The bare tribal noun ("Other Soldiers you control") means *permanents* with that subtype, not
+ * creatures — so the group filter is [GameObjectFilter.Permanent]`.withSubtype(Soldier)`, with
+ * `excludeSelf` carrying the "Other".
+ */
+val YotianTactician = card("Yotian Tactician") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 4
+    oracleText = "Other Soldiers you control get +1/+1."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype(Subtype.SOLDIER).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "228"
+        artist = "Fariba Khamseh"
+        flavorText = "\"Time for the Iron Alliance to remind the qadir's army how inhospitable the Sword Marches can be.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/760c0369-c2e4-4bd7-a301-9f707f5f48a8.jpg?1783920023"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/DisfigureReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/DisfigureReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Disfigure reprint in M20. Canonical CardDefinition lives in its earliest set (ZEN).
+ */
+val DisfigureReprint = Printing(
+    oracleId = "77eafe49-b9c5-461d-89c5-cec217dd2974",
+    name = "Disfigure",
+    setCode = "M20",
+    collectorNumber = "95",
+    scryfallId = "18069340-a698-4f75-82cc-cc94fcf82184",
+    artist = "Justin Sweet",
+    imageUri = "https://cards.scryfall.io/normal/front/1/8/18069340-a698-4f75-82cc-cc94fcf82184.jpg?1783932996",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/BRO.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BRO.json
@@ -1,3 +1,225 @@
+// Aeronaut's Wings
+{
+    "name": "Aeronaut's Wings",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "231",
+        "artist": "Leon Tukker",
+        "flavorText": "Volunteers rarely questioned why the airborne battalion always seemed to be recruiting.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fcc65821-e4e7-471c-941c-9d3e25ae8bb9.jpg?1783920019"
+    }
+}
+
+// Air Marshal
+{
+    "name": "Air Marshal",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "{3}: Target Soldier gains flying until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent Soldier"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "43",
+        "artist": "Johan Grenier",
+        "flavorText": "\"Today our blades remember Kroog! May the seven brass gods be with us!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/991e1a6c-914b-45c8-9170-c09e72696117.jpg?1783920115"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Ambush Paratrooper
+{
+    "name": "Ambush Paratrooper",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Flash\nFlying\n{5}: Creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "artist": "Vladimir Krisetskiy",
+        "flavorText": "\"It would be folly to fight a dragon engine head-on. Let's hit it from above.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/f/cfa00c0e-163d-4f59-b8b9-3ee9143d27bb.jpg?1783920135"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Argothian Sprite
+{
+    "name": "Argothian Sprite",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Faerie",
+    "oracleText": "This creature can't be blocked by artifact creatures.\n{7}: Put two +1/+1 counters on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{7}"
+                    }
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": "Self"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsArtifact",
+                        "IsCreature"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Rudy Siswanto",
+        "flavorText": "\"Make the exhaust vents smaller next time!\"\n—Urza, notes to his engineers",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5dbc383-7e08-4701-8d4a-6b99b74fe358.jpg?1783920053"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Bushwhack
 {
     "name": "Bushwhack",
@@ -92,6 +314,70 @@
     ]
 }
 
+// Coastal Bulwark
+{
+    "name": "Coastal Bulwark",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Wall",
+    "oracleText": "Defender\nThis creature gets +2/+0 as long as you control an Island.\n{2}, {T}: Surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Surveil",
+                    "count": 1
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "land Island"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "artist": "Artur Nakhodkin",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e24567f8-d195-4547-bba4-7a8131dc7889.jpg?1783920100"
+    }
+}
+
 // Deadly Riposte
 {
     "name": "Deadly Riposte",
@@ -140,6 +426,48 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Deathbloom Ritualist
+{
+    "name": "Deathbloom Ritualist",
+    "manaCost": "{3}{B}{G}",
+    "typeLine": "Creature — Elf Warlock",
+    "oracleText": "{T}: Add X mana of any one color, where X is the number of creature cards in your graveyard.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "amount": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "creature"
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "208",
+        "rarity": "RARE",
+        "artist": "Taras Susak",
+        "flavorText": "Each fallen friend was a seed of regret, eager to blossom again in Gaea's name.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/45ff816d-1eb7-4985-90ec-f44802a696fc.jpg?1783920033"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 
@@ -315,6 +643,229 @@
     "colorIdentityOverride": []
 }
 
+// Dwarven Forge-Chanter
+{
+    "name": "Dwarven Forge-Chanter",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Dwarf Wizard",
+    "oracleText": "Ward—Pay 2 life. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays 2 life.)\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "PROWESS",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Life",
+                "amount": 2
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "artist": "Bartłomiej Gaweł",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bbd6a95a-11b9-43aa-b293-20a3102bae71.jpg?1783920070",
+        "rulings": [
+            {
+                "date": "2022-10-14",
+                "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
+            },
+            {
+                "date": "2022-10-14",
+                "text": "Prowess goes on the stack on top of the spell that caused it to trigger. It will resolve before that spell."
+            },
+            {
+                "date": "2022-10-14",
+                "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Energy Refractor
+{
+    "name": "Energy Refractor",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, draw a card.\n{2}: Add one mana of any color.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "234",
+        "artist": "Maria Poliakova",
+        "flavorText": "\"Raw energy contains infinite possibility.\"\n—Urza",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc2a81fb-5045-4b7b-8cfb-b90c4f4a1f51.jpg?1783920019"
+    }
+}
+
+// Fallaji Chaindancer
+{
+    "name": "Fallaji Chaindancer",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "{2}: This creature gains double strike until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "artist": "Filipe Pagliuso",
+        "flavorText": "She was eager to show the invading Yotians how she earned her nickname, \"The Sandstorm of Tomakul.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4dc2da75-160d-47f9-b978-e153262ec1fc.jpg?1783920073"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Fallaji Vanguard
+{
+    "name": "Fallaji Vanguard",
+    "manaCost": "{2}{R}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "First strike\nWhenever this creature or another creature you control enters, target creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "rarity": "UNCOMMON",
+        "artist": "Joshua Cairos",
+        "flavorText": "\"The Burnished Banner will show the Warlord that the Suwwardi Marches belong to the Fallaji!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ffe9ee1c-5eb3-4d63-a641-0ec5adf7b058.jpg?1783920030"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "RED"
+    ]
+}
+
 // Flow of Knowledge
 {
     "name": "Flow of Knowledge",
@@ -424,6 +975,68 @@
     ]
 }
 
+// Gnarlroot Pallbearer
+{
+    "name": "Gnarlroot Pallbearer",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Treefolk Druid",
+    "oracleText": "Trample\nWhen this creature enters, target creature gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "creature"
+                    },
+                    "toughnessModifier": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "creature"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "When this creature enters, target creature gets +X/+X until end of turn, where X is the number of creature cards in your graveyard."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "artist": "Nino Is",
+        "flavorText": "The flames of war consumed most of Argoth's treefolk. Vengeance consumed the rest.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/7/b7382154-ac8f-40ca-94e4-2f0533c0cf20.jpg?1783920043"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Goblin Firebomb
 {
     "name": "Goblin Firebomb",
@@ -481,6 +1094,61 @@
     "colorIdentityOverride": []
 }
 
+// Machine Over Matter
+{
+    "name": "Machine Over Matter",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {1} less to cast if you control an artifact creature.\nReturn target nonland permanent to its owner's hand.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "Exists",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": "artifact creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "artist": "Tuan Duong Chu",
+        "flavorText": "The Warlord decreed that only someone who could move the statue would be strong enough to marry the princess. So Urza moved it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d08eadf5-a86d-4e8d-b65d-79b4f88477b9.jpg?1783920109"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Obliterating Bolt
 {
     "name": "Obliterating Bolt",
@@ -530,6 +1198,230 @@
     ]
 }
 
+// Overwhelming Remorse
+{
+    "name": "Overwhelming Remorse",
+    "manaCost": "{4}{B}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {1} less to cast for each creature card in your graveyard.\nExile target creature or planeswalker.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "CardsInGraveyardMatchingFilter",
+                        "filter": "creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "artist": "Ryan Valle",
+        "flavorText": "Tocasia's face haunted his vision. The explosion still rung in his ears. Mishra kept running and never once looked back.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/202cbfa4-3b3d-47fd-84a6-892692c906d6.jpg?1783920082",
+        "rulings": [
+            {
+                "date": "2022-10-14",
+                "text": "Overwhelming Remorse's first ability doesn't change its mana cost or mana value. It just reduces the cost to cast the spell."
+            },
+            {
+                "date": "2022-10-14",
+                "text": "Overwhelming Remorse's first ability can't reduce its cost to less than {B}."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Perimeter Patrol
+{
+    "name": "Perimeter Patrol",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Whenever an artifact you control enters, this creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "This creature gets +1/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "188",
+        "artist": "Edgar Sánchez Hidalgo",
+        "flavorText": "The Fallaji quickly learned that the Kher Ridges held too many caves and valleys to be surveyed from the air alone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d4719bc1-4c27-45d8-89f7-8c76ccf946d2.jpg?1783920042"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Phalanx Vanguard
+{
+    "name": "Phalanx Vanguard",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Vigilance\nWhenever an artifact you control enters, this creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "This creature gets +1/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Izzy",
+        "flavorText": "The cool, sleek automatons beside her mirrored her own iron resolve.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2abe2af7-deba-4569-822a-2d9309aeaadd.jpg?1783920125"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Retrieval Agent
+{
+    "name": "Retrieval Agent",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "{2}: This creature gets +1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "Vladimir Krisetskiy",
+        "flavorText": "The humming tome burned his leather glove, nearly taking his hand along with it. Then a strange power coursed through him.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f333a7b1-936e-42f3-ba22-2c76dd2f1c9a.jpg?1783920107"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Roc Hunter
+{
+    "name": "Roc Hunter",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Reach",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "150",
+        "artist": "Ina Wong",
+        "flavorText": "\"Never track the roc itself with your eyes, for it will swoop with the sun at its back and blind you. Instead, track its shadow and, when it's almost upon you, heave your javelin upward with all your might.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5c8b2f2b-6f19-47f7-bb65-00665989bc30.jpg?1783920060"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Soul Partition
 {
     "name": "Soul Partition",
@@ -565,6 +1457,82 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// Supply Drop
+{
+    "name": "Supply Drop",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Flash\nWhen this artifact enters, target creature you control gets +2/+2 until end of turn.\n{4}, {T}, Sacrifice this artifact: Draw a card.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "250",
+        "artist": "Brian Valeza",
+        "flavorText": "New armaments, fresh provisions, and best of all, dry socks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/82a5d3e9-bada-448b-894d-9d4e7e0463c7.jpg?1783920011"
+    }
 }
 
 // Teferi, Temporal Pilgrim
@@ -734,6 +1702,564 @@
     },
     "startingLoyalty": 4,
     "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Third Path Savant
+{
+    "name": "Third Path Savant",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{7}: Draw two cards.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{7}"
+                    }
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "67",
+        "artist": "Artur Treffner",
+        "flavorText": "As Mishra's army bore down on Terisia City, Corlo felt his focus, his patience, and his willpower twine together. With a deep breath, he plucked answers from the air.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/9/793a51ab-59fb-424f-a315-3f63e8990322.jpg?1783920104"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Thopter Architect
+{
+    "name": "Thopter Architect",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "Whenever an artifact you control enters, target creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "creature"
+                },
+                "descriptionOverride": "Target creature gains flying until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "rarity": "UNCOMMON",
+        "artist": "Michal Ivan",
+        "flavorText": "\"She'll only fly once. Make it count!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61017325-cec0-46ac-aa32-5855e5904888.jpg?1783920121"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Tocasia's Dig Site
+{
+    "name": "Tocasia's Dig Site",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{3}, {T}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Surveil",
+                    "count": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "266",
+        "artist": "Nadia Hurianova",
+        "flavorText": "Sent by their noble parents to toughen up and learn something of the world's past, Urza and Mishra instead uncovered Terisiare's future.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/23d4b90c-95b1-4828-bc08-7067da0d5364.jpg?1783920004"
+    }
+}
+
+// Tomakul Honor Guard
+{
+    "name": "Tomakul Honor Guard",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "195",
+        "artist": "Francisco Miyara",
+        "flavorText": "In the Great Desert, one law is enforced over all others: water belongs to all.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c7745439-f40b-4647-8bff-53751d511bbd.jpg?1783920037"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Tyrant of Kher Ridges
+{
+    "name": "Tyrant of Kher Ridges",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nWhen this creature enters, it deals 4 damage to any target.\n{R}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "rarity": "RARE",
+        "artist": "Karl Kopinski",
+        "flavorText": "In war, dragons don't see sides, just side dishes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72a271b1-b757-4373-8e6d-e9698ae96bed.jpg?1783920058"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Urza's Rebuff
+{
+    "name": "Urza's Rebuff",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Counter target spell.\n• Tap up to two target creatures.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": "Counter",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {},
+                                "zone": "Stack"
+                            },
+                            "id": "target"
+                        }
+                    ]
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": "IterationSpace.Targets",
+                        "body": {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "count": 2,
+                            "optional": true,
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Tap up to two target creatures"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "artist": "Josu Hernaiz",
+        "flavorText": "\"As usual, my brother's maneuvers are brash and impulsive.\"\n—Urza",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8a6f90b3-450c-490a-b6d0-2393c4646c85.jpg?1783920103"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Whirling Strike
+{
+    "name": "Whirling Strike",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+0 and gains first strike and trample until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "artist": "Aaron J. Riley",
+        "flavorText": "\"I will trust desert steel in Fallaji hands over a soulless machine any day.\"\n—Hajar, Mishra's bodyguard",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b17950ae-43aa-4d03-a41e-726ca96eb1ba.jpg?1783920058"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Wing Commando
+{
+    "name": "Wing Commando",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Flying\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "PROWESS"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "artist": "David Auden Nash",
+        "flavorText": "\"The welds are weaker at the top.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/43e640c3-02bb-453c-a609-05d8214e2e2e.jpg?1783920103",
+        "rulings": [
+            {
+                "date": "2022-10-14",
+                "text": "Any spell you cast that doesn't have the type creature will cause prowess to trigger. If a spell has multiple types, and one of those types is creature (such as an artifact creature), casting it won't cause prowess to trigger. Playing a land also won't cause prowess to trigger."
+            },
+            {
+                "date": "2022-10-14",
+                "text": "Prowess goes on the stack on top of the spell that caused it to trigger. It will resolve before that spell."
+            },
+            {
+                "date": "2022-10-14",
+                "text": "Once it triggers, prowess isn't connected to the spell that caused it to trigger. If that spell is countered, prowess will still resolve."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Yotian Dissident
+{
+    "name": "Yotian Dissident",
+    "manaCost": "{G}{W}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "Whenever an artifact you control enters, put a +1/+1 counter on target creature you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "creature you control"
+                },
+                "descriptionOverride": "Put a +1/+1 counter on target creature you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Prescott",
+        "flavorText": "\"I joined this war to protect my homeland, not to destroy someone else's.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1eb02f00-c188-4193-a049-d26f7643e5da.jpg?1783920022"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
+// Yotian Medic
+{
+    "name": "Yotian Medic",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Cleric Soldier",
+    "oracleText": "Lifelink",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "33",
+        "artist": "Aaron J. Riley",
+        "flavorText": "\"Go, save as many as you can! The city walls may be rubble, but Kroog will live on in its people.\"\n—Queen Kayla bin-Kroog",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f21b9c48-6eca-4677-961b-614f5ec594ce.jpg?1783920120"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Yotian Tactician
+{
+    "name": "Yotian Tactician",
+    "manaCost": "{2}{W}{U}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Other Soldiers you control get +1/+1.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "permanent Soldier ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "rarity": "UNCOMMON",
+        "artist": "Fariba Khamseh",
+        "flavorText": "\"Time for the Iron Alliance to remind the qadir's army how inhospitable the Sword Marches can be.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/760c0369-c2e4-4bd7-a301-9f707f5f48a8.jpg?1783920023"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
         "BLUE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/M11.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M11.json
@@ -259,6 +259,93 @@
     ]
 }
 
+// Fauna Shaman
+{
+    "name": "Fauna Shaman",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "{G}, {T}, Discard a creature card: Search your library for a creature card, reveal it, put it into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomDiscard",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "creature"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "descriptionOverride": "Search your library for a creature card, reveal it, put it into your hand, then shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "172",
+        "rarity": "RARE",
+        "artist": "Steve Prescott",
+        "flavorText": "She wears the talismans of every creature she can evoke.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c685e4c3-eb7b-4b9e-9676-395d69d80974.jpg?1783941798"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Hoarding Dragon
 {
     "name": "Hoarding Dragon",

--- a/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
@@ -490,6 +490,49 @@
     ]
 }
 
+// Disfigure
+{
+    "name": "Disfigure",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -2/-2 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": -2
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -2
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Justin Sweet",
+        "flavorText": "\"Brave scar or unfortunate tale? It all depends on your pain threshold.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3842ad2-a449-4963-8c96-276554125757.jpg?1783942155"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Expedition Map
 {
     "name": "Expedition Map",


### PR DESCRIPTION
BRO's "Assay reads it whole and it isn't implemented yet" set is **36 cards**. The other 224 missing cards read 222 `LINE_DECLINED` and 2 `LINES_DO_NOT_FOLD` — a premier set whose identity is prototype, unearth, powerstones and meld puts one of those words on most of what's left, so the grammar declines it.

**BRO goes 20/275 → 56/275 (7% → 20%).**

## The four-way split

| Bucket | Count |
|---|---|
| New canonical cards in BRO | 29 |
| Canonical belongs to an earlier set | 2 |
| Basic lands | 5 (20 art variants) |
| Reprint-row-only | 0 |

**Disfigure** (ZEN, 2009) and **Fauna Shaman** (M11, 2010) get their full `card(...)` in their earliest real printing and a `Printing(...)` row in BRO, per the house rule. Computing that split first mattered — it's what kept two duplicate canonicals out of BRO.

## No new SDK vocabulary

Every one of the 31 non-basic cards composes existing primitives, which is what "Assay reads it whole" implies and what the differential then confirms:

- the artifact-enters trigger — `Triggers.entersBattlefield(GameObjectFilter.Artifact.youControl(), TriggerBinding.ANY)`, Weldfast Wingsmith's shape, shared by four cards
- ward in both spellings (`KeywordAbility.ward("{2}")`, `KeywordAbility.wardLife(2)`) and prowess via `CardBuilder.prowess()` — the bare `Keyword.PROWESS` is inert on its own
- `DynamicAmounts.creatureCardsInYourGraveyard()` for all three graveyard-counting cards
- `Patterns.Library.surveil` / `.searchLibrary`, the modal spell shape, `ActivatedAbility.equip`
- `TriggerBinding.ANY` for Fallaji Vanguard's "this creature **or another** creature you control enters"

`docs/card-sdk-language-reference.md` is unchanged, and no card left the batch for `add-feature`.

## Basic lands

Per-set `basicLand(...)` vals, not `Printing` rows. BRO prints four art variants of each type — two normal-frame (268–277) and two full-art (278–287), all booster-eligible on Scryfall — plus the `basicLands` override on the set object that files them into the pool a limited player may add to a deck freely.

## The M20 Disfigure row

Real drift, but **invisible before this change**: `check-card-printing` used to exit "card not implemented" for a card with no canonical anywhere, so creating the ZEN canonical is what let the gate see that M20 (scaffolded) had no row. One line, added here rather than deferred because this PR is what surfaced it.

## Gates

| Gate | Result |
|---|---|
| `just build` | green — card snapshots re-blessed for BRO, M11, ZEN only |
| `just assay-differential` | **3148/3161 confirmed**; `DIVERGENT` unchanged at the same **13 pre-existing** cards (Pearl of Wisdom, Ghalta, Wizard's Lightning/Retort, Mistmeadow Council, Arcane Epiphany, Goblin/Krosan Warchief, three SPM cards, Dragon's Prey, Bolt Bend) — none in a set this PR touches |
| per-set differential | BRO **30/30**, ZEN **13/13**, M11 **9/9** — all 100.0% |
| `just check-card-printing` | clean for both relocated canonicals and a sample of the new ones |

The differential is the correctness net here, not the build: it compares Assay's independent reading of each new card against what was written, across the `staticAbilities`/filter layer no other gate looks at. Baseline was recorded **before** any edit (3119/3132, same 13 divergences), so the delta is +29 compared / +29 confirmed / **+0 divergent**.

No scenario tests: every card composes primitives that already have engine coverage, and the differential covers the modelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
