### PR TITLE
Read New Capenna Commander's Assay-ready tail: 31 cards

### DIFF
--- a/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ody/cards/ShadowmageInfiltrator.kt
+++ b/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ody/cards/ShadowmageInfiltrator.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ody.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Shadowmage Infiltrator
+ * {1}{U}{B}
+ * Creature — Human Wizard
+ * 1/3
+ *
+ * Fear
+ * Whenever this creature deals combat damage to a player, you may draw a card.
+ */
+val ShadowmageInfiltrator = card("Shadowmage Infiltrator") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 3
+    oracleText = "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\n" +
+        "Whenever this creature deals combat damage to a player, you may draw a card."
+
+    keywords(Keyword.FEAR)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = MayEffect(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "294"
+        artist = "Rick Farrell"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/932ce702-565f-4d8c-b9fc-2d7c939ef7d7.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dis/cards/IndrikStomphowler.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dis/cards/IndrikStomphowler.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.dis.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Indrik Stomphowler
+ * {4}{G}
+ * Creature — Beast
+ * 4/4
+ *
+ * When this creature enters, destroy target artifact or enchantment.
+ */
+val IndrikStomphowler = card("Indrik Stomphowler") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature enters, destroy target artifact or enchantment."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target = Targets.ArtifactOrEnchantment
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "86"
+        artist = "Carl Critchlow"
+        flavorText = "\"An indrik's howl has destructive power much subtler than that of its crushing foot. The sound is mundane, but inaudible vibrations scatter and sunder magical contrivances.\"\n—Simic research notes"
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/fe57b3a2-0fd9-4f99-bb2b-828979dbcfc3.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ArcaneSanctum.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ArcaneSanctum.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Arcane Sanctum
+ * Land
+ * This land enters tapped.
+ * {T}: Add {W}, {U}, or {B}.
+ *
+ * One of the Alara "tri-lands": no basic land types, so the three mana abilities are authored
+ * explicitly rather than derived from the type line.
+ */
+val ArcaneSanctum = card("Arcane Sanctum") {
+    manaCost = ""
+    colorIdentity = "WUB"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n{T}: Add {W}, {U}, or {B}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "220"
+        artist = "Anthony Francisco"
+        flavorText = "\"We must rely on our own knowledge, not on the dogma of the seekers or the mutterings of the sphinxes.\"\n—Tullus of Palandius"
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6edc0681-4252-4d3d-baf3-f03c22af1208.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/CrumblingNecropolis.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/CrumblingNecropolis.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Crumbling Necropolis
+ * Land
+ * This land enters tapped.
+ * {T}: Add {U}, {B}, or {R}.
+ *
+ * One of the Alara "tri-lands": no basic land types, so the three mana abilities are authored
+ * explicitly rather than derived from the type line.
+ */
+val CrumblingNecropolis = card("Crumbling Necropolis") {
+    manaCost = ""
+    colorIdentity = "UBR"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n{T}: Add {U}, {B}, or {R}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "222"
+        artist = "Dave Kendall"
+        flavorText = "\"They say the ruins of Sedraxis were once a shining capital in Vithia. Now it is a blight, a place to be avoided by the living.\"\n—Olcot, Rider of Joffik"
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/94da8e38-77a4-4d25-9e1f-f33c246f60c8.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/JungleShrine.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/JungleShrine.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Jungle Shrine
+ * Land
+ * This land enters tapped.
+ * {T}: Add {R}, {G}, or {W}.
+ *
+ * One of the Alara "tri-lands": no basic land types, so the three mana abilities are authored
+ * explicitly rather than derived from the type line.
+ */
+val JungleShrine = card("Jungle Shrine") {
+    manaCost = ""
+    colorIdentity = "WRG"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n{T}: Add {R}, {G}, or {W}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "226"
+        artist = "Wayne Reynolds"
+        flavorText = "On Naya, ambition and treachery are scarce, hunted nearly to extinction by the awe owed to terrestrial gods."
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e4f0d262-cbfe-42d2-9066-0b48a38995d6.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SavageLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SavageLands.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Savage Lands
+ * Land
+ * This land enters tapped.
+ * {T}: Add {B}, {R}, or {G}.
+ *
+ * One of the Alara "tri-lands": no basic land types, so the three mana abilities are authored
+ * explicitly rather than derived from the type line.
+ */
+val SavageLands = card("Savage Lands") {
+    manaCost = ""
+    colorIdentity = "BRG"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n{T}: Add {B}, {R}, or {G}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "228"
+        artist = "Vance Kovacs"
+        flavorText = "Jund is a world as cruel as those who call it home. Their brutal struggles scar the land even as it carves them in its image, a vicious circle spiraling out of control."
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6bcded3-6eea-4533-a855-e03d4c4620d6.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SeasideCitadel.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SeasideCitadel.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Seaside Citadel
+ * Land
+ * This land enters tapped.
+ * {T}: Add {G}, {W}, or {U}.
+ *
+ * One of the Alara "tri-lands": no basic land types, so the three mana abilities are authored
+ * explicitly rather than derived from the type line.
+ */
+val SeasideCitadel = card("Seaside Citadel") {
+    manaCost = ""
+    colorIdentity = "WUG"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n{T}: Add {G}, {W}, or {U}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "229"
+        artist = "Volkan Baǵa"
+        flavorText = "For wisdom's sake, it was built high to gaze on all things. For glory's sake, it was built high as a testament of power. For strength's sake, it was built high to repel all attacks."
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1995d2a-4550-4c84-ad44-183b06579e98.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/JenaraAsuraOfWar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/JenaraAsuraOfWar.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.arb.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Jenara, Asura of War
+ * {G}{W}{U}
+ * Legendary Creature — Angel
+ * 3/3
+ *
+ * Flying
+ * {1}{W}: Put a +1/+1 counter on Jenara.
+ */
+val JenaraAsuraOfWar = card("Jenara, Asura of War") {
+    manaCost = "{G}{W}{U}"
+    colorIdentity = "WUG"
+    typeLine = "Legendary Creature — Angel"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n{1}{W}: Put a +1/+1 counter on Jenara."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}")
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "128"
+        artist = "Chris Rahn"
+        flavorText = "Wounded soldiers looked up, grateful for her appearance. But she passed over them, her eyes firmly on their foe."
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d643c335-e3a7-461d-a024-095795ab6770.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/CanopyVista.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/CanopyVista.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Canopy Vista
+ *
+ * Land — Forest Plains
+ * ({T}: Add {G} or {W}.)
+ * This land enters tapped unless you control two or more basic lands.
+ */
+val CanopyVista = card("Canopy Vista") {
+    colorIdentity = "GW"
+    typeLine = "Land — Forest Plains"
+    oracleText = "({T}: Add {G} or {W}.)\nThis land enters tapped unless you control two or more basic lands."
+
+    // Mana abilities are intrinsic from the basic land types in the type line.
+
+    replacementEffect(EntersTapped(
+        unlessCondition = Compare(
+            DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.BasicLand),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(2)
+        )
+    ))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "234"
+        artist = "Adam Paquette"
+        flavorText = "The continent of Murasa lies beneath a blanket of dense vegetation, its enormous branches tangled so thickly that some inhabitants never see the ground."
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3262c7f-4fdf-4648-ba59-9279c75d222d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/PrairieStream.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/PrairieStream.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Prairie Stream
+ *
+ * Land — Plains Island
+ * ({T}: Add {W} or {U}.)
+ * This land enters tapped unless you control two or more basic lands.
+ */
+val PrairieStream = card("Prairie Stream") {
+    colorIdentity = "WU"
+    typeLine = "Land — Plains Island"
+    oracleText = "({T}: Add {W} or {U}.)\nThis land enters tapped unless you control two or more basic lands."
+
+    // Mana abilities are intrinsic from the basic land types in the type line.
+
+    replacementEffect(EntersTapped(
+        unlessCondition = Compare(
+            DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.BasicLand),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(2)
+        )
+    ))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "241"
+        artist = "Adam Paquette"
+        flavorText = "The continent of Ondu is a vast plateau crisscrossed by deep trenches and meandering rivers."
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/9625911f-1dd3-4044-ac06-3c0c3198b6fd.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SmolderingMarsh.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SmolderingMarsh.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Smoldering Marsh
+ *
+ * Land — Swamp Mountain
+ * ({T}: Add {B} or {R}.)
+ * This land enters tapped unless you control two or more basic lands.
+ */
+val SmolderingMarsh = card("Smoldering Marsh") {
+    colorIdentity = "BR"
+    typeLine = "Land — Swamp Mountain"
+    oracleText = "({T}: Add {B} or {R}.)\nThis land enters tapped unless you control two or more basic lands."
+
+    // Mana abilities are intrinsic from the basic land types in the type line.
+
+    replacementEffect(EntersTapped(
+        unlessCondition = Compare(
+            DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.BasicLand),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(2)
+        )
+    ))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "247"
+        artist = "Adam Paquette"
+        flavorText = "The continent of Guul Draz is a geothermal swampland reeking of heat and decay."
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/359b189d-aa51-4e90-820a-e79884562e34.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SunkenHollow.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SunkenHollow.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sunken Hollow
+ *
+ * Land — Island Swamp
+ * ({T}: Add {U} or {B}.)
+ * This land enters tapped unless you control two or more basic lands.
+ */
+val SunkenHollow = card("Sunken Hollow") {
+    colorIdentity = "UB"
+    typeLine = "Land — Island Swamp"
+    oracleText = "({T}: Add {U} or {B}.)\nThis land enters tapped unless you control two or more basic lands."
+
+    // Mana abilities are intrinsic from the basic land types in the type line.
+
+    replacementEffect(EntersTapped(
+        unlessCondition = Compare(
+            DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.BasicLand),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(2)
+        )
+    ))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "249"
+        artist = "Adam Paquette"
+        flavorText = "On the continent of Tazeem, rushing waters plunge through narrow canyons into mist-cloaked lakes."
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0dd1726f-b899-491a-8b0e-8e3d25f17d3d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eve/cards/WickerboughElder.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eve/cards/WickerboughElder.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.eve.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wickerbough Elder
+ * {3}{G}
+ * Creature — Treefolk Shaman
+ * 4/4
+ *
+ * This creature enters with a -1/-1 counter on it.
+ * {G}, Remove a -1/-1 counter from this creature: Destroy target artifact or enchantment.
+ *
+ * The -1/-1 counter is what makes the printed 4/4 a 3/3 on the battlefield, and removing it as
+ * part of the activation cost is what turns the body back into a 4/4 — so the counter is the
+ * ability's one-shot fuel, not a drawback the card ever sheds for free.
+ */
+val WickerboughElder = card("Wickerbough Elder") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Treefolk Shaman"
+    power = 4
+    toughness = 4
+    oracleText = "This creature enters with a -1/-1 counter on it.\n" +
+        "{G}, Remove a -1/-1 counter from this creature: Destroy target artifact or enchantment."
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.MinusOneMinusOne,
+            count = 1,
+            selfOnly = true
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{G}"),
+            Costs.RemoveCounterFromSelf(Counters.MINUS_ONE_MINUS_ONE)
+        )
+        target = Targets.ArtifactOrEnchantment
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "80"
+        artist = "Jesper Ejsing"
+        flavorText = "\"Living scarecrows make a mockery of the natural order. Dead ones make fine hats.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/acc283b4-9106-4a32-88b4-000f2a3bed84.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/TalrandsInvocation.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/TalrandsInvocation.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Talrand's Invocation
+ * {2}{U}{U}
+ * Sorcery
+ *
+ * Create two 2/2 blue Drake creature tokens with flying.
+ */
+val TalrandsInvocation = card("Talrand's Invocation") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Create two 2/2 blue Drake creature tokens with flying."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Drake"),
+            keywords = setOf(Keyword.FLYING),
+            count = 2
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "73"
+        artist = "Svetlin Velinov"
+        flavorText = "After Talrand conquered the depths of Shandalar, his ambitions drove him skyward, joined by servants whose drive and curiosity equaled his own."
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2cd809c-557a-42a5-950b-56b5b47b325b.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/Thragtusk.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/Thragtusk.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thragtusk
+ * {4}{G}
+ * Creature — Beast
+ * 5/3
+ *
+ * When this creature enters, you gain 5 life.
+ * When this creature leaves the battlefield, create a 3/3 green Beast creature token.
+ *
+ * The second trigger is a *leaves-the-battlefield* trigger, not a dies trigger: exiling or
+ * bouncing Thragtusk still pays out the Beast.
+ */
+val Thragtusk = card("Thragtusk") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 3
+    oracleText = "When this creature enters, you gain 5 life.\n" +
+        "When this creature leaves the battlefield, create a 3/3 green Beast creature token."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(5)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 3,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Beast")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "193"
+        artist = "Nils Hamm"
+        flavorText = "\"Always carry two spears.\"\n—Mokgar, Kalonian hunter"
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/28667c8b-d02c-4e57-a050-1549207b65d1.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/ArtisanOfKozilek.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/ArtisanOfKozilek.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Artisan of Kozilek
+ * {9}
+ * Creature — Eldrazi
+ * 10/9
+ *
+ * When you cast this spell, you may return target creature card from your graveyard to the
+ * battlefield.
+ * Annihilator 2
+ *
+ * Modeling notes:
+ *  - The reanimation is a **cast trigger** ([Triggers.WhenYouCastThisSpell]), not an enters
+ *    trigger — it resolves before Artisan itself, and it still resolves if Artisan is countered.
+ *  - Annihilator is a display-only [KeywordAbility.Numeric] in the SDK, so the behaviour is
+ *    lowered here as the triggered ability the keyword abbreviates: on attack, the defending
+ *    player sacrifices two permanents of their choice. [Effects.Sacrifice] is the edict form —
+ *    the *defending player* chooses — and the filter is [GameObjectFilter.Permanent] rather than
+ *    `Creature`, because annihilator eats any permanent.
+ */
+val ArtisanOfKozilek = card("Artisan of Kozilek") {
+    manaCost = "{9}"
+    colorIdentity = ""
+    typeLine = "Creature — Eldrazi"
+    power = 10
+    toughness = 9
+    oracleText = "When you cast this spell, you may return target creature card from your " +
+        "graveyard to the battlefield.\n" +
+        "Annihilator 2 (Whenever this creature attacks, defending player sacrifices two " +
+        "permanents of their choice.)"
+
+    keywordAbility(KeywordAbility.annihilator(2))
+
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        val creatureCard = target(
+            "target creature card from your graveyard",
+            TargetObject(filter = TargetFilter.CreatureInYourGraveyard)
+        )
+        effect = MayEffect(Effects.Move(creatureCard, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD))
+        description = "When you cast this spell, you may return target creature card from your " +
+            "graveyard to the battlefield."
+    }
+
+    // Annihilator 2 — the lowering of the display-only keyword ability above.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Sacrifice(
+            GameObjectFilter.Permanent,
+            2,
+            EffectTarget.PlayerRef(Player.DefendingPlayer)
+        )
+        description = "Annihilator 2"
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "2"
+        artist = "Jason Felix"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3ac80eb8-321d-476a-87e7-d25bdac6a91c.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WoodfallPrimus.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WoodfallPrimus.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Woodfall Primus
+ * {5}{G}{G}{G}
+ * Creature — Treefolk Shaman
+ * 6/6
+ *
+ * Trample
+ * When this creature enters, destroy target noncreature permanent.
+ * Persist
+ *
+ * Persist is engine-live ([Keyword.PERSIST] is read by the death/leave trigger detector), so the
+ * keyword alone carries the behaviour — and the returning body brings the ETB destroy with it.
+ */
+val WoodfallPrimus = card("Woodfall Primus") {
+    manaCost = "{5}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Treefolk Shaman"
+    power = 6
+    toughness = 6
+    oracleText = "Trample\n" +
+        "When this creature enters, destroy target noncreature permanent.\n" +
+        "Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the " +
+        "battlefield under its owner's control with a -1/-1 counter on it.)"
+
+    keywords(Keyword.TRAMPLE, Keyword.PERSIST)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target = TargetPermanent(filter = TargetFilter.NoncreaturePermanent)
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+        description = "When this creature enters, destroy target noncreature permanent."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "135"
+        artist = "Adam Rex"
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/43aa7e35-55ee-4e02-a8aa-ea2b267055d1.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/LifecraftersBestiary.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/LifecraftersBestiary.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.aer.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Lifecrafter's Bestiary
+ * {3}
+ * Artifact
+ *
+ * At the beginning of your upkeep, scry 1.
+ * Whenever you cast a creature spell, you may pay {G}. If you do, draw a card.
+ *
+ * The second ability is a plain "you may pay … if you do" gate ([MayPayManaEffect]), not a
+ * reflexive trigger — nothing is targeted, so the payment and the draw happen in one resolution.
+ */
+val LifecraftersBestiary = card("Lifecrafter's Bestiary") {
+    manaCost = "{3}"
+    colorIdentity = "G"
+    typeLine = "Artifact"
+    oracleText = "At the beginning of your upkeep, scry 1.\n" +
+        "Whenever you cast a creature spell, you may pay {G}. If you do, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Scry(1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCastCreature
+        effect = MayPayManaEffect(ManaCost.parse("{G}"), Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "162"
+        artist = "Izzy"
+        flavorText = "\"Inspiration is found by looking outward.\"\n—Oviya Pashiri, sage lifecrafter"
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/7439a855-4041-4d14-8edf-6741a734e55d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/CastleArdenvale.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/CastleArdenvale.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+
+/** A Plains — the land type, not the card name, so a dual land with the type counts. */
+private val APlainsYouControl = GameObjectFilter(
+    cardPredicates = listOf(CardPredicate.IsLand, CardPredicate.HasSubtype(Subtype.PLAINS))
+)
+
+/**
+ * Castle Ardenvale
+ * Land
+ *
+ * This land enters tapped unless you control a Plains.
+ * {T}: Add {W}.
+ * {2}{W}{W}, {T}: Create a 1/1 white Human creature token.
+ */
+val CastleArdenvale = card("Castle Ardenvale") {
+    manaCost = ""
+    colorIdentity = "W"
+    typeLine = "Land"
+    oracleText = "This land enters tapped unless you control a Plains.\n" +
+        "{T}: Add {W}.\n" +
+        "{2}{W}{W}, {T}: Create a 1/1 white Human creature token."
+
+    replacementEffect(
+        EntersTapped(
+            unlessCondition = Exists(
+                player = Player.You,
+                zone = Zone.BATTLEFIELD,
+                filter = APlainsYouControl
+            )
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{W}{W}"), Costs.Tap)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Human")
+        )
+        description = "Create a 1/1 white Human creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "238"
+        artist = "Volkan Baǵa"
+        flavorText = "Without Ardenvale's loyalty, the realm would greedily devour itself."
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f910495-8bd7-4134-a281-c16fd666d5cc.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/CastleEmbereth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/CastleEmbereth.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/** A Mountain — the land type, not the card name, so a dual land with the type counts. */
+private val AMountainYouControl = GameObjectFilter(
+    cardPredicates = listOf(CardPredicate.IsLand, CardPredicate.HasSubtype(Subtype.MOUNTAIN))
+)
+
+/**
+ * Castle Embereth
+ * Land
+ *
+ * This land enters tapped unless you control a Mountain.
+ * {T}: Add {R}.
+ * {1}{R}{R}, {T}: Creatures you control get +1/+0 until end of turn.
+ *
+ * The pump is a one-shot over the creatures you control *as the ability resolves*
+ * ([Effects.ForEachInGroup]) — creatures that arrive later in the turn are not affected.
+ */
+val CastleEmbereth = card("Castle Embereth") {
+    manaCost = ""
+    colorIdentity = "R"
+    typeLine = "Land"
+    oracleText = "This land enters tapped unless you control a Mountain.\n" +
+        "{T}: Add {R}.\n" +
+        "{1}{R}{R}, {T}: Creatures you control get +1/+0 until end of turn."
+
+    replacementEffect(
+        EntersTapped(
+            unlessCondition = Exists(
+                player = Player.You,
+                zone = Zone.BATTLEFIELD,
+                filter = AMountainYouControl
+            )
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{R}{R}"), Costs.Tap)
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.ModifyStats(1, 0, EffectTarget.Self)
+        )
+        description = "Creatures you control get +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "239"
+        artist = "Jaime Jones"
+        flavorText = "Without Embereth's courage, the realm would falter and fall."
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8bb8512e-6913-4be6-8828-24cfcbec042e.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/MarchOfTheMultitudes.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/MarchOfTheMultitudes.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * March of the Multitudes
+ * {X}{G}{W}{W}
+ * Instant
+ *
+ * Convoke
+ * Create X 1/1 white Soldier creature tokens with lifelink.
+ */
+val MarchOfTheMultitudes = card("March of the Multitudes") {
+    manaCost = "{X}{G}{W}{W}"
+    colorIdentity = "WG"
+    typeLine = "Instant"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while " +
+        "casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Create X 1/1 white Soldier creature tokens with lifelink."
+
+    keywords(Keyword.CONVOKE)
+
+    spell {
+        effect = Effects.CreateToken(
+            count = DynamicAmount.XValue,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Soldier"),
+            keywords = setOf(Keyword.LIFELINK)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "188"
+        artist = "Zack Stella"
+        flavorText = "\"Our forces number more than the leaves of Vitu-Ghazi. Do not provoke us.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2cc2b646-0181-4f0a-a141-00ca56069a06.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/DrawnFromDreams.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/DrawnFromDreams.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Drawn from Dreams
+ * {2}{U}{U}
+ * Sorcery
+ *
+ * Look at the top seven cards of your library. Put two of them into your hand and the rest on
+ * the bottom of your library in a random order.
+ *
+ * The keep is mandatory and unfiltered — [SelectionMode.ChooseExactly] over the gathered seven —
+ * so the remainder that goes to the bottom is whatever wasn't chosen, in a random order.
+ */
+val DrawnFromDreams = card("Drawn from Dreams") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top seven cards of your library. Put two of them into your hand " +
+        "and the rest on the bottom of your library in a random order."
+
+    spell {
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(7)),
+                storeAs = "looked"
+            ),
+            SelectFromCollectionEffect(
+                from = "looked",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(2)),
+                storeSelected = "kept",
+                storeRemainder = "rest",
+                selectedLabel = "Put in hand",
+                remainderLabel = "Put on bottom"
+            ),
+            MoveCollectionEffect(
+                from = "kept",
+                destination = CardDestination.ToZone(Zone.HAND)
+            ),
+            MoveCollectionEffect(
+                from = "rest",
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                order = CardOrder.Random
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "56"
+        artist = "Chris Seaman"
+        flavorText = "\"From a sea of infinite possibilities, our choices create the future.\"\n—Mu Yanling"
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/5677cd48-de9f-4827-94d7-8a2301945742.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ArastaOfTheEndlessWebReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ArastaOfTheEndlessWebReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arasta of the Endless Web reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Theros Beyond Death's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val ArastaOfTheEndlessWebReprint = Printing(
+    oracleId = "695eea46-1535-48c5-bbb6-0b8379e77bfc",
+    name = "Arasta of the Endless Web",
+    setCode = "NCC",
+    collectorNumber = "279",
+    scryfallId = "e905a310-02d5-4a86-bb58-2bb3502edba2",
+    artist = "Sam Rowan",
+    imageUri = "https://cards.scryfall.io/normal/front/e/9/e905a310-02d5-4a86-bb58-2bb3502edba2.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ArcaneSanctumReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ArcaneSanctumReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arcane Sanctum reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Shards of Alara's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val ArcaneSanctumReprint = Printing(
+    oracleId = "7d7cf15c-06b9-4062-a1eb-32614c458a3b",
+    name = "Arcane Sanctum",
+    setCode = "NCC",
+    collectorNumber = "385",
+    scryfallId = "10ed5393-e274-4412-ba5d-6faecf3c18d8",
+    artist = "Anthony Francisco",
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/10ed5393-e274-4412-ba5d-6faecf3c18d8.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ArtisanOfKozilekReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ArtisanOfKozilekReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Artisan of Kozilek reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Rise of the Eldrazi's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val ArtisanOfKozilekReprint = Printing(
+    oracleId = "19409704-09c4-4a4b-a5a7-f95120b425db",
+    name = "Artisan of Kozilek",
+    setCode = "NCC",
+    collectorNumber = "191",
+    scryfallId = "e3fef480-ee0e-41e1-9db3-68e945e7e867",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e3fef480-ee0e-41e1-9db3-68e945e7e867.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/AshBarrensReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/AshBarrensReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ash Barrens reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Commander 2016's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val AshBarrensReprint = Printing(
+    oracleId = "58257464-278e-45fa-8e0b-bcd9a7500bc1",
+    name = "Ash Barrens",
+    setCode = "NCC",
+    collectorNumber = "386",
+    scryfallId = "5233b31f-a179-4ae9-95a2-2ff75b374edf",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/5/2/5233b31f-a179-4ae9-95a2-2ff75b374edf.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/BorosCharmReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/BorosCharmReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Boros Charm reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Gatecrash's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val BorosCharmReprint = Printing(
+    oracleId = "2679d0dd-ba30-4a1c-b6a0-b3ac6c790496",
+    name = "Boros Charm",
+    setCode = "NCC",
+    collectorNumber = "332",
+    scryfallId = "437b0685-ed50-40b9-ae0d-ec2f75026474",
+    artist = "Zoltan Boros",
+    imageUri = "https://cards.scryfall.io/normal/front/4/3/437b0685-ed50-40b9-ae0d-ec2f75026474.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/CanopyVistaReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/CanopyVistaReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Canopy Vista reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Battle for Zendikar's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val CanopyVistaReprint = Printing(
+    oracleId = "dcb7e046-f01b-497c-88e5-57794eb30ce5",
+    name = "Canopy Vista",
+    setCode = "NCC",
+    collectorNumber = "389",
+    scryfallId = "79dffd83-05c8-4698-9677-5decb997e29f",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/7/9/79dffd83-05c8-4698-9677-5decb997e29f.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/CastleArdenvaleReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/CastleArdenvaleReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Castle Ardenvale reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Throne of Eldraine's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val CastleArdenvaleReprint = Printing(
+    oracleId = "f8f4fc60-725d-46d8-8e8f-e68e00d20589",
+    name = "Castle Ardenvale",
+    setCode = "NCC",
+    collectorNumber = "391",
+    scryfallId = "eed204e1-45bd-4160-aaef-dde33bd9884a",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/eed204e1-45bd-4160-aaef-dde33bd9884a.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/CastleEmberethReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/CastleEmberethReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Castle Embereth reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Throne of Eldraine's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val CastleEmberethReprint = Printing(
+    oracleId = "91fbb25b-8521-483f-88b0-77778d25f7fd",
+    name = "Castle Embereth",
+    setCode = "NCC",
+    collectorNumber = "392",
+    scryfallId = "a42a8db8-bc8d-47f6-a1d4-78adfcbdd19e",
+    artist = "Jaime Jones",
+    imageUri = "https://cards.scryfall.io/normal/front/a/4/a42a8db8-bc8d-47f6-a1d4-78adfcbdd19e.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/CrumblingNecropolisReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/CrumblingNecropolisReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crumbling Necropolis reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Shards of Alara's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val CrumblingNecropolisReprint = Printing(
+    oracleId = "7190debf-708b-4f41-9714-0d0a5bd5a74e",
+    name = "Crumbling Necropolis",
+    setCode = "NCC",
+    collectorNumber = "397",
+    scryfallId = "e0f698f6-28b6-499e-af63-c223c02c3b4b",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/e/0/e0f698f6-28b6-499e-af63-c223c02c3b4b.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/DrawnFromDreamsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/DrawnFromDreamsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Drawn from Dreams reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Core Set 2020's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val DrawnFromDreamsReprint = Printing(
+    oracleId = "77acdc13-e1b5-4a6c-9be1-b987e8256f10",
+    name = "Drawn from Dreams",
+    setCode = "NCC",
+    collectorNumber = "220",
+    scryfallId = "d61e811a-a744-40df-8d98-93f41a7bb0a0",
+    artist = "Chris Seaman",
+    imageUri = "https://cards.scryfall.io/normal/front/d/6/d61e811a-a744-40df-8d98-93f41a7bb0a0.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/GrandCrescendo.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/GrandCrescendo.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Grand Crescendo
+ * {X}{W}{W}
+ * Instant
+ *
+ * Create X 1/1 green and white Citizen creature tokens. Creatures you control gain
+ * indestructible until end of turn.
+ *
+ * Order matters: the tokens are created first, so the indestructible grant — a one-shot over the
+ * creatures you control *as the spell finishes resolving* ([Effects.ForEachInGroup]) — covers the
+ * Citizens it just made.
+ */
+val GrandCrescendo = card("Grand Crescendo") {
+    manaCost = "{X}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Create X 1/1 green and white Citizen creature tokens. Creatures you control " +
+        "gain indestructible until end of turn."
+
+    spell {
+        effect = Effects.Composite(
+            Effects.CreateToken(
+                count = DynamicAmount.XValue,
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.GREEN, Color.WHITE),
+                creatureTypes = setOf("Citizen")
+            ),
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature.youControl()),
+                Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "16"
+        artist = "Raluca Marinescu"
+        flavorText = "The roar of applause drowned out the melee raging in the lobby."
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e09ff04d-cdcc-4798-b89a-9ad08ef52ad9.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/IndrikStomphowlerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/IndrikStomphowlerReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Indrik Stomphowler reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Dissension's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val IndrikStomphowlerReprint = Printing(
+    oracleId = "de47a1e8-9c69-4af6-9d72-1bdd41352b32",
+    name = "Indrik Stomphowler",
+    setCode = "NCC",
+    collectorNumber = "297",
+    scryfallId = "1fa77af1-96e1-445b-a935-a5eb4c23e954",
+    artist = "Carl Critchlow",
+    imageUri = "https://cards.scryfall.io/normal/front/1/f/1fa77af1-96e1-445b-a935-a5eb4c23e954.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/JenaraAsuraOfWarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/JenaraAsuraOfWarReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jenara, Asura of War reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Alara Reborn's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val JenaraAsuraOfWarReprint = Printing(
+    oracleId = "d06cd670-7ffc-4295-97d1-0eff042fb6d5",
+    name = "Jenara, Asura of War",
+    setCode = "NCC",
+    collectorNumber = "343",
+    scryfallId = "4bcf5b5f-b908-4975-91f7-c4c6f819e0a6",
+    artist = "Chris Rahn",
+    imageUri = "https://cards.scryfall.io/normal/front/4/b/4bcf5b5f-b908-4975-91f7-c4c6f819e0a6.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/JungleShrineReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/JungleShrineReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jungle Shrine reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Shards of Alara's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val JungleShrineReprint = Printing(
+    oracleId = "2e69537c-c898-4e13-a72d-ce3957a90304",
+    name = "Jungle Shrine",
+    setCode = "NCC",
+    collectorNumber = "409",
+    scryfallId = "256b65d6-f50d-4b5c-afae-77935b33f7de",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/2/5/256b65d6-f50d-4b5c-afae-77935b33f7de.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/LifecraftersBestiaryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/LifecraftersBestiaryReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lifecrafter's Bestiary reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Aether Revolt's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val LifecraftersBestiaryReprint = Printing(
+    oracleId = "5f2a3797-28aa-4c7a-ba2b-fd243a1747fd",
+    name = "Lifecrafter's Bestiary",
+    setCode = "NCC",
+    collectorNumber = "370",
+    scryfallId = "457d1102-9ba7-47d1-bced-cc8a28e38ad9",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/4/5/457d1102-9ba7-47d1-bced-cc8a28e38ad9.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/LightningGreavesReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/LightningGreavesReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Greaves reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Mirrodin's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val LightningGreavesReprint = Printing(
+    oracleId = "ca204b66-8d0c-431a-8d34-282f7c2d17da",
+    name = "Lightning Greaves",
+    setCode = "NCC",
+    collectorNumber = "371",
+    scryfallId = "205430f6-2d00-4dce-98c7-3d24a8ae73fc",
+    artist = "Jeremy Jarvis",
+    imageUri = "https://cards.scryfall.io/normal/front/2/0/205430f6-2d00-4dce-98c7-3d24a8ae73fc.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/LuminarchAspirantReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/LuminarchAspirantReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Luminarch Aspirant reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Zendikar Rising's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val LuminarchAspirantReprint = Printing(
+    oracleId = "cb9994b9-924b-4e10-9075-9cfbec88f2bf",
+    name = "Luminarch Aspirant",
+    setCode = "NCC",
+    collectorNumber = "205",
+    scryfallId = "dcd27fa3-f6b6-4137-9b6c-4cba7187664c",
+    artist = "Mads Ahm",
+    imageUri = "https://cards.scryfall.io/normal/front/d/c/dcd27fa3-f6b6-4137-9b6c-4cba7187664c.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/MarchOfTheMultitudesReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/MarchOfTheMultitudesReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * March of the Multitudes reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Guilds of Ravnica's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val MarchOfTheMultitudesReprint = Printing(
+    oracleId = "0c26ab0d-80f6-4e5b-9d0e-af17c1519583",
+    name = "March of the Multitudes",
+    setCode = "NCC",
+    collectorNumber = "346",
+    scryfallId = "65c7067d-61ec-4558-b0d4-0048d2d86743",
+    artist = "Zack Stella",
+    imageUri = "https://cards.scryfall.io/normal/front/6/5/65c7067d-61ec-4558-b0d4-0048d2d86743.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/PrairieStreamReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/PrairieStreamReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prairie Stream reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Battle for Zendikar's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val PrairieStreamReprint = Printing(
+    oracleId = "5330e24a-8568-446e-840a-594cd08bd1bc",
+    name = "Prairie Stream",
+    setCode = "NCC",
+    collectorNumber = "421",
+    scryfallId = "40e52996-863b-46ee-893a-6ecb29f23106",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/4/0/40e52996-863b-46ee-893a-6ecb29f23106.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/PreordainReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/PreordainReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Preordain reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Magic 2011's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val PreordainReprint = Printing(
+    oracleId = "ac641490-ca14-48d7-8cc4-b69ce984befa",
+    name = "Preordain",
+    setCode = "NCC",
+    collectorNumber = "230",
+    scryfallId = "d10b9be3-d4ff-4e3c-b0d5-5ab2c4e6d684",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d10b9be3-d4ff-4e3c-b0d5-5ab2c4e6d684.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ProsperousPartnership.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ProsperousPartnership.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Prosperous Partnership
+ * {1}{R}{W}
+ * Enchantment
+ *
+ * When this enchantment enters, create two 1/1 green and white Citizen creature tokens.
+ * Tap three untapped creatures you control: Create a Treasure token.
+ *
+ * The activation cost is [Costs.TapPermanents] — tapping the creatures is the cost, so it is paid
+ * on activation and the creatures need not be untapped when the ability resolves. It is not a
+ * mana ability (it makes a Treasure, not mana), so it uses the stack.
+ */
+val ProsperousPartnership = card("Prosperous Partnership") {
+    manaCost = "{1}{R}{W}"
+    colorIdentity = "WR"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, create two 1/1 green and white Citizen creature " +
+        "tokens.\n" +
+        "Tap three untapped creatures you control: Create a Treasure token."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN, Color.WHITE),
+            creatureTypes = setOf("Citizen"),
+            count = 2
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.TapPermanents(3, GameObjectFilter.Creature)
+        effect = Effects.CreateTreasure()
+        description = "Create a Treasure token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "78"
+        artist = "Evyn Fong"
+        flavorText = "Partners in love, partners in life, and partners in crime."
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a50267d1-f4b7-494f-b50b-cfb08b760b47.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SavageLandsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SavageLandsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Savage Lands reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Shards of Alara's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val SavageLandsReprint = Printing(
+    oracleId = "a3292406-3f49-42d6-a547-e43dd5797f84",
+    name = "Savage Lands",
+    setCode = "NCC",
+    collectorNumber = "424",
+    scryfallId = "05bd2945-af12-4f36-b2b3-47d766af521e",
+    artist = "Vance Kovacs",
+    imageUri = "https://cards.scryfall.io/normal/front/0/5/05bd2945-af12-4f36-b2b3-47d766af521e.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SeasideCitadelReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SeasideCitadelReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seaside Citadel reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Shards of Alara's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val SeasideCitadelReprint = Printing(
+    oracleId = "2ae77795-6a80-498b-bf69-6fd612f601e4",
+    name = "Seaside Citadel",
+    setCode = "NCC",
+    collectorNumber = "425",
+    scryfallId = "816ce96f-9180-4f95-a7cd-334f4a159fa7",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/816ce96f-9180-4f95-a7cd-334f4a159fa7.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ShadowmageInfiltratorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ShadowmageInfiltratorReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shadowmage Infiltrator reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Odyssey's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val ShadowmageInfiltratorReprint = Printing(
+    oracleId = "3a6f886b-2043-47e9-9c0f-f7913a6fa67d",
+    name = "Shadowmage Infiltrator",
+    setCode = "NCC",
+    collectorNumber = "351",
+    scryfallId = "c2ac3ee0-3adf-4e81-9194-cb0e9faf2826",
+    artist = "Tomasz Jedruszek",
+    imageUri = "https://cards.scryfall.io/normal/front/c/2/c2ac3ee0-3adf-4e81-9194-cb0e9faf2826.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SmolderingMarshReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SmolderingMarshReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Smoldering Marsh reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Battle for Zendikar's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val SmolderingMarshReprint = Printing(
+    oracleId = "390f1b56-264e-4336-83be-dc1fe79bfdcf",
+    name = "Smoldering Marsh",
+    setCode = "NCC",
+    collectorNumber = "428",
+    scryfallId = "e0e4a509-09bb-41e5-a37a-53d98c7f2e04",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/e/0/e0e4a509-09bb-41e5-a37a-53d98c7f2e04.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SunkenHollowReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SunkenHollowReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunken Hollow reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Battle for Zendikar's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val SunkenHollowReprint = Printing(
+    oracleId = "cd2c90ac-2b04-461c-92f3-939871b6b6a3",
+    name = "Sunken Hollow",
+    setCode = "NCC",
+    collectorNumber = "431",
+    scryfallId = "0fb2782e-6fe9-4383-9ba4-02d21b7cb4d7",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0fb2782e-6fe9-4383-9ba4-02d21b7cb4d7.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SwiftfootBootsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SwiftfootBootsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftfoot Boots reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Magic 2012's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val SwiftfootBootsReprint = Printing(
+    oracleId = "c8b143ad-43ec-4e0d-a440-e348daa31391",
+    name = "Swiftfoot Boots",
+    setCode = "NCC",
+    collectorNumber = "382",
+    scryfallId = "3cb171ef-42eb-466e-b425-e3c16301c0ca",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3cb171ef-42eb-466e-b425-e3c16301c0ca.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/TalrandsInvocationReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/TalrandsInvocationReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Talrand's Invocation reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Magic 2013's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val TalrandsInvocationReprint = Printing(
+    oracleId = "43355ac4-bf8c-48f6-a322-fafbc9d132d1",
+    name = "Talrand's Invocation",
+    setCode = "NCC",
+    collectorNumber = "234",
+    scryfallId = "88f43c2c-fee4-4df2-b326-a1d9840f64b0",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/88f43c2c-fee4-4df2-b326-a1d9840f64b0.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ThragtuskReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ThragtuskReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thragtusk reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Magic 2013's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val ThragtuskReprint = Printing(
+    oracleId = "0dd0e91a-d16b-4718-8d11-1a3fcf8e0753",
+    name = "Thragtusk",
+    setCode = "NCC",
+    collectorNumber = "316",
+    scryfallId = "beda7acd-e970-4222-9577-5133765d6052",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/b/e/beda7acd-e970-4222-9577-5133765d6052.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/WickerboughElderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/WickerboughElderReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wickerbough Elder reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Eventide's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val WickerboughElderReprint = Printing(
+    oracleId = "3d794629-9014-460a-8d3b-785eadc1cdb5",
+    name = "Wickerbough Elder",
+    setCode = "NCC",
+    collectorNumber = "320",
+    scryfallId = "3a5832cc-f9f6-4881-99dd-c0728a52cabe",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/3/a/3a5832cc-f9f6-4881-99dd-c0728a52cabe.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/WoodfallPrimusReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/WoodfallPrimusReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Woodfall Primus reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Shadowmoor's `cards/` package; this
+ * file contributes only the New Capenna Commander presentation row.
+ */
+val WoodfallPrimusReprint = Printing(
+    oracleId = "2f70f1bb-29fa-4abb-afc2-653acd0a08b9",
+    name = "Woodfall Primus",
+    setCode = "NCC",
+    collectorNumber = "322",
+    scryfallId = "97914abe-71d5-4bd6-87d7-8e7379abf1aa",
+    artist = "Adam Rex",
+    imageUri = "https://cards.scryfall.io/normal/front/9/7/97914abe-71d5-4bd6-87d7-8e7379abf1aa.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ArastaOfTheEndlessWeb.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ArastaOfTheEndlessWeb.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Arasta of the Endless Web
+ * {2}{G}{G}
+ * Legendary Enchantment Creature — Spider
+ * 3/5
+ *
+ * Reach
+ * Whenever an opponent casts an instant or sorcery spell, create a 1/2 green Spider creature
+ * token with reach.
+ *
+ * The trigger watches *opponents only* ([Triggers.opponentCasts]), so Arasta's controller casting
+ * their own removal spell doesn't feed them Spiders.
+ */
+val ArastaOfTheEndlessWeb = card("Arasta of the Endless Web") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Enchantment Creature — Spider"
+    power = 3
+    toughness = 5
+    oracleText = "Reach\n" +
+        "Whenever an opponent casts an instant or sorcery spell, create a 1/2 green Spider " +
+        "creature token with reach."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.opponentCasts(GameObjectFilter.InstantOrSorcery)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Spider"),
+            keywords = setOf(Keyword.REACH)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "165"
+        artist = "Sam Rowan"
+        flavorText = "Her webs, spun from her own hair, reach from Nyx to the mortal world and even into the Underworld."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c38833a-96c5-48b5-8dd8-23f10e798537.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/LuminarchAspirant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/LuminarchAspirant.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Luminarch Aspirant
+ * {1}{W}
+ * Creature — Human Cleric
+ * 1/1
+ *
+ * At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.
+ */
+val LuminarchAspirant = card("Luminarch Aspirant") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 1
+    oracleText = "At the beginning of combat on your turn, put a +1/+1 counter on target " +
+        "creature you control."
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        target = Targets.CreatureYouControl
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "24"
+        artist = "Mads Ahm"
+        flavorText = "\"Rally to my light, and together we will drive out this darkness!\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/fe964e7e-e2c5-4263-889d-0a531eb51442.jpg"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/AER.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AER.json
@@ -97,6 +97,69 @@
     ]
 }
 
+// Lifecrafter's Bestiary
+{
+    "name": "Lifecrafter's Bestiary",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "At the beginning of your upkeep, scry 1.\nWhenever you cast a creature spell, you may pay {G}. If you do, draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{G}"
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "162",
+        "rarity": "RARE",
+        "artist": "Izzy",
+        "flavorText": "\"Inspiration is found by looking outward.\"\n—Oviya Pashiri, sage lifecrafter",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/7439a855-4041-4d14-8edf-6741a734e55d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Metallic Mimic
 {
     "name": "Metallic Mimic",

--- a/mtg-sets/src/test/resources/snapshots/cards/ALA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ALA.json
@@ -1,3 +1,60 @@
+// Arcane Sanctum
+{
+    "name": "Arcane Sanctum",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {W}, {U}, or {B}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "rarity": "UNCOMMON",
+        "artist": "Anthony Francisco",
+        "flavorText": "\"We must rely on our own knowledge, not on the dogma of the seekers or the mutterings of the sphinxes.\"\n—Tullus of Palandius",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/e/6edc0681-4252-4d3d-baf3-f03c22af1208.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Bone Splinters
 {
     "name": "Bone Splinters",
@@ -41,6 +98,63 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Crumbling Necropolis
+{
+    "name": "Crumbling Necropolis",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {U}, {B}, or {R}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "rarity": "UNCOMMON",
+        "artist": "Dave Kendall",
+        "flavorText": "\"They say the ruins of Sedraxis were once a shining capital in Vithia. Now it is a blight, a place to be avoided by the living.\"\n—Olcot, Rider of Joffik",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/94da8e38-77a4-4d25-9e1f-f33c246f60c8.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -297,6 +411,63 @@
     ]
 }
 
+// Jungle Shrine
+{
+    "name": "Jungle Shrine",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {R}, {G}, or {W}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "rarity": "UNCOMMON",
+        "artist": "Wayne Reynolds",
+        "flavorText": "On Naya, ambition and treachery are scarce, hunted nearly to extinction by the awe owed to terrestrial gods.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e4f0d262-cbfe-42d2-9066-0b48a38995d6.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Sanctum Gargoyle
 {
     "name": "Sanctum Gargoyle",
@@ -355,6 +526,120 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Savage Lands
+{
+    "name": "Savage Lands",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {B}, {R}, or {G}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "rarity": "UNCOMMON",
+        "artist": "Vance Kovacs",
+        "flavorText": "Jund is a world as cruel as those who call it home. Their brutal struggles scar the land even as it carves them in its image, a vicious circle spiraling out of control.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6bcded3-6eea-4533-a855-e03d4c4620d6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED",
+        "GREEN"
+    ]
+}
+
+// Seaside Citadel
+{
+    "name": "Seaside Citadel",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {G}, {W}, or {U}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "229",
+        "rarity": "UNCOMMON",
+        "artist": "Volkan Baǵa",
+        "flavorText": "For wisdom's sake, it was built high to gaze on all things. For glory's sake, it was built high as a testament of power. For strength's sake, it was built high to repel all attacks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c1995d2a-4550-4c84-ad44-183b06579e98.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/ARB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARB.json
@@ -19,6 +19,53 @@
     ]
 }
 
+// Jenara, Asura of War
+{
+    "name": "Jenara, Asura of War",
+    "manaCost": "{G}{W}{U}",
+    "typeLine": "Legendary Creature — Angel",
+    "oracleText": "Flying\n{1}{W}: Put a +1/+1 counter on Jenara.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "rarity": "MYTHIC",
+        "artist": "Chris Rahn",
+        "flavorText": "Wounded soldiers looked up, grateful for her appearance. But she passed over them, her eyes firmly on their foe.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d643c335-e3a7-461d-a024-095795ab6770.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "GREEN"
+    ]
+}
+
 // Maelstrom Pulse
 {
     "name": "Maelstrom Pulse",

--- a/mtg-sets/src/test/resources/snapshots/cards/BFZ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BFZ.json
@@ -106,6 +106,45 @@
     ]
 }
 
+// Canopy Vista
+{
+    "name": "Canopy Vista",
+    "manaCost": "",
+    "typeLine": "Land — Forest Plains",
+    "oracleText": "({T}: Add {G} or {W}.)\nThis land enters tapped unless you control two or more basic lands.",
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "basicland"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "234",
+        "rarity": "RARE",
+        "artist": "Adam Paquette",
+        "flavorText": "The continent of Murasa lies beneath a blanket of dense vegetation, its enormous branches tangled so thickly that some inhabitants never see the ground.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3262c7f-4fdf-4648-ba59-9279c75d222d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Cinder Glade
 {
     "name": "Cinder Glade",
@@ -406,6 +445,45 @@
     ]
 }
 
+// Prairie Stream
+{
+    "name": "Prairie Stream",
+    "manaCost": "",
+    "typeLine": "Land — Plains Island",
+    "oracleText": "({T}: Add {W} or {U}.)\nThis land enters tapped unless you control two or more basic lands.",
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "basicland"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "rarity": "RARE",
+        "artist": "Adam Paquette",
+        "flavorText": "The continent of Ondu is a vast plateau crisscrossed by deep trenches and meandering rivers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/9625911f-1dd3-4044-ac06-3c0c3198b6fd.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Sandstone Bridge
 {
     "name": "Sandstone Bridge",
@@ -480,6 +558,45 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Smoldering Marsh
+{
+    "name": "Smoldering Marsh",
+    "manaCost": "",
+    "typeLine": "Land — Swamp Mountain",
+    "oracleText": "({T}: Add {B} or {R}.)\nThis land enters tapped unless you control two or more basic lands.",
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "basicland"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "rarity": "RARE",
+        "artist": "Adam Paquette",
+        "flavorText": "The continent of Guul Draz is a geothermal swampland reeking of heat and decay.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/359b189d-aa51-4e90-820a-e79884562e34.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -652,6 +769,45 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Sunken Hollow
+{
+    "name": "Sunken Hollow",
+    "manaCost": "",
+    "typeLine": "Land — Island Swamp",
+    "oracleText": "({T}: Add {U} or {B}.)\nThis land enters tapped unless you control two or more basic lands.",
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "basicland"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "249",
+        "rarity": "RARE",
+        "artist": "Adam Paquette",
+        "flavorText": "On the continent of Tazeem, rushing waters plunge through narrow canyons into mist-cloaked lakes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0dd1726f-b899-491a-8b0e-8e3d25f17d3d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/DIS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DIS.json
@@ -179,6 +179,54 @@
     ]
 }
 
+// Indrik Stomphowler
+{
+    "name": "Indrik Stomphowler",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "When this creature enters, destroy target artifact or enchantment.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact|enchantment"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "rarity": "UNCOMMON",
+        "artist": "Carl Critchlow",
+        "flavorText": "\"An indrik's howl has destructive power much subtler than that of its crushing foot. The sound is mundane, but inaudible vibrations scatter and sunder magical contrivances.\"\n—Simic research notes",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/e/fe57b3a2-0fd9-4f99-bb2b-828979dbcfc3.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Macabre Waltz
 {
     "name": "Macabre Waltz",

--- a/mtg-sets/src/test/resources/snapshots/cards/ELD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ELD.json
@@ -44,6 +44,158 @@
     ]
 }
 
+// Castle Ardenvale
+{
+    "name": "Castle Ardenvale",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless you control a Plains.\n{T}: Add {W}.\n{2}{W}{W}, {T}: Create a 1/1 white Human creature token.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Human"
+                    ]
+                },
+                "descriptionOverride": "Create a 1/1 white Human creature token."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "land Plains"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "rarity": "RARE",
+        "artist": "Volkan Baǵa",
+        "flavorText": "Without Ardenvale's loyalty, the realm would greedily devour itself.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f910495-8bd7-4134-a281-c16fd666d5cc.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Castle Embereth
+{
+    "name": "Castle Embereth",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless you control a Mountain.\n{T}: Add {R}.\n{1}{R}{R}, {T}: Creatures you control get +1/+0 until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Creatures you control get +1/+0 until end of turn."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "land Mountain"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "239",
+        "rarity": "RARE",
+        "artist": "Jaime Jones",
+        "flavorText": "Without Embereth's courage, the realm would falter and fall.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8bb8512e-6913-4be6-8828-24cfcbec042e.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Charming Prince
 {
     "name": "Charming Prince",

--- a/mtg-sets/src/test/resources/snapshots/cards/EVE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EVE.json
@@ -49,3 +49,76 @@
         "WHITE"
     ]
 }
+
+// Wickerbough Elder
+{
+    "name": "Wickerbough Elder",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Treefolk Shaman",
+    "oracleText": "This creature enters with a -1/-1 counter on it.\n{G}, Remove a -1/-1 counter from this creature: Destroy target artifact or enchantment.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "-1/-1",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact|enchantment"
+                        }
+                    }
+                ]
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": "MinusOneMinusOne",
+                "count": 1,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "artist": "Jesper Ejsing",
+        "flavorText": "\"Living scarecrows make a mockery of the natural order. Dead ones make fine hats.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/acc283b4-9106-4a32-88b4-000f2a3bed84.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/GRN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GRN.json
@@ -264,6 +264,45 @@
     ]
 }
 
+// March of the Multitudes
+{
+    "name": "March of the Multitudes",
+    "manaCost": "{X}{G}{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreate X 1/1 white Soldier creature tokens with lifelink.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": "XValue",
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "WHITE"
+            ],
+            "creatureTypes": [
+                "Soldier"
+            ],
+            "keywords": [
+                "LIFELINK"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "188",
+        "rarity": "MYTHIC",
+        "artist": "Zack Stella",
+        "flavorText": "\"Our forces number more than the leaves of Vitu-Ghazi. Do not provoke us.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2cc2b646-0181-4f0a-a141-00ca56069a06.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
 // Midnight Reaper
 {
     "name": "Midnight Reaper",

--- a/mtg-sets/src/test/resources/snapshots/cards/M13.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M13.json
@@ -475,3 +475,99 @@
         "GREEN"
     ]
 }
+
+// Talrand's Invocation
+{
+    "name": "Talrand's Invocation",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create two 2/2 blue Drake creature tokens with flying.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "power": 2,
+            "toughness": 2,
+            "colors": [
+                "BLUE"
+            ],
+            "creatureTypes": [
+                "Drake"
+            ],
+            "keywords": [
+                "FLYING"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "rarity": "UNCOMMON",
+        "artist": "Svetlin Velinov",
+        "flavorText": "After Talrand conquered the depths of Shandalar, his ambitions drove him skyward, joined by servants whose drive and curiosity equaled his own.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2cd809c-557a-42a5-950b-56b5b47b325b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Thragtusk
+{
+    "name": "Thragtusk",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "When this creature enters, you gain 5 life.\nWhen this creature leaves the battlefield, create a 3/3 green Beast creature token.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 3,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Beast"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "rarity": "RARE",
+        "artist": "Nils Hamm",
+        "flavorText": "\"Always carry two spears.\"\n—Mokgar, Kalonian hunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/28667c8b-d02c-4e57-a050-1549207b65d1.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/M20.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M20.json
@@ -350,6 +350,75 @@
     ]
 }
 
+// Drawn from Dreams
+{
+    "name": "Drawn from Dreams",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top seven cards of your library. Put two of them into your hand and the rest on the bottom of your library in a random order.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 7
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "selectedLabel": "Put in hand",
+                    "remainderLabel": "Put on bottom"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "Random"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "rarity": "RARE",
+        "artist": "Chris Seaman",
+        "flavorText": "\"From a sea of infinite possibilities, our choices create the future.\"\n—Mu Yanling",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/5677cd48-de9f-4827-94d7-8a2301945742.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Empyrean Eagle
 {
     "name": "Empyrean Eagle",

--- a/mtg-sets/src/test/resources/snapshots/cards/NCC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/NCC.json
@@ -43,6 +43,122 @@
     ]
 }
 
+// Grand Crescendo
+{
+    "name": "Grand Crescendo",
+    "manaCost": "{X}{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Create X 1/1 green and white Citizen creature tokens. Creatures you control gain indestructible until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreateToken",
+                    "count": "XValue",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN",
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Citizen"
+                    ]
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "INDESTRUCTIBLE",
+                        "target": "Self"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "rarity": "RARE",
+        "artist": "Raluca Marinescu",
+        "flavorText": "The roar of applause drowned out the melee raging in the lobby.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e09ff04d-cdcc-4798-b89a-9ad08ef52ad9.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Prosperous Partnership
+{
+    "name": "Prosperous Partnership",
+    "manaCost": "{1}{R}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, create two 1/1 green and white Citizen creature tokens.\nTap three untapped creatures you control: Create a Treasure token.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN",
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Citizen"
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 3,
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                },
+                "descriptionOverride": "Create a Treasure token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "rarity": "RARE",
+        "artist": "Evyn Fong",
+        "flavorText": "Partners in love, partners in life, and partners in crime.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a50267d1-f4b7-494f-b50b-cfb08b760b47.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "RED"
+    ]
+}
+
 // Rain of Riches
 {
     "name": "Rain of Riches",

--- a/mtg-sets/src/test/resources/snapshots/cards/ODY.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ODY.json
@@ -4791,6 +4791,54 @@
     ]
 }
 
+// Shadowmage Infiltrator
+{
+    "name": "Shadowmage Infiltrator",
+    "manaCost": "{1}{U}{B}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhenever this creature deals combat damage to a player, you may draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FEAR"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "294",
+        "rarity": "RARE",
+        "artist": "Rick Farrell",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/932ce702-565f-4d8c-b9fc-2d7c939ef7d7.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Skull Fracture
 {
     "name": "Skull Fracture",

--- a/mtg-sets/src/test/resources/snapshots/cards/ROE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ROE.json
@@ -1,3 +1,76 @@
+// Artisan of Kozilek
+{
+    "name": "Artisan of Kozilek",
+    "manaCost": "{9}",
+    "typeLine": "Creature — Eldrazi",
+    "oracleText": "When you cast this spell, you may return target creature card from your graveyard to the battlefield.\nAnnihilator 2 (Whenever this creature attacks, defending player sacrifices two permanents of their choice.)",
+    "creatureStats": {
+        "power": 10,
+        "toughness": 9
+    },
+    "keywords": [
+        "ANNIHILATOR"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "ANNIHILATOR",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature card from your graveyard"
+                        },
+                        "destination": "Battlefield",
+                        "fromZone": "Graveyard"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card from your graveyard"
+                },
+                "descriptionOverride": "When you cast this spell, you may return target creature card from your graveyard to the battlefield."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ForceSacrifice",
+                    "filter": "permanent",
+                    "count": 2,
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "DefendingPlayer"
+                    }
+                },
+                "descriptionOverride": "Annihilator 2"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Felix",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3ac80eb8-321d-476a-87e7-d25bdac6a91c.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Battle-Rattle Shaman
 {
     "name": "Battle-Rattle Shaman",

--- a/mtg-sets/src/test/resources/snapshots/cards/SHM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SHM.json
@@ -169,3 +169,55 @@
         "WHITE"
     ]
 }
+
+// Woodfall Primus
+{
+    "name": "Woodfall Primus",
+    "manaCost": "{5}{G}{G}{G}",
+    "typeLine": "Creature — Treefolk Shaman",
+    "oracleText": "Trample\nWhen this creature enters, destroy target noncreature permanent.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "TRAMPLE",
+        "PERSIST"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "noncreature permanent"
+                    }
+                },
+                "descriptionOverride": "When this creature enters, destroy target noncreature permanent."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "rarity": "RARE",
+        "artist": "Adam Rex",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/43aa7e35-55ee-4e02-a8aa-ea2b267055d1.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/THB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THB.json
@@ -1,3 +1,65 @@
+// Arasta of the Endless Web
+{
+    "name": "Arasta of the Endless Web",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Legendary Enchantment Creature — Spider",
+    "oracleText": "Reach\nWhenever an opponent casts an instant or sorcery spell, create a 1/2 green Spider creature token with reach.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    },
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Spider"
+                    ],
+                    "keywords": [
+                        "REACH"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "RARE",
+        "artist": "Sam Rowan",
+        "flavorText": "Her webs, spun from her own hair, reach from Nyx to the mortal world and even into the Underworld.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c38833a-96c5-48b5-8dd8-23f10e798537.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Archon of Sun's Grace
 {
     "name": "Archon of Sun's Grace",

--- a/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
@@ -466,6 +466,55 @@
     ]
 }
 
+// Luminarch Aspirant
+{
+    "name": "Luminarch Aspirant",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "RARE",
+        "artist": "Mads Ahm",
+        "flavorText": "\"Rally to my light, and together we will drive out this darkness!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/e/fe964e7e-e2c5-4263-889d-0a531eb51442.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Marauding Blight-Priest
 {
     "name": "Marauding Blight-Priest",


### PR DESCRIPTION
NCC's 290 missing cards read **256 LINE_DECLINED / 3 absent** (the split-card halves Commit, Dusk, Indulge) **/ 31 whole**. Those 31 are this PR. **60/350 → 91/350.**

## The split

A *Commander deck* set's Assay-ready tail is lopsided toward reprints, and NCC is the extreme case — **zero** basic lands, and only 2 of the 31 are actually NCC cards:

| | count | |
|---|---|---|
| canonical already existed | 5 | Ash Barrens, Boros Charm, Lightning Greaves, Preordain, Swiftfoot Boots |
| canonical belongs in an earlier *scaffolded* set | 24 | ALA (5), BFZ (4), ELD (2), M13 (2), THB / ROE / M20 / DIS / ARB / AER / ZNR / GRN / ODY / EVE / SHM (1 each) |
| new NCC canonical | 2 | Grand Crescendo, Prosperous Partnership |

So: **26 new `card(...)` definitions + 29 NCC `Printing(...)` rows.**

## Authoring

Every card was written against `assay compile "<name>"`'s JSON — the exact SDK model Assay's grammar builds — rather than from the oracle text. The differential is the payoff: **0 divergences among the 26 new canonicals.**

Two shapes worth naming:

- **Annihilator is still display-only.** Nothing in `rules-engine` reads `Keyword.ANNIHILATOR`, so **Artisan of Kozilek** carries the lowering documented in `card-sdk-language-reference.md` (Nulldrifter's shape) alongside the printed keyword ability: an attack trigger → `Effects.Sacrifice(Permanent, 2, DefendingPlayer)` — the edict form, because the *defending player* chooses and annihilator eats any permanent. Persist (Woodfall Primus), fear (Shadowmage Infiltrator), convoke (March of the Multitudes) and reach were each checked against `rules-engine` and are engine-live, so the bare keyword is correct for them.
- **`assay compile "Savage Lands"` reads the wrong card.** The Oracle bulk resolves that name to an FMSC `(Theme color: {G})` art card, not the ALA triland. Savage Lands was authored from its four ALA siblings instead. Worth knowing before trusting compile output for a name shared with a non-card.

## Verification

- `just build` — green after the expected snapshot re-bless.
- `just rebless-cards` — **16 snapshot goldens, 1428 insertions, 0 deletions.** Exactly the 16 sets touched; no unrelated card moved, which is the whole point of that net.
- `just assay-differential` — **3281 compared / 3268 confirmed / 13 divergent (99.6%)**. All 13 are in sets this PR does not touch (BLB, BLC, DOM, ECL, FDN, SCG, SPM, TDM, WAR) and are pre-existing. None of the 26 new canonicals diverge.
- `scripts/check-card-printing.py` — canonical placement is correct for all 31. The drift it still reports is the known *"missing `Printing` rows in **other** scaffolded sets"* class (c13/c16/c17 for the ALA trilands, jmp for Thragtusk, blc for Castle Ardenvale) — real, but a separate change, and blc is another agent's in-flight worktree.

No scenario tests are owed: every card composes primitives that already exist and are already covered, and the one mechanic without an engine reader (annihilator) is lowered to a trigger that is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)