### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/AssassinsTrophy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/AssassinsTrophy.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Assassin's Trophy
+ * {B}{G}
+ * Instant
+ *
+ * Destroy target permanent an opponent controls. Its controller may search their library for a
+ * basic land card, put it onto the battlefield, then shuffle.
+ *
+ * Canonical printing is Guilds of Ravnica (GRN #152); Murders at Karlov Manor carries only a
+ * [com.wingedsheep.sdk.model.Printing] row.
+ *
+ * The Volatile Fault / Demolition Field shape, widened from "nonbasic land" to *any* permanent an
+ * opponent controls. The consolation fetch belongs to the destroyed permanent's controller, not to
+ * the caster, so it runs under [Effects.ForEachPlayer] with [Player.ControllerOf] — that rebinds
+ * `Player.You` inside the search to that player, which is what makes
+ * [Patterns.Library.searchLibrary] (hard-wired to `Player.You`) read the right library.
+ *
+ * Two printed rulings fall out of the ordering rather than needing a gate of their own:
+ * the fetch is *not* conditional on the destruction actually happening, so an indestructible
+ * target still hands its controller the basic land; and because the spell fizzles wholesale on an
+ * illegal target, no player searches in that case. The [MayEffect] wrapper carries the third —
+ * declining the search skips the shuffle with it, since `shuffleAfter` lives inside the search
+ * pipeline that never runs.
+ */
+val AssassinsTrophy = card("Assassin's Trophy") {
+    manaCost = "{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Instant"
+    oracleText = "Destroy target permanent an opponent controls. Its controller may search their " +
+        "library for a basic land card, put it onto the battlefield, then shuffle."
+
+    spell {
+        val permanent = target("target permanent an opponent controls", Targets.PermanentOpponentControls)
+        effect = Effects.Destroy(permanent) then
+            Effects.ForEachPlayer(
+                Player.ControllerOf("the destroyed permanent"),
+                listOf(
+                    MayEffect(
+                        Patterns.Library.searchLibrary(
+                            filter = GameObjectFilter.BasicLand,
+                            count = 1,
+                            destination = SearchDestination.BATTLEFIELD
+                        )
+                    )
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "152"
+        artist = "Seb McKinnon"
+        flavorText = "A power vacuum for the Azorius. A keepsake for Vraska."
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/906b6e99-128f-4c11-8daf-16099d35b0d4.jpg?1783934143"
+
+        ruling(
+            "2018-10-05",
+            "If the target permanent is a legal target but isn't destroyed, most likely because " +
+                "it has indestructible, its controller may search their library."
+        )
+        ruling(
+            "2018-10-05",
+            "If the permanent's controller doesn't search their library, they don't shuffle " +
+                "their library."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AssassinsTrophyReprint.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AssassinsTrophyReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Assassin's Trophy reprint in Murders at Karlov Manor. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Guilds of Ravnica's `cards/` package
+ * (its earliest real-expansion printing); this file contributes only presentation data.
+ */
+val AssassinsTrophyReprint = Printing(
+    oracleId = "ac10d218-f9a6-4058-9cda-a15ca1b0b7b5",
+    name = "Assassin's Trophy",
+    setCode = "MKM",
+    collectorNumber = "187",
+    scryfallId = "ed6c7d29-71b4-4134-b591-5598f479d592",
+    artist = "Dmitry Burmak",
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/ed6c7d29-71b4-4134-b591-5598f479d592.jpg?1783912858",
+    releaseDate = "2024-02-09",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AssembleThePlayers.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AssembleThePlayers.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+
+/**
+ * Assemble the Players — Murders at Karlov Manor #3
+ * {1}{W} · Enchantment · Rare
+ *
+ * You may look at the top card of your library any time.
+ * Once each turn, you may cast a creature spell with power 2 or less from the top of your library.
+ *
+ * The Precognition Field shape with a power ceiling and a per-turn allowance. Visibility and play
+ * permission are separate statics on purpose: [LookAtTopOfLibrary] is the *private* peek (only the
+ * controller sees the card — this is not Future Sight's public reveal), and
+ * [CastSpellTypesFromTopOfLibrary] is the casting grant. `maxCastsPerTurn = 1` belongs to the
+ * granting permanent rather than to the player, which is exactly the printed ruling: two
+ * Assemble the Players are two independent permissions, and one that leaves and returns in the
+ * same turn comes back with a fresh one.
+ *
+ * The filter is the *spell's* power, so the disguise/morph ruling falls out for free — a face-down
+ * spell is a 2/2 and qualifies whatever the card's printed power is.
+ */
+val AssembleThePlayers = card("Assemble the Players") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "You may look at the top card of your library any time.\n" +
+        "Once each turn, you may cast a creature spell with power 2 or less from the top of your " +
+        "library."
+
+    staticAbility {
+        ability = LookAtTopOfLibrary
+    }
+
+    staticAbility {
+        ability = CastSpellTypesFromTopOfLibrary(
+            filter = GameObjectFilter.Creature.powerAtMost(2),
+            maxCastsPerTurn = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "3"
+        artist = "Evyn Fong"
+        flavorText = "\"All will soon be made clear, but I can give you this: our killer is here " +
+            "with us, in this very room.\"\n—Alquist Proft"
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f5bcb21a-8559-4791-8cd0-482e7b8dcfd2.jpg?1783912930"
+
+        ruling(
+            "2024-02-02",
+            "If Assemble the Players leaves the battlefield and returns to the battlefield in the " +
+                "same turn, the casting permission granted by the old one is different than the " +
+                "casting permission granted by the new one. Similarly, if you control multiple " +
+                "Assemble the Players, each one has a different casting permission that may be " +
+                "used once each turn."
+        )
+        ruling(
+            "2024-02-02",
+            "Because you never \"cast\" a land card, Assemble the Players doesn't allow you to " +
+                "play a land creature (such as Dryad Arbor) from the top of your library."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AudienceWithTrostani.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AudienceWithTrostani.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Audience with Trostani — Murders at Karlov Manor #152
+ * {2}{G} · Sorcery · Rare
+ *
+ * Create a 0/1 green Plant creature token, then draw cards equal to the number of differently
+ * named creature tokens you control.
+ *
+ * The "then" is load-bearing: the Plant is created *before* the count is taken, so the card always
+ * draws at least one — and exactly one when the Plant is the only token, or when you already
+ * controlled other Plant tokens (a name already counted doesn't count twice).
+ *
+ * `distinctNames()` over `Creature.token()` is the whole count: [DynamicAmounts] resolves it
+ * against the battlefield at resolution time, keying on each permanent's name, so two Plants are
+ * one and a Plant plus a Detective is two. Non-creature tokens (a Clue, a Treasure) are filtered
+ * out before the names are gathered, and nontoken creatures never enter the set at all.
+ */
+val AudienceWithTrostani = card("Audience with Trostani") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Create a 0/1 green Plant creature token, then draw cards equal to the number of " +
+        "differently named creature tokens you control."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 0,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Plant"),
+        ) then Effects.DrawCards(
+            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.token()).distinctNames()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "152"
+        artist = "Ben Hill"
+        flavorText = "Trostani was as regal and vibrant as ever, but Kaya couldn't shake the " +
+            "sense that there was something off, some discordant note lurking deep within the " +
+            "chorus."
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a8e23d15-33af-4fd8-964b-8ca4efdebc37.jpg?1783912873"
+
+        ruling(
+            "2024-02-02",
+            "To determine the number of differently named creature tokens you control, count each " +
+                "creature token you control once, but only if its English name isn't exactly the " +
+                "same as another creature token you've already counted this way."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DetectivesSatchel.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DetectivesSatchel.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Detective's Satchel — Murders at Karlov Manor #196
+ * {2}{U}{R} · Artifact · Uncommon
+ *
+ * When this artifact enters, investigate twice.
+ * {T}: Create a 1/1 colorless Thopter artifact creature token with flying. Activate only if you've
+ * sacrificed an artifact this turn.
+ *
+ * The Satchel is its own enabler: the two Clues it makes on entry are artifacts, and sacrificing
+ * one to draw sets the gate for the Thopter. That gate is
+ * [Conditions.SacrificedArtifactThisTurn] — MKM's `ARTIFACT_SACRIFICED` turn tracker, the same one
+ * behind Suspicious Detonation and Furtive Courier — wrapped in
+ * [ActivationRestriction.OnlyIfCondition] so the tap ability simply isn't offered until it holds.
+ *
+ * Turn history, not a board scan: the sacrificed artifact having since left the graveyard doesn't
+ * clear it, an opponent sacrificing their own artifact never sets it, and it resets at cleanup —
+ * so the Satchel makes at most one Thopter per turn in practice only because it taps for it, not
+ * because the tracker is spent.
+ */
+val DetectivesSatchel = card("Detective's Satchel") {
+    manaCost = "{2}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, investigate twice. (To investigate, create a Clue " +
+        "token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\n" +
+        "{T}: Create a 1/1 colorless Thopter artifact creature token with flying. Activate only " +
+        "if you've sacrificed an artifact this turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Investigate(2)
+        description = "When this artifact enters, investigate twice."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = emptySet(),
+            creatureTypes = setOf("Thopter"),
+            keywords = setOf(Keyword.FLYING),
+            artifactToken = true,
+            name = "Thopter",
+        )
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(Conditions.SacrificedArtifactThisTurn)
+        )
+        description = "{T}: Create a 1/1 colorless Thopter artifact creature token with flying. " +
+            "Activate only if you've sacrificed an artifact this turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "196"
+        artist = "Andrew Mar"
+        flavorText = "It's a crime lab in a bag."
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2c05bf2d-7d4f-4717-b1ea-ec4284854f4f.jpg?1783912852"
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/FussBother.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/FussBother.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fuss // Bother — Murders at Karlov Manor #248
+ * Split-layout spell (CR 709). Cast either half from hand; only the chosen half goes on the stack.
+ *
+ * Fuss {2}{R/W} — Instant
+ *   Put a +1/+1 counter on each attacking creature you control.
+ *
+ * Bother {4}{W/U}{W/U} — Sorcery
+ *   Create three 1/1 colorless Thopter artifact creature tokens with flying. Surveil 2.
+ *
+ * Neither half targets, so Fuss is [Effects.ForEachInGroup] over the attacking creatures you
+ * control rather than a target list — it hits whatever is attacking as it resolves, and does
+ * nothing at all outside combat. `EffectTarget.Self` inside the group body is the *iterated*
+ * permanent, not the spell.
+ *
+ * Bother's Thopters take their art from the MKM `tokenArt` layer, so no `imageUri` is baked in.
+ * Surveil comes last, matching printed order — the tokens exist before the surveil's graveyard
+ * decision, which matters for anything watching token creation.
+ */
+val FussBother = card("Fuss // Bother") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "WUR"
+
+    face("Fuss") {
+        manaCost = "{2}{R/W}"
+        typeLine = "Instant"
+        oracleText = "Put a +1/+1 counter on each attacking creature you control."
+
+        spell {
+            effect = Effects.ForEachInGroup(
+                filter = GroupFilter(GameObjectFilter.Creature.youControl().attacking()),
+                effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            )
+        }
+    }
+
+    face("Bother") {
+        manaCost = "{4}{W/U}{W/U}"
+        typeLine = "Sorcery"
+        oracleText = "Create three 1/1 colorless Thopter artifact creature tokens with flying. " +
+            "Surveil 2."
+
+        spell {
+            effect = Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = emptySet(),
+                creatureTypes = setOf("Thopter"),
+                keywords = setOf(Keyword.FLYING),
+                count = 3,
+                artifactToken = true,
+                name = "Thopter",
+            ) then Patterns.Library.surveil(2)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "248"
+        artist = "Dominik Mayer"
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/269a031e-0b89-40e1-b11b-ae870d72161c.jpg?1783912831"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/GRN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GRN.json
@@ -50,6 +50,110 @@
     ]
 }
 
+// Assassin's Trophy
+{
+    "name": "Assassin's Trophy",
+    "manaCost": "{B}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target permanent an opponent controls. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target permanent an opponent controls"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": {
+                            "type": "ControllerOf",
+                            "targetDescription": "the destroyed permanent"
+                        }
+                    },
+                    "body": {
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Library",
+                                        "filter": "basicland"
+                                    },
+                                    "storeAs": "searchable"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "searchable",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "found"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "found",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield"
+                                    }
+                                },
+                                "ShuffleLibrary",
+                                "EmitLibrarySearchedEvent"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "permanent ctrl:opponent"
+                },
+                "id": "target permanent an opponent controls"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "rarity": "RARE",
+        "artist": "Seb McKinnon",
+        "flavorText": "A power vacuum for the Azorius. A keepsake for Vraska.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/906b6e99-128f-4c11-8daf-16099d35b0d4.jpg?1783934143",
+        "rulings": [
+            {
+                "date": "2018-10-05",
+                "text": "If the target permanent is a legal target but isn't destroyed, most likely because it has indestructible, its controller may search their library."
+            },
+            {
+                "date": "2018-10-05",
+                "text": "If the permanent's controller doesn't search their library, they don't shuffle their library."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Burglar Rat
 {
     "name": "Burglar Rat",

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -613,6 +613,95 @@
     ]
 }
 
+// Assemble the Players
+{
+    "name": "Assemble the Players",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "You may look at the top card of your library any time.\nOnce each turn, you may cast a creature spell with power 2 or less from the top of your library.",
+    "script": {
+        "staticAbilities": [
+            "LookAtTopOfLibrary",
+            {
+                "type": "CastSpellTypesFromTopOfLibrary",
+                "filter": "creature pow<=2",
+                "maxCastsPerTurn": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "RARE",
+        "artist": "Evyn Fong",
+        "flavorText": "\"All will soon be made clear, but I can give you this: our killer is here with us, in this very room.\"\n—Alquist Proft",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5bcb21a-8559-4791-8cd0-482e7b8dcfd2.jpg?1783912930",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If Assemble the Players leaves the battlefield and returns to the battlefield in the same turn, the casting permission granted by the old one is different than the casting permission granted by the new one. Similarly, if you control multiple Assemble the Players, each one has a different casting permission that may be used once each turn."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because you never \"cast\" a land card, Assemble the Players doesn't allow you to play a land creature (such as Dryad Arbor) from the top of your library."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Audience with Trostani
+{
+    "name": "Audience with Trostani",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a 0/1 green Plant creature token, then draw cards equal to the number of differently named creature tokens you control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreateToken",
+                    "power": 0,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Plant"
+                    ]
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature token",
+                        "aggregation": "DISTINCT_NAMES"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "rarity": "RARE",
+        "artist": "Ben Hill",
+        "flavorText": "Trostani was as regal and vibrant as ever, but Kaya couldn't shake the sense that there was something off, some discordant note lurking deep within the chorus.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a8e23d15-33af-4fd8-964b-8ca4efdebc37.jpg?1783912873",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "To determine the number of differently named creature tokens you control, count each creature token you control once, but only if its English name isn't exactly the same as another creature token you've already counted this way."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Auspicious Arrival
 {
     "name": "Auspicious Arrival",
@@ -3035,6 +3124,81 @@
     ]
 }
 
+// Detective's Satchel
+{
+    "name": "Detective's Satchel",
+    "manaCost": "{2}{U}{R}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, investigate twice. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\n{T}: Create a 1/1 colorless Thopter artifact creature token with flying. Activate only if you've sacrificed an artifact this turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue",
+                    "count": 2
+                },
+                "descriptionOverride": "When this artifact enters, investigate twice."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Thopter"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "name": "Thopter",
+                    "artifactToken": true
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "TurnTracking",
+                                "player": "You",
+                                "tracker": "ARTIFACT_SACRIFICED"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "{T}: Create a 1/1 colorless Thopter artifact creature token with flying. Activate only if you've sacrificed an artifact this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "196",
+        "rarity": "UNCOMMON",
+        "artist": "Andrew Mar",
+        "flavorText": "It's a crime lab in a bag.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2c05bf2d-7d4f-4717-b1ea-ec4284854f4f.jpg?1783912852"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // Dog Walker
 {
     "name": "Dog Walker",
@@ -4957,6 +5121,87 @@
     "colorIdentityOverride": [
         "BLUE"
     ]
+}
+
+// Fuss // Bother
+{
+    "name": "Fuss // Bother",
+    "manaCost": "",
+    "typeLine": "Instant",
+    "oracleText": "Put a +1/+1 counter on each attacking creature you control.\n//\nCreate three 1/1 colorless Thopter artifact creature tokens with flying. Surveil 2.",
+    "metadata": {
+        "collectorNumber": "248",
+        "rarity": "UNCOMMON",
+        "artist": "Dominik Mayer",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/269a031e-0b89-40e1-b11b-ae870d72161c.jpg?1783912831"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "RED"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Fuss",
+            "manaCost": "{2}{R/W}",
+            "typeLine": "Instant",
+            "oracleText": "Put a +1/+1 counter on each attacking creature you control.",
+            "script": {
+                "spellEffect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature attacking ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                }
+            }
+        },
+        {
+            "name": "Bother",
+            "manaCost": "{4}{W/U}{W/U}",
+            "typeLine": "Sorcery",
+            "oracleText": "Create three 1/1 colorless Thopter artifact creature tokens with flying. Surveil 2.",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Thopter"
+                            ],
+                            "keywords": [
+                                "FLYING"
+                            ],
+                            "name": "Thopter",
+                            "artifactToken": true
+                        },
+                        {
+                            "type": "Surveil",
+                            "count": 2
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "hasNoManaCost": true
 }
 
 // Gadget Technician


### PR DESCRIPTION
Five Murders at Karlov Manor cards, all composed from existing `Effects.*` / `Patterns.*` / `Conditions.*` — no new SDK vocabulary.

- **Assassin's Trophy** — `{B}{G}` instant. Destroy target permanent an opponent controls; its controller may fetch a basic. Canonical goes in **Guilds of Ravnica** (#152, the earliest real-expansion printing); MKM #187 gets a `Printing` row. The consolation fetch belongs to the destroyed permanent's controller, so it runs under `Effects.ForEachPlayer(Player.ControllerOf(...))` — that rebinds `Player.You` inside `Patterns.Library.searchLibrary`, which is hard-wired to `Player.You`. Same shape as Volatile Fault / Demolition Field, widened from "nonbasic land" to any permanent.
- **Audience with Trostani** — `{2}{G}` sorcery. `Effects.CreateToken` then `Effects.DrawCards(DynamicAmounts.battlefield(You, Creature.token()).distinctNames())`. The "then" is load-bearing: the Plant exists before the count, so it always draws at least one.
- **Detective's Satchel** — `{2}{U}{R}` artifact. `Effects.Investigate(2)` on entry; the `{T}` Thopter is gated by `ActivationRestriction.OnlyIfCondition(Conditions.SacrificedArtifactThisTurn)`, MKM's existing `ARTIFACT_SACRIFICED` turn tracker. Self-enabling — the Clues it makes are the artifacts you sacrifice.
- **Fuss // Bother** — `{2}{R/W}` // `{4}{W/U}{W/U}`, split layout (CR 709). Fuss is `Effects.ForEachInGroup` over attacking creatures you control (no targets); Bother is three Thopters then `surveil(2)`, in printed order.
- **Assemble the Players** — `{1}{W}` enchantment. `LookAtTopOfLibrary` (private peek, not Future Sight's public reveal) plus `CastSpellTypesFromTopOfLibrary(Creature.powerAtMost(2), maxCastsPerTurn = 1)`. The per-turn allowance belongs to the granting permanent, which is exactly the printed ruling about controlling two copies.

**Dropped from the batch: Cryptex.** It needs an `unlock` counter, and counters are stored as a `CounterType` enum — an arbitrary name isn't supported, so it's new SDK vocabulary and gets its own PR (precedent: `Add Blood Spatter Analysis with bloodstain counter support`). Assemble the Players took its slot.

## Verification

`just build` — green after re-blessing. The golden diff is purely additive (349 insertions, 0 deletions) and touches only the five cards; no unrelated card moved. `just check-card-printing` passes for all five, including the GRN-canonical / MKM-reprint split for Assassin's Trophy.

No scenario tests: every card is built from existing primitives, so the snapshot and lint nets cover them (skill Step 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
