### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -708,12 +708,24 @@ preview — in the turn-face-up handler.)
 - `Costs.pay.Discard(filter = Any, count = 1, random = false)` — discard cards matching `filter`.
   Random variant prompts a yes/no and the engine picks the discards (Pillaging Horde).
 - `Costs.pay.Sacrifice(filter = Any, count = 1)` — sacrifice permanents you control matching
-  `filter`. Source is auto-excluded. "...unless you sacrifice three Forests" (Primeval Force).
+  `filter`. **The source is included when it matches** — "sacrifice it unless you sacrifice an
+  artifact" on an artifact creature may name that creature. "...unless you sacrifice three Forests"
+  (Primeval Force).
+- `Costs.pay.SacrificeAnother(filter = Any, count = 1)` — the printed-"another" variant; same cost
+  with the source excluded.
 - `Costs.pay.Exile(filter = Any, zone = HAND, count = 1)` — exile cards from `zone` matching
   `filter`. "...unless you exile a blue card from your hand."
 - `Costs.pay.Tap(filter = Any, count = 1)` — tap untapped permanents you control matching `filter`.
-  Source is auto-excluded. Tapping each emits a `TappedEvent` so "becomes tapped" triggers fire.
+  **The source is included when it matches and is untapped** — Public Thoroughfare's and Command
+  Bridge's rulings both allow tapping the land itself when something untapped it in response.
+  Tapping each emits a `TappedEvent` so "becomes tapped" triggers fire.
   "...unless you tap an untapped permanent you control" (Command Bridge).
+- `Costs.pay.TapAnother(filter = Any, count = 1)` — the printed-"another" variant; same cost with
+  the source excluded.
+
+The word **"another"** is the only thing that decides self-exclusion, and it lives on the cost atom
+(`excludeSelf`). Both `PayOrSufferExecutor` and `CostPaymentService` read that flag; neither applies
+a blanket exclusion.
 - `Costs.pay.Choice(options)` — present several `PayCost`s; player picks one (or the suffer effect).
   Unaffordable options are hidden. "...unless they sacrifice a nonland permanent or discard a card."
 - `Costs.pay.ReturnToHand(filter, count = 1)` — return permanents you control to their owner's hand.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -704,9 +704,17 @@ object Costs {
             random: Boolean = false
         ): PayCost = PayCost.Atom(CostAtom.Discard(count, filter, random))
 
-        /** Sacrifice [count] permanents matching [filter]. */
+        /**
+         * Sacrifice [count] permanents matching [filter]. The source is a legal choice when it
+         * matches — "sacrifice it unless you sacrifice an artifact" on an artifact creature lets
+         * you name the creature itself. Use [SacrificeAnother] for a printed "another".
+         */
         fun Sacrifice(filter: GameObjectFilter = GameObjectFilter.Any, count: Int = 1): PayCost =
             PayCost.Atom(CostAtom.Sacrifice(filter, count))
+
+        /** Sacrifice [count] permanents matching [filter] **other than the source** ("another"). */
+        fun SacrificeAnother(filter: GameObjectFilter = GameObjectFilter.Any, count: Int = 1): PayCost =
+            PayCost.Atom(CostAtom.Sacrifice(filter, count, excludeSelf = true))
 
         /** Pay [amount] life. */
         fun PayLife(amount: Int): PayCost = PayCost.Atom(CostAtom.PayLife(amount))
