### PR TITLE
Read Streets of New Capenna's Assay-ready tail: +62 whole cards

### DIFF
--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SuspiciousBookcaseReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SuspiciousBookcaseReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Suspicious Bookcase reprint in Jumpstart. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in `definitions/m19/cards/SuspiciousBookcase.kt`; this file contributes only presentation data.
+ */
+val SuspiciousBookcaseReprint = Printing(
+    oracleId = "ca611c90-7753-43dd-af91-81694d004eeb",
+    name = "Suspicious Bookcase",
+    setCode = "JMP",
+    collectorNumber = "487",
+    scryfallId = "7b14ff70-6817-4539-b19b-142f8f6b6b1f",
+    artist = "Anastasia Ovchinnikova",
+    imageUri = "https://cards.scryfall.io/normal/front/7/b/7b14ff70-6817-4539-b19b-142f8f6b6b1f.jpg?1783930330",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SuspiciousBookcase.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SuspiciousBookcase.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Suspicious Bookcase
+ * {2}
+ * Artifact Creature — Wall
+ * 0 / 4
+ * Defender
+ * {3}, {T}: Target creature can't be blocked this turn.
+ */
+val SuspiciousBookcase = card("Suspicious Bookcase") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Wall"
+    oracleText = "Defender\n{3}, {T}: Target creature can't be blocked this turn."
+    power = 0
+    toughness = 4
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "246"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "All the books were dusty with disuse, save the one titled *Camouflage and Its Practical Applications*."
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/ccf01421-856e-4cdd-8938-148928626f56.jpg?1783934508"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/ALittleChat.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/ALittleChat.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+
+/**
+ * A Little Chat
+ * {1}{U}
+ * Instant
+ * Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)
+ * Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.
+ *
+ * Casualty 1 (CR 702.153) is the printed [KeywordAbility.Casualty] — the cast flow surfaces the
+ * optional sacrifice and queues the reflexive copy.
+ *
+ * The dig is exactly [Patterns.Library.lookAtTopAndKeep] with count = 2 / keepCount = 1: the kept
+ * card goes to hand (the facade default) and the remainder to the bottom of the library, which is
+ * also where the "Put in hand" / "Put on bottom" selection labels come from.
+ */
+val ALittleChat = card("A Little Chat") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)\nLook at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library."
+
+    keywordAbility(KeywordAbility.casualty(1))
+
+    spell {
+        effect = Patterns.Library.lookAtTopAndKeep(
+            count = 2,
+            keepCount = 1,
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "47"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4d7424b6-b56a-47b7-8204-294d3dca925f.jpg?1783923145"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/AngelicObserver.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/AngelicObserver.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Angelic Observer
+ * {5}{W}
+ * Creature — Angel Advisor
+ * 3 / 3
+ * Affinity for Citizens (This spell costs {1} less to cast for each Citizen you control.)
+ * Flying
+ *
+ * Affinity must be the [KeywordAbility.AffinityForSubtype] data class, not `Keyword.AFFINITY`:
+ * the cost reduction is read off the keyword *ability*, so the bare enum would print the text
+ * and reduce nothing. It derives `Keyword.AFFINITY` into the keyword set on its own.
+ */
+val AngelicObserver = card("Angelic Observer") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel Advisor"
+    oracleText = "Affinity for Citizens (This spell costs {1} less to cast for each Citizen you control.)\nFlying"
+    power = 3
+    toughness = 3
+
+    keywordAbility(KeywordAbility.AffinityForSubtype(Subtype.CITIZEN))
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "1"
+        artist = "Zack Stella"
+        flavorText = "Still and solemn as the statues of her kind that decorated the Park Heights rooftops, she gazed in sorrow on the city below."
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e6cce4d3-e6d8-4c6f-9d9c-c0a8a607a42f.jpg?1783923164"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/Antagonize.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/Antagonize.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Antagonize
+ * {1}{R}
+ * Instant
+ * Target creature gets +4/+3 until end of turn.
+ */
+val Antagonize = card("Antagonize") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +4/+3 until end of turn."
+
+    spell {
+        val creature = target("target creature to get +4/+3", TargetCreature())
+        effect = Effects.ModifyStats(4, 3, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "100"
+        artist = "Gabor Szikszai"
+        flavorText = "\"The little guy had guts at least. You can see 'em right there between those cobbles.\"\n—Glunk, freelance crusher"
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8bac1d2a-99dd-40b3-8823-ce9225efcdcf.jpg?1783923123"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/AttendedSocialite.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/AttendedSocialite.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Attended Socialite
+ * {1}{G}
+ * Creature — Elf Druid
+ * 2 / 1
+ * Alliance — Whenever another creature you control enters, this creature gets +1/+1 until end of turn.
+ *
+ * "Alliance" is a pure ability word — no rules meaning — so the trigger is the plain
+ * [Triggers.OtherCreatureEnters] (OTHER binding over creatures you control), with the ability word
+ * carried only in the printed text and the [description].
+ */
+val AttendedSocialite = card("Attended Socialite") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid"
+    oracleText = "Alliance — Whenever another creature you control enters, this creature gets +1/+1 until end of turn."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Alliance — Whenever another creature you control enters, this creature gets +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "133"
+        artist = "Drew Baker"
+        flavorText = "\"Say hello to my little friend.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8bccccf9-3ee5-4485-ae01-4dcbad989d18.jpg?1783923110"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/BackupAgent.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/BackupAgent.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Backup Agent
+ * {1}{W}
+ * Creature — Human Citizen
+ * 1 / 1
+ * When this creature enters, put a +1/+1 counter on target creature.
+ *
+ * The target is unrestricted ("target creature", not "creature you control"), so it is the bare
+ * [Targets.Creature] requirement.
+ */
+val BackupAgent = card("Backup Agent") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Citizen"
+    oracleText = "When this creature enters, put a +1/+1 counter on target creature."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+        description = "When this creature enters, put a +1/+1 counter on target creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "2"
+        artist = "Aaron J. Riley"
+        flavorText = "\"My sources say the Beamtown Bullies were spotted in the Mezzio. Keep your eyes sharp and stay close to me.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2a46af75-3880-4141-b26e-19834d67e7a8.jpg?1783923164"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/BigScore.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/BigScore.kt
@@ -1,4 +1,4 @@
-package com.wingedsheep.mtg.sets.definitions.blc.cards
+package com.wingedsheep.mtg.sets.definitions.snc.cards
 
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
@@ -30,9 +30,10 @@ val BigScore = card("Big Score") {
     }
 
     metadata {
-        rarity = Rarity.UNCOMMON
-        collectorNumber = "193"
-        artist = "Daren Bader"
-        imageUri = "https://cards.scryfall.io/normal/front/2/4/243b460e-e67a-40d7-a874-a61fdb011c5a.jpg?1721429138"
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Gaboleps"
+        flavorText = "\"Unimaginable riches? I assure you, I have a *vivid* imagination.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/39d1578f-e2cf-4b93-8204-ed5434feb183.jpg?1783923123"
     }
 }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/BootleggersStash.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/BootleggersStash.kt
@@ -1,4 +1,4 @@
-package com.wingedsheep.mtg.sets.definitions.blc.cards
+package com.wingedsheep.mtg.sets.definitions.snc.cards
 
 import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
@@ -36,8 +36,9 @@ val BootleggersStash = card("Bootleggers' Stash") {
 
     metadata {
         rarity = Rarity.MYTHIC
-        collectorNumber = "207"
+        collectorNumber = "134"
         artist = "Anastasia Ovchinnikova"
-        imageUri = "https://cards.scryfall.io/normal/front/c/1/c10525b5-067c-4a30-a069-875f11f2ff19.jpg?1721429213"
+        flavorText = "Labyrinths of tunnels beneath the streets of the Caldaia offer an ample array of discreet routes for enterprising smugglers."
+        imageUri = "https://cards.scryfall.io/normal/front/8/0/80b5b7e1-52c2-4453-b3c0-efe2cebad6ce.jpg?1783923109"
     }
 }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/BotanicalPlaza.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/BotanicalPlaza.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Botanical Plaza
+ * Land
+ * This land enters tapped.
+ * {T}: Add {G} or {W}.
+ * {2}{G}{W}, {T}, Sacrifice this land: Draw a card.
+ */
+val BotanicalPlaza = card("Botanical Plaza") {
+    colorIdentity = "GW"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n{T}: Add {G} or {W}.\n{2}{G}{W}, {T}, Sacrifice this land: Draw a card."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{G}{W}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "247"
+        artist = "Grady Frederick"
+        flavorText = "Public parks are a favored meeting spot for those considering a shift in allegiance."
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f8a6f93-1fc8-4690-add4-538763277f8e.jpg?1783923058"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/BrazenUpstart.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/BrazenUpstart.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Brazen Upstart
+ * {R}{G}{W}
+ * Creature — Elf Shaman
+ * 4 / 2
+ * Vigilance
+ * When this creature dies, look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
+ */
+val BrazenUpstart = card("Brazen Upstart") {
+    manaCost = "{R}{G}{W}"
+    colorIdentity = "GRW"
+    typeLine = "Creature — Elf Shaman"
+    oracleText = "Vigilance\nWhen this creature dies, look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order."
+    power = 4
+    toughness = 2
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Patterns.Library.lookAtTopRevealMatchingToHand(
+            count = DynamicAmount.Fixed(5),
+            filter = GameObjectFilter.Creature,
+            prompt = "You may reveal a creature card from among them and put it into your hand"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "169"
+        artist = "Dallas Williams"
+        flavorText = "\"Trust me, you want to deal with me. My associates are much less pleasant.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3ae69722-9cb9-4fb7-830f-a284d4a72027.jpg?1783923093"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/BrokersVeteran.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/BrokersVeteran.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brokers Veteran
+ * {1}{U}
+ * Creature — Human Soldier
+ * 2 / 1
+ * When this creature dies, put a shield counter on target creature you control. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)
+ *
+ * The shield counter is the engine's CR 122.1c counter — the reminder text's replacement +
+ * prevention pair is wired at the damage and destroy chokepoints, so the card only has to put
+ * the counter on.
+ */
+val BrokersVeteran = card("Brokers Veteran") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "When this creature dies, put a shield counter on target creature you control. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)"
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val t = target("target", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.SHIELD, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Lie Setiawan"
+        flavorText = "One last job before he retires."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d4a54bd-5598-4313-b5e6-29fd38da016a.jpg?1783923149"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CabarettiCharm.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CabarettiCharm.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cabaretti Charm
+ * {R}{G}{W}
+ * Instant
+ * Choose one —
+ * • Cabaretti Charm deals damage equal to the number of creatures you control to target creature or planeswalker.
+ * • Creatures you control get +1/+1 and gain trample until end of turn.
+ * • Create two 1/1 green and white Citizen creature tokens.
+ *
+ * The three-mode charm shape: a dynamic burn mode counting the board
+ * ([DynamicAmounts.creaturesYouControl]), the one-group-said-twice pump
+ * ([Patterns.Group.pumpAndGrantToAll], the same call Overcome makes), and the set's shared
+ * 1/1 green and white Citizen token.
+ */
+val CabarettiCharm = card("Cabaretti Charm") {
+    manaCost = "{R}{G}{W}"
+    colorIdentity = "GRW"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n• Cabaretti Charm deals damage equal to the number of creatures you control to target creature or planeswalker.\n• Creatures you control get +1/+1 and gain trample until end of turn.\n• Create two 1/1 green and white Citizen creature tokens."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Cabaretti Charm deals damage equal to the number of creatures you control to target creature or planeswalker") {
+                val t = target("target", Targets.CreatureOrPlaneswalker)
+                effect = Effects.DealDamage(DynamicAmounts.creaturesYouControl(), t)
+            }
+            mode("Creatures you control get +1/+1 and gain trample until end of turn") {
+                effect = Patterns.Group.pumpAndGrantToAll(
+                    power = 1,
+                    toughness = 1,
+                    keyword = Keyword.TRAMPLE,
+                    filter = Filters.Group.creaturesYouControl,
+                )
+            }
+            mode("Create two 1/1 green and white Citizen creature tokens") {
+                effect = Effects.CreateToken(
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.GREEN, Color.WHITE),
+                    creatureTypes = setOf("Citizen"),
+                    count = 2,
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "173"
+        artist = "Steve Argyle"
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/08f33c8a-8e93-4296-964b-da132a854b3b.jpg?1783923091"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CabarettiInitiate.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CabarettiInitiate.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cabaretti Initiate
+ * {G}
+ * Creature — Raccoon Citizen
+ * 1 / 2
+ * {2}{R/W}: This creature gains double strike until end of turn.
+ */
+val CabarettiInitiate = card("Cabaretti Initiate") {
+    manaCost = "{G}"
+    colorIdentity = "GRW"
+    typeLine = "Creature — Raccoon Citizen"
+    oracleText = "{2}{R/W}: This creature gains double strike until end of turn."
+    power = 1
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{R/W}")
+        effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "137"
+        artist = "Jason A. Engle"
+        flavorText = "\"Now there's a fellow who knows how to have a good time!\"\n—Jetmir"
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6c691f62-009b-4178-8e8b-d6e88229a282.jpg?1783923106"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CelebrityFencer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CelebrityFencer.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Celebrity Fencer
+ * {3}{W}
+ * Creature — Elf Druid
+ * 3 / 2
+ * Alliance — Whenever another creature you control enters, put a +1/+1 counter on this creature.
+ *
+ * "Alliance" is a pure ability word, so this is the plain [Triggers.OtherCreatureEnters] (OTHER
+ * binding over creatures you control); the ability word lives only in the printed text.
+ */
+val CelebrityFencer = card("Celebrity Fencer") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elf Druid"
+    oracleText = "Alliance — Whenever another creature you control enters, put a +1/+1 counter on this creature."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Alliance — Whenever another creature you control enters, put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "7"
+        artist = "Inka Schulz"
+        flavorText = "After a brief but memorable incident at her first performance, she was never heckled again."
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5afb5c5c-06e0-4b11-ad07-aef7be6e2cd4.jpg?1783923161"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/ChromeCat.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/ChromeCat.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chrome Cat
+ * {3}
+ * Artifact Creature — Cat
+ * 3 / 2
+ * When this creature enters, scry 1.
+ */
+val ChromeCat = card("Chrome Cat") {
+    manaCost = "{3}"
+    typeLine = "Artifact Creature — Cat"
+    oracleText = "When this creature enters, scry 1."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Scry(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "236"
+        artist = "Joe Slucher"
+        flavorText = "\"I always say, 'If it's breathing, it's lying.' Luckily my friend here does neither.\"\n—Lord Xander"
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85da50ba-2061-40f0-b3af-950b87f812cd.jpg?1783923062"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CivicGardener.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CivicGardener.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Civic Gardener
+ * {1}{G}
+ * Creature — Human Citizen
+ * 2 / 2
+ * Whenever this creature attacks, untap target creature or land.
+ */
+val CivicGardener = card("Civic Gardener") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Citizen"
+    oracleText = "Whenever this creature attacks, untap target creature or land."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val t = target("target", TargetObject(filter = TargetFilter.CreatureOrLandPermanent))
+        effect = Effects.Untap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "140"
+        artist = "Drew Baker"
+        flavorText = "\"I've told you knuckleheads a hundred times: You can kill 'em here, but bury the bodies somewhere else. If you disturb my prized azaleas again, you'd better dig a second hole for yourself!\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f58d39d7-62bf-43c8-97b3-0f9069af0e29.jpg?1783923105"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CleanupCrew.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CleanupCrew.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Cleanup Crew
+ * {4}{G}{G}
+ * Creature — Human Citizen
+ * 6 / 6
+ * When this creature enters, choose one —
+ * • Destroy target artifact.
+ * • Destroy target enchantment.
+ * • Exile target card from a graveyard.
+ * • You gain 4 life.
+ *
+ * A four-mode "choose one" enters trigger via [ModalEffect.chooseOne] (Exhibition Magician's shape
+ * with two more modes): each targeting mode carries its own requirement, and the life mode is the
+ * lone [Mode.noTarget].
+ */
+val CleanupCrew = card("Cleanup Crew") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Citizen"
+    oracleText = "When this creature enters, choose one —\n• Destroy target artifact.\n• Destroy target enchantment.\n• Exile target card from a graveyard.\n• You gain 4 life."
+    power = 6
+    toughness = 6
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect.chooseOne(
+            Mode.withTarget(
+                effect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+                target = TargetObject(filter = TargetFilter.Artifact),
+                description = "Destroy target artifact"
+            ),
+            Mode.withTarget(
+                effect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+                target = TargetObject(filter = TargetFilter.Enchantment),
+                description = "Destroy target enchantment"
+            ),
+            Mode.withTarget(
+                effect = Effects.Exile(EffectTarget.ContextTarget(0)),
+                target = TargetObject(filter = TargetFilter.CardInGraveyard),
+                description = "Exile target card from a graveyard"
+            ),
+            Mode.noTarget(
+                Effects.GainLife(4),
+                "You gain 4 life"
+            )
+        )
+        description = "When this creature enters, choose one — Destroy target artifact; or destroy " +
+            "target enchantment; or exile target card from a graveyard; or you gain 4 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "141"
+        artist = "Josu Hernaiz"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/5354868b-c96b-4765-b0c8-8895093e4019.jpg?1783923105"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CouriersBriefcase.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CouriersBriefcase.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Courier's Briefcase
+ * {1}{G}
+ * Artifact — Treasure
+ * When this artifact enters, create a 1/1 green and white Citizen creature token.
+ * {T}, Sacrifice this artifact: Add one mana of any color.
+ * {W}{U}{B}{R}{G}, {T}, Sacrifice this artifact: Draw three cards.
+ *
+ * The card *is* a Treasure rather than making one, so the Treasure mana ability is spelled out here
+ * the way Buried Treasure spells it out — [Costs.Composite] of tap plus sacrifice-self over
+ * [Effects.AddAnyColorMana], flagged `manaAbility`. The five-color ability adds the mana atom in
+ * front of the same tap/sacrifice pair.
+ */
+val CouriersBriefcase = card("Courier's Briefcase") {
+    manaCost = "{1}{G}"
+    colorIdentity = "BGRUW"
+    typeLine = "Artifact — Treasure"
+    oracleText = "When this artifact enters, create a 1/1 green and white Citizen creature token.\n{T}, Sacrifice this artifact: Add one mana of any color.\n{W}{U}{B}{R}{G}, {T}, Sacrifice this artifact: Draw three cards."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN, Color.WHITE),
+            creatureTypes = setOf("Citizen"),
+        )
+        description = "When this artifact enters, create a 1/1 green and white Citizen creature token."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}{U}{B}{R}{G}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(3)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "142"
+        artist = "Josu Hernaiz"
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2f375674-7ae2-4430-b1f3-c26fa5b201d1.jpg?1783923106"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CrookedCustodian.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CrookedCustodian.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Crooked Custodian
+ * {1}{B}
+ * Creature — Ogre Rogue
+ * 3 / 2
+ * This creature enters tapped.
+ */
+val CrookedCustodian = card("Crooked Custodian") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Ogre Rogue"
+    oracleText = "This creature enters tapped."
+    power = 3
+    toughness = 2
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "71"
+        artist = "Tony Foti"
+        flavorText = "\"Nothing to see here. Just carrying a carpet. Yes, the carpet wears boots. Stop asking questions.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/723d6f60-3e8a-4c58-8b3c-9ba59a01c867.jpg?1783923135"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CutthroatContender.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CutthroatContender.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cutthroat Contender
+ * {B}
+ * Creature — Vampire Warrior
+ * 1 / 1
+ * Pay 1 life: This creature gets +1/+0 until end of turn. Activate only once each turn.
+ */
+val CutthroatContender = card("Cutthroat Contender") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Warrior"
+    oracleText = "Pay 1 life: This creature gets +1/+0 until end of turn. Activate only once each turn."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.PayLife(1)
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "73"
+        artist = "Mark Behm"
+        flavorText = "The fights may sometimes be rigged, but the front-row spectators know the wounds are real."
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6b23b3e4-58cf-4b5d-bdcb-410a403b4987.jpg?1783923133"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/DaringEscape.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/DaringEscape.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Daring Escape
+ * {R}
+ * Instant
+ * Target creature gets +1/+0 and gains first strike until end of turn. Scry 1.
+ */
+val DaringEscape = card("Daring Escape") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1."
+
+    spell {
+        val creature = target("target creature to get +1/+0 and first strike", TargetCreature())
+        effect = Effects.ModifyStats(1, 0, creature)
+            .then(Effects.GrantKeyword(Keyword.FIRST_STRIKE, creature))
+            .then(Effects.Scry(1))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "104"
+        artist = "Ekaterina Burmak"
+        flavorText = "As the Adversary's forces descended upon the gala, Elspeth whispered to Giada, \"I can get you out of here, but we have to go now.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d09dbcd-188b-4b52-943e-947cbf2c0002.jpg?1783923120"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/DarlingOfTheMasses.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/DarlingOfTheMasses.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Darling of the Masses
+ * {2}{G}{W}
+ * Creature — Elf Citizen
+ * 2 / 4
+ * Other Citizens you control get +1/+0.
+ * Whenever this creature attacks, create a 1/1 green and white Citizen creature token.
+ *
+ * "Other Citizens you control" is a bare tribal noun, so the anthem's filter is a *permanent*
+ * filter with the subtype ([GameObjectFilter.Permanent] + `withSubtype`), not a creature filter,
+ * with `excludeSelf` for "other".
+ */
+val DarlingOfTheMasses = card("Darling of the Masses") {
+    manaCost = "{2}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Elf Citizen"
+    oracleText = "Other Citizens you control get +1/+0.\nWhenever this creature attacks, create a 1/1 green and white Citizen creature token."
+    power = 2
+    toughness = 4
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 0,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype("Citizen").youControl(),
+                excludeSelf = true,
+            ),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN, Color.WHITE),
+            creatureTypes = setOf("Citizen"),
+        )
+        description = "Whenever this creature attacks, create a 1/1 green and white Citizen creature token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "181"
+        artist = "Mila Pesic"
+        flavorText = "The people flocked to the glittering parade, turning their backs on the threats in the shadows."
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52aa9815-6b47-4c80-87c7-4277166ea0df.jpg?1783923087"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/DemonsDue.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/DemonsDue.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Demon's Due
+ * {3}{B}
+ * Instant
+ * Scry 2, then draw two cards. You lose 2 life.
+ */
+val DemonsDue = card("Demon's Due") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Scry 2, then draw two cards. You lose 2 life."
+
+    spell {
+        effect = Effects.Scry(2)
+            .then(Effects.DrawCards(2))
+            .then(Effects.LoseLife(2, EffectTarget.Controller))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "75"
+        artist = "Slawomir Maniak"
+        flavorText = "Ob Nixilis extends his hand not in partnership, but to affirm your subservience."
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e59fb98-c887-42f1-a620-9e6b40b94cb5.jpg?1783923132"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/DisciplinedDuelist.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/DisciplinedDuelist.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Disciplined Duelist
+ * {G}{W}{U}
+ * Creature — Human Citizen
+ * 2 / 1
+ * Double strike
+ * This creature enters with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)
+ *
+ * The shield counter is the engine's CR 122.1c counter — its replacement + prevention pair is
+ * wired at the damage and destroy chokepoints, so entering with one is the plain
+ * [EntersWithCounters] as-enters replacement and nothing else is needed card-side.
+ */
+val DisciplinedDuelist = card("Disciplined Duelist") {
+    manaCost = "{G}{W}{U}"
+    colorIdentity = "GUW"
+    typeLine = "Creature — Human Citizen"
+    oracleText = "Double strike\nThis creature enters with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)"
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.DOUBLE_STRIKE)
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.SHIELD),
+            count = 1,
+            selfOnly = true,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "182"
+        artist = "Josu Hernaiz"
+        flavorText = "Brokers agents defend their charges by all means available, from intricate logic to blunt force trauma."
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e23cdb0a-e114-47f8-aceb-c54c4683bbc5.jpg?1783923087"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/ExhibitionMagician.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/ExhibitionMagician.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+
+/**
+ * Exhibition Magician
+ * {2}{R}
+ * Creature — Human Wizard
+ * 2 / 1
+ * When this creature enters, choose one —
+ * • Create a 1/1 green and white Citizen creature token.
+ * • Create a Treasure token. (It's an artifact with "{T}, Sacrifice this token: Add one mana of any color.")
+ *
+ * A "choose one" enters trigger via [ModalEffect.chooseOne] (same shape as Damage Control Crew);
+ * neither mode targets, so both are [Mode.noTarget] — the Citizen is the shared
+ * [Effects.CreateToken] and the Treasure the predefined [Effects.CreateTreasure].
+ */
+val ExhibitionMagician = card("Exhibition Magician") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "When this creature enters, choose one —\n• Create a 1/1 green and white Citizen creature token.\n• Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(
+                effect = Effects.CreateToken(
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.GREEN, Color.WHITE),
+                    creatureTypes = setOf("Citizen"),
+                ),
+                description = "Create a 1/1 green and white Citizen creature token."
+            ),
+            Mode.noTarget(
+                effect = Effects.CreateTreasure(1),
+                description = "Create a Treasure token."
+            )
+        )
+        description = "When this creature enters, choose one — Create a 1/1 green and white Citizen creature token. • Create a Treasure token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "106"
+        artist = "Greg Staples"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cbb4479f-3157-44b4-b18b-7553c7513118.jpg?1783923118"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/FleetfootDancer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/FleetfootDancer.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fleetfoot Dancer
+ * {1}{R}{G}{W}
+ * Creature — Elf Druid
+ * 4 / 4
+ * Trample, lifelink, haste
+ */
+val FleetfootDancer = card("Fleetfoot Dancer") {
+    manaCost = "{1}{R}{G}{W}"
+    colorIdentity = "GRW"
+    typeLine = "Creature — Elf Druid"
+    oracleText = "Trample, lifelink, haste"
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.TRAMPLE, Keyword.LIFELINK, Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "188"
+        artist = "Joshua Raphael"
+        flavorText = "The Vanto Beatdown began as an improvised dance-battle at the Rose Room lounge. When word spread of how many were slain at the first event, it became a citywide obsession."
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/2473d738-fe15-402a-ad24-0d6e5c4dfda3.jpg?1783923085"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/GildedPinions.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/GildedPinions.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Gilded Pinions
+ * {2}
+ * Artifact — Equipment
+ * When this Equipment enters, create a Treasure token. (It's an artifact with "{T}, Sacrifice this token: Add one mana of any color.")
+ * Equipped creature has flying.
+ * Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)
+ *
+ * The enters trigger is the shared [Effects.CreateTreasure]; the equipped-creature grant is the
+ * default-filter [GrantKeyword] (Neurok Hoversail's shape), and `equipAbility("{2}")` lowers
+ * CR 702.6a's sorcery-speed attach ability.
+ */
+val GildedPinions = card("Gilded Pinions") {
+    manaCost = "{2}"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nEquipped creature has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateTreasure(1)
+        description = "When this Equipment enters, create a Treasure token."
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "238"
+        artist = "Irina Nordsol"
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dca8554a-f74c-4d2d-95b6-ef6e74431d7c.jpg?1783923062"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/Glittermonger.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/Glittermonger.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glittermonger
+ * {3}{G}
+ * Creature — Elf Rogue
+ * 1 / 4
+ * {T}: Create a Treasure token. (It's an artifact with "{T}, Sacrifice this token: Add one mana of any color.")
+ *
+ * A bare tap-cost activated ability over the shared [Effects.CreateTreasure] predefined token — no
+ * mana, no sacrifice, so the cost is [Costs.Tap] on its own rather than a composite.
+ */
+val Glittermonger = card("Glittermonger") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Rogue"
+    oracleText = "{T}: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+    power = 1
+    toughness = 4
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.CreateTreasure(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "149"
+        artist = "Evyn Fong"
+        flavorText = "Street corners in the Mezzio are a tantalizing bazaar of the fantastic, the illicit, and the fake."
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a3d70d2-0604-41b3-8dd1-bfeb05832271.jpg?1783923102"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/IncandescentAria.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/IncandescentAria.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Incandescent Aria
+ * {R}{G}{W}
+ * Sorcery
+ * Incandescent Aria deals 3 damage to each nontoken creature.
+ *
+ * Slagstorm's sweep with one predicate added: "nontoken" is a card predicate on the group's
+ * base filter ([GameObjectFilter.nontoken]), so tokens are simply outside the iterated group.
+ */
+val IncandescentAria = card("Incandescent Aria") {
+    manaCost = "{R}{G}{W}"
+    colorIdentity = "GRW"
+    typeLine = "Sorcery"
+    oracleText = "Incandescent Aria deals 3 damage to each nontoken creature."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.nontoken()),
+            Effects.DealDamage(3, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "192"
+        artist = "Randy Gallegos"
+        flavorText = "As the assassins converged on Kitt Kanto, she struck a high note and held it, unbroken, for nearly a minute. When the room fell silent, she was surrounded only by rose petals falling gently to the floor."
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/77e2ed9e-ee1d-440a-94b4-d4b17d30b800.jpg?1783923082"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/Jackhammer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/Jackhammer.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Jackhammer
+ * {1}{R}
+ * Artifact — Equipment
+ * Equipped creature gets +2/+0.
+ * Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)
+ */
+val Jackhammer = card("Jackhammer") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(+2, +0, Filters.EquippedCreature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "John Severin Brassell"
+        flavorText = "\"Subtlety is overrated.\"\n—Mr. Orfeo, the Boulder"
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d74ba9fe-2dcb-4da7-ba64-cd932edb5b24.jpg?1783923118"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/JetmirsGarden.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/JetmirsGarden.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Jetmir's Garden
+ * Land — Mountain Forest Plains
+ * ({T}: Add {R}, {G}, or {W}.)
+ * This land enters tapped.
+ * Cycling {3} ({3}, Discard this card: Draw a card.)
+ */
+val JetmirsGarden = card("Jetmir's Garden") {
+    colorIdentity = "GRW"
+    typeLine = "Land — Mountain Forest Plains"
+    oracleText = "({T}: Add {R}, {G}, or {W}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    keywordAbility(KeywordAbility.cycling("{3}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "250"
+        artist = "Kasia 'Kafis' Zielińska"
+        flavorText = "The parklike Cabaretti grounds offer rest, food, and the perfect place to shake off a tail."
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/26d40e03-6de4-4373-9fbf-04c1dd79e995.jpg?1783923058"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/JewelThief.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/JewelThief.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jewel Thief
+ * {2}{G}
+ * Creature — Cat Rogue
+ * 3 / 3
+ * Vigilance, trample
+ * When this creature enters, create a Treasure token. (It's an artifact with "{T}, Sacrifice this token: Add one mana of any color.")
+ *
+ * Two simple keywords plus the shared enters trigger over [Effects.CreateTreasure] — the same
+ * predefined-token shape Ticket Tortoise uses, without the intervening-if.
+ */
+val JewelThief = card("Jewel Thief") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat Rogue"
+    oracleText = "Vigilance, trample\nWhen this creature enters, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.VIGILANCE, Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateTreasure(1)
+        description = "When this creature enters, create a Treasure token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "151"
+        artist = "Joe Slucher"
+        flavorText = "\"They can afford the loss. They build it into their prices.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/736e498e-1245-40c1-96a4-c9bcfd1cfe1f.jpg?1783923101"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/KillShotReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/KillShotReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kill Shot reprint in SNC. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in `definitions/ktk/cards/KillShot.kt`; this file contributes only presentation data.
+ */
+val KillShotReprint = Printing(
+    oracleId = "e1ce32c7-a882-4d3a-9fd6-e5e2943382fb",
+    name = "Kill Shot",
+    setCode = "SNC",
+    collectorNumber = "19",
+    scryfallId = "61b0b9a3-8f50-4fba-9978-409f3369afa6",
+    artist = "Josh Hass",
+    imageUri = "https://cards.scryfall.io/normal/front/6/1/61b0b9a3-8f50-4fba-9978-409f3369afa6.jpg?1783923156",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/KnockoutBlow.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/KnockoutBlow.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Knockout Blow
+ * {2}{W}
+ * Instant
+ * This spell costs {2} less to cast if it targets a red creature.
+ * Knockout Blow deals 4 damage to target attacking or blocking creature and you gain 2 life.
+ *
+ * The discount is the Ride's End shape — [SpellCostTarget.SelfCast] over
+ * [CostReductionSource.FixedIfAnyTargetMatches], a *generic* reduction gated on the spell's own
+ * chosen target matching a red-creature filter.
+ */
+val KnockoutBlow = card("Knockout Blow") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "This spell costs {2} less to cast if it targets a red creature.\nKnockout Blow deals 4 damage to target attacking or blocking creature and you gain 2 life."
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature))
+        effect = Effects.Composite(
+            Effects.DealDamage(4, t),
+            Effects.GainLife(2)
+        )
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfAnyTargetMatches(
+                    amount = 2,
+                    filter = GameObjectFilter.Creature.withColor(Color.RED),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "20"
+        artist = "Zoltan Boros"
+        flavorText = "\"Subsequent efforts to deconstruct this facility will be punished with increasing severity.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b00bbec-61d0-464c-bf82-4ecf5ddb3451.jpg?1783923155"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/LightEmUp.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/LightEmUp.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Light 'Em Up
+ * {1}{R}
+ * Sorcery
+ * Casualty 2 (As you cast this spell, you may sacrifice a creature with power 2 or greater. When you do, copy this spell and you may choose a new target for the copy.)
+ * Light 'Em Up deals 2 damage to target creature or planeswalker.
+ *
+ * Casualty 2 (CR 702.153) is the printed [KeywordAbility.Casualty]; the reflexive copy it queues
+ * may choose a new target.
+ */
+val LightEmUp = card("Light 'Em Up") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Casualty 2 (As you cast this spell, you may sacrifice a creature with power 2 or greater. When you do, copy this spell and you may choose a new target for the copy.)\nLight 'Em Up deals 2 damage to target creature or planeswalker."
+
+    keywordAbility(KeywordAbility.casualty(2))
+
+    spell {
+        val t = target("target", Targets.CreatureOrPlaneswalker)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "113"
+        artist = "Tony Foti"
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/ee31d56a-9b7e-4de0-81cb-3b7c76b6fbd5.jpg?1783923117"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/MidnightAssassin.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/MidnightAssassin.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Midnight Assassin
+ * {2}{B}
+ * Creature — Vampire Assassin
+ * 1 / 2
+ * Flying
+ * Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)
+ */
+val MidnightAssassin = card("Midnight Assassin") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Assassin"
+    oracleText = "Flying\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)"
+    power = 1
+    toughness = 2
+
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Christina Davis"
+        flavorText = "The broad avenues and graceful spires of Park Heights are the playground of the affluent. After nightfall, they also make a fine hunting ground."
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02a4a5b3-0477-4709-8bce-3e01f54001b6.jpg?1783923128"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/MurderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/MurderReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Murder reprint in SNC. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in `definitions/m13/cards/Murder.kt`; this file contributes only presentation data.
+ */
+val MurderReprint = Printing(
+    oracleId = "938b4e2c-88d9-4637-bc00-e228920c9a78",
+    name = "Murder",
+    setCode = "SNC",
+    collectorNumber = "88",
+    scryfallId = "1c13ac76-7cd9-456f-9b89-92bfa07c64c5",
+    artist = "Yongjae Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/1/c/1c13ac76-7cd9-456f-9b89-92bfa07c64c5.jpg?1783923127",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/ObscuraInitiate.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/ObscuraInitiate.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Obscura Initiate
+ * {2}{U}
+ * Creature — Bird Citizen
+ * 2 / 2
+ * Flying
+ * {1}{W/B}: This creature gains lifelink until end of turn.
+ */
+val ObscuraInitiate = card("Obscura Initiate") {
+    manaCost = "{2}{U}"
+    colorIdentity = "BUW"
+    typeLine = "Creature — Bird Citizen"
+    oracleText = "Flying\n{1}{W/B}: This creature gains lifelink until end of turn."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W/B}")
+        effect = Effects.GrantKeyword(Keyword.LIFELINK, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "Kim Sokol"
+        flavorText = "Obscura initiates are required to bring a gift of information. They are judged on both how useful it is and how hard it was to obtain."
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67774a11-158b-437c-ac16-2d42fbb5c223.jpg?1783923142"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/OminousParcel.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/OminousParcel.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Ominous Parcel
+ * {1}
+ * Artifact
+ * {2}, {T}, Sacrifice this artifact: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.
+ * {5}, {T}, Sacrifice this artifact: It deals 4 damage to target creature.
+ */
+val OminousParcel = card("Ominous Parcel") {
+    manaCost = "{1}"
+    typeLine = "Artifact"
+    oracleText = "{2}, {T}, Sacrifice this artifact: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n{5}, {T}, Sacrifice this artifact: It deals 4 damage to target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap, Costs.SacrificeSelf)
+        val t = target("target", Targets.Creature)
+        effect = Effects.DealDamage(4, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "241"
+        artist = "Joe Slucher"
+        flavorText = "The rest of Anhelo's assistant arrived over the following week."
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e1691374-e9f2-4a8b-abdb-0bb1dbc96715.jpg?1783923059"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/RacersRing.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/RacersRing.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Racers' Ring
+ * Land
+ * This land enters tapped.
+ * {T}: Add {R} or {G}.
+ * {2}{R}{G}, {T}, Sacrifice this land: Draw a card.
+ */
+val RacersRing = card("Racers' Ring") {
+    colorIdentity = "GR"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n{T}: Add {R} or {G}.\n{2}{R}{G}, {T}, Sacrifice this land: Draw a card."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}{G}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "253"
+        artist = "Sam White"
+        flavorText = "Purchasing chrome racehorses with cash is a common means of dispersing mysterious income."
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2a11bdb2-a269-4038-85f3-69fbd02982e9.jpg?1783923055"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/RaffinesTower.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/RaffinesTower.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Raffine's Tower
+ * Land — Plains Island Swamp
+ * ({T}: Add {W}, {U}, or {B}.)
+ * This land enters tapped.
+ * Cycling {3} ({3}, Discard this card: Draw a card.)
+ */
+val RaffinesTower = card("Raffine's Tower") {
+    colorIdentity = "BUW"
+    typeLine = "Land — Plains Island Swamp"
+    oracleText = "({T}: Add {W}, {U}, or {B}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    keywordAbility(KeywordAbility.cycling("{3}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "254"
+        artist = "Sam White"
+        flavorText = "The Obscura's Cloud Spire dominates the skyline, its eye a beacon of progress that sees all."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2c56479-4bee-4edb-80d7-4af010b7c793.jpg?1783923055"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/ReadyToRumble.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/ReadyToRumble.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Ready to Rumble
+ * {4}{R}
+ * Sorcery
+ * Choose one —
+ * • Ready to Rumble deals 5 damage to target creature or planeswalker.
+ * • Destroy target artifact.
+ */
+val ReadyToRumble = card("Ready to Rumble") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n• Ready to Rumble deals 5 damage to target creature or planeswalker.\n• Destroy target artifact."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Ready to Rumble deals 5 damage to target creature or planeswalker") {
+                val t = target("target", Targets.CreatureOrPlaneswalker)
+                effect = Effects.DealDamage(5, t)
+            }
+            mode("Destroy target artifact") {
+                val t = target("target", TargetObject(filter = TargetFilter.Artifact))
+                effect = Effects.Destroy(t)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "119"
+        artist = "Josu Hernaiz"
+        flavorText = "\"It's too quiet tonight. Go make trouble.\"\n—Ziatora"
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/16998689-345d-41e3-a368-e97b696ed689.jpg?1783923115"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/RiveteersInitiate.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/RiveteersInitiate.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Riveteers Initiate
+ * {1}{R}
+ * Creature — Lizard Citizen
+ * 2 / 2
+ * {1}{B/G}: This creature gains deathtouch until end of turn.
+ */
+val RiveteersInitiate = card("Riveteers Initiate") {
+    manaCost = "{1}{R}"
+    colorIdentity = "BGR"
+    typeLine = "Creature — Lizard Citizen"
+    oracleText = "{1}{B/G}: This creature gains deathtouch until end of turn."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{B/G}")
+        effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "120"
+        artist = "Svetlin Velinov"
+        flavorText = "Young viashino flock to the Riveteers for Ziatora's leadership, eager to unleash their own inner dragons."
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2e65a50-d2bc-43a0-a9d4-0e846d170f78.jpg?1783923114"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/RobTheArchives.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/RobTheArchives.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Rob the Archives
+ * {1}{R}
+ * Sorcery
+ * Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)
+ * Exile the top two cards of your library. You may play those cards this turn.
+ *
+ * Casualty 1 (CR 702.153) is the printed [KeywordAbility.Casualty]. The body is the plain impulse
+ * draw — [Patterns.Exile.impulse] with count = 2 and the default end-of-turn play window.
+ */
+val RobTheArchives = card("Rob the Archives") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)\nExile the top two cards of your library. You may play those cards this turn."
+
+    keywordAbility(KeywordAbility.casualty(1))
+
+    spell {
+        effect = Patterns.Exile.impulse(count = 2)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "122"
+        artist = "Steve Argyle"
+        flavorText = "\"Well, I guess stealth's out of the question.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3ec95f6-88c8-4daf-882f-8b4bc73452c3.jpg?1783923112"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/SkybridgeTowers.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/SkybridgeTowers.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Skybridge Towers
+ * Land
+ * This land enters tapped.
+ * {T}: Add {W} or {U}.
+ * {2}{W}{U}, {T}, Sacrifice this land: Draw a card.
+ */
+val SkybridgeTowers = card("Skybridge Towers") {
+    colorIdentity = "UW"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n{T}: Add {W} or {U}.\n{2}{W}{U}, {T}, Sacrifice this land: Draw a card."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{W}{U}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "256"
+        artist = "Muhammad Firdaus"
+        flavorText = "New Capenna's districts are a series of tiers; wealth and power always rise to the top."
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e28c871f-a96a-4e7d-a159-2e93aeb276d4.jpg?1783923054"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/SocialClimber.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/SocialClimber.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Social Climber
+ * {2}{G}
+ * Creature — Human Druid
+ * 3 / 2
+ * Alliance — Whenever another creature you control enters, you gain 1 life.
+ *
+ * "Alliance" is a pure ability word, so this is the plain [Triggers.OtherCreatureEnters] (OTHER
+ * binding over creatures you control); the ability word lives only in the printed text.
+ */
+val SocialClimber = card("Social Climber") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Druid"
+    oracleText = "Alliance — Whenever another creature you control enters, you gain 1 life."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = Effects.GainLife(1)
+        description = "Alliance — Whenever another creature you control enters, you gain 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "157"
+        artist = "Carly Mazur"
+        flavorText = "\"It's all about who you know, darling. And now you're lucky enough to know me.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9fb74fd-767f-4dd4-822a-828d59f633ad.jpg?1783923098"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/SparasHeadquarters.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/SparasHeadquarters.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Spara's Headquarters
+ * Land — Forest Plains Island
+ * ({T}: Add {G}, {W}, or {U}.)
+ * This land enters tapped.
+ * Cycling {3} ({3}, Discard this card: Draw a card.)
+ */
+val SparasHeadquarters = card("Spara's Headquarters") {
+    colorIdentity = "GUW"
+    typeLine = "Land — Forest Plains Island"
+    oracleText = "({T}: Add {G}, {W}, or {U}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    keywordAbility(KeywordAbility.cycling("{3}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "257"
+        artist = "Kieran Yanner"
+        flavorText = "To most, the Nido Sanctuary is an office complex. To the Brokers, it's a vault of secrets."
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/7363f1fb-9af3-4212-921f-d59533faf0e5.jpg?1783923052"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/Strangle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/Strangle.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreatureOrPlaneswalker
+
+/**
+ * Strangle
+ * {R}
+ * Sorcery
+ * Strangle deals 3 damage to target creature or planeswalker.
+ */
+val Strangle = card("Strangle") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Strangle deals 3 damage to target creature or planeswalker."
+
+    spell {
+        val victim = target("target creature or planeswalker", TargetCreatureOrPlaneswalker())
+        effect = Effects.DealDamage(3, victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "125"
+        artist = "Vincent Proce"
+        flavorText = "They'd warned him greed would be the death of him. He never thought to take it literally."
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b91d727-c0ee-4bf0-8c7d-8475ecb88083.jpg?1783923112"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/StreetsOfNewCapennaBasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/StreetsOfNewCapennaBasicLands.kt
@@ -1,0 +1,162 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Streets of New Capenna Basic Lands
+ *
+ * SNC contains 4 art variants of each basic land type, all booster-eligible:
+ * cards 262-271 (two standard-frame artists per type) and 272-281 (two full-art
+ * "New Capenna skyline" treatments per type).
+ */
+
+// =============================================================================
+// Plains (Cards 262, 263, 272, 273)
+// =============================================================================
+
+val SncPlains262 = basicLand("Plains") {
+    collectorNumber = "262"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8bbb3646-c427-4302-86ac-9ac28d045959.jpg?1783923050"
+}
+
+val SncPlains263 = basicLand("Plains") {
+    collectorNumber = "263"
+    artist = "Thomas Stoop"
+    imageUri = "https://cards.scryfall.io/normal/front/a/a/aa6f0743-c433-4348-bcef-20cfe7b28293.jpg?1783923051"
+}
+
+val SncPlains272 = basicLand("Plains") {
+    collectorNumber = "272"
+    artist = "Elektrodeko"
+    imageUri = "https://cards.scryfall.io/normal/front/e/8/e882099c-63cd-42f0-b160-35e6922106b1.jpg?1783923048"
+}
+
+val SncPlains273 = basicLand("Plains") {
+    collectorNumber = "273"
+    artist = "Olga Tereshenko"
+    imageUri = "https://cards.scryfall.io/normal/front/a/a/aa69cedc-49ce-48f3-88e1-94b9bc061bf4.jpg?1783923047"
+}
+
+// =============================================================================
+// Island (Cards 264, 265, 274, 275)
+// =============================================================================
+
+val SncIsland264 = basicLand("Island") {
+    collectorNumber = "264"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/2/e/2ef2c956-cf03-462c-8981-ae80edfc0c5a.jpg?1783923049"
+}
+
+val SncIsland265 = basicLand("Island") {
+    collectorNumber = "265"
+    artist = "Jedd Chevrier"
+    imageUri = "https://cards.scryfall.io/normal/front/8/d/8dd1b4d2-ccf0-498d-81e0-c9d755f5eb13.jpg?1783923049"
+}
+
+val SncIsland274 = basicLand("Island") {
+    collectorNumber = "274"
+    artist = "Matteo Bassini"
+    imageUri = "https://cards.scryfall.io/normal/front/8/2/8221d15c-c993-4345-a6bb-6a7d215e3273.jpg?1783923046"
+}
+
+val SncIsland275 = basicLand("Island") {
+    collectorNumber = "275"
+    artist = "WFlemming Illustration"
+    imageUri = "https://cards.scryfall.io/normal/front/5/a/5aaba7cd-c1dc-49cf-8d63-8bb3594a6541.jpg?1783923046"
+}
+
+// =============================================================================
+// Swamp (Cards 266, 267, 276, 277)
+// =============================================================================
+
+val SncSwamp266 = basicLand("Swamp") {
+    collectorNumber = "266"
+    artist = "Christian Dimitrov"
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b0175a2a-db46-4d25-ab8e-feca7e565b8d.jpg?1783923049"
+}
+
+val SncSwamp267 = basicLand("Swamp") {
+    collectorNumber = "267"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/0/b/0b8515d2-e8a4-45ab-b361-88eb4ec959bd.jpg?1783923048"
+}
+
+val SncSwamp276 = basicLand("Swamp") {
+    collectorNumber = "276"
+    artist = "Matteo Bassini"
+    imageUri = "https://cards.scryfall.io/normal/front/5/f/5f917d8d-7037-4f11-91f6-1ef96b3541bb.jpg?1783923045"
+}
+
+val SncSwamp277 = basicLand("Swamp") {
+    collectorNumber = "277"
+    artist = "Zoran Cardula"
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b4569823-af23-4eea-acc9-2a2c62bce3b0.jpg?1783923044"
+}
+
+// =============================================================================
+// Mountain (Cards 268, 269, 278, 279)
+// =============================================================================
+
+val SncMountain268 = basicLand("Mountain") {
+    collectorNumber = "268"
+    artist = "Christian Dimitrov"
+    imageUri = "https://cards.scryfall.io/normal/front/f/a/fac247df-aa19-4627-8d65-6ddf5e7e5c8c.jpg?1783923051"
+}
+
+val SncMountain269 = basicLand("Mountain") {
+    collectorNumber = "269"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/4/a/4abb2702-6f5e-4832-9e23-46aaf9f960f8.jpg?1783923049"
+}
+
+val SncMountain278 = basicLand("Mountain") {
+    collectorNumber = "278"
+    artist = "Zbigniew M. Bielak"
+    imageUri = "https://cards.scryfall.io/normal/front/6/a/6a58066e-f9a2-4508-9cc0-908b1cf747e3.jpg?1783923044"
+}
+
+val SncMountain279 = basicLand("Mountain") {
+    collectorNumber = "279"
+    artist = "Ann-Sophie De Steur"
+    imageUri = "https://cards.scryfall.io/normal/front/2/e/2e97dadd-0849-4c18-9523-4775d09fca9a.jpg?1783923043"
+}
+
+// =============================================================================
+// Forest (Cards 270, 271, 280, 281)
+// =============================================================================
+
+val SncForest270 = basicLand("Forest") {
+    collectorNumber = "270"
+    artist = "Christian Dimitrov"
+    imageUri = "https://cards.scryfall.io/normal/front/c/0/c086cb5e-3146-4a41-a471-fcbbf8fa4e09.jpg?1783923046"
+}
+
+val SncForest271 = basicLand("Forest") {
+    collectorNumber = "271"
+    artist = "Thomas Stoop"
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/818442df-fb81-4f1c-bcf2-fbd6b05912ed.jpg?1783923047"
+}
+
+val SncForest280 = basicLand("Forest") {
+    collectorNumber = "280"
+    artist = "Matteo Bassini"
+    imageUri = "https://cards.scryfall.io/normal/front/c/7/c726424a-3336-4e15-9055-4a26371df361.jpg?1783923042"
+}
+
+val SncForest281 = basicLand("Forest") {
+    collectorNumber = "281"
+    artist = "WFlemming Illustration"
+    imageUri = "https://cards.scryfall.io/normal/front/6/3/633eb269-916e-4d79-821e-1f304283416c.jpg?1783923042"
+}
+
+/**
+ * All Streets of New Capenna basic land variants.
+ */
+val StreetsOfNewCapennaBasicLands = listOf(
+    SncPlains262, SncPlains263, SncPlains272, SncPlains273,
+    SncIsland264, SncIsland265, SncIsland274, SncIsland275,
+    SncSwamp266, SncSwamp267, SncSwamp276, SncSwamp277,
+    SncMountain268, SncMountain269, SncMountain278, SncMountain279,
+    SncForest270, SncForest271, SncForest280, SncForest281,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/SuspiciousBookcaseReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/SuspiciousBookcaseReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Suspicious Bookcase reprint in SNC. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in `definitions/m19/cards/SuspiciousBookcase.kt`; this file contributes only presentation data.
+ */
+val SuspiciousBookcaseReprint = Printing(
+    oracleId = "ca611c90-7753-43dd-af91-81694d004eeb",
+    name = "Suspicious Bookcase",
+    setCode = "SNC",
+    collectorNumber = "245",
+    scryfallId = "fc574b42-e1bb-428f-a71f-bc3d7f5451da",
+    artist = "Josu Hernaiz",
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fc574b42-e1bb-428f-a71f-bc3d7f5451da.jpg?1783923059",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/SwoopingProtector.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/SwoopingProtector.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Swooping Protector
+ * {3}{W}
+ * Creature — Bird Citizen
+ * 2 / 1
+ * Flash
+ * Flying
+ * This creature enters with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)
+ *
+ * The shield counter is the engine's CR 122.1c counter — its replacement + prevention pair is
+ * wired at the damage and destroy chokepoints, so entering with one is the plain
+ * [EntersWithCounters] as-enters replacement and nothing else is needed card-side.
+ */
+val SwoopingProtector = card("Swooping Protector") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Citizen"
+    oracleText = "Flash\nFlying\nThis creature enters with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)"
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.SHIELD),
+            count = 1,
+            selfOnly = true,
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "33"
+        artist = "Mark Behm"
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/8713498f-a467-4a11-9de2-53a1bbd0b18b.jpg?1783923149"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/TramwayStation.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/TramwayStation.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Tramway Station
+ * Land
+ * This land enters tapped.
+ * {T}: Add {B} or {R}.
+ * {2}{B}{R}, {T}, Sacrifice this land: Draw a card.
+ */
+val TramwayStation = card("Tramway Station") {
+    colorIdentity = "BR"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n{T}: Add {B} or {R}.\n{2}{B}{R}, {T}, Sacrifice this land: Draw a card."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}{R}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "258"
+        artist = "Alexander Forssberg"
+        flavorText = "A ten-minute ride can take you to the luxury of Park Heights, or the grit of the Caldaia."
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0532304-da6d-45cd-b1e6-4779d3f3b2bc.jpg?1783923053"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/VoidRend.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/VoidRend.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Void Rend
+ * {W}{U}{B}
+ * Instant
+ * This spell can't be countered.
+ * Destroy target nonland permanent.
+ *
+ * "This spell can't be countered" is the card-level [cantBeCountered] flag (the Long Goodbye
+ * idiom) — it stamps `CantBeCounteredComponent` on the spell, which every counter path checks.
+ */
+val VoidRend = card("Void Rend") {
+    manaCost = "{W}{U}{B}"
+    colorIdentity = "BUW"
+    typeLine = "Instant"
+    oracleText = "This spell can't be countered.\nDestroy target nonland permanent."
+
+    cantBeCountered = true
+
+    spell {
+        val t = target("target", TargetPermanent(filter = TargetFilter.NonlandPermanent))
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "230"
+        artist = "Rovina Cai"
+        flavorText = "Bits of the missing agent were discovered in various alleys across all three boroughs."
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2daab74d-d66b-4164-aa19-24e8d5536f7d.jpg?1783923066"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/WarmWelcome.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/WarmWelcome.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Warm Welcome
+ * {2}{G}
+ * Instant
+ * Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. Create a 1/1 green and white Citizen creature token.
+ *
+ * The look-at-top clause is the Star Charter shape via
+ * [Patterns.Library.lookAtTopRevealMatchingToHand] — its defaults already put the remainder on the
+ * bottom of the library in a random order — followed by the shared Citizen [Effects.CreateToken].
+ */
+val WarmWelcome = card("Warm Welcome") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. Create a 1/1 green and white Citizen creature token."
+
+    spell {
+        effect = Effects.Composite(
+            Patterns.Library.lookAtTopRevealMatchingToHand(
+                count = DynamicAmount.Fixed(5),
+                filter = GameObjectFilter.Creature,
+                prompt = "You may reveal a creature card from among them and put it into your hand"
+            ),
+            Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.GREEN, Color.WHITE),
+                creatureTypes = setOf("Citizen"),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "164"
+        artist = "Inka Schulz"
+        flavorText = "\"Welcome to the family. Chef Rocco sends their congratulations.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/bad9e58e-c9a3-4a0d-9a59-71c20a3275b6.jpg?1783923094"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/WaterfrontDistrict.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/WaterfrontDistrict.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Waterfront District
+ * Land
+ * This land enters tapped.
+ * {T}: Add {U} or {B}.
+ * {2}{U}{B}, {T}, Sacrifice this land: Draw a card.
+ */
+val WaterfrontDistrict = card("Waterfront District") {
+    colorIdentity = "BU"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n{T}: Add {U} or {B}.\n{2}{U}{B}, {T}, Sacrifice this land: Draw a card."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{U}{B}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "259"
+        artist = "Alexander Forssberg"
+        flavorText = "The bottom of the dark canals is littered with countless corpses and treasures."
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/debf7aac-4d31-49b4-955b-79036258df69.jpg?1783923052"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/Whack.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/Whack.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Whack
+ * {3}{B}
+ * Sorcery
+ * This spell costs {3} less to cast if it targets a white creature.
+ * Target creature gets -4/-4 until end of turn.
+ *
+ * The discount is the Ride's End shape — [SpellCostTarget.SelfCast] over
+ * [CostReductionSource.FixedIfAnyTargetMatches], a *generic* reduction gated on the spell's own
+ * chosen target matching a white-creature filter.
+ */
+val Whack = card("Whack") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "This spell costs {3} less to cast if it targets a white creature.\nTarget creature gets -4/-4 until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(-4, -4, t)
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfAnyTargetMatches(
+                    amount = 3,
+                    filter = GameObjectFilter.Creature.withColor(Color.WHITE),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99"
+        artist = "John Thacker"
+        flavorText = "\"It's just business. You understand.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c862769d-f8bd-4cb6-b2b2-816179795f8b.jpg?1783923123"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/WreckingCrew.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/WreckingCrew.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wrecking Crew
+ * {4}{R}
+ * Creature — Human Warrior
+ * 4 / 5
+ * Reach (This creature can block creatures with flying.)
+ * Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)
+ */
+val WreckingCrew = card("Wrecking Crew") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warrior"
+    oracleText = "Reach (This creature can block creatures with flying.)\nTrample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)"
+    power = 4
+    toughness = 5
+
+    keywords(Keyword.REACH, Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "132"
+        artist = "Joshua Raphael"
+        flavorText = "They built the neighborhood. They know its weak points. They know all the hiding places. When they come for you, they'll find you and bring the roof down on your head."
+        imageUri = "https://cards.scryfall.io/normal/front/9/2/92691507-b1ce-40d0-87e7-b79e81370511.jpg?1783923111"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/XandersLounge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/XandersLounge.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Xander's Lounge
+ * Land — Island Swamp Mountain
+ * ({T}: Add {U}, {B}, or {R}.)
+ * This land enters tapped.
+ * Cycling {3} ({3}, Discard this card: Draw a card.)
+ */
+val XandersLounge = card("Xander's Lounge") {
+    colorIdentity = "BRU"
+    typeLine = "Land — Island Swamp Mountain"
+    oracleText = "({T}: Add {U}, {B}, or {R}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    keywordAbility(KeywordAbility.cycling("{3}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "260"
+        artist = "James Paick"
+        flavorText = "Maestros agents can lie low in high style at the opulent Shadow Hostel."
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/54f449ff-4025-465e-9ec5-a5cf42c4c9d3.jpg?1783923052"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/ZiatorasProvingGround.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/ZiatorasProvingGround.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Ziatora's Proving Ground
+ * Land — Swamp Mountain Forest
+ * ({T}: Add {B}, {R}, or {G}.)
+ * This land enters tapped.
+ * Cycling {3} ({3}, Discard this card: Draw a card.)
+ */
+val ZiatorasProvingGround = card("Ziatora's Proving Ground") {
+    colorIdentity = "BGR"
+    typeLine = "Land — Swamp Mountain Forest"
+    oracleText = "({T}: Add {B}, {R}, or {G}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    keywordAbility(KeywordAbility.cycling("{3}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "261"
+        artist = "Viko Menezes"
+        flavorText = "Restless Riveteers can always find a sparring partner in the sprawling Treza warehouse."
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75fdce80-e338-4a50-bdc6-786511feaeef.jpg?1783923052"
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BootleggersStashTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BootleggersStashTest.kt
@@ -5,7 +5,7 @@ import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.legalactions.utils.CastPermissionUtils
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
-import com.wingedsheep.mtg.sets.definitions.blc.cards.BootleggersStash
+import com.wingedsheep.mtg.sets.definitions.snc.cards.BootleggersStash
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/BigScoreReprint.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/BigScoreReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.blc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Big Score reprint in Bloomburrow Commander. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in `definitions/snc/cards/BigScore.kt`; this file contributes only presentation data.
+ */
+val BigScoreReprint = Printing(
+    oracleId = "a5cbd257-c836-493e-bb1a-76242619dea2",
+    name = "Big Score",
+    setCode = "BLC",
+    collectorNumber = "193",
+    scryfallId = "243b460e-e67a-40d7-a874-a61fdb011c5a",
+    artist = "Daren Bader",
+    imageUri = "https://cards.scryfall.io/normal/front/2/4/243b460e-e67a-40d7-a874-a61fdb011c5a.jpg?1721429138",
+    releaseDate = "2024-08-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/BootleggersStashReprint.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/BootleggersStashReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.blc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bootleggers' Stash reprint in Bloomburrow Commander. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in `definitions/snc/cards/BootleggersStash.kt`;
+ * this file contributes only presentation data.
+ */
+val BootleggersStashReprint = Printing(
+    oracleId = "d1deba03-b26a-4a0d-b242-24bb3a3f9ea6",
+    name = "Bootleggers' Stash",
+    setCode = "BLC",
+    collectorNumber = "207",
+    scryfallId = "c10525b5-067c-4a30-a069-875f11f2ff19",
+    artist = "Anastasia Ovchinnikova",
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c10525b5-067c-4a30-a069-875f11f2ff19.jpg?1721429213",
+    releaseDate = "2024-08-02",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/SuspiciousBookcaseReprint.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/SuspiciousBookcaseReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.tle.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Suspicious Bookcase reprint in TLE. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in `definitions/m19/cards/SuspiciousBookcase.kt`; this file contributes only presentation data.
+ */
+val SuspiciousBookcaseReprint = Printing(
+    oracleId = "ca611c90-7753-43dd-af91-81694d004eeb",
+    name = "Suspicious Bookcase",
+    setCode = "TLE",
+    collectorNumber = "170",
+    scryfallId = "09af9bc0-1c73-4d16-8116-b76ad23c6b8f",
+    artist = "Kotakan",
+    imageUri = "https://cards.scryfall.io/normal/front/0/9/09af9bc0-1c73-4d16-8116-b76ad23c6b8f.jpg?1783904802",
+    releaseDate = "2025-11-21",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/BLC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLC.json
@@ -574,48 +574,6 @@
     ]
 }
 
-// Big Score
-{
-    "name": "Big Score",
-    "manaCost": "{3}{R}",
-    "typeLine": "Instant",
-    "oracleText": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this token: Add one mana of any color.\")",
-    "script": {
-        "spellEffect": {
-            "type": "Composite",
-            "effects": [
-                {
-                    "type": "DrawCards",
-                    "count": {
-                        "type": "Fixed",
-                        "amount": 2
-                    }
-                },
-                {
-                    "type": "CreatePredefinedToken",
-                    "tokenType": "Treasure",
-                    "count": 2
-                }
-            ]
-        },
-        "additionalCosts": [
-            {
-                "type": "AdditionalAtom",
-                "atom": "AtomDiscard"
-            }
-        ]
-    },
-    "metadata": {
-        "collectorNumber": "193",
-        "rarity": "UNCOMMON",
-        "artist": "Daren Bader",
-        "imageUri": "https://cards.scryfall.io/normal/front/2/4/243b460e-e67a-40d7-a874-a61fdb011c5a.jpg?1721429138"
-    },
-    "colorIdentityOverride": [
-        "RED"
-    ]
-}
-
 // Blasphemous Act
 {
     "name": "Blasphemous Act",
@@ -677,41 +635,6 @@
     },
     "colorIdentityOverride": [
         "RED"
-    ]
-}
-
-// Bootleggers' Stash
-{
-    "name": "Bootleggers' Stash",
-    "manaCost": "{5}{G}",
-    "typeLine": "Artifact",
-    "oracleText": "Lands you control have \"{T}: Create a Treasure token.\"",
-    "script": {
-        "staticAbilities": [
-            {
-                "type": "GrantActivatedAbility",
-                "ability": {
-                    "id": "ability_1",
-                    "cost": "CostTap",
-                    "effect": {
-                        "type": "CreatePredefinedToken",
-                        "tokenType": "Treasure"
-                    }
-                },
-                "filter": {
-                    "baseFilter": "land ctrl:you"
-                }
-            }
-        ]
-    },
-    "metadata": {
-        "collectorNumber": "207",
-        "rarity": "MYTHIC",
-        "artist": "Anastasia Ovchinnikova",
-        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c10525b5-067c-4a30-a069-875f11f2ff19.jpg?1721429213"
-    },
-    "colorIdentityOverride": [
-        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/M19.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M19.json
@@ -1431,6 +1431,65 @@
     ]
 }
 
+// Suspicious Bookcase
+{
+    "name": "Suspicious Bookcase",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Wall",
+    "oracleText": "Defender\n{3}, {T}: Target creature can't be blocked this turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "246",
+        "rarity": "UNCOMMON",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "All the books were dusty with disuse, save the one titled *Camouflage and Its Practical Applications*.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/ccf01421-856e-4cdd-8938-148928626f56.jpg?1783934508"
+    }
+}
+
 // Trusty Packbeast
 {
     "name": "Trusty Packbeast",

--- a/mtg-sets/src/test/resources/snapshots/cards/SNC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SNC.json
@@ -1,3 +1,79 @@
+// A Little Chat
+{
+    "name": "A Little Chat",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)\nLook at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
+    "keywords": [
+        "CASUALTY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Casualty",
+            "threshold": 1
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "selectedLabel": "Put in hand",
+                    "remainderLabel": "Put on bottom"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "47",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Stewart",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4d7424b6-b56a-47b7-8204-294d3dca925f.jpg?1783923145"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // An Offer You Can't Refuse
 {
     "name": "An Offer You Can't Refuse",
@@ -37,6 +113,1247 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Angelic Observer
+{
+    "name": "Angelic Observer",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Angel Advisor",
+    "oracleText": "Affinity for Citizens (This spell costs {1} less to cast for each Citizen you control.)\nFlying",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "AffinityForSubtype",
+            "forSubtype": "Citizen"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "UNCOMMON",
+        "artist": "Zack Stella",
+        "flavorText": "Still and solemn as the statues of her kind that decorated the Park Heights rooftops, she gazed in sorrow on the city below.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e6cce4d3-e6d8-4c6f-9d9c-c0a8a607a42f.jpg?1783923164"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Antagonize
+{
+    "name": "Antagonize",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +4/+3 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature to get +4/+3"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature to get +4/+3"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "artist": "Gabor Szikszai",
+        "flavorText": "\"The little guy had guts at least. You can see 'em right there between those cobbles.\"\n—Glunk, freelance crusher",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8bac1d2a-99dd-40b3-8823-ce9225efcdcf.jpg?1783923123"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Attended Socialite
+{
+    "name": "Attended Socialite",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "Alliance — Whenever another creature you control enters, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Alliance — Whenever another creature you control enters, this creature gets +1/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "artist": "Drew Baker",
+        "flavorText": "\"Say hello to my little friend.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8bccccf9-3ee5-4485-ae01-4dcbad989d18.jpg?1783923110"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Backup Agent
+{
+    "name": "Backup Agent",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Citizen",
+    "oracleText": "When this creature enters, put a +1/+1 counter on target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "When this creature enters, put a +1/+1 counter on target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "artist": "Aaron J. Riley",
+        "flavorText": "\"My sources say the Beamtown Bullies were spotted in the Mezzio. Keep your eyes sharp and stay close to me.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2a46af75-3880-4141-b26e-19834d67e7a8.jpg?1783923164"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Big Score
+{
+    "name": "Big Score",
+    "manaCost": "{3}{R}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, discard a card.\nDraw two cards and create two Treasure tokens. (They're artifacts with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure",
+                    "count": 2
+                }
+            ]
+        },
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": "AtomDiscard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Gaboleps",
+        "flavorText": "\"Unimaginable riches? I assure you, I have a *vivid* imagination.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/39d1578f-e2cf-4b93-8204-ed5434feb183.jpg?1783923123"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Bootleggers' Stash
+{
+    "name": "Bootleggers' Stash",
+    "manaCost": "{5}{G}",
+    "typeLine": "Artifact",
+    "oracleText": "Lands you control have \"{T}: Create a Treasure token.\"",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "CreatePredefinedToken",
+                        "tokenType": "Treasure"
+                    }
+                },
+                "filter": {
+                    "baseFilter": "land ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "rarity": "MYTHIC",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "Labyrinths of tunnels beneath the streets of the Caldaia offer an ample array of discreet routes for enterprising smugglers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/0/80b5b7e1-52c2-4453-b3c0-efe2cebad6ce.jpg?1783923109"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Botanical Plaza
+{
+    "name": "Botanical Plaza",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {G} or {W}.\n{2}{G}{W}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{G}{W}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "artist": "Grady Frederick",
+        "flavorText": "Public parks are a favored meeting spot for those considering a shift in allegiance.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9f8a6f93-1fc8-4690-add4-538763277f8e.jpg?1783923058"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Brazen Upstart
+{
+    "name": "Brazen Upstart",
+    "manaCost": "{R}{G}{W}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "Vigilance\nWhen this creature dies, look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "creature",
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "prompt": "You may reveal a creature card from among them and put it into your hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "169",
+        "rarity": "UNCOMMON",
+        "artist": "Dallas Williams",
+        "flavorText": "\"Trust me, you want to deal with me. My associates are much less pleasant.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3ae69722-9cb9-4fb7-830f-a284d4a72027.jpg?1783923093"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Brokers Veteran
+{
+    "name": "Brokers Veteran",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "When this creature dies, put a shield counter on target creature you control. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "shield",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Lie Setiawan",
+        "flavorText": "One last job before he retires.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d4a54bd-5598-4313-b5e6-29fd38da016a.jpg?1783923149"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Cabaretti Charm
+{
+    "name": "Cabaretti Charm",
+    "manaCost": "{R}{G}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Cabaretti Charm deals damage equal to the number of creatures you control to target creature or planeswalker.\n• Creatures you control get +1/+1 and gain trample until end of turn.\n• Create two 1/1 green and white Citizen creature tokens.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "creature"
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetCreatureOrPlaneswalker",
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Cabaretti Charm deals damage equal to the number of creatures you control to target creature or planeswalker"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "ModifyStats",
+                                    "powerModifier": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "toughnessModifier": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "target": "Self"
+                                },
+                                {
+                                    "type": "GrantKeyword",
+                                    "keyword": "TRAMPLE",
+                                    "target": "Self"
+                                }
+                            ]
+                        }
+                    },
+                    "description": "Creatures you control get +1/+1 and gain trample until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "CreateToken",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "GREEN",
+                            "WHITE"
+                        ],
+                        "creatureTypes": [
+                            "Citizen"
+                        ]
+                    },
+                    "description": "Create two 1/1 green and white Citizen creature tokens"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Argyle",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/08f33c8a-8e93-4296-964b-da132a854b3b.jpg?1783923091"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Cabaretti Initiate
+{
+    "name": "Cabaretti Initiate",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Raccoon Citizen",
+    "oracleText": "{2}{R/W}: This creature gains double strike until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{R/W}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "artist": "Jason A. Engle",
+        "flavorText": "\"Now there's a fellow who knows how to have a good time!\"\n—Jetmir",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6c691f62-009b-4178-8e8b-d6e88229a282.jpg?1783923106"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Celebrity Fencer
+{
+    "name": "Celebrity Fencer",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "Alliance — Whenever another creature you control enters, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Alliance — Whenever another creature you control enters, put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "artist": "Inka Schulz",
+        "flavorText": "After a brief but memorable incident at her first performance, she was never heckled again.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5afb5c5c-06e0-4b11-ad07-aef7be6e2cd4.jpg?1783923161"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Chrome Cat
+{
+    "name": "Chrome Cat",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Cat",
+    "oracleText": "When this creature enters, scry 1.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "artist": "Joe Slucher",
+        "flavorText": "\"I always say, 'If it's breathing, it's lying.' Luckily my friend here does neither.\"\n—Lord Xander",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/85da50ba-2061-40f0-b3af-950b87f812cd.jpg?1783923062"
+    }
+}
+
+// Civic Gardener
+{
+    "name": "Civic Gardener",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Citizen",
+    "oracleText": "Whenever this creature attacks, untap target creature or land.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "tap": false
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|land"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "artist": "Drew Baker",
+        "flavorText": "\"I've told you knuckleheads a hundred times: You can kill 'em here, but bury the bodies somewhere else. If you disturb my prized azaleas again, you'd better dig a second hole for yourself!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f58d39d7-62bf-43c8-97b3-0f9069af0e29.jpg?1783923105"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Cleanup Crew
+{
+    "name": "Cleanup Crew",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Human Citizen",
+    "oracleText": "When this creature enters, choose one —\n• Destroy target artifact.\n• Destroy target enchantment.\n• Exile target card from a graveyard.\n• You gain 4 life.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "artifact"
+                                    }
+                                }
+                            ],
+                            "description": "Destroy target artifact"
+                        },
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "enchantment"
+                                    }
+                                }
+                            ],
+                            "description": "Destroy target enchantment"
+                        },
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Exile"
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": {},
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ],
+                            "description": "Exile target card from a graveyard"
+                        },
+                        {
+                            "effect": {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, choose one — Destroy target artifact; or destroy target enchantment; or exile target card from a graveyard; or you gain 4 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "141",
+        "rarity": "UNCOMMON",
+        "artist": "Josu Hernaiz",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/5354868b-c96b-4765-b0c8-8895093e4019.jpg?1783923105"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Courier's Briefcase
+{
+    "name": "Courier's Briefcase",
+    "manaCost": "{1}{G}",
+    "typeLine": "Artifact — Treasure",
+    "oracleText": "When this artifact enters, create a 1/1 green and white Citizen creature token.\n{T}, Sacrifice this artifact: Add one mana of any color.\n{W}{U}{B}{R}{G}, {T}, Sacrifice this artifact: Draw three cards.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN",
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Citizen"
+                    ]
+                },
+                "descriptionOverride": "When this artifact enters, create a 1/1 green and white Citizen creature token."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}{U}{B}{R}{G}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "rarity": "UNCOMMON",
+        "artist": "Josu Hernaiz",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2f375674-7ae2-4430-b1f3-c26fa5b201d1.jpg?1783923106"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "RED",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Crooked Custodian
+{
+    "name": "Crooked Custodian",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Ogre Rogue",
+    "oracleText": "This creature enters tapped.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "artist": "Tony Foti",
+        "flavorText": "\"Nothing to see here. Just carrying a carpet. Yes, the carpet wears boots. Stop asking questions.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/723d6f60-3e8a-4c58-8b3c-9ba59a01c867.jpg?1783923135"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Cutthroat Contender
+{
+    "name": "Cutthroat Contender",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Vampire Warrior",
+    "oracleText": "Pay 1 life: This creature gets +1/+0 until end of turn. Activate only once each turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomPayLife",
+                        "amount": 1
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "restrictions": [
+                    "OncePerTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "artist": "Mark Behm",
+        "flavorText": "The fights may sometimes be rigged, but the front-row spectators know the wounds are real.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6b23b3e4-58cf-4b5d-bdcb-410a403b4987.jpg?1783923133"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Daring Escape
+{
+    "name": "Daring Escape",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +1/+0 and gains first strike until end of turn. Scry 1.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature to get +1/+0 and first strike"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature to get +1/+0 and first strike"
+                    }
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature to get +1/+0 and first strike"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "104",
+        "artist": "Ekaterina Burmak",
+        "flavorText": "As the Adversary's forces descended upon the gala, Elspeth whispered to Giada, \"I can get you out of here, but we have to go now.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d09dbcd-188b-4b52-943e-947cbf2c0002.jpg?1783923120"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Darling of the Masses
+{
+    "name": "Darling of the Masses",
+    "manaCost": "{2}{G}{W}",
+    "typeLine": "Creature — Elf Citizen",
+    "oracleText": "Other Citizens you control get +1/+0.\nWhenever this creature attacks, create a 1/1 green and white Citizen creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN",
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Citizen"
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature attacks, create a 1/1 green and white Citizen creature token."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": "permanent Citizen ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "181",
+        "rarity": "UNCOMMON",
+        "artist": "Mila Pesic",
+        "flavorText": "The people flocked to the glittering parade, turning their backs on the threats in the shadows.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/52aa9815-6b47-4c80-87c7-4277166ea0df.jpg?1783923087"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Demon's Due
+{
+    "name": "Demon's Due",
+    "manaCost": "{3}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Scry 2, then draw two cards. You lose 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Scry",
+                    "count": 2
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Controller"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "artist": "Slawomir Maniak",
+        "flavorText": "Ob Nixilis extends his hand not in partnership, but to affirm your subservience.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e59fb98-c887-42f1-a620-9e6b40b94cb5.jpg?1783923132"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Disciplined Duelist
+{
+    "name": "Disciplined Duelist",
+    "manaCost": "{G}{W}{U}",
+    "typeLine": "Creature — Human Citizen",
+    "oracleText": "Double strike\nThis creature enters with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "DOUBLE_STRIKE"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "shield"
+                },
+                "count": 1,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "rarity": "UNCOMMON",
+        "artist": "Josu Hernaiz",
+        "flavorText": "Brokers agents defend their charges by all means available, from intricate logic to blunt force trauma.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e23cdb0a-e114-47f8-aceb-c54c4683bbc5.jpg?1783923087"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Exhibition Magician
+{
+    "name": "Exhibition Magician",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "When this creature enters, choose one —\n• Create a 1/1 green and white Citizen creature token.\n• Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "CreateToken",
+                                "power": 1,
+                                "toughness": 1,
+                                "colors": [
+                                    "GREEN",
+                                    "WHITE"
+                                ],
+                                "creatureTypes": [
+                                    "Citizen"
+                                ]
+                            },
+                            "description": "Create a 1/1 green and white Citizen creature token."
+                        },
+                        {
+                            "effect": {
+                                "type": "CreatePredefinedToken",
+                                "tokenType": "Treasure"
+                            },
+                            "description": "Create a Treasure token."
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, choose one — Create a 1/1 green and white Citizen creature token. • Create a Treasure token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "artist": "Greg Staples",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cbb4479f-3157-44b4-b18b-7553c7513118.jpg?1783923118"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -118,6 +1435,35 @@
     ]
 }
 
+// Fleetfoot Dancer
+{
+    "name": "Fleetfoot Dancer",
+    "manaCost": "{1}{R}{G}{W}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "Trample, lifelink, haste",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE",
+        "LIFELINK",
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "188",
+        "rarity": "RARE",
+        "artist": "Joshua Raphael",
+        "flavorText": "The Vanto Beatdown began as an improvised dance-battle at the Rose Room lounge. When word spread of how many were slain at the first event, it became a citywide obsession.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/2473d738-fe15-402a-ad24-0d6e5c4dfda3.jpg?1783923085"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Giada, Font of Hope
 {
     "name": "Giada, Font of Hope",
@@ -187,6 +1533,105 @@
     ]
 }
 
+// Gilded Pinions
+{
+    "name": "Gilded Pinions",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nEquipped creature has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                },
+                "descriptionOverride": "When this Equipment enters, create a Treasure token."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "238",
+        "artist": "Irina Nordsol",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dca8554a-f74c-4d2d-95b6-ef6e74431d7c.jpg?1783923062"
+    }
+}
+
+// Glittermonger
+{
+    "name": "Glittermonger",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf Rogue",
+    "oracleText": "{T}: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "149",
+        "artist": "Evyn Fong",
+        "flavorText": "Street corners in the Mezzio are a tantalizing bazaar of the fantastic, the illicit, and the fake.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a3d70d2-0604-41b3-8dd1-bfeb05832271.jpg?1783923102"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Goldhound
 {
     "name": "Goldhound",
@@ -236,6 +1681,45 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Incandescent Aria
+{
+    "name": "Incandescent Aria",
+    "manaCost": "{R}{G}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Incandescent Aria deals 3 damage to each nontoken creature.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature nontoken"
+                }
+            },
+            "body": {
+                "type": "DealDamage",
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 3
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "rarity": "RARE",
+        "artist": "Randy Gallegos",
+        "flavorText": "As the assassins converged on Kitt Kanto, she struck a high note and held it, unbroken, for nearly a minute. When the room fell silent, she was surrounded only by rose petals falling gently to the floor.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/77e2ed9e-ee1d-440a-94b4-d4b17d30b800.jpg?1783923082"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "WHITE"
     ]
 }
 
@@ -354,6 +1838,986 @@
     ]
 }
 
+// Jackhammer
+{
+    "name": "Jackhammer",
+    "manaCost": "{1}{R}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 0
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "111",
+        "artist": "John Severin Brassell",
+        "flavorText": "\"Subtlety is overrated.\"\n—Mr. Orfeo, the Boulder",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d74ba9fe-2dcb-4da7-ba64-cd932edb5b24.jpg?1783923118"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Jetmir's Garden
+{
+    "name": "Jetmir's Garden",
+    "manaCost": "",
+    "typeLine": "Land — Mountain Forest Plains",
+    "oracleText": "({T}: Add {R}, {G}, or {W}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{3}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "250",
+        "rarity": "RARE",
+        "artist": "Kasia 'Kafis' Zielińska",
+        "flavorText": "The parklike Cabaretti grounds offer rest, food, and the perfect place to shake off a tail.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/26d40e03-6de4-4373-9fbf-04c1dd79e995.jpg?1783923058"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Jewel Thief
+{
+    "name": "Jewel Thief",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Cat Rogue",
+    "oracleText": "Vigilance, trample\nWhen this creature enters, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE",
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                },
+                "descriptionOverride": "When this creature enters, create a Treasure token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "artist": "Joe Slucher",
+        "flavorText": "\"They can afford the loss. They build it into their prices.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/736e498e-1245-40c1-96a4-c9bcfd1cfe1f.jpg?1783923101"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Knockout Blow
+{
+    "name": "Knockout Blow",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {2} less to cast if it targets a red creature.\nKnockout Blow deals 4 damage to target attacking or blocking creature and you gain 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "FixedIfAnyTargetMatches",
+                        "amount": 2,
+                        "filter": "creature red"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros",
+        "flavorText": "\"Subsequent efforts to deconstruct this facility will be punished with increasing severity.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b00bbec-61d0-464c-bf82-4ecf5ddb3451.jpg?1783923155"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Light 'Em Up
+{
+    "name": "Light 'Em Up",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Casualty 2 (As you cast this spell, you may sacrifice a creature with power 2 or greater. When you do, copy this spell and you may choose a new target for the copy.)\nLight 'Em Up deals 2 damage to target creature or planeswalker.",
+    "keywords": [
+        "CASUALTY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Casualty",
+            "threshold": 2
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "artist": "Tony Foti",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/ee31d56a-9b7e-4de0-81cb-3b7c76b6fbd5.jpg?1783923117"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Midnight Assassin
+{
+    "name": "Midnight Assassin",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Vampire Assassin",
+    "oracleText": "Flying\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Christina Davis",
+        "flavorText": "The broad avenues and graceful spires of Park Heights are the playground of the affluent. After nightfall, they also make a fine hunting ground.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02a4a5b3-0477-4709-8bce-3e01f54001b6.jpg?1783923128"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Obscura Initiate
+{
+    "name": "Obscura Initiate",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Bird Citizen",
+    "oracleText": "Flying\n{1}{W/B}: This creature gains lifelink until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W/B}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "Kim Sokol",
+        "flavorText": "Obscura initiates are required to bring a gift of information. They are judged on both how useful it is and how hard it was to obtain.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/67774a11-158b-437c-ac16-2d42fbb5c223.jpg?1783923142"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Ominous Parcel
+{
+    "name": "Ominous Parcel",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}, {T}, Sacrifice this artifact: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n{5}, {T}, Sacrifice this artifact: It deals 4 damage to target creature.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "basicland"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "artist": "Joe Slucher",
+        "flavorText": "The rest of Anhelo's assistant arrived over the following week.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e1691374-e9f2-4a8b-abdb-0bb1dbc96715.jpg?1783923059"
+    }
+}
+
+// Racers' Ring
+{
+    "name": "Racers' Ring",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {R} or {G}.\n{2}{R}{G}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}{G}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "253",
+        "artist": "Sam White",
+        "flavorText": "Purchasing chrome racehorses with cash is a common means of dispersing mysterious income.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2a11bdb2-a269-4038-85f3-69fbd02982e9.jpg?1783923055"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Raffine's Tower
+{
+    "name": "Raffine's Tower",
+    "manaCost": "",
+    "typeLine": "Land — Plains Island Swamp",
+    "oracleText": "({T}: Add {W}, {U}, or {B}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{3}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "254",
+        "rarity": "RARE",
+        "artist": "Sam White",
+        "flavorText": "The Obscura's Cloud Spire dominates the skyline, its eye a beacon of progress that sees all.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2c56479-4bee-4edb-80d7-4af010b7c793.jpg?1783923055"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Ready to Rumble
+{
+    "name": "Ready to Rumble",
+    "manaCost": "{4}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Ready to Rumble deals 5 damage to target creature or planeswalker.\n• Destroy target artifact.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetCreatureOrPlaneswalker",
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Ready to Rumble deals 5 damage to target creature or planeswalker"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target artifact"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "artist": "Josu Hernaiz",
+        "flavorText": "\"It's too quiet tonight. Go make trouble.\"\n—Ziatora",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/16998689-345d-41e3-a368-e97b696ed689.jpg?1783923115"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Riveteers Initiate
+{
+    "name": "Riveteers Initiate",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Lizard Citizen",
+    "oracleText": "{1}{B/G}: This creature gains deathtouch until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B/G}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "artist": "Svetlin Velinov",
+        "flavorText": "Young viashino flock to the Riveteers for Ziatora's leadership, eager to unleash their own inner dragons.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2e65a50-d2bc-43a0-a9d4-0e846d170f78.jpg?1783923114"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Rob the Archives
+{
+    "name": "Rob the Archives",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)\nExile the top two cards of your library. You may play those cards this turn.",
+    "keywords": [
+        "CASUALTY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Casualty",
+            "threshold": 1
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "storeAs": "impulseExiled"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "impulseExiled",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Exile"
+                    }
+                },
+                {
+                    "type": "GrantMayPlayFromExile",
+                    "from": "impulseExiled"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Argyle",
+        "flavorText": "\"Well, I guess stealth's out of the question.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3ec95f6-88c8-4daf-882f-8b4bc73452c3.jpg?1783923112"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Skybridge Towers
+{
+    "name": "Skybridge Towers",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {W} or {U}.\n{2}{W}{U}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}{U}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "256",
+        "artist": "Muhammad Firdaus",
+        "flavorText": "New Capenna's districts are a series of tiers; wealth and power always rise to the top.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e28c871f-a96a-4e7d-a159-2e93aeb276d4.jpg?1783923054"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Social Climber
+{
+    "name": "Social Climber",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Druid",
+    "oracleText": "Alliance — Whenever another creature you control enters, you gain 1 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Alliance — Whenever another creature you control enters, you gain 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "artist": "Carly Mazur",
+        "flavorText": "\"It's all about who you know, darling. And now you're lucky enough to know me.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a9fb74fd-767f-4dd4-822a-828d59f633ad.jpg?1783923098"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Spara's Headquarters
+{
+    "name": "Spara's Headquarters",
+    "manaCost": "",
+    "typeLine": "Land — Forest Plains Island",
+    "oracleText": "({T}: Add {G}, {W}, or {U}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{3}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "257",
+        "rarity": "RARE",
+        "artist": "Kieran Yanner",
+        "flavorText": "To most, the Nido Sanctuary is an office complex. To the Brokers, it's a vault of secrets.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/7363f1fb-9af3-4212-921f-d59533faf0e5.jpg?1783923052"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Strangle
+{
+    "name": "Strangle",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Strangle deals 3 damage to target creature or planeswalker.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature or planeswalker"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target creature or planeswalker"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "artist": "Vincent Proce",
+        "flavorText": "They'd warned him greed would be the death of him. He never thought to take it literally.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b91d727-c0ee-4bf0-8c7d-8475ecb88083.jpg?1783923112"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Swooping Protector
+{
+    "name": "Swooping Protector",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Bird Citizen",
+    "oracleText": "Flash\nFlying\nThis creature enters with a shield counter on it. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "shield"
+                },
+                "count": 1,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Behm",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/8713498f-a467-4a11-9de2-53a1bbd0b18b.jpg?1783923149"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Tramway Station
+{
+    "name": "Tramway Station",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {B} or {R}.\n{2}{B}{R}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}{R}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "258",
+        "artist": "Alexander Forssberg",
+        "flavorText": "A ten-minute ride can take you to the luxury of Park Heights, or the grit of the Caldaia.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0532304-da6d-45cd-b1e6-4779d3f3b2bc.jpg?1783923053"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Venom Connoisseur
 {
     "name": "Venom Connoisseur",
@@ -424,6 +2888,261 @@
     ]
 }
 
+// Void Rend
+{
+    "name": "Void Rend",
+    "manaCost": "{W}{U}{B}",
+    "typeLine": "Instant",
+    "oracleText": "This spell can't be countered.\nDestroy target nonland permanent.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target"
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "230",
+        "rarity": "RARE",
+        "artist": "Rovina Cai",
+        "flavorText": "Bits of the missing agent were discovered in various alleys across all three boroughs.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2daab74d-d66b-4164-aa19-24e8d5536f7d.jpg?1783923066"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Warm Welcome
+{
+    "name": "Warm Welcome",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Look at the top five cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. Create a 1/1 green and white Citizen creature token.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "creature",
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "prompt": "You may reveal a creature card from among them and put it into your hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                },
+                {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN",
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Citizen"
+                    ]
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "artist": "Inka Schulz",
+        "flavorText": "\"Welcome to the family. Chef Rocco sends their congratulations.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/bad9e58e-c9a3-4a0d-9a59-71c20a3275b6.jpg?1783923094"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Waterfront District
+{
+    "name": "Waterfront District",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {U} or {B}.\n{2}{U}{B}, {T}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}{B}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "259",
+        "artist": "Alexander Forssberg",
+        "flavorText": "The bottom of the dark canals is littered with countless corpses and treasures.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/debf7aac-4d31-49b4-955b-79036258df69.jpg?1783923052"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
+// Whack
+{
+    "name": "Whack",
+    "manaCost": "{3}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "This spell costs {3} less to cast if it targets a white creature.\nTarget creature gets -4/-4 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": -4
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "FixedIfAnyTargetMatches",
+                        "amount": 3,
+                        "filter": "creature white"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "rarity": "UNCOMMON",
+        "artist": "John Thacker",
+        "flavorText": "\"It's just business. You understand.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c862769d-f8bd-4cb6-b2b2-816179795f8b.jpg?1783923123"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Witness Protection
 {
     "name": "Witness Protection",
@@ -467,5 +3186,92 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Wrecking Crew
+{
+    "name": "Wrecking Crew",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Reach (This creature can block creatures with flying.)\nTrample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "REACH",
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "132",
+        "artist": "Joshua Raphael",
+        "flavorText": "They built the neighborhood. They know its weak points. They know all the hiding places. When they come for you, they'll find you and bring the roof down on your head.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/2/92691507-b1ce-40d0-87e7-b79e81370511.jpg?1783923111"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Xander's Lounge
+{
+    "name": "Xander's Lounge",
+    "manaCost": "",
+    "typeLine": "Land — Island Swamp Mountain",
+    "oracleText": "({T}: Add {U}, {B}, or {R}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{3}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "260",
+        "rarity": "RARE",
+        "artist": "James Paick",
+        "flavorText": "Maestros agents can lie low in high style at the opulent Shadow Hostel.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/54f449ff-4025-465e-9ec5-a5cf42c4c9d3.jpg?1783923052"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED",
+        "BLUE"
+    ]
+}
+
+// Ziatora's Proving Ground
+{
+    "name": "Ziatora's Proving Ground",
+    "manaCost": "",
+    "typeLine": "Land — Swamp Mountain Forest",
+    "oracleText": "({T}: Add {B}, {R}, or {G}.)\nThis land enters tapped.\nCycling {3} ({3}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{3}"
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "261",
+        "rarity": "RARE",
+        "artist": "Viko Menezes",
+        "flavorText": "Restless Riveteers can always find a sparring partner in the sprawling Treza warehouse.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75fdce80-e338-4a50-bdc6-786511feaeef.jpg?1783923052"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "RED"
     ]
 }


### PR DESCRIPTION
SNC's Assay verdict ledger badges **62 of its 256 missing cards** as read-whole. Implementing all of them takes the set from **10/266 to 72/266** (4% → 27%).

## The four-way split

| kind | count | notes |
|---|---|---|
| new canonicals | 53 | the set's commons plus both land cycles |
| basic-land variants | 20 | 5 names × 4 arts, collector 262–281 |
| reprint rows | 2 | Kill Shot (canonical in KTK), Murder (M13) |
| canonical relocations | 3 | see below |

**Relocations.** Big Score and Bootleggers' Stash had their canonical in BLC (2024) though SNC is the earliest real printing — both move to `snc/cards/`, BLC gets `Printing(...)` rows. Suspicious Bookcase went the other way: it reads as an SNC card but first printed in M19, so its canonical lands in `m19/cards/` and SNC, JMP and TLE all get rows.

## Two mechanics traced live before authoring, both traps

- **`Keyword.AFFINITY` is the display-only half.** `CostCalculator` matches on the `KeywordAbility.AffinityForSubtype` data class, never the enum. Angelic Observer writes `keywordAbility(KeywordAbility.AffinityForSubtype(Subtype.CITIZEN))`; `keywords(Keyword.AFFINITY)` would have printed the text and reduced nothing.
- **Alliance is not vocabulary.** No `abilityWord`/`flavorWord` field exists anywhere in the SDK — every ability word in the corpus lives only as a prefix string in `oracleText`. The three Alliance cards use plain `Triggers.OtherCreatureEnters`.

A Little Chat, Light 'Em Up and Rob the Archives are the corpus's **first cards with printed Casualty**. The mechanic is wired end-to-end (enumerator → validation → sacrifice → reflexive copy trigger with retargeting), but every prior test drove it through the *granted* path (Silverquill, the Disputant).

## Verification

- `:mtg-sets:{2017-2022,2024,2025}:compileKotlin` — BUILD SUCCESSFUL
- Card snapshot goldens re-blessed: **BLC, M19, SNC only**
- `just assay-differential --set SNC` → **54 compared / 54 confirmed / 0 divergent**
- Whole corpus: 3257 / 3244 / 13 → **3309 / 3296 / 13** — +52 compared, +52 confirmed, **no new divergence**. The 13 are pre-existing and untouched (Pearl of Wisdom, Ghalta, the two DOM Wizard's cards, Mistmeadow Council, Arcane Epiphany, the two SCG Warchiefs, three SPM, Dragon's Prey, Bolt Bend).

Authoring to `assay compile`'s JSON rather than to the oracle text is what held the divergence at zero across a 53-card fan-out.

## Known follow-ups (not in this PR)

- **No scenario test for printed Casualty yet.** House rules owe one to a mechanic with no prior implementation; the three cards compile and read clean through the differential, but the printed path is not yet exercised by a test.
- `check-card-printing "Big Score"` still reports one missing `Printing(...)` row in **MSC**. Pre-existing — it was flagged the same way before this change, and MSC is a separate set's file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