@@ -729,9 +737,17 @@ object Costs {
         fun ReturnToHand(filter: GameObjectFilter = GameObjectFilter.Any, count: Int = 1): PayCost =
             PayCost.Atom(CostAtom.ReturnToHand(filter, count))
 
-        /** Tap [count] untapped permanents matching [filter] you control. */
+        /**
+         * Tap [count] untapped permanents matching [filter] you control. The source is a legal
+         * choice when it matches and is untapped — Public Thoroughfare's and Command Bridge's
+         * rulings both allow tapping the land itself. Use [TapAnother] for a printed "another".
+         */
         fun Tap(filter: GameObjectFilter = GameObjectFilter.Any, count: Int = 1): PayCost =
             PayCost.Atom(CostAtom.TapPermanents(count, filter))
+
+        /** Tap [count] untapped permanents matching [filter] **other than the source** ("another"). */
+        fun TapAnother(filter: GameObjectFilter = GameObjectFilter.Any, count: Int = 1): PayCost =
+            PayCost.Atom(CostAtom.TapPermanents(count, filter, excludeSelf = true))
 
         /**
          * Remove [count] counters of the specified [counterType] (or any type when null)

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AlquistProftMasterSleuth.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AlquistProftMasterSleuth.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Alquist Proft, Master Sleuth — Murders at Karlov Manor #185
+ * {1}{W}{U} · Legendary Creature — Human Detective · 3/3 · Mythic
+ *
+ * Vigilance
+ * When Alquist Proft enters, investigate.
+ * {X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life.
+ *
+ * The enters trigger is the set's plain [Effects.Investigate] — one Clue, which is also the first
+ * payment for the activated ability, so the card arrives holding its own fuel.
+ *
+ * Two details in the activated ability are worth stating, because both are places a card like this
+ * is usually modelled wrong:
+ *
+ * - **The Clue is a cost, not a target.** `Sacrifice a Clue` is filtered on the *artifact subtype*
+ *   ([GameObjectFilter.Artifact] `.withSubtype("Clue")`), never on tokenness — Clue is an artifact
+ *   type like any other (2024-02-02 ruling), so a printed Clue artifact such as Wrench pays it just
+ *   as well as an investigated token. Because it is a cost, the sacrifice is spent: the same Clue
+ *   can't also pay for its own "{2}, Sacrifice this token: Draw a card", and any
+ *   `Triggers.YouSacrificeA(Clue)` payoff on the board sees it.
+ * - **X is one value read twice.** `{X}` is announced when the ability is activated (CR 601.2b via
+ *   the activation path), and both halves of the payoff read the same
+ *   [DynamicAmount.XValue] — so the draw and the lifegain can never disagree, which a pair of
+ *   independently-evaluated amounts could.
+ *
+ * The composition needs nothing new: [Costs.Composite] already stacks mana + tap + sacrifice, and
+ * the payoff is a two-element [Effects.Composite]. Ballista Squad established the same
+ * `{X}`-in-an-activated-cost shape.
+ */
+val AlquistProftMasterSleuth = card("Alquist Proft, Master Sleuth") {
+    manaCost = "{1}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Human Detective"
+    power = 3
+    toughness = 3
+    oracleText = "Vigilance\n" +
+        "When Alquist Proft enters, investigate. (Create a Clue token. It's an artifact with " +
+        "\"{2}, Sacrifice this token: Draw a card.\")\n" +
+        "{X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Investigate()
+        description = "When Alquist Proft enters, investigate."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{X}{W}{U}{U}"),
+            Costs.Tap,
+            Costs.Sacrifice(GameObjectFilter.Artifact.withSubtype("Clue"))
+        )
+        effect = Effects.Composite(
+            Effects.DrawCards(DynamicAmount.XValue),
+            Effects.GainLife(DynamicAmount.XValue)
+        )
+        description = "{X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "185"
+        artist = "Andreas Zafiratos"
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/41129b44-4fa7-473b-b2b7-48c6a58be03c.jpg?1783912857"
+
+        ruling(
+            "2024-02-02",
+            "Clue is an artifact type. Even though it appears on some cards with other permanent " +
+                "types, it's never a creature type, a land type, or anything but an artifact type."
+        )
+        ruling(
+            "2024-02-02",
+            "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact " +
+                "token. For example, you can sacrifice Wrench to pay for Alquist Proft, Master " +
+                "Sleuth's activated ability."
+        )
+        ruling(
+            "2024-02-02",
+            "You can't sacrifice a Clue to pay multiple costs. For example, you can't sacrifice a " +
+                "Clue token to activate its own ability and also to activate Alquist Proft, " +
+                "Master Sleuth's ability."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/EzrimAgencyChief.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/EzrimAgencyChief.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ezrim, Agency Chief — Murders at Karlov Manor #202
+ * {1}{W}{W}{U}{U} · Legendary Creature — Archon Detective · 5/5 · Rare
+ *
+ * Flying
+ * When Ezrim enters, investigate twice.
+ * {1}, Sacrifice an artifact: Ezrim gains your choice of vigilance, lifelink, or hexproof until
+ * end of turn.
+ *
+ * The two halves are deliberately self-feeding: the enters trigger banks two Clues, and Clues are
+ * artifacts, so the activated ability's fodder arrives with the body. Nothing links them, though —
+ * *any* artifact pays, and the Clues are equally free to be cracked for cards instead.
+ *
+ * "Gains your choice of vigilance, lifelink, or hexproof" is [ModalEffect.chooseOne] over three
+ * no-target [Mode]s, the shape Butcher of the Horde established for the identical wording. Each
+ * mode is a plain [Effects.GrantKeyword] on [EffectTarget.Self] whose default duration is already
+ * end of turn, so the "until end of turn" clause needs nothing spelled out.
+ *
+ * Three points of rules pedantry the modelling has to respect:
+ *
+ * - **The choice is made on resolution**, not on activation — `ModalEffectExecutor` resolves an
+ *   activated ability's modes when the ability resolves, which is what "your choice of" (as opposed
+ *   to a printed "Choose one —") means. An opponent responding to the activation therefore can't
+ *   see which keyword is coming.
+ * - **Hexproof chosen in response to removal still saves it**, for the same reason: the grant lands
+ *   before the removal spell resolves, and hexproof is checked on resolution.
+ * - **Ezrim isn't an artifact**, so the sacrifice is a plain [Costs.Sacrifice] over
+ *   [GameObjectFilter.Artifact] rather than the `SacrificeAnother` variant — there is no self to
+ *   exclude, and no printed "another" to honour.
+ */
+val EzrimAgencyChief = card("Ezrim, Agency Chief") {
+    manaCost = "{1}{W}{W}{U}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Archon Detective"
+    power = 5
+    toughness = 5
+    oracleText = "Flying\n" +
+        "When Ezrim enters, investigate twice. (To investigate, create a Clue token. It's an " +
+        "artifact with \"{2}, Sacrifice this token: Draw a card.\")\n" +
+        "{1}, Sacrifice an artifact: Ezrim gains your choice of vigilance, lifelink, or hexproof " +
+        "until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Investigate(2)
+        description = "When Ezrim enters, investigate twice."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.Sacrifice(GameObjectFilter.Artifact)
+        )
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(
+                Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self),
+                "Ezrim gains vigilance until end of turn"
+            ),
+            Mode.noTarget(
+                Effects.GrantKeyword(Keyword.LIFELINK, EffectTarget.Self),
+                "Ezrim gains lifelink until end of turn"
+            ),
+            Mode.noTarget(
+                Effects.GrantKeyword(Keyword.HEXPROOF, EffectTarget.Self),
+                "Ezrim gains hexproof until end of turn"
+            )
+        )
+        description = "{1}, Sacrifice an artifact: Ezrim gains your choice of vigilance, " +
+            "lifelink, or hexproof until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "202"
+        artist = "Jason A. Engle"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/9554d5f2-7a33-4734-8cf3-dfae2ccc3596.jpg?1783912850"
+
+        ruling(
+            "2024-02-02",
+            "Clue is an artifact type. Even though it appears on some cards with other permanent " +
+                "types, it's never a creature type, a land type, or anything but an artifact type."
+        )
+        ruling(
+            "2024-02-02",
+            "Some abilities trigger \"whenever you sacrifice a Clue\". Those abilities trigger " +
+                "whenever you sacrifice a Clue for any reason, not just to activate a Clue's " +
+                "activated ability."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/MassacreGirlKnownKiller.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/MassacreGirlKnownKiller.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Massacre Girl, Known Killer — Murders at Karlov Manor #94
+ * {2}{B}{B} · Legendary Creature — Human Assassin · 4/4 · Mythic
+ *
+ * Menace
+ * Creatures you control have wither.
+ * Whenever a creature an opponent controls dies, if its toughness was less than 1, draw a card.
+ *
+ * The two non-menace abilities are one machine. Wither turns your creatures' damage into -1/-1
+ * counters (CR 702.90a), so a creature that "dies to combat damage" against your board doesn't die
+ * with its toughness intact — it dies with its toughness *shrunk to zero*, as a state-based action
+ * (CR 704.5f). The draw trigger reads exactly that condition, so it fires on the same kills the
+ * first ability caused, and stays silent on kills it didn't: a creature that took plain lethal
+ * damage from a burn spell dies at toughness 3, not 0, and draws nothing.
+ *
+ * **The toughness is last-known information.** By the time the trigger is evaluated the creature is
+ * already in the graveyard, where it has no toughness at all, so the check has to run against the
+ * value it had as it last existed on the battlefield (2024-02-02 ruling). That is why the condition
+ * lives in the *trigger filter* rather than as an `interveningIf`: `TriggerMatcher` evaluates a
+ * `ToughnessAtMost` predicate against the `lastKnownToughness` carried on the zone-change event,
+ * falling back to projected state only for entities that are still around. An intervening-if would
+ * be evaluated twice (on trigger and again on resolution) against a value that can no longer be
+ * read — and since last-known information is frozen, the second check could only ever be worse.
+ *
+ * "Toughness was less than 1" is `toughnessAtMost(0)`, not `toughnessAtMost(1)` — the printed text
+ * is a strict inequality, and it includes negative toughness, which a pile of -1/-1 counters
+ * reaches routinely.
+ *
+ * Scope notes: the wither grant covers **all** creatures you control, Massacre Girl herself
+ * included, and the draw trigger is scoped to creatures an *opponent* controls, so your own losses
+ * are never a payoff.
+ */
+val MassacreGirlKnownKiller = card("Massacre Girl, Known Killer") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Assassin"
+    power = 4
+    toughness = 4
+    oracleText = "Menace\n" +
+        "Creatures you control have wither. (They deal damage to creatures in the form of -1/-1 " +
+        "counters.)\n" +
+        "Whenever a creature an opponent controls dies, if its toughness was less than 1, draw a " +
+        "card."
+
+    keywords(Keyword.MENACE)
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.WITHER,
+            GroupFilter(GameObjectFilter.Creature.youControl())
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.opponentControls().toughnessAtMost(0),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.DrawCards(1)
+        description = "Whenever a creature an opponent controls dies, if its toughness was less " +
+            "than 1, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "94"
+        artist = "Billy Christian"
+        flavorText = "\"'Did I do it?' You'll have to be more specific.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb1c8800-9d33-485c-b776-042003b9ea92.jpg?1783912894"
+
+        ruling(
+            "2024-02-02",
+            "Use the toughness of the creature as it last existed on the battlefield to determine " +
+                "whether or not Massacre Girl's ability triggers."
+        )
+        ruling(
+            "2024-02-02",
+            "Wither applies to any damage dealt to creatures by creatures you control. This " +
+                "includes combat damage as well as anything that causes creatures you control to " +
+                "deal noncombat damage, such as Incinerator of the Guilty's reflexive triggered " +
+                "ability or the effect of Hard-Hitting Question."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PublicThoroughfare.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PublicThoroughfare.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+
+/**
+ * Public Thoroughfare — Murders at Karlov Manor #265
+ * Land · Common
+ *
+ * This land enters tapped.
+ * When this land enters, sacrifice it unless you tap an untapped artifact or land you control.
+ * {T}: Add one mana of any color.
+ *
+ * A five-color land whose price is a second permanent's turn. All three lines are existing rails:
+ * [EntersTapped] as a replacement effect, [PayOrSufferEffect] for the "unless" clause, and
+ * [Effects.AddAnyColorMana] behind a `manaAbility` activation.
+ *
+ * The "unless" is a **cost, paid on resolution of the trigger** — not a targeted choice and not a
+ * may-gate. [PayOrSufferEffect] models exactly that asymmetry: pay [Costs.pay.Tap] and keep the
+ * land, decline (or be unable to pay) and [SacrificeSelfEffect] fires. `Costs.pay.Tap` already
+ * means "tap N *untapped* permanents matching the filter that *you control*", so the printed
+ * "untapped … you control" needs no further narrowing; the filter carries only the type union,
+ * [GameObjectFilter.ArtifactOrLand].
+ *
+ * There is deliberately **no self-exclusion** on that filter. Public Thoroughfare normally enters
+ * tapped and so can't pay for itself, but the 2024-02-02 ruling calls out the unusual case where it
+ * is untapped as the trigger resolves — an effect that untapped it in response — and in that case
+ * tapping itself is a legal payment. `CostAtom.TapPermanents.excludeSelf` defaults to false and is
+ * left that way; the printed text says "an untapped artifact or land you control", not "another".
+ *
+ * That line did not work before this card: `PayOrSufferExecutor` used to drop the source from the
+ * candidate set unconditionally, disagreeing with `CostPaymentService`, which has always read the
+ * atom's flag. Fixed in the same change — the executor now honours `excludeSelf` on both its
+ * sacrifice and tap costs, which also repairs Command Bridge's identical ruling.
+ *
+ * Ordering note: the land enters tapped by replacement, so the enters trigger sees a tapped
+ * permanent. The mana ability is a real mana ability ([TimingRule.ManaAbility], `manaAbility =
+ * true`) — it never uses the stack, so it can be activated while paying for something else.
+ */
+val PublicThoroughfare = card("Public Thoroughfare") {
+    typeLine = "Land"
+    colorIdentity = ""
+    oracleText = "This land enters tapped.\n" +
+        "When this land enters, sacrifice it unless you tap an untapped artifact or land you " +
+        "control.\n" +
+        "{T}: Add one mana of any color."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = PayOrSufferEffect(
+            cost = Costs.pay.Tap(GameObjectFilter.ArtifactOrLand),
+            suffer = SacrificeSelfEffect
+        )
+        description = "When this land enters, sacrifice it unless you tap an untapped artifact " +
+            "or land you control."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "265"
+        artist = "Anthony Devine"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f8b915f-3e82-4b05-b963-01ebff7a8f7b.jpg?1783912824"
+
+        ruling(
+            "2024-02-02",
+            "In the unusual case where Public Thoroughfare is untapped as its triggered ability " +
+                "is resolving, you can tap it for its own triggered ability."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/TreacherousGreed.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/TreacherousGreed.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Treacherous Greed — Murders at Karlov Manor #237
+ * {1}{W}{B} · Instant · Rare
+ *
+ * As an additional cost to cast this spell, sacrifice a creature that dealt damage this turn.
+ * Draw three cards. Each opponent loses 3 life and you gain 3 life.
+ *
+ * The whole card is the additional cost. `Sacrifice a creature that dealt damage this turn` is
+ * `GameObjectFilter.Creature.hasDealtDamageThisTurn()` — the **active**-voice predicate, the one
+ * that asks what the creature dealt, not what was dealt to it. Its passive sibling
+ * `wasDealtDamageThisTurn()` reads almost identically and means the opposite; picking the wrong one
+ * would let a creature that merely *survived* a Shock pay this, and would refuse the attacker that
+ * actually connected.
+ *
+ * The tracker behind that predicate records the fact of dealing, not the recipient, which is why
+ * the 2024-02-02 ruling holds for free: a creature that killed a blocker still qualifies once the
+ * blocker is gone, and a creature that hit a player who has since left the game still qualifies too.
+ * There is nothing to look up at cast time beyond the flag itself.
+ *
+ * Because the sacrifice is an additional *cost*, it happens on announcement (CR 601.2h) — before
+ * anyone can respond, and it happens whether or not the spell resolves. Note also that the creature
+ * doesn't have to be the one that dealt the damage on your behalf: any creature you control that
+ * dealt damage this turn is legal, including one that dealt damage while an opponent controlled it.
+ *
+ * The payoff is a flat three-part [Effects.Composite]. `Each opponent loses 3 life` is
+ * [Player.EachOpponent] rather than three separate effects, and the 3 life you gain is a fixed
+ * number — not "life equal to the life lost this way", which is a different card and a different
+ * amount in multiplayer.
+ */
+val TreacherousGreed = card("Treacherous Greed") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature that dealt " +
+        "damage this turn.\n" +
+        "Draw three cards. Each opponent loses 3 life and you gain 3 life."
+
+    additionalCost(
+        Costs.additional.SacrificePermanent(GameObjectFilter.Creature.hasDealtDamageThisTurn())
+    )
+
+    spell {
+        effect = Effects.Composite(
+            Effects.DrawCards(3),
+            Effects.LoseLife(3, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "237"
+        artist = "Eli Minaya"
+        flavorText = "Loot's easy to divide by one."
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e4b9260b-0993-42c5-9bcf-87ab394d51db.jpg?1783912838"
+
+        ruling(
+            "2024-02-02",
+            "You can sacrifice any creature you control that dealt damage this turn to pay " +
+                "Treacherous Greed's additional cost, even if the permanent it dealt damage to is " +
+                "no longer on the battlefield or the player it dealt damage to is no longer in the " +
+                "game."
+        )
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AlquistProftMasterSleuthScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AlquistProftMasterSleuthScenarioTest.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Alquist Proft, Master Sleuth (MKM #185) — {1}{W}{U} 3/3 Legendary Human Detective.
+ *
+ * "Vigilance
+ *  When Alquist Proft enters, investigate.
+ *  {X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life."
+ *
+ * Three claims worth pinning:
+ *
+ *  - the enters trigger produces the Clue that the activated ability then eats, so the card is
+ *    self-sufficient the turn after it lands;
+ *  - `X` is announced once and read twice — the cards drawn and the life gained must agree, which a
+ *    pair of independently-evaluated amounts would not guarantee;
+ *  - **a Clue is an artifact type, not a token-ness test** (2024-02-02 ruling). Wrench is a printed
+ *    `Artifact — Clue Equipment`, and it pays the cost exactly as an investigated token would. A
+ *    filter written against tokens instead of the subtype would reject it, which is why the payment
+ *    test deliberately uses Wrench rather than the Clue the creature makes for itself.
+ */
+class AlquistProftMasterSleuthScenarioTest : ScenarioTestBase() {
+
+    private val proftAbility by lazy {
+        cardRegistry.getCard("Alquist Proft, Master Sleuth")!!.script.activatedAbilities.single().id
+    }
+
+    init {
+        context("Alquist Proft, Master Sleuth") {
+
+            test("entering investigates for the Clue that fuels its own ability") {
+                val game = scenario()
+                    .withPlayers("Sleuth", "Opponent")
+                    .withCardInHand(1, "Alquist Proft, Master Sleuth")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Alquist Proft, Master Sleuth")
+                withClue("casting should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("the enters trigger investigates exactly once") {
+                    game.findPermanents("Clue").size shouldBe 1
+                }
+            }
+
+            test("X = 2 sacrifices a Clue artifact to draw two and gain two") {
+                val game = scenario()
+                    .withPlayers("Sleuth", "Opponent")
+                    .withCardOnBattlefield(1, "Alquist Proft, Master Sleuth", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Wrench")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Centaur Courser")
+                    .withCardInLibrary(1, "Savannah Lions")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val proft = game.findPermanent("Alquist Proft, Master Sleuth")!!
+                val wrench = game.findPermanent("Wrench")!!
+                val handBefore = game.handSize(1)
+                val lifeBefore = game.getLifeTotal(1)
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = proft,
+                        abilityId = proftAbility,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(wrench)),
+                        xValue = 2
+                    )
+                )
+                withClue("a printed Clue artifact pays the sacrifice: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("X = 2 draws two") { game.handSize(1) shouldBe handBefore + 2 }
+                withClue("and the same X gains two") {
+                    game.getLifeTotal(1) shouldBe lifeBefore + 2
+                }
+                withClue("the Clue was spent as a cost") {
+                    game.isInGraveyard(1, "Wrench") shouldBe true
+                }
+            }
+
+            test("X = 0 is a legal activation that draws and gains nothing") {
+                val game = scenario()
+                    .withPlayers("Sleuth", "Opponent")
+                    .withCardOnBattlefield(1, "Alquist Proft, Master Sleuth", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Wrench")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val proft = game.findPermanent("Alquist Proft, Master Sleuth")!!
+                val wrench = game.findPermanent("Wrench")!!
+                val handBefore = game.handSize(1)
+                val lifeBefore = game.getLifeTotal(1)
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = proft,
+                        abilityId = proftAbility,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(wrench)),
+                        xValue = 0
+                    )
+                )
+                withClue("X = 0 is a legal announcement: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("zero cards") { game.handSize(1) shouldBe handBefore }
+                withClue("zero life") { game.getLifeTotal(1) shouldBe lifeBefore }
+                withClue("but the Clue is still spent — costs are paid regardless") {
+                    game.isInGraveyard(1, "Wrench") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EzrimAgencyChiefScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EzrimAgencyChiefScenarioTest.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ezrim, Agency Chief (MKM #202) — {1}{W}{W}{U}{U} 5/5 Legendary Archon Detective.
+ *
+ * "Flying
+ *  When Ezrim enters, investigate twice.
+ *  {1}, Sacrifice an artifact: Ezrim gains your choice of vigilance, lifelink, or hexproof until
+ *  end of turn."
+ *
+ * The enters trigger banks the fodder the activated ability burns, so the two halves are tested
+ * together: enter, then eat one of the Clues you just made.
+ *
+ * The mode tests each pick a *different* branch, because a modal effect whose executor ignored the
+ * chosen index would still pass a single-mode test. Selecting "lifelink" and finding vigilance
+ * would be a silent index bug; selecting each in turn makes that impossible to miss.
+ */
+class EzrimAgencyChiefScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    private val ezrimAbility by lazy {
+        cardRegistry.getCard("Ezrim, Agency Chief")!!.script.activatedAbilities.single().id
+    }
+
+    init {
+        /** Ezrim on the battlefield with two Clues banked by its own enters trigger. */
+        fun ezrimWithClues(): TestGame {
+            val game = scenario()
+                .withPlayers("Chief", "Opponent")
+                .withCardInHand(1, "Ezrim, Agency Chief")
+                // Five for Ezrim, plus headroom for two {1} activations.
+                .withLandsOnBattlefield(1, "Plains", 4)
+                .withLandsOnBattlefield(1, "Island", 4)
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+            val cast = game.castSpell(1, "Ezrim, Agency Chief")
+            withClue("casting should succeed: ${cast.error}") { cast.error shouldBe null }
+            game.resolveStack()
+            return game
+        }
+
+        /** Activate, sacrificing [artifact], and pick mode [modeIndex] (0 vig, 1 lifelink, 2 hexproof). */
+        fun activateChoosing(game: TestGame, ezrim: EntityId, artifact: EntityId, modeIndex: Int) {
+            val result = game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = ezrim,
+                    abilityId = ezrimAbility,
+                    costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(artifact))
+                )
+            )
+            withClue("activating should succeed: ${result.error}") { result.error shouldBe null }
+            game.resolveStack()
+            val modeDecision = game.getPendingDecision() as ChooseOptionDecision
+            game.submitDecision(OptionChosenResponse(modeDecision.id, modeIndex))
+            game.resolveStack()
+        }
+
+        context("Ezrim, Agency Chief") {
+
+            test("entering investigates twice") {
+                val game = ezrimWithClues()
+
+                withClue("two Clues, not one — 'investigate twice' is two tokens") {
+                    game.findPermanents("Clue").size shouldBe 2
+                }
+                withClue("and Ezrim itself flies") {
+                    val ezrim = game.findPermanent("Ezrim, Agency Chief")!!
+                    stateProjector.project(game.state).hasKeyword(ezrim, Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("sacrificing a Clue for vigilance grants vigilance and nothing else") {
+                val game = ezrimWithClues()
+                val ezrim = game.findPermanent("Ezrim, Agency Chief")!!
+                val clue = game.findPermanents("Clue").first()
+
+                activateChoosing(game, ezrim, clue, modeIndex = 0)
+
+                val projected = stateProjector.project(game.state)
+                withClue("mode 0 is vigilance") {
+                    projected.hasKeyword(ezrim, Keyword.VIGILANCE) shouldBe true
+                }
+                withClue("the other two modes were not chosen, so they were not granted") {
+                    projected.hasKeyword(ezrim, Keyword.LIFELINK) shouldBe false
+                    projected.hasKeyword(ezrim, Keyword.HEXPROOF) shouldBe false
+                }
+                withClue("one Clue was spent as the cost, one remains") {
+                    game.findPermanents("Clue").size shouldBe 1
+                }
+            }
+
+            test("a second activation picks a different mode") {
+                val game = ezrimWithClues()
+                val ezrim = game.findPermanent("Ezrim, Agency Chief")!!
+                val clues = game.findPermanents("Clue")
+
+                activateChoosing(game, ezrim, clues[0], modeIndex = 1)
+                activateChoosing(game, ezrim, clues[1], modeIndex = 2)
+
+                val projected = stateProjector.project(game.state)
+                withClue("both grants stack — the ability isn't a mutually exclusive switch") {
+                    projected.hasKeyword(ezrim, Keyword.LIFELINK) shouldBe true
+                    projected.hasKeyword(ezrim, Keyword.HEXPROOF) shouldBe true
+                }
+                withClue("vigilance was never chosen") {
+                    projected.hasKeyword(ezrim, Keyword.VIGILANCE) shouldBe false
+                }
+                withClue("both Clues are gone") {
+                    game.findPermanents("Clue").size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MassacreGirlKnownKillerScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MassacreGirlKnownKillerScenarioTest.kt
@@ -1,0 +1,172 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Massacre Girl, Known Killer (MKM #94) — {2}{B}{B} 4/4 Legendary Human Assassin.
+ *
+ * "Menace
+ *  Creatures you control have wither.
+ *  Whenever a creature an opponent controls dies, if its toughness was less than 1, draw a card."
+ *
+ * The card is one machine wearing two abilities. Wither turns your creatures' damage into -1/-1
+ * counters, so an opposing creature killed by your board dies at toughness 0 or below rather than
+ * at its printed toughness — which is exactly the condition the draw trigger reads.
+ *
+ * The tests are built around the three ways this can silently break:
+ *
+ *  - **the toughness is last-known information.** The creature is in the graveyard by the time the
+ *    trigger is checked, where it has no toughness at all. If the check read live state instead of
+ *    the value stamped on the zone-change event, the wither kill would draw nothing. The withered
+ *    blocker there dies at *negative* toughness, which only the strict "less than 1" reading covers.
+ *  - **the clauses must not collapse into "an opponent's creature died."** A creature that dies at
+ *    its printed toughness — burned down rather than withered — must draw nothing.
+ *  - **your own losses are not a payoff**, even though your creatures are the ones carrying wither.
+ */
+class MassacreGirlKnownKillerScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Massacre Girl, Known Killer") {
+
+            test("she hands out wither to your whole board, herself included") {
+                val game = scenario()
+                    .withPlayers("Killer", "Victim")
+                    .withCardOnBattlefield(1, "Massacre Girl, Known Killer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val projected = stateProjector.project(game.state)
+                val girl = game.findPermanent("Massacre Girl, Known Killer")!!
+                val yours = game.findPermanent("Grizzly Bears")!!
+                val theirs = game.findPermanent("Centaur Courser")!!
+
+                withClue("'creatures you control' includes the source") {
+                    projected.hasKeyword(girl, Keyword.WITHER) shouldBe true
+                }
+                withClue("and every other creature you control") {
+                    projected.hasKeyword(yours, Keyword.WITHER) shouldBe true
+                }
+                withClue("but not the opponent's") {
+                    projected.hasKeyword(theirs, Keyword.WITHER) shouldBe false
+                }
+                withClue("menace is printed on her") {
+                    projected.hasKeyword(girl, Keyword.MENACE) shouldBe true
+                }
+            }
+
+            test("a withered blocker dies below 1 toughness and draws exactly one card") {
+                val game = scenario()
+                    .withPlayers("Killer", "Victim")
+                    .withCardOnBattlefield(1, "Massacre Girl, Known Killer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Savannah Lions")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Goblin Guide")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                // The 1/1 Lions blocks the withering 2/2 Bears. The Bears' 2 damage arrives as two
+                // -1/-1 counters, taking the Lions to -1/-1 — dead at *negative* toughness, which
+                // only the strict "less than 1" reading covers. The Lions' 1 damage back is not
+                // lethal to a 2/2, so the only death is on the opponent's side.
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Savannah Lions" to listOf("Grizzly Bears")))
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+
+                withClue("the withered Lions died; the attacker survived a 1-power blocker") {
+                    game.isInGraveyard(2, "Savannah Lions") shouldBe true
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                }
+                withClue(
+                    "exactly one card, off last-known information: the Lions had no toughness at " +
+                        "all by the time the trigger was checked, so the -1 has to come off the " +
+                        "zone change rather than live state"
+                ) {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+
+            test("your own creature dying is never the payoff") {
+                val game = scenario()
+                    .withPlayers("Killer", "Victim")
+                    .withCardOnBattlefield(1, "Massacre Girl, Known Killer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                // The 3/3 Courser survives two -1/-1 counters as a 1/1 and kills the 2/2 Bears.
+                // Your creature carries the wither, but the trigger is scoped to theirs.
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Centaur Courser" to listOf("Grizzly Bears")))
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+
+                withClue("your Bears died and their withered Courser is a 1/1 survivor") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                    val courser = game.findPermanent("Centaur Courser")!!
+                    val projected = stateProjector.project(game.state)
+                    projected.getPower(courser) shouldBe 1
+                    projected.getToughness(courser) shouldBe 1
+                }
+                withClue("no opponent's creature died, so no card is drawn") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+
+            test("a creature that dies at its printed toughness draws nothing") {
+                val game = scenario()
+                    .withPlayers("Killer", "Victim")
+                    .withCardOnBattlefield(1, "Massacre Girl, Known Killer", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Savannah Lions")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val bolt = game.castSpell(1, "Lightning Bolt", bears)
+                withClue("bolting the opponent's Bears should succeed: ${bolt.error}") {
+                    bolt.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the Bears died") { game.isInGraveyard(2, "Grizzly Bears") shouldBe true }
+                withClue(
+                    "but it died a 2/2 — wither only touches damage dealt by creatures you " +
+                        "control, so the condition is false and the only hand change is the Bolt " +
+                        "leaving it"
+                ) {
+                    game.handSize(1) shouldBe handBefore - 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PublicThoroughfareScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PublicThoroughfareScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Public Thoroughfare (MKM #265) — Land.
+ *
+ * "This land enters tapped.
+ *  When this land enters, sacrifice it unless you tap an untapped artifact or land you control.
+ *  {T}: Add one mana of any color."
+ *
+ * The "unless" is a cost paid on resolution of the enters trigger, not a may-gate and not a target,
+ * so the three outcomes are: pay and keep it, decline and lose it, or have nothing to pay with and
+ * lose it without ever being asked. All three are covered.
+ *
+ * The filter carries only the type union — `Costs.pay.Tap` already means "untapped, yours" — and it
+ * carries **no self-exclusion**, which the last test pins: the 2024-02-02 ruling calls out that an
+ * untapped Public Thoroughfare may tap *itself* to pay. `PayOrSufferExecutor` used to drop the
+ * source from the candidate set regardless of the atom's `excludeSelf`, which silently outlawed
+ * that line; it now reads the flag, matching `CostPaymentService`. The engine-level coverage for
+ * both halves of that fix lives in `PayOrSufferSelfExclusionTest`.
+ */
+class PublicThoroughfareScenarioTest : ScenarioTestBase() {
+
+    private fun ScenarioTestBase.TestGame.isTapped(id: EntityId): Boolean =
+        state.getEntity(id)?.get<TappedComponent>() != null
+
+    init {
+        context("Public Thoroughfare") {
+
+            test("tapping another land keeps it, and it entered tapped") {
+                val game = scenario()
+                    .withPlayers("Traveller", "Opponent")
+                    .withCardInHand(1, "Public Thoroughfare")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forest = game.findPermanent("Forest")!!
+                val land = game.findCardsInHand(1, "Public Thoroughfare").single()
+                game.execute(com.wingedsheep.engine.core.PlayLand(game.player1Id, land))
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                withClue("the unless-clause raises a selection over the payable permanents") {
+                    (decision as? SelectCardsDecision)?.options.orEmpty() shouldContain forest
+                }
+                game.selectCards(listOf(forest))
+
+                withClue("paying keeps the land") {
+                    game.findPermanent("Public Thoroughfare") shouldBe land
+                }
+                withClue("and the Forest is now tapped — that was the payment") {
+                    game.isTapped(forest) shouldBe true
+                }
+                withClue("the Thoroughfare itself entered tapped by replacement") {
+                    game.isTapped(land) shouldBe true
+                }
+            }
+
+            test("declining sacrifices it") {
+                val game = scenario()
+                    .withPlayers("Traveller", "Opponent")
+                    .withCardInHand(1, "Public Thoroughfare")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val land = game.findCardsInHand(1, "Public Thoroughfare").single()
+                game.execute(com.wingedsheep.engine.core.PlayLand(game.player1Id, land))
+                game.resolveStack()
+                game.selectCards(emptyList())
+
+                withClue("declining the cost means suffering the sacrifice") {
+                    game.findPermanent("Public Thoroughfare") shouldBe null
+                    game.isInGraveyard(1, "Public Thoroughfare") shouldBe true
+                }
+            }
+
+            test("with nothing untapped to tap, it is sacrificed without a prompt") {
+                val game = scenario()
+                    .withPlayers("Traveller", "Opponent")
+                    .withCardInHand(1, "Public Thoroughfare")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val land = game.findCardsInHand(1, "Public Thoroughfare").single()
+                game.execute(com.wingedsheep.engine.core.PlayLand(game.player1Id, land))
+                game.resolveStack()
+
+                withClue("an unpayable cost is never offered") {
+                    game.getPendingDecision() shouldBe null
+                }
+                withClue("and the land goes straight to the graveyard") {
+                    game.isInGraveyard(1, "Public Thoroughfare") shouldBe true
+                }
+            }
+
+            test("an untapped Thoroughfare may tap itself to pay") {
+                val game = scenario()
+                    .withPlayers("Traveller", "Opponent")
+                    .withCardInHand(1, "Public Thoroughfare")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val land = game.findCardsInHand(1, "Public Thoroughfare").single()
+                game.execute(com.wingedsheep.engine.core.PlayLand(game.player1Id, land))
+
+                // Untap it before the trigger resolves — the unusual case the 2024-02-02 ruling
+                // describes, where tapping itself is a legal payment.
+                game.state = game.state.updateEntity(game.findPermanent("Public Thoroughfare")!!) {
+                    it.without<TappedComponent>()
+                }
+                withClue("the untap took, so the ruling's precondition genuinely holds") {
+                    game.isTapped(game.findPermanent("Public Thoroughfare")!!) shouldBe false
+                }
+                game.resolveStack()
+
+                val thoroughfare = game.findPermanent("Public Thoroughfare")
+                withClue(
+                    "it is its own legal payment — the cost atom's excludeSelf is false, and the " +
+                        "executor honours it rather than dropping the source unconditionally"
+                ) {
+                    thoroughfare shouldBe land
+                    val decision = game.getPendingDecision() as? SelectCardsDecision
+                    decision?.options.orEmpty() shouldContain land
+                }
+                game.selectCards(listOf(land))
+
+                withClue("paying with itself keeps it on the battlefield, tapped") {
+                    game.findPermanent("Public Thoroughfare") shouldBe land
+                    game.isTapped(land) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TreacherousGreedScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TreacherousGreedScenarioTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeEmpty
+
+/**
+ * Treacherous Greed (MKM #237) — {1}{W}{B} Instant.
+ *
+ * "As an additional cost to cast this spell, sacrifice a creature that dealt damage this turn.
+ *  Draw three cards. Each opponent loses 3 life and you gain 3 life."
+ *
+ * The whole card hangs on which creatures are legal fodder, so that is what these tests measure.
+ * The filter is the **active**-voice `hasDealtDamageThisTurn()`, and the failure it guards against
+ * is subtle: its passive sibling `wasDealtDamageThisTurn()` reads almost identically and selects
+ * almost the opposite set. The third test pins exactly that — a creature that *took* damage but
+ * never dealt any must not pay, and under the passive predicate it would.
+ *
+ * Combat is the natural way to stamp the tracker, so the attacker connects first and the spell is
+ * cast in the postcombat main phase.
+ */
+class TreacherousGreedScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Treacherous Greed") {
+
+            test("an attacker that connected pays the cost, and the spell drains for three") {
+                val game = scenario()
+                    .withPlayers("Boss", "Underling")
+                    .withCardInHand(1, "Treacherous Greed")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Centaur Courser")
+                    .withCardInLibrary(1, "Savannah Lions")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Goblin Guide")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareNoBlockers()
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+
+                withClue("the Bears connected for 2 — that is the stamp the cost looks for") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                val handBefore = game.handSize(1)
+
+                val cast = game.castSpellWithAdditionalSacrifice(1, "Treacherous Greed", "Grizzly Bears")
+                withClue("a creature that dealt damage this turn pays the cost: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                withClue("the sacrifice happens on announcement, before the spell resolves") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                game.resolveStack()
+
+                withClue("draw three — the spell left the hand, so net is +2") {
+                    game.handSize(1) shouldBe handBefore + 2
+                }
+                withClue("each opponent loses 3 on top of the 2 combat damage") {
+                    game.getLifeTotal(2) shouldBe 15
+                }
+                withClue("and you gain 3") { game.getLifeTotal(1) shouldBe 23 }
+            }
+
+            test("a creature that never dealt damage can't pay the cost") {
+                val game = scenario()
+                    .withPlayers("Boss", "Underling")
+                    .withCardInHand(1, "Treacherous Greed")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Centaur Courser")
+                    .withCardInLibrary(1, "Savannah Lions")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpellWithAdditionalSacrifice(1, "Treacherous Greed", "Grizzly Bears")
+                withClue("an idle creature is not legal fodder") {
+                    cast.error.orEmpty().shouldNotBeEmpty()
+                }
+                withClue("nothing was sacrificed and nothing was drained") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                    game.getLifeTotal(2) shouldBe 20
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+
+            test("a creature that was only dealt damage can't pay — active voice, not passive") {
+                val game = scenario()
+                    .withPlayers("Boss", "Underling")
+                    .withCardInHand(1, "Treacherous Greed")
+                    // Combat would stamp *both* voices on a blocker, so the fodder here has to take
+                    // damage without ever dealing any. A 5/5 bolted for 3 survives and has been
+                    // dealt damage this turn — and has still dealt none.
+                    .withCardOnBattlefield(1, "Force of Nature", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Centaur Courser")
+                    .withCardInLibrary(1, "Savannah Lions")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val force = game.findPermanent("Force of Nature")!!
+                val bolt = game.castSpell(1, "Lightning Bolt", force)
+                withClue("bolting your own 5/5 should succeed: ${bolt.error}") {
+                    bolt.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the 5/5 survived 3 damage marked on it") {
+                    game.findPermanent("Force of Nature") shouldBe force
+                }
+
+                val cast = game.castSpellWithAdditionalSacrifice(1, "Treacherous Greed", "Force of Nature")
+                withClue("having been dealt damage is not having dealt damage") {
+                    cast.error.orEmpty().shouldNotBeEmpty()
+                }
+                game.isInGraveyard(1, "Force of Nature") shouldBe false
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -389,6 +389,100 @@
     ]
 }
 
+// Alquist Proft, Master Sleuth
+{
+    "name": "Alquist Proft, Master Sleuth",
+    "manaCost": "{1}{W}{U}",
+    "typeLine": "Legendary Creature — Human Detective",
+    "oracleText": "Vigilance\nWhen Alquist Proft enters, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\n{X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                },
+                "descriptionOverride": "When Alquist Proft enters, investigate."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}{W}{U}{U}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact Clue"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": "XValue"
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": "XValue"
+                        }
+                    ]
+                },
+                "descriptionOverride": "{X}{W}{U}{U}, {T}, Sacrifice a Clue: You draw X cards and gain X life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "rarity": "MYTHIC",
+        "artist": "Andreas Zafiratos",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/41129b44-4fa7-473b-b2b7-48c6a58be03c.jpg?1783912857",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Clue is an artifact type. Even though it appears on some cards with other permanent types, it's never a creature type, a land type, or anything but an artifact type."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact token. For example, you can sacrifice Wrench to pay for Alquist Proft, Master Sleuth's activated ability."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "You can't sacrifice a Clue to pay multiple costs. For example, you can't sacrifice a Clue token to activate its own ability and also to activate Alquist Proft, Master Sleuth's ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Analyze the Pollen
 {
     "name": "Analyze the Pollen",
@@ -3812,6 +3906,112 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Ezrim, Agency Chief
+{
+    "name": "Ezrim, Agency Chief",
+    "manaCost": "{1}{W}{W}{U}{U}",
+    "typeLine": "Legendary Creature — Archon Detective",
+    "oracleText": "Flying\nWhen Ezrim enters, investigate twice. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\n{1}, Sacrifice an artifact: Ezrim gains your choice of vigilance, lifelink, or hexproof until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue",
+                    "count": 2
+                },
+                "descriptionOverride": "When Ezrim enters, investigate twice."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "GrantKeyword",
+                                "keyword": "VIGILANCE",
+                                "target": "Self"
+                            },
+                            "description": "Ezrim gains vigilance until end of turn"
+                        },
+                        {
+                            "effect": {
+                                "type": "GrantKeyword",
+                                "keyword": "LIFELINK",
+                                "target": "Self"
+                            },
+                            "description": "Ezrim gains lifelink until end of turn"
+                        },
+                        {
+                            "effect": {
+                                "type": "GrantKeyword",
+                                "keyword": "HEXPROOF",
+                                "target": "Self"
+                            },
+                            "description": "Ezrim gains hexproof until end of turn"
+                        }
+                    ]
+                },
+                "descriptionOverride": "{1}, Sacrifice an artifact: Ezrim gains your choice of vigilance, lifelink, or hexproof until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "202",
+        "rarity": "RARE",
+        "artist": "Jason A. Engle",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/9554d5f2-7a33-4734-8cf3-dfae2ccc3596.jpg?1783912850",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Clue is an artifact type. Even though it appears on some cards with other permanent types, it's never a creature type, a land type, or anything but an artifact type."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Some abilities trigger \"whenever you sacrifice a Clue\". Those abilities trigger whenever you sacrifice a Clue for any reason, not just to activate a Clue's activated ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
     ]
 }
 
@@ -7414,6 +7614,72 @@
     ]
 }
 
+// Massacre Girl, Known Killer
+{
+    "name": "Massacre Girl, Known Killer",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Legendary Creature — Human Assassin",
+    "oracleText": "Menace\nCreatures you control have wither. (They deal damage to creatures in the form of -1/-1 counters.)\nWhenever a creature an opponent controls dies, if its toughness was less than 1, draw a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature tou<=0 ctrl:opponent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever a creature an opponent controls dies, if its toughness was less than 1, draw a card."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "WITHER",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "rarity": "MYTHIC",
+        "artist": "Billy Christian",
+        "flavorText": "\"'Did I do it?' You'll have to be more specific.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cb1c8800-9d33-485c-b776-042003b9ea92.jpg?1783912894",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Use the toughness of the creature as it last existed on the battlefield to determine whether or not Massacre Girl's ability triggers."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Wither applies to any damage dealt to creatures by creatures you control. This includes combat damage as well as anything that causes creatures you control to deal noncombat damage, such as Incinerator of the Guilty's reflexive triggered ability or the effect of Hard-Hitting Question."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Meddling Youths
 {
     "name": "Meddling Youths",
@@ -9054,6 +9320,61 @@
     "colorIdentityOverride": [
         "BLUE"
     ]
+}
+
+// Public Thoroughfare
+{
+    "name": "Public Thoroughfare",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\nWhen this land enters, sacrifice it unless you tap an untapped artifact or land you control.\n{T}: Add one mana of any color.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomTapPermanents",
+                            "filter": "artifact|land"
+                        }
+                    },
+                    "suffer": "SacrificeSelf"
+                },
+                "descriptionOverride": "When this land enters, sacrifice it unless you tap an untapped artifact or land you control."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "265",
+        "artist": "Anthony Devine",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f8b915f-3e82-4b05-b963-01ebff7a8f7b.jpg?1783912824",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "In the unusual case where Public Thoroughfare is untapped as its triggered ability is resolving, you can tap it for its own triggered ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Pyrotechnic Performer
@@ -11873,6 +12194,82 @@
         "imageUri": "https://cards.scryfall.io/normal/front/0/e/0eda1aff-c1f4-4171-a800-605396cc8168.jpg?1783912889"
     },
     "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Treacherous Greed
+{
+    "name": "Treacherous Greed",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a creature that dealt damage this turn.\nDraw three cards. Each opponent loses 3 life and you gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "HasDealtDamage",
+                                "thisTurnOnly": true
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "RARE",
+        "artist": "Eli Minaya",
+        "flavorText": "Loot's easy to divide by one.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e4b9260b-0993-42c5-9bcf-87ab394d51db.jpg?1783912838",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "You can sacrifice any creature you control that dealt damage this turn to pay Treacherous Greed's additional cost, even if the permanent it dealt damage to is no longer on the battlefield or the player it dealt damage to is no longer in the game."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
         "BLACK"
     ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -251,7 +251,9 @@ class PayOrSufferExecutor(
         controllerId: EntityId
     ): EffectResult {
         // Find all valid permanents on the battlefield that the player controls
-        val validPermanents = findValidPermanentsOnBattlefield(state, controllerId, cost.filter, sourceId)
+        val validPermanents = findValidPermanentsOnBattlefield(
+            state, controllerId, cost.filter, selfExclusion(cost.excludeSelf, sourceId)
+        )
 
         // If the player doesn't have enough permanents, automatically execute suffer effect
         if (validPermanents.size < cost.count) {
@@ -306,9 +308,8 @@ class PayOrSufferExecutor(
      * Handle a tap cost - player must tap one or more of their untapped permanents
      * to avoid the suffer effect.
      *
-     * Filters candidates to permanents the paying player controls that are untapped,
-     * excluding the source itself (the source is typically tapped or off-battlefield
-     * but we exclude defensively, matching the sacrifice-cost convention).
+     * Filters candidates to permanents the paying player controls that are untapped. Whether the
+     * source itself is among them is the atom's call, not this method's — see [selfExclusion].
      */
     private fun handleTapCost(
         state: GameState,
@@ -319,9 +320,9 @@ class PayOrSufferExecutor(
         sourceName: String,
         controllerId: EntityId
     ): EffectResult {
-        // Untapped permanents the player controls that match the filter, excluding the source.
+        // Untapped permanents the player controls that match the filter.
         val validPermanents = findValidUntappedPermanentsOnBattlefield(
-            state, controllerId, cost.filter, sourceId
+            state, controllerId, cost.filter, selfExclusion(cost.excludeSelf, sourceId)
         )
 
         // If the player doesn't have enough untapped permanents, automatically suffer.
@@ -708,14 +709,18 @@ class PayOrSufferExecutor(
             is PayCost.Choice -> cost.options.any { canPayCost(state, playerId, it, sourceId) }
             is PayCost.Atom -> when (val atom = cost.atom) {
                 is CostAtom.Discard -> findValidCardsInHand(state, playerId, atom.filter).size >= atom.count
-                is CostAtom.Sacrifice -> findValidPermanentsOnBattlefield(state, playerId, atom.filter, sourceId).size >= atom.count
+                is CostAtom.Sacrifice -> findValidPermanentsOnBattlefield(
+                    state, playerId, atom.filter, selfExclusion(atom.excludeSelf, sourceId)
+                ).size >= atom.count
                 is CostAtom.PayLife -> {
                     val life = state.lifeTotal(playerId) // CR 810.9a — team's shared total
                     life > atom.amount
                 }
                 is CostAtom.Mana -> ManaSolver(cardRegistry).canPay(state, playerId, atom.cost)
                 is CostAtom.ExileFrom -> findValidCardsInZone(state, playerId, atom.filter, atom.zone).size >= atom.count
-                is CostAtom.TapPermanents -> findValidUntappedPermanentsOnBattlefield(state, playerId, atom.filter, sourceId).size >= atom.count
+                is CostAtom.TapPermanents -> findValidUntappedPermanentsOnBattlefield(
+                    state, playerId, atom.filter, selfExclusion(atom.excludeSelf, sourceId)
+                ).size >= atom.count
                 is CostAtom.ReturnToHand -> false
                 is CostAtom.RevealFromHand -> false
                 is CostAtom.PutCountersOnSelf -> false
@@ -788,34 +793,56 @@ class PayOrSufferExecutor(
     }
 
     /**
+     * The source id to keep out of a cost's candidate set, or `null` to leave it in.
+     *
+     * The printed word "another" is what decides this, and the cost atom already carries it as
+     * `excludeSelf` — so the answer has to come from the atom, never from a blanket policy here.
+     * Vulshok War-Boar's "sacrifice an artifact" and Public Thoroughfare's "tap an untapped
+     * artifact or land you control" are both self-inclusive as printed; only a cost authored with
+     * `Costs.SacrificeAnother`-style intent excludes the source.
+     *
+     * This mirrors [com.wingedsheep.engine.mechanics.cost.CostPaymentService], which has always
+     * read the flag. Hardcoding the exclusion here made the two payment paths disagree about the
+     * same atom, and silently outlawed the self-payment line that Public Thoroughfare's and
+     * Command Bridge's rulings both spell out (2024-02-02: "In the unusual case where Public
+     * Thoroughfare is untapped as its triggered ability is resolving, you can tap it for its own
+     * triggered ability.").
+     */
+    private fun selfExclusion(excludeSelf: Boolean, sourceId: EntityId): EntityId? =
+        if (excludeSelf) sourceId else null
+
+    /**
      * Find all permanents on the battlefield that match the filter.
-     * Excludes the source permanent itself.
+     *
+     * [excludeSelfId] is the source only when the cost atom asks for it — see
+     * [selfExclusion] for why this can't be hardcoded.
      */
     private fun findValidPermanentsOnBattlefield(
         state: GameState,
         playerId: EntityId,
         filter: GameObjectFilter,
-        sourceId: EntityId
+        excludeSelfId: EntityId?
     ): List<EntityId> {
         return BattlefieldFilterUtils.findMatchingOnBattlefield(
-            state, filter.youControl(), PredicateContext(controllerId = playerId), excludeSelfId = sourceId
+            state, filter.youControl(), PredicateContext(controllerId = playerId), excludeSelfId = excludeSelfId
         )
     }
 
     /**
      * Find all untapped permanents the player controls that match the filter.
-     * Excludes the source permanent itself.
+     *
+     * [excludeSelfId] is the source only when the cost atom asks for it — see [selfExclusion].
      */
     private fun findValidUntappedPermanentsOnBattlefield(
         state: GameState,
         playerId: EntityId,
         filter: GameObjectFilter,
-        sourceId: EntityId
+        excludeSelfId: EntityId?
     ): List<EntityId> {
         return BattlefieldFilterUtils.findMatchingOnBattlefield(
             state, filter.youControl().untapped(),
             PredicateContext(controllerId = playerId),
-            excludeSelfId = sourceId
+            excludeSelfId = excludeSelfId
         )
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PayOrSufferSelfExclusionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PayOrSufferSelfExclusionTest.kt
@@ -1,0 +1,210 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.CreatureStats
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * "Sacrifice/tap it unless you [cost]" — whether the source itself is a legal way to pay.
+ *
+ * The answer is the printed word "another", carried on the cost atom as `excludeSelf`.
+ * `PayOrSufferExecutor` used to ignore that flag and drop the source from every candidate set,
+ * which disagreed with `CostPaymentService` (which has always read it) and silently outlawed two
+ * printed rulings — Public Thoroughfare's and Command Bridge's "you can tap it for its own
+ * triggered ability" (2024-02-02).
+ *
+ * Both directions matter, so both are pinned here:
+ *
+ *  - `excludeSelf = false` (the default, and what a filter-matching source is printed as) must
+ *    offer the source as a choice, and paying with it must work end to end;
+ *  - `excludeSelf = true` must still keep the source out — and, when it is the *only* match, fall
+ *    through to the suffer effect without ever raising a prompt.
+ *
+ * The tap and sacrifice paths are separate code in the executor, so each gets its own pair.
+ */
+class PayOrSufferSelfExclusionTest : FunSpec({
+
+    /**
+     * An artifact creature whose enters trigger reads "sacrifice it unless you sacrifice an
+     * artifact" — the source matches its own filter, so it is legal fodder for itself.
+     */
+    fun selfSacrificer(name: String, excludeSelf: Boolean) = CardDefinition(
+        name = name,
+        manaCost = ManaCost.parse("{2}"),
+        typeLine = TypeLine.artifactCreature(setOf(Subtype("Construct"))),
+        oracleText = "When this creature enters, sacrifice it unless you sacrifice " +
+            (if (excludeSelf) "another artifact." else "an artifact."),
+        creatureStats = CreatureStats(3, 3),
+        script = CardScript.creature(
+            TriggeredAbility.create(
+                trigger = EventPattern.ZoneChangeEvent(to = Zone.BATTLEFIELD),
+                binding = TriggerBinding.SELF,
+                effect = PayOrSufferEffect(
+                    cost = if (excludeSelf) Costs.pay.SacrificeAnother(GameObjectFilter.Artifact)
+                    else Costs.pay.Sacrifice(GameObjectFilter.Artifact),
+                    suffer = SacrificeSelfEffect
+                )
+            )
+        )
+    )
+
+    /**
+     * The Public Thoroughfare shape reduced to its bones: an *untapped* artifact creature whose
+     * enters trigger reads "sacrifice it unless you tap an untapped artifact you control".
+     */
+    fun selfTapper(name: String, excludeSelf: Boolean) = CardDefinition(
+        name = name,
+        manaCost = ManaCost.parse("{2}"),
+        typeLine = TypeLine.artifactCreature(setOf(Subtype("Construct"))),
+        oracleText = "When this creature enters, sacrifice it unless you tap " +
+            (if (excludeSelf) "another untapped artifact you control." else "an untapped artifact you control."),
+        creatureStats = CreatureStats(3, 3),
+        script = CardScript.creature(
+            TriggeredAbility.create(
+                trigger = EventPattern.ZoneChangeEvent(to = Zone.BATTLEFIELD),
+                binding = TriggerBinding.SELF,
+                effect = PayOrSufferEffect(
+                    cost = if (excludeSelf) Costs.pay.TapAnother(GameObjectFilter.Artifact)
+                    else Costs.pay.Tap(GameObjectFilter.Artifact),
+                    suffer = SacrificeSelfEffect
+                )
+            )
+        )
+    )
+
+    val SelfSacrificer = selfSacrificer("Self Sacrificer", excludeSelf = false)
+    val AnotherSacrificer = selfSacrificer("Another Sacrificer", excludeSelf = true)
+    val SelfTapper = selfTapper("Self Tapper", excludeSelf = false)
+    val AnotherTapper = selfTapper("Another Tapper", excludeSelf = true)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        listOf(SelfSacrificer, AnotherSacrificer, SelfTapper, AnotherTapper).forEach(driver::registerCard)
+        return driver
+    }
+
+    /** Cast [cardName] as the only artifact on an otherwise empty board and resolve to the trigger. */
+    fun castAlone(driver: GameTestDriver, cardName: String): com.wingedsheep.sdk.model.EntityId {
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20), skipMulligans = true)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val card = driver.putCardInHand(active, cardName)
+        driver.giveMana(active, Color.GREEN, 2)
+        driver.castSpell(active, card).isSuccess shouldBe true
+        driver.bothPass() // resolve the permanent
+        driver.stackSize shouldBe 1
+        driver.bothPass() // resolve the enters trigger
+        return active
+    }
+
+    test("sacrifice: excludeSelf = false offers the source, and paying with it works") {
+        val driver = createDriver()
+        val active = castAlone(driver, "Self Sacrificer")
+        val self = driver.findPermanent(active, "Self Sacrificer")!!
+
+        val decision = driver.pendingDecision
+        withClue("the source matches its own filter, so it is a legal choice") {
+            decision.shouldBeInstanceOf<SelectCardsDecision>().options shouldContain self
+        }
+
+        driver.submitCardSelection(active, listOf(self))
+        withClue("paying with itself costs the permanent — it is sacrificed as the cost, not as the suffer") {
+            driver.findPermanent(active, "Self Sacrificer") shouldBe null
+            driver.getGraveyardCardNames(active) shouldContain "Self Sacrificer"
+        }
+    }
+
+    test("sacrifice: excludeSelf = true keeps the source out and falls through to the suffer") {
+        val driver = createDriver()
+        val active = castAlone(driver, "Another Sacrificer")
+
+        withClue("'another' with no other artifact is unpayable, so no prompt is raised") {
+            driver.pendingDecision shouldBe null
+        }
+        withClue("and the suffer effect sacrifices it") {
+            driver.findPermanent(active, "Another Sacrificer") shouldBe null
+            driver.getGraveyardCardNames(active) shouldContain "Another Sacrificer"
+        }
+    }
+
+    test("sacrifice: excludeSelf = true still offers a genuine 'another'") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20), skipMulligans = true)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val other = driver.putCreatureOnBattlefield(active, "Artifact Creature")
+        val card = driver.putCardInHand(active, "Another Sacrificer")
+        driver.giveMana(active, Color.GREEN, 2)
+        driver.castSpell(active, card).isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass()
+
+        val self = driver.findPermanent(active, "Another Sacrificer")!!
+        val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        withClue("the other artifact is offered") { decision.options shouldContain other }
+        withClue("but the source is not — that is what 'another' means") {
+            decision.options shouldNotContain self
+        }
+
+        driver.submitCardSelection(active, listOf(other))
+        withClue("paying keeps the source on the battlefield") {
+            driver.findPermanent(active, "Another Sacrificer") shouldBe self
+        }
+    }
+
+    test("tap: excludeSelf = false offers the untapped source, and tapping it pays") {
+        val driver = createDriver()
+        val active = castAlone(driver, "Self Tapper")
+        val self = driver.findPermanent(active, "Self Tapper")!!
+
+        val decision = driver.pendingDecision
+        withClue("an untapped source that matches its own filter can pay the tap cost") {
+            decision.shouldBeInstanceOf<SelectCardsDecision>().options shouldContain self
+        }
+
+        driver.submitCardSelection(active, listOf(self))
+        withClue("it survives, tapped — the Public Thoroughfare / Command Bridge ruling") {
+            driver.findPermanent(active, "Self Tapper") shouldBe self
+            driver.isTapped(self) shouldBe true
+        }
+    }
+
+    test("tap: excludeSelf = true keeps the source out and falls through to the suffer") {
+        val driver = createDriver()
+        val active = castAlone(driver, "Another Tapper")
+
+        withClue("'another' with no other untapped artifact is unpayable, so no prompt is raised") {
+            driver.pendingDecision shouldBe null
+        }
+        withClue("and the suffer effect sacrifices it") {
+            driver.findPermanent(active, "Another Tapper") shouldBe null
+            driver.getGraveyardCardNames(active) shouldContain "Another Tapper"
+        }
+    }
+})


### PR DESCRIPTION
Five MKM cards, all built from existing primitives, plus the one engine fix the last of them needed.

## Cards

- **Alquist Proft, Master Sleuth** — vigilance; enters investigates; `{X}{W}{U}{U}, {T}, Sacrifice a Clue: draw X and gain X life`. `Effects.Investigate` + `Costs.Composite(mana, tap, Costs.Sacrifice)` filtered on the **Clue artifact subtype** (not tokenness — the 2024-02-02 ruling is explicit that a printed Clue such as Wrench pays it, and the test uses Wrench for exactly that reason). Both halves of the payoff read one `DynamicAmount.XValue`, so the draw and the lifegain can't disagree.
- **Ezrim, Agency Chief** — flying; enters investigates twice; `{1}, Sacrifice an artifact:` gains your choice of vigilance, lifelink, or hexproof. `ModalEffect.chooseOne` over three no-target modes, the shape Butcher of the Horde established for the identical wording.
- **Treacherous Greed** — additional cost sacrifice a creature that dealt damage this turn; draw three, each opponent loses 3, you gain 3. `Costs.additional.SacrificePermanent` over the **active-voice** `hasDealtDamageThisTurn()`. Its passive sibling `wasDealtDamageThisTurn()` reads almost identically and selects nearly the opposite set, so a test pins each direction.
- **Massacre Girl, Known Killer** — menace; `GrantKeyword(WITHER)` over creatures you control; dies-trigger drawing when an opponent's creature died under 1 toughness. The condition is a **trigger filter** (`toughnessAtMost(0)`), not an `interveningIf`: `TriggerMatcher` evaluates that predicate against the `lastKnownToughness` on the zone change, which is the only place the value still exists once the creature is in the graveyard.
- **Public Thoroughfare** — enters tapped; `PayOrSufferEffect` over `Costs.pay.Tap(ArtifactOrLand)`; `{T}`: add one mana of any color.

## Engine fix: PayOrSuffer ignored `excludeSelf`

Public Thoroughfare's ruling says an untapped copy may tap **itself** to pay its own enters trigger. That was unreachable: `PayOrSufferExecutor` dropped the source from every sacrifice- and tap-cost candidate set unconditionally, while `CostPaymentService` has always read the atom's `excludeSelf`. The two payment paths disagreed about the same atom.

The printed word "another" is what decides it, so the answer now comes from the atom — both finders take a nullable `excludeSelfId`, and all four call sites pass `selfExclusion(atom.excludeSelf, sourceId)`. This also repairs **Command Bridge**, which is the same design with the same ruling.

Since the excluding variant was previously only reachable by accident, the fix adds the facades for it: `Costs.pay.SacrificeAnother` and `Costs.pay.TapAnother`. `docs/card-sdk-language-reference.md` updated in the same change.

**Blast radius checked card by card.** The only corpus cards whose PayOrSuffer filter could match their own source are Vulshok War-Boar — a plain `Creature — Boar Beast`, so the `Artifact` filter never matched it — and the two "tap an untapped permanent/land" lands, which are the cards this fixes. Nothing else changes.

## Verification

- `just build` and `just test-rules` green (full engine suite plus every card scenario).
- New engine coverage in `PayOrSufferSelfExclusionTest`: both branches (`excludeSelf` false → source offered and payable; true → source kept out, and falls through to the suffer with no prompt when it is the only match), for both the sacrifice and tap paths.
- One scenario test per card, 17 tests total, all passing.
- `just check-card-printing` ok for all five (MKM is the earliest real printing for each; no reprint rows needed).
- MKM card snapshot re-blessed: **397 insertions, 0 deletions** — only the five new cards moved, confirming the engine fix altered no existing card's data.
- Every `imageUri` verified HTTP 200 against Scryfall, and all mechanical fields re-checked field-by-field against the API.

## Dropped from the batch

**Lamplight Phoenix** — "When this creature dies, you may exile it and collect evidence 4. If you do, return this card to the battlefield tapped." Neither may-gate honors CR 701.59b through a composite: `GatedEffectExecutor` only applies the collect-evidence reachability check when `then` is a bare `CollectEvidenceEffect`, and its `canAfford` fails open on that shape inside a `Gate.MayPay` cost. The phoenix has to be exiled *before* the collection (the ruling forbids exiling it as its own evidence), so a naive composite would exile it, no-op the unreachable collect, and return it — free recursion. That needs a `GatedEffectExecutor` change with its own tests, so it gets its own PR rather than growing this one. Public Thoroughfare took its slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)