### PR TITLE
Add Baldur's Gate's whole Assay-ready list: 78 cards, 5/651 -> 83/651

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/ThunderDragon.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/ThunderDragon.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Thunder Dragon
+ * {5}{R}{R}
+ * Creature — Dragon
+ * 5/5
+ * Flying
+ * When this creature enters, it deals 3 damage to each creature without flying.
+ *
+ * A one-sided sweeper in an ETB slot: [Patterns.Group.dealDamageToAll] over
+ * [GroupFilter.AllCreatures]`.withoutKeyword(FLYING)` is the same iteration Earthquake uses, so the
+ * "without flying" clause is a filter predicate rather than any new damage vocabulary — and the
+ * Dragon's own flying keeps it out of its own blast.
+ */
+val ThunderDragon = card("Thunder Dragon") {
+    manaCost = "{5}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    power = 5
+    toughness = 5
+    oracleText = "Flying\n" +
+        "When this creature enters, it deals 3 damage to each creature without flying."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Group.dealDamageToAll(3, GroupFilter.AllCreatures.withoutKeyword(Keyword.FLYING))
+        description = "When this creature enters, it deals 3 damage to each creature without flying."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "119"
+        artist = "Dana Knutson"
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e9b06a8-c3f3-4174-b992-7da7ca163990.jpg?1783946025"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/DauthiHorror.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/DauthiHorror.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Dauthi Horror
+ * {1}{B}
+ * Creature — Dauthi Horror
+ * 2/1
+ * Shadow (This creature can block or be blocked by only creatures with shadow.)
+ * This creature can't be blocked by white creatures.
+ *
+ * Two independent evasion rules stacked: [Keyword.SHADOW] is read directly by the block-evasion
+ * rules, and the white clause is a separate [CantBeBlockedBy] over a colored creature filter — the
+ * two narrow each other rather than composing into one filter.
+ */
+val DauthiHorror = card("Dauthi Horror") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Dauthi Horror"
+    power = 2
+    toughness = 1
+    oracleText = "Shadow (This creature can block or be blocked by only creatures with shadow.)\n" +
+        "This creature can't be blocked by white creatures."
+
+    keywords(Keyword.SHADOW)
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.withColor(Color.WHITE))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "122"
+        artist = "Jeff Laubenstein"
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5a8bb3a-3a84-442f-8e31-8af2f04408ab.jpg?1783946642"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/Propaganda.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/Propaganda.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AttackTax
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Propaganda
+ * {2}{U}
+ * Enchantment
+ * Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.
+ *
+ * The whole card is one [AttackTax] static — the engine's combat-tax rules already charge the
+ * per-attacker amount to each attacking creature's controller, so a flat [DynamicAmount.Fixed] of 2
+ * is the entire card (the same shape Windborn Muse uses for the identical line).
+ */
+val Propaganda = card("Propaganda") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you."
+
+    staticAbility {
+        ability = AttackTax(amountPerAttacker = DynamicAmount.Fixed(2))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "80"
+        artist = "Jeff Miracola"
+        flavorText = "\"You've failed Gerrard. You've failed the Legacy. You've failed yourself. I can do no more.\"\n—Volrath, to Karn"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f67dde4d-3df1-480d-a8b8-ab22c768bb12.jpg?1783946652"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/RyuseiTheFallingStar.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/RyuseiTheFallingStar.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Ryusei, the Falling Star
+ * {5}{R}
+ * Legendary Creature — Dragon Spirit
+ * 5/5
+ * Flying
+ * When Ryusei dies, it deals 5 damage to each creature without flying.
+ *
+ * Thunder Dragon's sweeper moved from the enters slot to the dies slot: [Triggers.Dies] plus
+ * [Patterns.Group.dealDamageToAll] over [GroupFilter.AllCreatures]`.withoutKeyword(FLYING)`. The
+ * loop reads nothing off Ryusei itself — each damage instance targets the iterated creature — so
+ * the ability needs no last-known information about the source that has already left the
+ * battlefield.
+ */
+val RyuseiTheFallingStar = card("Ryusei, the Falling Star") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Dragon Spirit"
+    power = 5
+    toughness = 5
+    oracleText = "Flying\n" +
+        "When Ryusei dies, it deals 5 damage to each creature without flying."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Patterns.Group.dealDamageToAll(5, GroupFilter.AllCreatures.withoutKeyword(Keyword.FLYING))
+        description = "When Ryusei dies, it deals 5 damage to each creature without flying."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "185"
+        artist = "Nottsuo"
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/17898412-6275-4762-a03b-04daf30fee7f.jpg?1783944296"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/SearchForTomorrow.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/SearchForTomorrow.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Search for Tomorrow
+ * {2}{G}
+ * Sorcery
+ * Search your library for a basic land card, put it onto the battlefield, then shuffle.
+ * Suspend 2—{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)
+ *
+ * The spell half is the stock ramp tutor, [Patterns.Library.searchLibrary] over
+ * [GameObjectFilter.BasicLand] into [SearchDestination.BATTLEFIELD] with a shuffle after.
+ * `Keyword.SUSPEND` is display-only — the engine's `SuspendEnumerator` reads the parameterized
+ * [KeywordAbility.Suspend] instead, so suspend is written as `suspend("{G}", 2)` (cost first,
+ * time counters second) exactly as on `tsp/cards/AncestralVision.kt`; the keyword is derived from it.
+ */
+val SearchForTomorrow = card("Search for Tomorrow") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Search your library for a basic land card, put it onto the battlefield, then " +
+        "shuffle.\n" +
+        "Suspend 2—{G} (Rather than cast this card from your hand, you may pay {G} and exile it " +
+        "with two time counters on it. At the beginning of your upkeep, remove a time counter. " +
+        "When the last is removed, you may cast it without paying its mana cost.)"
+
+    spell {
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            count = 1,
+            destination = SearchDestination.BATTLEFIELD,
+            shuffleAfter = true
+        )
+    }
+
+    keywordAbility(KeywordAbility.suspend("{G}", 2))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "216"
+        artist = "Randy Gallegos"
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/56f739e8-b4ba-426a-a159-0e0d5a0ebb6f.jpg?1783943208"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/BloodbraidElf.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/BloodbraidElf.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.arb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bloodbraid Elf
+ * {2}{R}{G}
+ * Creature — Elf Berserker
+ * 3/2
+ * Haste (This creature can attack and {T} as soon as it comes under your control.)
+ * Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)
+ *
+ * Haste is a plain keyword, but [Keyword.CASCADE] is display-only — nothing in the rules engine
+ * reads it. Cascade is itself a "when you cast this spell" triggered ability (CR 702.85a), so the
+ * behavior lives in the [Triggers.WhenYouCastThisSpell] trigger feeding [Effects.Cascade], with the
+ * keyword kept only for the printed line — the same shape as `cmr/cards/AnnoyedAltisaur.kt`.
+ */
+val BloodbraidElf = card("Bloodbraid Elf") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Elf Berserker"
+    power = 3
+    toughness = 2
+    oracleText = "Haste (This creature can attack and {T} as soon as it comes under your control.)\n" +
+        "Cascade (When you cast this spell, exile cards from the top of your library until you " +
+        "exile a nonland card that costs less. You may cast it without paying its mana cost. Put " +
+        "the exiled cards on the bottom in a random order.)"
+
+    keywords(Keyword.HASTE, Keyword.CASCADE)
+
+    // Cascade — the cast trigger the keyword abbreviates.
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        effect = Effects.Cascade
+        description = "Cascade"
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "50"
+        artist = "Dominick Domingo"
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7ef67487-c8e5-49bb-b0f7-e073ff2e31f1.jpg?1783942431"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/RyuseiTheFallingStarReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/RyuseiTheFallingStarReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ryusei, the Falling Star reprint in ARC. The canonical CardDefinition lives in
+ * Champions of Kamigawa (`chk`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val RyuseiTheFallingStarReprint = Printing(
+    oracleId = "5e99ba3b-dc2b-4c3c-84ce-228d4772cfee",
+    name = "Ryusei, the Falling Star",
+    setCode = "ARC",
+    collectorNumber = "45",
+    scryfallId = "f05861f1-f6f1-44fa-91e9-f7cfa66b38ff",
+    artist = "Nottsuo",
+    imageUri = "https://cards.scryfall.io/normal/front/f/0/f05861f1-f6f1-44fa-91e9-f7cfa66b38ff.jpg?1783941907",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/DesolateLighthouse.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/DesolateLighthouse.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Desolate Lighthouse
+ *
+ * Land
+ * {T}: Add {C}.
+ * {1}{U}{R}, {T}: Draw a card, then discard a card.
+ *
+ * Two plain activated abilities: a written [Effects.AddColorlessMana] mana ability — the type line
+ * carries no basic land subtype, so nothing grants it intrinsically — and [Patterns.Hand.loot],
+ * whose default draw-1/discard-1 is exactly the printed rummage, behind a [Costs.Composite] of the
+ * mana and the tap.
+ */
+val DesolateLighthouse = card("Desolate Lighthouse") {
+    manaCost = ""
+    colorIdentity = "RU"
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{1}{U}{R}, {T}: Draw a card, then discard a card."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}{R}"), Costs.Tap)
+        effect = Patterns.Hand.loot()
+        description = "{1}{U}{R}, {T}: Draw a card, then discard a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "227"
+        artist = "Scott Chou"
+        flavorText = "A lonely sentinel facing gales, hurricanes, and tides of homicidal spirits."
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/16fb45bc-6152-4b01-9831-a8e80b1c1852.jpg?1783940649"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SunkenHollow.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SunkenHollow.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Sunken Hollow
+ *
+ * Land — Island Swamp
+ * ({T}: Add {U} or {B}.)
+ * This land enters tapped unless you control two or more basic lands.
+ *
+ * The battle land cycle is one line of real rules text: [EntersTapped] with an `unlessCondition`
+ * of [Conditions.YouControlAtLeast] over basic lands — a count, not a mere existence check, and
+ * without the "other" variant because the printed line does not say "other". The mana is *not*
+ * written: the `Island Swamp` subtypes on the type line make `IntrinsicManaAbilities` grant {U}
+ * and {B} already, which is exactly why the printed tap line sits in reminder parentheses.
+ */
+val SunkenHollow = card("Sunken Hollow") {
+    manaCost = ""
+    colorIdentity = "BU"
+    typeLine = "Land — Island Swamp"
+    oracleText = "({T}: Add {U} or {B}.)\n" +
+        "This land enters tapped unless you control two or more basic lands."
+
+    replacementEffect(
+        EntersTapped(
+            unlessCondition = Conditions.YouControlAtLeast(2, GameObjectFilter.BasicLand)
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "249"
+        artist = "Adam Paquette"
+        flavorText = "On the continent of Tazeem, rushing waters plunge through narrow canyons into mist-cloaked lakes."
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0dd1726f-b899-491a-8b0e-8e3d25f17d3d.jpg?1783938172"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/PropagandaReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/PropagandaReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Propaganda reprint in C13. The canonical CardDefinition lives in
+ * Tempest (`tmp`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val PropagandaReprint = Printing(
+    oracleId = "ea9709b6-4c37-4d5a-b04d-cd4c42e4f9dd",
+    name = "Propaganda",
+    setCode = "C13",
+    collectorNumber = "53",
+    scryfallId = "5bb7c8eb-6286-4fb9-a52e-f61930dc0217",
+    artist = "Clint Cearley",
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5bb7c8eb-6286-4fb9-a52e-f61930dc0217.jpg?1783939681",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/BloodbraidElfReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/BloodbraidElfReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bloodbraid Elf reprint in C16. The canonical CardDefinition lives in
+ * Alara Reborn (`arb`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val BloodbraidElfReprint = Printing(
+    oracleId = "3f0c9466-5ab9-4205-a84f-b4b27b5a678e",
+    name = "Bloodbraid Elf",
+    setCode = "C16",
+    collectorNumber = "184",
+    scryfallId = "81c46232-bfd6-4661-953d-84f31ed94a9a",
+    artist = "Raymond Swanland",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/81c46232-bfd6-4661-953d-84f31ed94a9a.jpg?1783937052",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/ManagorgerHydraReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/ManagorgerHydraReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Managorger Hydra reprint in C16. The canonical CardDefinition lives in
+ * Magic Origins (`ori`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val ManagorgerHydraReprint = Printing(
+    oracleId = "b3f2265b-dd65-4b74-8b74-35ee0b147617",
+    name = "Managorger Hydra",
+    setCode = "C16",
+    collectorNumber = "157",
+    scryfallId = "f2e4ab33-150e-4004-a346-4842f4e701cc",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/f/2/f2e4ab33-150e-4004-a346-4842f4e701cc.jpg?1783937058",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/PropagandaReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/PropagandaReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Propaganda reprint in C16. The canonical CardDefinition lives in
+ * Tempest (`tmp`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val PropagandaReprint = Printing(
+    oracleId = "ea9709b6-4c37-4d5a-b04d-cd4c42e4f9dd",
+    name = "Propaganda",
+    setCode = "C16",
+    collectorNumber = "94",
+    scryfallId = "c180f9bd-7dd7-4318-8625-2fa674cbc528",
+    artist = "Clint Cearley",
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c180f9bd-7dd7-4318-8625-2fa674cbc528.jpg?1783937071",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/HornetQueen.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/HornetQueen.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hornet Queen
+ * {4}{G}{G}{G}
+ * Creature — Insect
+ * 2/2
+ * Flying, deathtouch
+ * When this creature enters, create four 1/1 green Insect creature tokens with flying and deathtouch.
+ *
+ * A single [Effects.CreateToken] carries the whole card: the token's colors, creature types and
+ * granted keywords are parameters of that one effect, and `count = 4` makes the swarm one effect
+ * rather than four — no repetition primitive is needed.
+ */
+val HornetQueen = card("Hornet Queen") {
+    manaCost = "{4}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect"
+    power = 2
+    toughness = 2
+    oracleText = "Flying, deathtouch\n" +
+        "When this creature enters, create four 1/1 green Insect creature tokens with flying and deathtouch."
+
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Insect"),
+            keywords = setOf(Keyword.FLYING, Keyword.DEATHTOUCH),
+            count = 4
+        )
+        description = "When this creature enters, create four 1/1 green Insect creature tokens " +
+            "with flying and deathtouch."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "159"
+        artist = "Martina Pilcerova"
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/714cd47b-88f6-448d-9242-481935565250.jpg?1783941193"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/PropagandaReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/PropagandaReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Propaganda reprint in CMD. The canonical CardDefinition lives in
+ * Tempest (`tmp`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val PropagandaReprint = Printing(
+    oracleId = "ea9709b6-4c37-4d5a-b04d-cd4c42e4f9dd",
+    name = "Propaganda",
+    setCode = "CMD",
+    collectorNumber = "55",
+    scryfallId = "48f9976c-e8a2-4f5a-a2d0-aa63b27c19dc",
+    artist = "Jeff Miracola",
+    imageUri = "https://cards.scryfall.io/normal/front/4/8/48f9976c-e8a2-4f5a-a2d0-aa63b27c19dc.jpg?1783941235",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/MarduStrikeLeader.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/MarduStrikeLeader.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.frf.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mardu Strike Leader
+ * {2}{B}
+ * Creature — Human Warrior
+ * 3/2
+ * Whenever this creature attacks, create a 2/1 black Warrior creature token.
+ * Dash {3}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)
+ *
+ * Ragavan's dash shape: `dash` is a builder property rather than a keyword constant, and setting it
+ * is what adds the `KeywordAbility.Dash` the cast enumerator reads. The printed body is one
+ * [Triggers.Attacks] trigger over [Effects.CreateToken]; the token's art comes from the set's
+ * token sheet, so no image is spelled here.
+ */
+val MarduStrikeLeader = card("Mardu Strike Leader") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warrior"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever this creature attacks, create a 2/1 black Warrior creature token.\n" +
+        "Dash {3}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)"
+
+    dash = "{3}{B}"
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Warrior")
+        )
+        description = "Whenever this creature attacks, create a 2/1 black Warrior creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "75"
+        artist = "Jason Rainville"
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c93fd5f0-fb62-42cc-8c7d-c0368e191c4b.jpg?1783938696"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/HighPriestOfPenance.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/HighPriestOfPenance.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.gtc.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * High Priest of Penance
+ * {W}{B}
+ * Creature — Human Cleric
+ * 1/1
+ * Whenever this creature is dealt damage, you may destroy target nonland permanent.
+ *
+ * A 1/1 that punishes any answer aimed at it: [Triggers.TakesDamage] is the SELF-bound incoming-damage
+ * event, so it fires even on lethal damage (the trigger is detected off the damage event before
+ * state-based actions bury the Priest), and "you may" is the [MayEffect] wrapper around
+ * [Effects.Destroy].
+ */
+val HighPriestOfPenance = card("High Priest of Penance") {
+    manaCost = "{W}{B}"
+    colorIdentity = "BW"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever this creature is dealt damage, you may destroy target nonland permanent."
+
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        val t = target(
+            "target nonland permanent",
+            TargetPermanent(filter = TargetFilter.NonlandPermanent),
+        )
+        effect = MayEffect(Effects.Destroy(t))
+        description = "Whenever this creature is dealt damage, you may destroy target nonland permanent."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "171"
+        artist = "Mark Zug"
+        flavorText = "\"All I require is faith, loyalty, obedience, trust, and complete and utter devotion.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/84a3ff8d-6d7e-49f0-8d30-7f8c23db568b.jpg?1783940106"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/HornetQueenReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/HornetQueenReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hornet Queen reprint in M15. The canonical CardDefinition lives in
+ * Commander 2011 (`cmd`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val HornetQueenReprint = Printing(
+    oracleId = "3b1f8108-6911-49e9-8f78-f950bb58cb6c",
+    name = "Hornet Queen",
+    setCode = "M15",
+    collectorNumber = "178",
+    scryfallId = "494f761a-dbc4-4cfa-a258-e4de46bb825e",
+    artist = "Martina Pilcerova",
+    imageUri = "https://cards.scryfall.io/normal/front/4/9/494f761a-dbc4-4cfa-a258-e4de46bb825e.jpg?1783939166",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ManagorgerHydra.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ManagorgerHydra.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Managorger Hydra
+ * {2}{G}
+ * Creature — Hydra
+ * 1/1
+ * Trample
+ * Whenever a player casts a spell, put a +1/+1 counter on this creature.
+ *
+ * The whole card is one cast watcher scoped to *every* player: [Triggers.AnyPlayerCastsSpell] is the
+ * `Player.Each` form of the spell-cast event, so the Hydra grows off opponents' spells as well as
+ * your own — the untargeted, self-directed [Effects.AddCounters] needs no target plumbing.
+ */
+val ManagorgerHydra = card("Managorger Hydra") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Hydra"
+    power = 1
+    toughness = 1
+    oracleText = "Trample\n" +
+        "Whenever a player casts a spell, put a +1/+1 counter on this creature."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.AnyPlayerCastsSpell
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever a player casts a spell, put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "186"
+        artist = "Lucas Graciano"
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a08e5ab-1ff9-4470-ab28-fea19bb79845.jpg?1783938321"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/BloodbraidElfReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/BloodbraidElfReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bloodbraid Elf reprint in PC2. The canonical CardDefinition lives in
+ * Alara Reborn (`arb`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val BloodbraidElfReprint = Printing(
+    oracleId = "3f0c9466-5ab9-4205-a84f-b4b27b5a678e",
+    name = "Bloodbraid Elf",
+    setCode = "PC2",
+    collectorNumber = "84",
+    scryfallId = "13a35076-fc69-42f9-bae8-695462c67425",
+    artist = "Steve Argyle",
+    imageUri = "https://cards.scryfall.io/normal/front/1/3/13a35076-fc69-42f9-bae8-695462c67425.jpg?1783940602",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/afr/cards/PriestOfAncientLore.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/afr/cards/PriestOfAncientLore.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.afr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Priest of Ancient Lore
+ * {2}{W}
+ * Creature — Dwarf Cleric
+ * 2/1
+ * When this creature enters, you gain 1 life and draw a card.
+ *
+ * Two independent rewards joined by "and", so the body is [Effects.Composite] over [Effects.GainLife]
+ * and [Effects.DrawCards] in printed order — both default to the controller, which is who the line means.
+ */
+val PriestOfAncientLore = card("Priest of Ancient Lore") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dwarf Cleric"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature enters, you gain 1 life and draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Effects.GainLife(1),
+            Effects.DrawCards(1),
+        )
+        description = "When this creature enters, you gain 1 life and draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "35"
+        artist = "Jarel Threat"
+        flavorText = "\"We are a product of our ancestors, the apotheosis of countless noble generations. Speak their names with reverence, and they will guide your path.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b10caff0-701a-48d8-a943-f947482e795a.jpg?1783926524"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/RyuseiTheFallingStarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/RyuseiTheFallingStarReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ryusei, the Falling Star reprint in C17. The canonical CardDefinition lives in
+ * Champions of Kamigawa (`chk`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val RyuseiTheFallingStarReprint = Printing(
+    oracleId = "5e99ba3b-dc2b-4c3c-84ce-228d4772cfee",
+    name = "Ryusei, the Falling Star",
+    setCode = "C17",
+    collectorNumber = "141",
+    scryfallId = "a8d9e6c9-695f-4606-870a-3e2dad5e5d70",
+    artist = "Nottsuo",
+    imageUri = "https://cards.scryfall.io/normal/front/a/8/a8d9e6c9-695f-4606-870a-3e2dad5e5d70.jpg?1783935896",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/CommanderLegendsBattleForBaldursGateSet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/CommanderLegendsBattleForBaldursGateSet.kt
@@ -27,6 +27,10 @@ object CommanderLegendsBattleForBaldursGateSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ArastaOfTheEndlessWebReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ArastaOfTheEndlessWebReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arasta of the Endless Web reprint in CLB. The canonical CardDefinition lives in
+ * Theros Beyond Death (`thb`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val ArastaOfTheEndlessWebReprint = Printing(
+    oracleId = "695eea46-1535-48c5-bbb6-0b8379e77bfc",
+    name = "Arasta of the Endless Web",
+    setCode = "CLB",
+    collectorNumber = "817",
+    scryfallId = "558b6db8-4a54-4d25-98e7-e27efc1cab38",
+    artist = "Sam Rowan",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/558b6db8-4a54-4d25-98e7-e27efc1cab38.jpg?1783922411",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+    frameEffects = listOf("enchantment", "legendary"),
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ArcaneEncyclopediaReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ArcaneEncyclopediaReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arcane Encyclopedia reprint in CLB. The canonical CardDefinition lives in
+ * Core Set 2019 (`m19`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val ArcaneEncyclopediaReprint = Printing(
+    oracleId = "d91ea728-2d69-42cb-bb5d-e2b058f0d7b1",
+    name = "Arcane Encyclopedia",
+    setCode = "CLB",
+    collectorNumber = "297",
+    scryfallId = "00ff4cb8-a0e0-4527-a77d-03394065ffe0",
+    artist = "Victor Harmatiuk",
+    imageUri = "https://cards.scryfall.io/normal/front/0/0/00ff4cb8-a0e0-4527-a77d-03394065ffe0.jpg?1783922682",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/AshBarrensReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/AshBarrensReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ash Barrens reprint in CLB. The canonical CardDefinition lives in
+ * Commander 2016 (`c16`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val AshBarrensReprint = Printing(
+    oracleId = "58257464-278e-45fa-8e0b-bcd9a7500bc1",
+    name = "Ash Barrens",
+    setCode = "CLB",
+    collectorNumber = "880",
+    scryfallId = "fb71aebf-f5d3-45ee-91a4-51088f7141ec",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/f/b/fb71aebf-f5d3-45ee-91a4-51088f7141ec.jpg?1783922381",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/BasiliskCollarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/BasiliskCollarReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Basilisk Collar reprint in CLB. The canonical CardDefinition lives in
+ * Worldwake (`wwk`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val BasiliskCollarReprint = Printing(
+    oracleId = "f5f4dd28-f4ae-4d39-b9b8-6ebfd63c93fe",
+    name = "Basilisk Collar",
+    setCode = "CLB",
+    collectorNumber = "300",
+    scryfallId = "52a55efe-a870-4cd7-b22b-37c917065653",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/5/2/52a55efe-a870-4cd7-b22b-37c917065653.jpg?1783922681",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/BlasphemousActReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/BlasphemousActReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blasphemous Act reprint in CLB. The canonical CardDefinition lives in
+ * Bloomburrow Commander (`blc`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val BlasphemousActReprint = Printing(
+    oracleId = "7a2484a9-04fd-41a0-8224-610c1c07ed10",
+    name = "Blasphemous Act",
+    setCode = "CLB",
+    collectorNumber = "780",
+    scryfallId = "ba975f60-ca29-4fc8-b2f0-416be395f200",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/ba975f60-ca29-4fc8-b2f0-416be395f200.jpg?1783922433",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/BloodbraidElfReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/BloodbraidElfReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bloodbraid Elf reprint in CLB. The canonical CardDefinition lives in
+ * Alara Reborn (`arb`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val BloodbraidElfReprint = Printing(
+    oracleId = "3f0c9466-5ab9-4205-a84f-b4b27b5a678e",
+    name = "Bloodbraid Elf",
+    setCode = "CLB",
+    collectorNumber = "839",
+    scryfallId = "8174d8dc-ae0f-469f-a773-cb294540ea25",
+    artist = "Raymond Swanland",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/8174d8dc-ae0f-469f-a773-cb294540ea25.jpg?1783922400",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/BonecallerCleric.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/BonecallerCleric.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Bonecaller Cleric
+ * {1}{B}
+ * Creature — Human Cleric
+ * 2/1
+ * {3}{B}, Sacrifice this creature: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.
+ *
+ * Broodheart Engine's reanimation shape on a creature: a [Costs.Composite] of mana plus
+ * [Costs.SacrificeSelf], and [Effects.Move] out of the graveyard onto the battlefield. "Activate
+ * only as a sorcery" is a [TimingRule], not an activation restriction — a different field and a
+ * different code path from "only during your turn".
+ */
+val BonecallerCleric = card("Bonecaller Cleric") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 1
+    oracleText = "{3}{B}, Sacrifice this creature: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{B}"), Costs.SacrificeSelf)
+        val creature = target("target", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.Move(creature, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+        timing = TimingRule.SorcerySpeed
+        description = "{3}{B}, Sacrifice this creature: Return target creature card from your " +
+            "graveyard to the battlefield. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "117"
+        artist = "Jason A. Engle"
+        flavorText = "The bell's unearthly chime slips into the ears of the dead, waking them rudely from their eternal slumber."
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/87f411d0-c796-443f-b957-c632aa23deb0.jpg?1783922765"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/BreathWeapon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/BreathWeapon.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Breath Weapon
+ * {2}{R}
+ * Instant
+ * Breath Weapon deals 2 damage to each non-Dragon creature.
+ *
+ * A plain sweeper with a tribal hole in it: [Patterns.Group.dealDamageToAll] iterates a
+ * [GroupFilter] whose base is [GameObjectFilter.Creature] narrowed by `notSubtype(DRAGON)`, so the
+ * damage lands on every creature on the battlefield that isn't a Dragon — the printed word is
+ * "creature", so the Dragon exclusion rides on the creature filter rather than a bare tribal one.
+ */
+val BreathWeapon = card("Breath Weapon") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Breath Weapon deals 2 damage to each non-Dragon creature."
+
+    spell {
+        effect = Patterns.Group.dealDamageToAll(
+            amount = 2,
+            filter = GroupFilter(GameObjectFilter.Creature.notSubtype(Subtype.DRAGON)),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "165"
+        artist = "Adam Vehige"
+        flavorText = "\"In the name of Tempus, Lord of Battles, you will die honorably in righteous fire.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/0174e40a-0ef5-4439-91e6-3fc39f482520.jpg?1783922743"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/BronzeWalrus.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/BronzeWalrus.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Bronze Walrus
+ * {3}
+ * Artifact Creature — Walrus
+ * 2/2
+ * When this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+ * {T}: Add one mana of any color.
+ *
+ * Two stock bodies side by side: [Triggers.EntersBattlefield] with the [Effects.Scry] macro, and the
+ * any-color mana ability, which needs `manaAbility`/[TimingRule.ManaAbility] so it resolves without the stack.
+ */
+val BronzeWalrus = card("Bronze Walrus") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Walrus"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)\n" +
+        "{T}: Add one mana of any color."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Scry(2)
+        description = "When this creature enters, scry 2."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "302"
+        artist = "James Paick"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b2cfd2c0-2110-47f1-809e-487b9b0a1043.jpg?1783922682"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/CastleEmberethReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/CastleEmberethReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Castle Embereth reprint in CLB. The canonical CardDefinition lives in
+ * Throne of Eldraine (`eld`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val CastleEmberethReprint = Printing(
+    oracleId = "91fbb25b-8521-483f-88b0-77778d25f7fd",
+    name = "Castle Embereth",
+    setCode = "CLB",
+    collectorNumber = "883",
+    scryfallId = "eb4126a6-5f79-4dad-8d18-e279ca19d2b2",
+    artist = "Jaime Jones",
+    imageUri = "https://cards.scryfall.io/normal/front/e/b/eb4126a6-5f79-4dad-8d18-e279ca19d2b2.jpg?1783922381",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/CastleVantressReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/CastleVantressReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Castle Vantress reprint in CLB. The canonical CardDefinition lives in
+ * Throne of Eldraine (`eld`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val CastleVantressReprint = Printing(
+    oracleId = "cdf41cf4-4e77-453d-be5b-0abbbd358934",
+    name = "Castle Vantress",
+    setCode = "CLB",
+    collectorNumber = "885",
+    scryfallId = "dcf70844-18b1-4046-ae1d-ef41790bdcde",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/d/c/dcf70844-18b1-4046-ae1d-ef41790bdcde.jpg?1783922379",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/CharcoalDiamondReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/CharcoalDiamondReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Charcoal Diamond reprint in CLB. The canonical CardDefinition lives in
+ * Mirage (`mir`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val CharcoalDiamondReprint = Printing(
+    oracleId = "1386d111-a2a7-4df1-91d7-947664126989",
+    name = "Charcoal Diamond",
+    setCode = "CLB",
+    collectorNumber = "305",
+    scryfallId = "f0475c79-bc7f-4de8-a020-226bc658d303",
+    artist = "Gaboleps",
+    imageUri = "https://cards.scryfall.io/normal/front/f/0/f0475c79-bc7f-4de8-a020-226bc658d303.jpg?1783922679",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ChardalynDragon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ChardalynDragon.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chardalyn Dragon
+ * {6}
+ * Artifact Creature — Dragon
+ * 4/4
+ * Flying
+ *
+ * A vanilla body with one evergreen keyword: [Keyword.FLYING] via `keywords(...)` is the whole card,
+ * with no script at all.
+ */
+val ChardalynDragon = card("Chardalyn Dragon") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "306"
+        artist = "Sergey Glushakov"
+        flavorText = "First discovered in ancient Netheril, chardalyn stones absorb and hold magical energy, enabling constructs to be infused with fearsome power and unnatural malice."
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a950d8be-dcf7-4253-a3cc-c040ba632355.jpg?1783922678"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/CinderGladeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/CinderGladeReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cinder Glade reprint in CLB. The canonical CardDefinition lives in
+ * Battle for Zendikar (`bfz`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val CinderGladeReprint = Printing(
+    oracleId = "dfac0258-e148-4d7d-8ded-fc2466d9caa6",
+    name = "Cinder Glade",
+    setCode = "CLB",
+    collectorNumber = "887",
+    scryfallId = "801b5a17-491e-416f-990d-187fce6c4ce4",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/801b5a17-491e-416f-990d-187fce6c4ce4.jpg?1783922378",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/CloakOfTheBat.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/CloakOfTheBat.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Cloak of the Bat
+ * {2}
+ * Artifact — Equipment
+ * Equipped creature has flying and haste.
+ * Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)
+ *
+ * Vanilla Equipment: [equipAbility] lowers the printed equip line into the flagged, sorcery-speed
+ * attach ability, and the grant is two [GrantKeyword] statics over [Filters.EquippedCreature]
+ * because a single [GrantKeyword] holds exactly one keyword.
+ */
+val CloakOfTheBat = card("Cloak of the Bat") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature has flying and haste.\n" +
+        "Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE, Filters.EquippedCreature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "307"
+        artist = "Dominik Mayer"
+        flavorText = "\"How about the power of silent flight? Does that suit your needs, cutthroat?\"\n—Rivalen Blackhand, proprietor of Sorcerous Sundries"
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2f508a65-ff32-480a-b9c6-075074d0c3c3.jpg?1783922679"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/CommanderLegendsBattleForBaldursGateBasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/CommanderLegendsBattleForBaldursGateBasicLands.kt
@@ -1,0 +1,161 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Commander Legends: Battle for Baldur's Gate Basic Lands
+ *
+ * CLB prints four art variants of each basic land type (451-470), all in the same
+ * normal frame.
+ */
+
+// =============================================================================
+// Plains (451, 452, 453, 454)
+// =============================================================================
+
+val ClbPlains451 = basicLand("Plains") {
+    collectorNumber = "451"
+    artist = "Bruce Brenneise"
+    imageUri = "https://cards.scryfall.io/normal/front/1/4/14f5f561-39fd-4cdf-b22e-40cfd6a19d12.jpg?1783922616"
+}
+
+val ClbPlains452 = basicLand("Plains") {
+    collectorNumber = "452"
+    artist = "Leanna Crossan"
+    imageUri = "https://cards.scryfall.io/normal/front/4/b/4be390eb-3470-4f36-9bf4-3f9f8e5d5b31.jpg?1783922615"
+}
+
+val ClbPlains453 = basicLand("Plains") {
+    collectorNumber = "453"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/5/2/524ff04c-932e-4441-a2a7-1416cd43d232.jpg?1783922615"
+}
+
+val ClbPlains454 = basicLand("Plains") {
+    collectorNumber = "454"
+    artist = "Emmanuel Shiu"
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0f55597c-f265-4c4b-a5f1-cc58da609534.jpg?1783922614"
+}
+
+// =============================================================================
+// Island (455, 456, 457, 458)
+// =============================================================================
+
+val ClbIsland455 = basicLand("Island") {
+    collectorNumber = "455"
+    artist = "Bruce Brenneise"
+    imageUri = "https://cards.scryfall.io/normal/front/f/f/ff3ffe47-53a3-42ec-ae89-afc79793380d.jpg?1783922614"
+}
+
+val ClbIsland456 = basicLand("Island") {
+    collectorNumber = "456"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/2/1/21b99a83-bfe4-4149-b626-269953c5ac51.jpg?1783922616"
+}
+
+val ClbIsland457 = basicLand("Island") {
+    collectorNumber = "457"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/2/9/2995e06d-8145-485e-aeed-3da27a07545b.jpg?1783922613"
+}
+
+val ClbIsland458 = basicLand("Island") {
+    collectorNumber = "458"
+    artist = "Sam White"
+    imageUri = "https://cards.scryfall.io/normal/front/c/9/c9c9ea23-93c5-4aae-9786-3b3c03a07778.jpg?1783922614"
+}
+
+// =============================================================================
+// Swamp (459, 460, 461, 462)
+// =============================================================================
+
+val ClbSwamp459 = basicLand("Swamp") {
+    collectorNumber = "459"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fc4111be-6dae-4ca5-bd58-c1ce7cfa9cf6.jpg?1783922612"
+}
+
+val ClbSwamp460 = basicLand("Swamp") {
+    collectorNumber = "460"
+    artist = "Logan Feliciano"
+    imageUri = "https://cards.scryfall.io/normal/front/e/0/e0866a19-429b-43e4-a4a1-338fe12ead42.jpg?1783922612"
+}
+
+val ClbSwamp461 = basicLand("Swamp") {
+    collectorNumber = "461"
+    artist = "Grady Frederick"
+    imageUri = "https://cards.scryfall.io/normal/front/7/1/716460ce-2602-476c-aa53-40d1f22ea7c8.jpg?1783922613"
+}
+
+val ClbSwamp462 = basicLand("Swamp") {
+    collectorNumber = "462"
+    artist = "Sam White"
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/19c03592-debd-4b4f-a5ea-a31ce63f5d23.jpg?1783922611"
+}
+
+// =============================================================================
+// Mountain (463, 464, 465, 466)
+// =============================================================================
+
+val ClbMountain463 = basicLand("Mountain") {
+    collectorNumber = "463"
+    artist = "Matt Gaser"
+    imageUri = "https://cards.scryfall.io/normal/front/0/a/0ab63e49-0869-4c7c-a033-d8e50032dd13.jpg?1783922611"
+}
+
+val ClbMountain464 = basicLand("Mountain") {
+    collectorNumber = "464"
+    artist = "Lucas Graciano"
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b4376426-c901-44eb-8186-c009a3657893.jpg?1783922609"
+}
+
+val ClbMountain465 = basicLand("Mountain") {
+    collectorNumber = "465"
+    artist = "Muhammad Firdaus"
+    imageUri = "https://cards.scryfall.io/normal/front/0/3/0333e39b-45e7-46df-908c-0748092ce8c1.jpg?1783922608"
+}
+
+val ClbMountain466 = basicLand("Mountain") {
+    collectorNumber = "466"
+    artist = "Sam White"
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/35132c99-01b9-463c-a00d-6f125893c870.jpg?1783922608"
+}
+
+// =============================================================================
+// Forest (467, 468, 469, 470)
+// =============================================================================
+
+val ClbForest467 = basicLand("Forest") {
+    collectorNumber = "467"
+    artist = "Bruce Brenneise"
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3cf23791-1b15-43ee-b81a-5fe068709bc1.jpg?1783922608"
+}
+
+val ClbForest468 = basicLand("Forest") {
+    collectorNumber = "468"
+    artist = "Muhammad Firdaus"
+    imageUri = "https://cards.scryfall.io/normal/front/2/b/2b86b3a4-981e-497a-b78b-30b2dbc5ea7a.jpg?1783922608"
+}
+
+val ClbForest469 = basicLand("Forest") {
+    collectorNumber = "469"
+    artist = "Lucas Graciano"
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3ca33d91-3c1a-4351-9d9d-d46a6e3de084.jpg?1783922608"
+}
+
+val ClbForest470 = basicLand("Forest") {
+    collectorNumber = "470"
+    artist = "Julian Kok Joon Wen"
+    imageUri = "https://cards.scryfall.io/normal/front/3/8/3812e162-3511-4988-b2a1-3bc6945ac45b.jpg?1783922607"
+}
+
+/**
+ * All Commander Legends: Battle for Baldur's Gate basic land variants.
+ */
+val CommanderLegendsBattleForBaldursGateBasicLands = listOf(
+    ClbPlains451, ClbPlains452, ClbPlains453, ClbPlains454,
+    ClbIsland455, ClbIsland456, ClbIsland457, ClbIsland458,
+    ClbSwamp459, ClbSwamp460, ClbSwamp461, ClbSwamp462,
+    ClbMountain463, ClbMountain464, ClbMountain465, ClbMountain466,
+    ClbForest467, ClbForest468, ClbForest469, ClbForest470
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DarkHatchlingReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DarkHatchlingReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dark Hatchling reprint in CLB. The canonical CardDefinition lives in
+ * Urza's Saga (`usg`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val DarkHatchlingReprint = Printing(
+    oracleId = "36633b43-855b-4620-8afb-70c39fc07280",
+    name = "Dark Hatchling",
+    setCode = "CLB",
+    collectorNumber = "747",
+    scryfallId = "133e9654-74a3-4997-b371-7f36b5d9c4f1",
+    artist = "Brad Rigney",
+    imageUri = "https://cards.scryfall.io/normal/front/1/3/133e9654-74a3-4997-b371-7f36b5d9c4f1.jpg?1783922456",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DauthiHorrorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DauthiHorrorReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dauthi Horror reprint in CLB. The canonical CardDefinition lives in
+ * Tempest (`tmp`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val DauthiHorrorReprint = Printing(
+    oracleId = "07c20708-c305-46e7-a98e-c99f54aeafec",
+    name = "Dauthi Horror",
+    setCode = "CLB",
+    collectorNumber = "748",
+    scryfallId = "7c41afe6-7eed-4cf5-9bbb-ccc9f82cb4fa",
+    artist = "Jeff Laubenstein",
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7c41afe6-7eed-4cf5-9bbb-ccc9f82cb4fa.jpg?1783922452",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DemonBoltReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DemonBoltReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Demon Bolt reprint in CLB. The canonical CardDefinition lives in
+ * Kaldheim (`khm`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val DemonBoltReprint = Printing(
+    oracleId = "6e786f0b-e2cb-40ee-96bc-81945a0b35a3",
+    name = "Demon Bolt",
+    setCode = "CLB",
+    collectorNumber = "787",
+    scryfallId = "3c43bf24-399e-407a-a563-bb04f93a0497",
+    artist = "Campbell White",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3c43bf24-399e-407a-a563-bb04f93a0497.jpg?1783922427",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DesolateLighthouseReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DesolateLighthouseReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Desolate Lighthouse reprint in CLB. The canonical CardDefinition lives in
+ * Avacyn Restored (`avr`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val DesolateLighthouseReprint = Printing(
+    oracleId = "aa6dbdf2-2379-4ff5-8a6c-70258784dc35",
+    name = "Desolate Lighthouse",
+    setCode = "CLB",
+    collectorNumber = "890",
+    scryfallId = "8b7f5239-29d3-4b2b-b464-7e43107b1348",
+    artist = "Scott Chou",
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8b7f5239-29d3-4b2b-b464-7e43107b1348.jpg?1783922377",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DraconicLore.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DraconicLore.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Draconic Lore
+ * {5}{U}
+ * Instant
+ * This spell costs {2} less to cast if you control a Dragon.
+ * Draw three cards.
+ *
+ * A plain [Effects.DrawCards] spell wearing a cost reducer: [ModifySpellCost] over
+ * [SpellCostTarget.SelfCast] is the primitive the whole card hangs on, and its
+ * [CostGating.OnlyIf] takes [Conditions.ControlPermanentOfType] because the bare tribal
+ * noun "a Dragon" asks about any permanent with the subtype, not only a creature.
+ */
+val DraconicLore = card("Draconic Lore") {
+    manaCost = "{5}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "This spell costs {2} less to cast if you control a Dragon.\n" +
+        "Draw three cards."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.OnlyIf(Conditions.ControlPermanentOfType(Subtype.DRAGON)),
+        )
+    }
+
+    spell {
+        effect = Effects.DrawCards(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "64"
+        artist = "Tom Babbey"
+        flavorText = "The wyrmling studied the ancient carvings and dreamed of a day when her own exploits would be immortalized in stone."
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/557f2aa6-0b82-4f60-9617-610b613c2a48.jpg?1783922792"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DraconicMuralists.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DraconicMuralists.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Draconic Muralists
+ * {3}{G}
+ * Creature — Dragon Bard
+ * 4/3
+ * When this creature dies, you may search your library for a Dragon card, reveal it, put it into your hand, then shuffle.
+ *
+ * A dies trigger over the stock tutor recipe: [Patterns.Library.searchLibrary] is the whole
+ * gather / select / reveal-and-move / shuffle pipeline, so only the destination and the reveal are
+ * spelled here. "A Dragon card" is a bare tribal noun — any permanent card with the subtype, not
+ * only a creature — and the printed "you may" is the ability's `optional` flag, which the builder
+ * lowers into the consent gate around the search.
+ */
+val DraconicMuralists = card("Draconic Muralists") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dragon Bard"
+    power = 4
+    toughness = 3
+    oracleText = "When this creature dies, you may search your library for a Dragon card, reveal it, put it into your hand, then shuffle."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        optional = true
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.DRAGON),
+            count = 1,
+            destination = SearchDestination.HAND,
+            shuffleAfter = true,
+            reveal = true
+        )
+        description = "When this creature dies, you may search your library for a Dragon card, " +
+            "reveal it, put it into your hand, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "224"
+        artist = "Tom Babbey"
+        flavorText = "\"We must never allow the deeds of our great ancestors to be forgotten.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c9bf864-1f93-4d73-a212-f71265411768.jpg?1783922717"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DragonbornLooter.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DragonbornLooter.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonborn Looter
+ * {1}{U}
+ * Creature — Dragon Rogue
+ * 1/2
+ * {1}, {T}: Draw a card, then discard a card.
+ *
+ * Merfolk Looter with a mana surcharge: [Patterns.Hand.loot] is the whole effect — draw one, then
+ * the gather/select/move discard spine whose defaults already carry the choice prompt — under a
+ * [Costs.Composite] of the mana atom and [Costs.Tap].
+ */
+val DragonbornLooter = card("Dragonborn Looter") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Dragon Rogue"
+    power = 1
+    toughness = 2
+    oracleText = "{1}, {T}: Draw a card, then discard a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Patterns.Hand.loot()
+        description = "{1}, {T}: Draw a card, then discard a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "65"
+        artist = "Julio Reyna"
+        flavorText = "Erdur never thought of it as stealing. Treasure simply didn't deserve to be stuck underground where no one could admire it."
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/570e8aaa-5273-42f4-b151-51976ab7730c.jpg?1783922793"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DragonsHoardReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DragonsHoardReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragon's Hoard reprint in CLB. The canonical CardDefinition lives in
+ * Core Set 2019 (`m19`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val DragonsHoardReprint = Printing(
+    oracleId = "8cf77dc4-763b-41b7-a5da-0ef2734f08e6",
+    name = "Dragon's Hoard",
+    setCode = "CLB",
+    collectorNumber = "858",
+    scryfallId = "36b6f0a8-b6c2-49fc-880c-01ad63213271",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/36b6f0a8-b6c2-49fc-880c-01ad63213271.jpg?1783922391",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/EarthTremor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/EarthTremor.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Earth Tremor
+ * {3}{R}
+ * Instant
+ * Earth Tremor deals damage to target creature or planeswalker equal to the number of lands you control.
+ *
+ * The whole card is one [Effects.DealDamage] whose amount is the dynamic
+ * [DynamicAmounts.landsYouControl] board count rather than a fixed number, so the damage is
+ * recomputed on resolution; [Targets.CreatureOrPlaneswalker] carries the target clause.
+ */
+val EarthTremor = card("Earth Tremor") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Earth Tremor deals damage to target creature or planeswalker equal to the number of lands you control."
+
+    spell {
+        val t = target("target", Targets.CreatureOrPlaneswalker)
+        effect = Effects.DealDamage(DynamicAmounts.landsYouControl(), t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "171"
+        artist = "Borja Pindado"
+        flavorText = "\"Every cave-in is Moradin telling you to leave the earth where it is.\"\n—Halgar, dwarven recluse"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5f700c6-7591-481d-b223-21f5b820e831.jpg?1783922742"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/FireDiamondReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/FireDiamondReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fire Diamond reprint in CLB. The canonical CardDefinition lives in
+ * Mirage (`mir`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val FireDiamondReprint = Printing(
+    oracleId = "97b477d8-2e05-475e-8ed6-7d680cb21cd9",
+    name = "Fire Diamond",
+    setCode = "CLB",
+    collectorNumber = "313",
+    scryfallId = "5a561484-438b-4ce9-911e-97078ac5b0fa",
+    artist = "Gaboleps",
+    imageUri = "https://cards.scryfall.io/normal/front/5/a/5a561484-438b-4ce9-911e-97078ac5b0fa.jpg?1783922676",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/HedronArchiveReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/HedronArchiveReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hedron Archive reprint in CLB. The canonical CardDefinition lives in
+ * Battle for Zendikar (`bfz`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val HedronArchiveReprint = Printing(
+    oracleId = "32263baa-d3f0-463f-92b3-4e9938476add",
+    name = "Hedron Archive",
+    setCode = "CLB",
+    collectorNumber = "861",
+    scryfallId = "3d76d25c-b962-43e4-aa6f-7c6e3bd79f16",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3d76d25c-b962-43e4-aa6f-7c6e3bd79f16.jpg?1783922390",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/HexReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/HexReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hex reprint in CLB. The canonical CardDefinition lives in
+ * Ravnica: City of Guilds (`rav`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val HexReprint = Printing(
+    oracleId = "89457fa8-b0e2-4277-b6a9-c6601c59b46d",
+    name = "Hex",
+    setCode = "CLB",
+    collectorNumber = "757",
+    scryfallId = "067c38f3-4b5c-4e7f-af66-e410dea19314",
+    artist = "Michael Sutfin",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/067c38f3-4b5c-4e7f-af66-e410dea19314.jpg?1783922449",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/HighPriestOfPenanceReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/HighPriestOfPenanceReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * High Priest of Penance reprint in CLB. The canonical CardDefinition lives in
+ * Gatecrash (`gtc`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val HighPriestOfPenanceReprint = Printing(
+    oracleId = "d8070ee7-dbd1-4d38-9715-ba14e103e379",
+    name = "High Priest of Penance",
+    setCode = "CLB",
+    collectorNumber = "848",
+    scryfallId = "fc264fad-c541-4cc6-8b56-44abf3f1e8a0",
+    artist = "Mark Zug",
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fc264fad-c541-4cc6-8b56-44abf3f1e8a0.jpg?1783922397",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/HighlandForestReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/HighlandForestReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Highland Forest reprint in CLB. The canonical CardDefinition lives in
+ * Kaldheim (`khm`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val HighlandForestReprint = Printing(
+    oracleId = "35137378-6754-4bb1-a38e-5940890ccab1",
+    name = "Highland Forest",
+    setCode = "CLB",
+    collectorNumber = "896",
+    scryfallId = "59f64a32-c364-4750-94ed-d4d71c1a3511",
+    artist = "Alayna Danner",
+    imageUri = "https://cards.scryfall.io/normal/front/5/9/59f64a32-c364-4750-94ed-d4d71c1a3511.jpg?1783922375",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+    frameEffects = listOf("snow"),
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/HornetQueenReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/HornetQueenReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hornet Queen reprint in CLB. The canonical CardDefinition lives in
+ * Commander 2011 (`cmd`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val HornetQueenReprint = Printing(
+    oracleId = "3b1f8108-6911-49e9-8f78-f950bb58cb6c",
+    name = "Hornet Queen",
+    setCode = "CLB",
+    collectorNumber = "825",
+    scryfallId = "6ef7c1a5-eb4e-4f75-ad41-1b84741ecab1",
+    artist = "Jonathan Kuo",
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6ef7c1a5-eb4e-4f75-ad41-1b84741ecab1.jpg?1783922406",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/IrregularCohortReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/IrregularCohortReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Irregular Cohort reprint in CLB. The canonical CardDefinition lives in
+ * Modern Horizons (`mh1`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val IrregularCohortReprint = Printing(
+    oracleId = "c0636d16-671c-4e80-af8c-67d80d2cd979",
+    name = "Irregular Cohort",
+    setCode = "CLB",
+    collectorNumber = "696",
+    scryfallId = "61775227-34ad-469a-a4d4-ee8ce69dd10f",
+    artist = "Steve Argyle",
+    imageUri = "https://cards.scryfall.io/normal/front/6/1/61775227-34ad-469a-a4d4-ee8ce69dd10f.jpg?1783922491",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/LightningBoltReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/LightningBoltReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Bolt reprint in CLB. The canonical CardDefinition lives in
+ * Limited Edition Alpha (`lea`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val LightningBoltReprint = Printing(
+    oracleId = "4457ed35-7c10-48c8-9776-456485fdf070",
+    name = "Lightning Bolt",
+    setCode = "CLB",
+    collectorNumber = "187",
+    scryfallId = "ae5f9fb1-5a55-4db3-98a1-2628e3598c18",
+    artist = "Irina Nordsol",
+    imageUri = "https://cards.scryfall.io/normal/front/a/e/ae5f9fb1-5a55-4db3-98a1-2628e3598c18.jpg?1783922736",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/LightningGreavesReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/LightningGreavesReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Greaves reprint in CLB. The canonical CardDefinition lives in
+ * Mirrodin (`mrd`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val LightningGreavesReprint = Printing(
+    oracleId = "ca204b66-8d0c-431a-8d34-282f7c2d17da",
+    name = "Lightning Greaves",
+    setCode = "CLB",
+    collectorNumber = "864",
+    scryfallId = "8d9f47af-5929-44f4-bc6b-3ac7e521177d",
+    artist = "Jeremy Jarvis",
+    imageUri = "https://cards.scryfall.io/normal/front/8/d/8d9f47af-5929-44f4-bc6b-3ac7e521177d.jpg?1783922389",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ManagorgerHydraReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ManagorgerHydraReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Managorger Hydra reprint in CLB. The canonical CardDefinition lives in
+ * Magic Origins (`ori`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val ManagorgerHydraReprint = Printing(
+    oracleId = "b3f2265b-dd65-4b74-8b74-35ee0b147617",
+    name = "Managorger Hydra",
+    setCode = "CLB",
+    collectorNumber = "828",
+    scryfallId = "330aefb9-629f-4d07-94d4-7252f17f85ba",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/3/3/330aefb9-629f-4d07-94d4-7252f17f85ba.jpg?1783922407",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/MarbleDiamondReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/MarbleDiamondReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Marble Diamond reprint in CLB. The canonical CardDefinition lives in
+ * Mirage (`mir`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val MarbleDiamondReprint = Printing(
+    oracleId = "910488bf-66ab-415e-973b-1262b2ab7454",
+    name = "Marble Diamond",
+    setCode = "CLB",
+    collectorNumber = "320",
+    scryfallId = "0930f71c-c3c8-4bdd-8468-6a61349cc8ca",
+    artist = "Gaboleps",
+    imageUri = "https://cards.scryfall.io/normal/front/0/9/0930f71c-c3c8-4bdd-8468-6a61349cc8ca.jpg?1783922673",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/MarduStrikeLeaderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/MarduStrikeLeaderReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mardu Strike Leader reprint in CLB. The canonical CardDefinition lives in
+ * Fate Reforged (`frf`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val MarduStrikeLeaderReprint = Printing(
+    oracleId = "9be8e04f-f87f-4477-93f3-c546e9b346f0",
+    name = "Mardu Strike Leader",
+    setCode = "CLB",
+    collectorNumber = "761",
+    scryfallId = "626ed059-9bd1-4a18-ac85-7b00b8057426",
+    artist = "Jason Rainville",
+    imageUri = "https://cards.scryfall.io/normal/front/6/2/626ed059-9bd1-4a18-ac85-7b00b8057426.jpg?1783922445",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/MeteorGolemReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/MeteorGolemReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meteor Golem reprint in CLB. The canonical CardDefinition lives in
+ * Core Set 2019 (`m19`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val MeteorGolemReprint = Printing(
+    oracleId = "d9f11aa1-9219-42a8-85a9-a8f204160706",
+    name = "Meteor Golem",
+    setCode = "CLB",
+    collectorNumber = "323",
+    scryfallId = "14e17f8c-c705-43ab-ae1a-cde48aceca0a",
+    artist = "James Paick",
+    imageUri = "https://cards.scryfall.io/normal/front/1/4/14e17f8c-c705-43ab-ae1a-cde48aceca0a.jpg?1783922671",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/MindStoneReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/MindStoneReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mind Stone reprint in CLB. The canonical CardDefinition lives in
+ * Weatherlight (`wth`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val MindStoneReprint = Printing(
+    oracleId = "c97361b5-af16-4a7b-af85-a429dbaf4ad2",
+    name = "Mind Stone",
+    setCode = "CLB",
+    collectorNumber = "325",
+    scryfallId = "1969ddc0-ee6c-4c3d-a9dd-7f1c491609be",
+    artist = "Ioannis Fiore",
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/1969ddc0-ee6c-4c3d-a9dd-7f1c491609be.jpg?1783922670",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/MossDiamondReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/MossDiamondReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moss Diamond reprint in CLB. The canonical CardDefinition lives in
+ * Mirage (`mir`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val MossDiamondReprint = Printing(
+    oracleId = "02500f21-6e15-423e-93ff-891e09fe9904",
+    name = "Moss Diamond",
+    setCode = "CLB",
+    collectorNumber = "327",
+    scryfallId = "96fcae3a-d58c-4832-8280-3f65b5dfd853",
+    artist = "Gaboleps",
+    imageUri = "https://cards.scryfall.io/normal/front/9/6/96fcae3a-d58c-4832-8280-3f65b5dfd853.jpg?1783922671",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/MurderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/MurderReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Murder reprint in CLB. The canonical CardDefinition lives in
+ * Magic 2013 (`m13`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val MurderReprint = Printing(
+    oracleId = "938b4e2c-88d9-4637-bc00-e228920c9a78",
+    name = "Murder",
+    setCode = "CLB",
+    collectorNumber = "134",
+    scryfallId = "bdef7fea-2bd0-42a2-96f6-6def18bd7f0c",
+    artist = "David Astruga",
+    imageUri = "https://cards.scryfall.io/normal/front/b/d/bdef7fea-2bd0-42a2-96f6-6def18bd7f0c.jpg?1783922760",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/NaturalReclamationReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/NaturalReclamationReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Natural Reclamation reprint in CLB. The canonical CardDefinition lives in
+ * Commander Legends (`cmr`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val NaturalReclamationReprint = Printing(
+    oracleId = "98266582-12fd-4a7b-a9bb-e9cc4370ed28",
+    name = "Natural Reclamation",
+    setCode = "CLB",
+    collectorNumber = "829",
+    scryfallId = "70c4fc42-e5c6-438b-a4b7-1f77e818597f",
+    artist = "Alayna Danner",
+    imageUri = "https://cards.scryfall.io/normal/front/7/0/70c4fc42-e5c6-438b-a4b7-1f77e818597f.jpg?1783922406",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/NaturesLoreReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/NaturesLoreReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nature's Lore reprint in CLB. The canonical CardDefinition lives in
+ * Ice Age (`ice`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val NaturesLoreReprint = Printing(
+    oracleId = "78826359-fe63-44ad-adc4-a17ffcd710e4",
+    name = "Nature's Lore",
+    setCode = "CLB",
+    collectorNumber = "244",
+    scryfallId = "543d1e79-cac6-455c-9fda-f13c849579d6",
+    artist = "Kim Sokol",
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/543d1e79-cac6-455c-9fda-f13c849579d6.jpg?1783922708",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PilgrimsEyeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PilgrimsEyeReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pilgrim's Eye reprint in CLB. The canonical CardDefinition lives in
+ * Worldwake (`wwk`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val PilgrimsEyeReprint = Printing(
+    oracleId = "66155010-cc2c-449a-85d5-92c95aade514",
+    name = "Pilgrim's Eye",
+    setCode = "CLB",
+    collectorNumber = "333",
+    scryfallId = "32161267-e12b-454f-a7e1-94e078566ffa",
+    artist = "Sean Murray",
+    imageUri = "https://cards.scryfall.io/normal/front/3/2/32161267-e12b-454f-a7e1-94e078566ffa.jpg?1783922666",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PlagueSpitterReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PlagueSpitterReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plague Spitter reprint in CLB. The canonical CardDefinition lives in
+ * Invasion (`inv`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val PlagueSpitterReprint = Printing(
+    oracleId = "5feedfb0-30e6-400d-9e28-d541ea1aa14e",
+    name = "Plague Spitter",
+    setCode = "CLB",
+    collectorNumber = "767",
+    scryfallId = "a82559e5-110b-4c6a-956a-7cba83788dc8",
+    artist = "Chippy",
+    imageUri = "https://cards.scryfall.io/normal/front/a/8/a82559e5-110b-4c6a-956a-7cba83788dc8.jpg?1783922442",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PriestOfAncientLoreReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PriestOfAncientLoreReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Priest of Ancient Lore reprint in CLB. The canonical CardDefinition lives in
+ * Adventures in the Forgotten Realms (`afr`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val PriestOfAncientLoreReprint = Printing(
+    oracleId = "a89b0fd5-84b2-487c-8b03-e78d97276fd3",
+    name = "Priest of Ancient Lore",
+    setCode = "CLB",
+    collectorNumber = "704",
+    scryfallId = "8b6f7b89-1648-4c2b-8d68-88ad43267c6f",
+    artist = "Jarel Threat",
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8b6f7b89-1648-4c2b-8d68-88ad43267c6f.jpg?1783922483",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PrimevalBountyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PrimevalBountyReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Primeval Bounty reprint in CLB. The canonical CardDefinition lives in
+ * Magic 2014 (`m14`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val PrimevalBountyReprint = Printing(
+    oracleId = "f633c16d-d943-421c-ad18-af35db9ec9fc",
+    name = "Primeval Bounty",
+    setCode = "CLB",
+    collectorNumber = "830",
+    scryfallId = "03b9e943-9650-434c-a540-35ca7c96365b",
+    artist = "Christine Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/0/3/03b9e943-9650-434c-a540-35ca7c96365b.jpg?1783922407",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PrismariCampusReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PrismariCampusReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prismari Campus reprint in CLB. The canonical CardDefinition lives in
+ * Strixhaven: School of Mages (`stx`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val PrismariCampusReprint = Printing(
+    oracleId = "3a3a1b35-ae4d-49d5-ae09-5a1693ad53ce",
+    name = "Prismari Campus",
+    setCode = "CLB",
+    collectorNumber = "909",
+    scryfallId = "bf90c219-508f-49af-a7f9-540021d49d8c",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/b/f/bf90c219-508f-49af-a7f9-540021d49d8c.jpg?1783922367",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PropagandaReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PropagandaReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Propaganda reprint in CLB. The canonical CardDefinition lives in
+ * Tempest (`tmp`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val PropagandaReprint = Printing(
+    oracleId = "ea9709b6-4c37-4d5a-b04d-cd4c42e4f9dd",
+    name = "Propaganda",
+    setCode = "CLB",
+    collectorNumber = "730",
+    scryfallId = "e5f293d7-9c2b-41cb-8e3c-dfc1daa6635f",
+    artist = "Clint Cearley",
+    imageUri = "https://cards.scryfall.io/normal/front/e/5/e5f293d7-9c2b-41cb-8e3c-dfc1daa6635f.jpg?1783922465",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PropheticPrismReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PropheticPrismReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prophetic Prism reprint in CLB. The canonical CardDefinition lives in
+ * Rise of the Eldrazi (`roe`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val PropheticPrismReprint = Printing(
+    oracleId = "134a9877-5cfb-4a2a-a0f0-930dce45f58b",
+    name = "Prophetic Prism",
+    setCode = "CLB",
+    collectorNumber = "335",
+    scryfallId = "1b837b21-9165-4965-a7b5-c59811647951",
+    artist = "Diego Gisbert",
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1b837b21-9165-4965-a7b5-c59811647951.jpg?1783922666",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PseudodragonFamiliar.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/PseudodragonFamiliar.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pseudodragon Familiar
+ * {2}{U}
+ * Creature — Dragon
+ * 2/1
+ * Flying
+ * {2}{U}: Target creature gains flying until end of turn.
+ *
+ * A flyer that rents its wings out. The activated half is one [Effects.GrantKeyword] on a plain
+ * [Targets.Creature] slot — end-of-turn is that facade's default duration, so the printed "until end
+ * of turn" needs no argument.
+ */
+val PseudodragonFamiliar = card("Pseudodragon Familiar") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Dragon"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\n" +
+        "{2}{U}: Target creature gains flying until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{U}")
+        val creature = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.FLYING, creature)
+        description = "{2}{U}: Target creature gains flying until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "88"
+        artist = "Campbell White"
+        flavorText = "Pseudodragons are favored companions of wizards, prized for their cunning and curiosity."
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/50d69ee8-a616-4191-b111-1330dfb24f72.jpg?1783922780"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/RavenousChupacabraReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/RavenousChupacabraReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ravenous Chupacabra reprint in CLB. The canonical CardDefinition lives in
+ * Rivals of Ixalan (`rix`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val RavenousChupacabraReprint = Printing(
+    oracleId = "7b459306-149b-4f43-abc1-2dd70c748c0e",
+    name = "Ravenous Chupacabra",
+    setCode = "CLB",
+    collectorNumber = "770",
+    scryfallId = "e3de4804-d330-403a-9ab0-e8be78655618",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e3de4804-d330-403a-9ab0-e8be78655618.jpg?1783922438",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/RecklessBarbarian.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/RecklessBarbarian.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Reckless Barbarian
+ * {1}{R}
+ * Creature — Dragon Barbarian
+ * 2/2
+ * Sacrifice this creature: Add {R}{R}.
+ *
+ * Catalyst Elemental's shape exactly: a mana ability, so [Costs.SacrificeSelf] pays for
+ * [Effects.AddMana] with no target and no stack — the `manaAbility` flag is what makes the engine
+ * treat it as one, and it carries the [TimingRule.ManaAbility] timing with it.
+ */
+val RecklessBarbarian = card("Reckless Barbarian") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon Barbarian"
+    power = 2
+    toughness = 2
+    oracleText = "Sacrifice this creature: Add {R}{R}."
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.AddMana(Color.RED, 2)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "193"
+        artist = "Oleksandr Kozachenko"
+        flavorText = "The best defense is not even knowing what the word \"defense\" means."
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c912e984-1d27-4da2-9733-d56e437bcf58.jpg?1783922731"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/RoguesPassageReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/RoguesPassageReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rogue's Passage reprint in CLB. The canonical CardDefinition lives in
+ * Return to Ravnica (`rtr`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val RoguesPassageReprint = Printing(
+    oracleId = "f29dc596-2121-4421-8463-15f6c2e8b9b3",
+    name = "Rogue's Passage",
+    setCode = "CLB",
+    collectorNumber = "913",
+    scryfallId = "e1f1dd27-be41-4bfa-b59d-3a002647f1ad",
+    artist = "Christine Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e1f1dd27-be41-4bfa-b59d-3a002647f1ad.jpg?1783922366",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/RovingHarper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/RovingHarper.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Roving Harper
+ * {2}{W}
+ * Creature — Elf Scout
+ * 2/2
+ * When this creature enters, draw a card.
+ *
+ * The plainest cantrip body there is: [Triggers.EntersBattlefield] carrying [Effects.DrawCards], whose
+ * controller-drawing default is exactly what the printed line means.
+ */
+val RovingHarper = card("Roving Harper") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elf Scout"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+        description = "When this creature enters, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "The Harpers value peaceful coexistence, historical preservation, and harmony with nature, and each day they spread their ideals a little farther."
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c6b0ed9c-9a99-4a50-80a9-396420a8dcf9.jpg?1783922804"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/RyuseiTheFallingStarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/RyuseiTheFallingStarReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ryusei, the Falling Star reprint in CLB. The canonical CardDefinition lives in
+ * Champions of Kamigawa (`chk`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val RyuseiTheFallingStarReprint = Printing(
+    oracleId = "5e99ba3b-dc2b-4c3c-84ce-228d4772cfee",
+    name = "Ryusei, the Falling Star",
+    setCode = "CLB",
+    collectorNumber = "806",
+    scryfallId = "68d57ab8-fbe0-4f01-b7f7-2a5cccd2d13a",
+    artist = "Grzegorz Rutkowski",
+    imageUri = "https://cards.scryfall.io/normal/front/6/8/68d57ab8-fbe0-4f01-b7f7-2a5cccd2d13a.jpg?1783922416",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+    frameEffects = listOf("legendary"),
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SearchForTomorrowReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SearchForTomorrowReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Search for Tomorrow reprint in CLB. The canonical CardDefinition lives in
+ * Time Spiral (`tsp`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val SearchForTomorrowReprint = Printing(
+    oracleId = "9cdc9f99-c6fa-40cd-90b0-e47d43a8cc3c",
+    name = "Search for Tomorrow",
+    setCode = "CLB",
+    collectorNumber = "834",
+    scryfallId = "4c5e2fbf-87fe-48cd-aeca-e37f0a388a30",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/4/c/4c5e2fbf-87fe-48cd-aeca-e37f0a388a30.jpg?1783922403",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SelflessSpiritReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SelflessSpiritReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Selfless Spirit reprint in CLB. The canonical CardDefinition lives in
+ * Eldritch Moon (`emn`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val SelflessSpiritReprint = Printing(
+    oracleId = "71d785a9-ddc8-472e-a778-a551b444a4bd",
+    name = "Selfless Spirit",
+    setCode = "CLB",
+    collectorNumber = "706",
+    scryfallId = "ef8d8d0c-cb0e-4745-a0fb-d556c9324428",
+    artist = "Seb McKinnon",
+    imageUri = "https://cards.scryfall.io/normal/front/e/f/ef8d8d0c-cb0e-4745-a0fb-d556c9324428.jpg?1783922481",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SkyDiamondReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SkyDiamondReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sky Diamond reprint in CLB. The canonical CardDefinition lives in
+ * Mirage (`mir`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val SkyDiamondReprint = Printing(
+    oracleId = "2224b6e0-c5ff-45d0-84e3-83758c5fc99f",
+    name = "Sky Diamond",
+    setCode = "CLB",
+    collectorNumber = "337",
+    scryfallId = "d47abfb2-9bcf-485c-9bd4-2c09b714eb32",
+    artist = "Gaboleps",
+    imageUri = "https://cards.scryfall.io/normal/front/d/4/d47abfb2-9bcf-485c-9bd4-2c09b714eb32.jpg?1783922666",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SnowfieldSinkholeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SnowfieldSinkholeReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snowfield Sinkhole reprint in CLB. The canonical CardDefinition lives in
+ * Kaldheim (`khm`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val SnowfieldSinkholeReprint = Printing(
+    oracleId = "749c2c8e-9588-4e83-b07f-3c37eb63338b",
+    name = "Snowfield Sinkhole",
+    setCode = "CLB",
+    collectorNumber = "915",
+    scryfallId = "3c6e17f2-b1e4-4189-a02f-92fa4b13a1ed",
+    artist = "Marta Nael",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3c6e17f2-b1e4-4189-a02f-92fa4b13a1ed.jpg?1783922367",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+    frameEffects = listOf("snow"),
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SolRingReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SolRingReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sol Ring reprint in CLB. The canonical CardDefinition lives in
+ * Limited Edition Alpha (`lea`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val SolRingReprint = Printing(
+    oracleId = "6ad8011d-3471-4369-9d68-b264cc027487",
+    name = "Sol Ring",
+    setCode = "CLB",
+    collectorNumber = "871",
+    scryfallId = "199cde21-5bc3-49cd-acd4-bae3af6e5881",
+    artist = "Mike Bierek",
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/199cde21-5bc3-49cd-acd4-bae3af6e5881.jpg?1783922385",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SpriteDragonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SpriteDragonReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sprite Dragon reprint in CLB. The canonical CardDefinition lives in
+ * Ikoria: Lair of Behemoths (`iko`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val SpriteDragonReprint = Printing(
+    oracleId = "a9d8ab76-70a4-475e-b87e-4737c090553a",
+    name = "Sprite Dragon",
+    setCode = "CLB",
+    collectorNumber = "852",
+    scryfallId = "361385d8-d9c7-4de8-a5c8-683e682779f4",
+    artist = "Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/361385d8-d9c7-4de8-a5c8-683e682779f4.jpg?1783922395",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SteadfastUnicorn.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SteadfastUnicorn.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Steadfast Unicorn
+ * {W}
+ * Creature — Unicorn
+ * 1/2
+ * {3}{W}: Creatures you control get +1/+1 and gain vigilance until end of turn. Activate only during your turn. (Attacking doesn't cause them to tap.)
+ *
+ * A team pump written as an [Effects.ForEachInGroup] over the creatures you control, whose body pairs
+ * [Effects.ModifyStats] with [Effects.GrantKeyword] on each iterated permanent. "Activate only during
+ * your turn" is [ActivationRestriction.OnlyDuringYourTurn] — a restriction on *whose* turn, not the
+ * sorcery-speed timing rule, which would also forbid activating in your own combat.
+ */
+val SteadfastUnicorn = card("Steadfast Unicorn") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Unicorn"
+    power = 1
+    toughness = 2
+    oracleText = "{3}{W}: Creatures you control get +1/+1 and gain vigilance until end of turn. Activate only during your turn. (Attacking doesn't cause them to tap.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{W}")
+        restrictions = listOf(ActivationRestriction.OnlyDuringYourTurn)
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.Composite(
+                Effects.ModifyStats(1, 1, EffectTarget.Self),
+                Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self)
+            )
+        )
+        description = "{3}{W}: Creatures you control get +1/+1 and gain vigilance until end of turn. Activate only during your turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "44"
+        artist = "John Thacker"
+        flavorText = "Only the good-hearted may set foot in a unicorn's domain."
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13762890-6c5e-44e4-9bd8-998bd054db20.jpg?1783922804"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/Stoneskin.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/Stoneskin.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Stoneskin
+ * {2}{W}
+ * Enchantment — Aura
+ * Flash
+ * Enchant creature
+ * Enchanted creature gets +0/+10.
+ *
+ * A plain Aura: [TargetPermanent] over [GameObjectFilter.Creature] is the "enchant creature" line,
+ * and the whole card is one [ModifyStats] whose default filter is already the attached creature —
+ * no trigger, no target of its own. [Keyword.FLASH] is the only thing that makes it an instant-speed
+ * combat trick.
+ */
+val Stoneskin = card("Stoneskin") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\n" +
+        "Enchant creature\n" +
+        "Enchanted creature gets +0/+10."
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = TargetPermanent(filter = TargetFilter(GameObjectFilter.Creature))
+
+    staticAbility {
+        ability = ModifyStats(0, 10)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "45"
+        artist = "Jake Murray"
+        flavorText = "\"Ooh, nice shot! I almost felt that one.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/16b9fdaa-9da9-48ff-b271-e6a41aabf073.jpg?1783922802"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SunkenHollowReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SunkenHollowReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunken Hollow reprint in CLB. The canonical CardDefinition lives in
+ * Battle for Zendikar (`bfz`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val SunkenHollowReprint = Printing(
+    oracleId = "cd2c90ac-2b04-461c-92f3-939871b6b6a3",
+    name = "Sunken Hollow",
+    setCode = "CLB",
+    collectorNumber = "918",
+    scryfallId = "05c1fd3e-e899-4d66-8ad1-fdfbcdd70e8b",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/0/5/05c1fd3e-e899-4d66-8ad1-fdfbcdd70e8b.jpg?1783922364",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SwiftfootBootsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SwiftfootBootsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftfoot Boots reprint in CLB. The canonical CardDefinition lives in
+ * Magic 2012 (`m12`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val SwiftfootBootsReprint = Printing(
+    oracleId = "c8b143ad-43ec-4e0d-a440-e348daa31391",
+    name = "Swiftfoot Boots",
+    setCode = "CLB",
+    collectorNumber = "339",
+    scryfallId = "16c23cde-e1c0-4cdf-ae59-18d64db518d4",
+    artist = "Manuel Castañón",
+    imageUri = "https://cards.scryfall.io/normal/front/1/6/16c23cde-e1c0-4cdf-ae59-18d64db518d4.jpg?1783922663",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/TempleOfAbandonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/TempleOfAbandonReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temple of Abandon reprint in CLB. The canonical CardDefinition lives in
+ * Theros (`ths`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val TempleOfAbandonReprint = Printing(
+    oracleId = "3baa8e38-ef93-435d-b63e-f781d5bfcc68",
+    name = "Temple of Abandon",
+    setCode = "CLB",
+    collectorNumber = "921",
+    scryfallId = "e544fd20-019a-4f96-891a-6eab4d6a01d7",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/e/5/e544fd20-019a-4f96-891a-6eab4d6a01d7.jpg?1783922362",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/TempleOfDeceitReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/TempleOfDeceitReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temple of Deceit reprint in CLB. The canonical CardDefinition lives in
+ * Theros (`ths`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val TempleOfDeceitReprint = Printing(
+    oracleId = "33b9b3bd-33ca-46f3-b8bb-a978bc3d1085",
+    name = "Temple of Deceit",
+    setCode = "CLB",
+    collectorNumber = "922",
+    scryfallId = "f4e3214a-0f76-4c60-8df9-4984b8d56d89",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/f/4/f4e3214a-0f76-4c60-8df9-4984b8d56d89.jpg?1783922363",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/TempleOfEpiphanyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/TempleOfEpiphanyReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temple of Epiphany reprint in CLB. The canonical CardDefinition lives in
+ * Journey into Nyx (`jou`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val TempleOfEpiphanyReprint = Printing(
+    oracleId = "79f94050-d850-41ca-b1db-5ae0cf743f0a",
+    name = "Temple of Epiphany",
+    setCode = "CLB",
+    collectorNumber = "923",
+    scryfallId = "6b3692d4-be30-4b23-b6e7-0c4af8c034a2",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/6/b/6b3692d4-be30-4b23-b6e7-0c4af8c034a2.jpg?1783922362",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/TempleOfSilenceReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/TempleOfSilenceReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temple of Silence reprint in CLB. The canonical CardDefinition lives in
+ * Theros (`ths`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val TempleOfSilenceReprint = Printing(
+    oracleId = "e6e6fce8-0f6a-4b84-865e-d4e4a4182f9f",
+    name = "Temple of Silence",
+    setCode = "CLB",
+    collectorNumber = "924",
+    scryfallId = "2a3288ba-038c-4d8e-939d-c513a76fbfbf",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2a3288ba-038c-4d8e-939d-c513a76fbfbf.jpg?1783922361",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/TerramorphReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/TerramorphReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Terramorph reprint in CLB. The canonical CardDefinition lives in
+ * Modern Horizons 2 (`mh2`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val TerramorphReprint = Printing(
+    oracleId = "17a34f8d-a80f-4331-8be5-06cbb9d10d7b",
+    name = "Terramorph",
+    setCode = "CLB",
+    collectorNumber = "836",
+    scryfallId = "47c7b2ac-1263-402a-b2a0-bc31f61e66b5",
+    artist = "Darrell Riche",
+    imageUri = "https://cards.scryfall.io/normal/front/4/7/47c7b2ac-1263-402a-b2a0-bc31f61e66b5.jpg?1783922403",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ThreeVisitsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ThreeVisitsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Three Visits reprint in CLB. The canonical CardDefinition lives in
+ * Portal Three Kingdoms (`ptk`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val ThreeVisitsReprint = Printing(
+    oracleId = "1b882a0e-0ede-4d1a-bd1a-9b7cffbcde8e",
+    name = "Three Visits",
+    setCode = "CLB",
+    collectorNumber = "837",
+    scryfallId = "cad698c3-687e-4b73-88d2-fd0ac7d755c5",
+    artist = "Yeong-Hao Han",
+    imageUri = "https://cards.scryfall.io/normal/front/c/a/cad698c3-687e-4b73-88d2-fd0ac7d755c5.jpg?1783922401",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ThunderDragonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ThunderDragonReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thunder Dragon reprint in CLB. The canonical CardDefinition lives in
+ * Starter 1999 (`s99`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val ThunderDragonReprint = Printing(
+    oracleId = "70d9579f-c8a6-4406-afe1-9291fe5ee736",
+    name = "Thunder Dragon",
+    setCode = "CLB",
+    collectorNumber = "810",
+    scryfallId = "9ff75ff4-495f-4a0c-9d98-69eff1b3fa32",
+    artist = "Chris Rahn",
+    imageUri = "https://cards.scryfall.io/normal/front/9/f/9ff75ff4-495f-4a0c-9d98-69eff1b3fa32.jpg?1783922416",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/UniversalSolventReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/UniversalSolventReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Universal Solvent reprint in CLB. The canonical CardDefinition lives in
+ * Aether Revolt (`aer`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val UniversalSolventReprint = Printing(
+    oracleId = "f34ba913-cf9a-48fe-b5fe-68bf504693b2",
+    name = "Universal Solvent",
+    setCode = "CLB",
+    collectorNumber = "342",
+    scryfallId = "e142122f-3a04-436e-a958-dc2224b4fc6d",
+    artist = "Joe Slucher",
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e142122f-3a04-436e-a958-dc2224b4fc6d.jpg?1783922663",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/NaturalReclamation.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/NaturalReclamation.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Natural Reclamation
+ * {4}{G}
+ * Instant
+ * Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)
+ * Destroy target artifact or enchantment.
+ *
+ * A Disenchant body — [Effects.Destroy] on [Targets.ArtifactOrEnchantment] — priced up to make room
+ * for cascade. [Keyword.CASCADE] is display-only, so as on `cmr/cards/AnnoyedAltisaur.kt` the
+ * keyword only prints the line and the real work is a [Triggers.WhenYouCastThisSpell] trigger
+ * feeding [Effects.Cascade]; cascade fires on the cast, so an instant carries it unchanged.
+ */
+val NaturalReclamation = card("Natural Reclamation") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Cascade (When you cast this spell, exile cards from the top of your library " +
+        "until you exile a nonland card that costs less. You may cast it without paying its mana " +
+        "cost. Put the exiled cards on the bottom in a random order.)\n" +
+        "Destroy target artifact or enchantment."
+
+    keywords(Keyword.CASCADE)
+
+    spell {
+        val t = target("target", Targets.ArtifactOrEnchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    // Cascade — the cast trigger the keyword abbreviates.
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        effect = Effects.Cascade
+        description = "Cascade"
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "245"
+        artist = "Alayna Danner"
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3e98fb7c-6962-4b57-b7b7-c71899564002.jpg?1783928787"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/SearchForTomorrowReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/SearchForTomorrowReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Search for Tomorrow reprint in CMR. The canonical CardDefinition lives in
+ * Time Spiral (`tsp`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val SearchForTomorrowReprint = Printing(
+    oracleId = "9cdc9f99-c6fa-40cd-90b0-e47d43a8cc3c",
+    name = "Search for Tomorrow",
+    setCode = "CMR",
+    collectorNumber = "436",
+    scryfallId = "029b6d93-0f7a-4df4-8c01-96cbd5e03315",
+    artist = "Randy Gallegos",
+    imageUri = "https://cards.scryfall.io/normal/front/0/2/029b6d93-0f7a-4df4-8c01-96cbd5e03315.jpg?1783928704",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/CastleEmbereth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/CastleEmbereth.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Castle Embereth
+ *
+ * Land
+ * This land enters tapped unless you control a Mountain.
+ * {T}: Add {R}.
+ * {1}{R}{R}, {T}: Creatures you control get +1/+0 until end of turn.
+ *
+ * Three stock land pieces, nothing bespoke: [EntersTapped] carries the entry clause with an
+ * `unlessCondition` of [Exists] over Mountains you control (Arena of Glory's shape), the type line
+ * is bare `Land` so the {R} tap has to be written out as a real mana ability, and the pump is one
+ * [Patterns.Group.modifyStatsForAll] pass over `creaturesYouControl` — one group named once, which
+ * is why it is a single `ForEachInGroup` rather than a composition.
+ */
+val CastleEmbereth = card("Castle Embereth") {
+    manaCost = ""
+    colorIdentity = "R"
+    typeLine = "Land"
+    oracleText = "This land enters tapped unless you control a Mountain.\n" +
+        "{T}: Add {R}.\n" +
+        "{1}{R}{R}, {T}: Creatures you control get +1/+0 until end of turn."
+
+    replacementEffect(
+        EntersTapped(
+            unlessCondition = Exists(
+                Player.You,
+                Zone.BATTLEFIELD,
+                GameObjectFilter.Land.withSubtype("Mountain"),
+            )
+        )
+    )
+
+    // {T}: Add {R}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {1}{R}{R}, {T}: Creatures you control get +1/+0 until end of turn.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{R}{R}"), Costs.Tap)
+        effect = Patterns.Group.modifyStatsForAll(1, 0, Filters.Group.creaturesYouControl)
+        description = "{1}{R}{R}, {T}: Creatures you control get +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "239"
+        artist = "Jaime Jones"
+        flavorText = "Without Embereth's courage, the realm would falter and fall."
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8bb8512e-6913-4be6-8828-24cfcbec042e.jpg?1783932580"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/CastleVantress.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/CastleVantress.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Castle Vantress
+ *
+ * Land
+ * This land enters tapped unless you control an Island.
+ * {T}: Add {U}.
+ * {2}{U}{U}, {T}: Scry 2.
+ *
+ * The Castle cycle's entry clause is [EntersTapped] with an `unlessCondition` of [Exists] over
+ * Islands you control — a subtype check, so a dual or a nonbasic Island satisfies it just as well
+ * as the basic. The type line is bare `Land` (no Island subtype of its own), so the {U} tap is a
+ * written mana ability rather than an intrinsic one, and the payoff needs nothing new: it is
+ * [Effects.Scry] behind a mana-plus-tap [Costs.Composite].
+ */
+val CastleVantress = card("Castle Vantress") {
+    manaCost = ""
+    colorIdentity = "U"
+    typeLine = "Land"
+    oracleText = "This land enters tapped unless you control an Island.\n" +
+        "{T}: Add {U}.\n" +
+        "{2}{U}{U}, {T}: Scry 2."
+
+    replacementEffect(
+        EntersTapped(
+            unlessCondition = Exists(
+                Player.You,
+                Zone.BATTLEFIELD,
+                GameObjectFilter.Land.withSubtype("Island"),
+            )
+        )
+    )
+
+    // {T}: Add {U}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {2}{U}{U}, {T}: Scry 2.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{U}{U}"), Costs.Tap)
+        effect = Effects.Scry(2)
+        description = "{2}{U}{U}, {T}: Scry 2."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "242"
+        artist = "John Avon"
+        flavorText = "Without Vantress's knowledge, the realm would lose itself in darkness."
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0a8b9d37-e89c-44ad-bd1b-51cb06ec3e0b.jpg?1783932578"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SpriteDragon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SpriteDragon.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sprite Dragon
+ * {U}{R}
+ * Creature — Faerie Dragon
+ * 1/1
+ * Flying, haste
+ * Whenever you cast a noncreature spell, put a +1/+1 counter on this creature.
+ *
+ * A prowess-shaped payoff that keeps what it earns: [Triggers.YouCastNoncreature] is the
+ * `Player.You` + noncreature-filtered cast watcher, and the growth is a permanent
+ * [Effects.AddCounters] on itself rather than an until-end-of-turn pump.
+ */
+val SpriteDragon = card("Sprite Dragon") {
+    manaCost = "{U}{R}"
+    colorIdentity = "RU"
+    typeLine = "Creature — Faerie Dragon"
+    power = 1
+    toughness = 1
+    oracleText = "Flying, haste\n" +
+        "Whenever you cast a noncreature spell, put a +1/+1 counter on this creature."
+
+    keywords(Keyword.FLYING, Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever you cast a noncreature spell, put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "211"
+        artist = "Gabor Szikszai"
+        flavorText = "Size of a pixie, rage of a hellkite."
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/281f6118-adb8-4a7d-9c77-5570f3399e6e.jpg?1783931016"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ArcaneEncyclopediaReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ArcaneEncyclopediaReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arcane Encyclopedia reprint in JMP. The canonical CardDefinition lives in
+ * Core Set 2019 (`m19`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val ArcaneEncyclopediaReprint = Printing(
+    oracleId = "d91ea728-2d69-42cb-bb5d-e2b058f0d7b1",
+    name = "Arcane Encyclopedia",
+    setCode = "JMP",
+    collectorNumber = "459",
+    scryfallId = "416a2796-08c7-4370-8bc5-2152877e9034",
+    artist = "Nic Klein",
+    imageUri = "https://cards.scryfall.io/normal/front/4/1/416a2796-08c7-4370-8bc5-2152877e9034.jpg?1783930342",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RavenousChupacabraReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RavenousChupacabraReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ravenous Chupacabra reprint in JMP. The canonical CardDefinition lives in
+ * Rivals of Ixalan (`rix`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val RavenousChupacabraReprint = Printing(
+    oracleId = "7b459306-149b-4f43-abc1-2dd70c748c0e",
+    name = "Ravenous Chupacabra",
+    setCode = "JMP",
+    collectorNumber = "269",
+    scryfallId = "40d3e58e-f989-4169-9e2c-a66a23170dcf",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/4/0/40d3e58e-f989-4169-9e2c-a66a23170dcf.jpg?1783930411",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/DemonBolt.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/DemonBolt.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Demon Bolt
+ * {2}{R}
+ * Instant
+ * Demon Bolt deals 4 damage to target creature or planeswalker.
+ * Foretell {R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)
+ *
+ * A one-line burn spell: [Effects.DealDamage] with a fixed 4 aimed at a single
+ * [Targets.CreatureOrPlaneswalker] binding. Foretell is the only structural part — the bare
+ * `Keyword.FORETELL` is display-only, so it is lowered into [KeywordAbility.foretell], which the
+ * engine's ForetellEnumerator reads to offer the pay-{2}-and-exile special action and the later
+ * {R} cast from exile. The card builder derives the printed FORETELL keyword from that ability.
+ */
+val DemonBolt = card("Demon Bolt") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Demon Bolt deals 4 damage to target creature or planeswalker.\n" +
+        "Foretell {R} (During your turn, you may pay {2} and exile this card from your hand " +
+        "face down. Cast it on a later turn for its foretell cost.)"
+
+    spell {
+        val t = target("target", Targets.CreatureOrPlaneswalker)
+        effect = Effects.DealDamage(4, t)
+    }
+
+    keywordAbility(KeywordAbility.foretell("{R}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "129"
+        artist = "Campbell White"
+        flavorText = "\"Burn them from the sky.\"\n—Varragoth"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f856b0e-b413-49b0-9aa7-d935ad40ae53.jpg?1783928232"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/HighlandForest.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/HighlandForest.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Highland Forest
+ *
+ * Snow Land — Mountain Forest
+ * ({T}: Add {R} or {G}.)
+ * This land enters tapped.
+ *
+ * The whole card is one [EntersTapped] replacement effect: the parenthesised mana line is reminder
+ * text for the intrinsic abilities the Mountain and Forest subtypes already grant, so writing a mana
+ * ability here would double-tap the land. The Snow supertype rides along in the type line.
+ */
+val HighlandForest = card("Highland Forest") {
+    manaCost = ""
+    colorIdentity = "GR"
+    typeLine = "Snow Land — Mountain Forest"
+    oracleText = "({T}: Add {R} or {G}.)\n" +
+        "This land enters tapped."
+
+    // Mana abilities are intrinsic from the basic land types (Mountain -> {R}, Forest -> {G})
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "261"
+        artist = "Alayna Danner"
+        flavorText = "\"Tread carefully! The last time I walked this path, half the snowdrifts were, in fact, sleeping trolls. I've never run so fast in my life!\"\n—Iskene, Kannah storyteller"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/682eee5f-7986-45d3-910f-407303fdbcc4.jpg?1783928176"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SnowfieldSinkhole.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/SnowfieldSinkhole.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Snowfield Sinkhole
+ *
+ * Snow Land — Plains Swamp
+ * ({T}: Add {W} or {B}.)
+ * This land enters tapped.
+ *
+ * The whole card is one [EntersTapped] replacement effect: the parenthesised mana line is reminder
+ * text for the intrinsic abilities the Plains and Swamp subtypes already grant, so writing a mana
+ * ability here would double-tap the land. The Snow supertype rides along in the type line.
+ */
+val SnowfieldSinkhole = card("Snowfield Sinkhole") {
+    manaCost = ""
+    colorIdentity = "BW"
+    typeLine = "Snow Land — Plains Swamp"
+    oracleText = "({T}: Add {W} or {B}.)\n" +
+        "This land enters tapped."
+
+    // Mana abilities are intrinsic from the basic land types (Plains -> {W}, Swamp -> {B})
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "269"
+        artist = "Marta Nael"
+        flavorText = "\"Young Vitima bellowed to the Cosmos, daring the gods to punish her hubris! Well, she got their attention, as you can see.\"\n—Iskene, Kannah storyteller"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/6611dc5e-6acc-48df-b8c4-4b327314578b.jpg?1783928172"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ArcaneEncyclopedia.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ArcaneEncyclopedia.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arcane Encyclopedia
+ * {3}
+ * Artifact — Book
+ * {3}, {T}: Draw a card.
+ *
+ * A repeatable draw with nothing else on it: the whole card is one [Effects.DrawCards] behind a
+ * [Costs.Composite] of the mana atom and [Costs.Tap], which is exactly how the printed "{3}, {T}"
+ * comma reads. `Book` needs no `Subtype` constant — `TypeLine.parse` carries the word through.
+ */
+val ArcaneEncyclopedia = card("Arcane Encyclopedia") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact — Book"
+    oracleText = "{3}, {T}: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        effect = Effects.DrawCards(1)
+        description = "{3}, {T}: Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "227"
+        artist = "Nic Klein"
+        flavorText = "Knowledge itself is neither good nor evil. Just as the wrong book in the wrong hands could doom all existence, the same book in the right hands could save it."
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0ce4702d-f65b-413e-99da-112f632a0a63.jpg?1783934516"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/IrregularCohort.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/IrregularCohort.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Irregular Cohort
+ * {2}{W}{W}
+ * Creature — Shapeshifter
+ * 2/2
+ * Changeling (This card is every creature type.)
+ * When this creature enters, create a 2/2 colorless Shapeshifter creature token with changeling.
+ *
+ * Changeling is a real keyword the engine reads, so it stays a bare [Keyword.CHANGELING] on the card — and
+ * the token repeats it in [Effects.CreateToken]'s `keywords`, since a token's copy of it is its own grant.
+ */
+val IrregularCohort = card("Irregular Cohort") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Shapeshifter"
+    power = 2
+    toughness = 2
+    oracleText = "Changeling (This card is every creature type.)\n" +
+        "When this creature enters, create a 2/2 colorless Shapeshifter creature token with changeling."
+
+    keywords(Keyword.CHANGELING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            creatureTypes = setOf("Shapeshifter"),
+            keywords = setOf(Keyword.CHANGELING),
+        )
+        description = "When this creature enters, create a 2/2 colorless Shapeshifter creature token with changeling."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "15"
+        artist = "Steve Argyle"
+        flavorText = "Where fickle form meets lasting loyalty."
+        imageUri = "https://cards.scryfall.io/normal/front/9/2/92c46961-cf1a-4f20-83aa-3d256db2388f.jpg?1783933160"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/Terramorph.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/Terramorph.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Terramorph
+ * {3}{G}
+ * Sorcery
+ * Search your library for a basic land card, put it onto the battlefield, then shuffle.
+ * Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+ *
+ * Search for Tomorrow's spell half at a rebound price: [Patterns.Library.searchLibrary] over
+ * [GameObjectFilter.BasicLand] into [SearchDestination.BATTLEFIELD], shuffling after. Unlike
+ * cascade and suspend, [Keyword.REBOUND] has a real consumer — `StackResolver` reads it off
+ * `cardDef.keywords` when the spell resolves — so the bare keyword is the whole implementation.
+ */
+val Terramorph = card("Terramorph") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Search your library for a basic land card, put it onto the battlefield, then " +
+        "shuffle.\n" +
+        "Rebound (If you cast this spell from your hand, exile it as it resolves. At the " +
+        "beginning of your next upkeep, you may cast this card from exile without paying its " +
+        "mana cost.)"
+
+    keywords(Keyword.REBOUND)
+
+    spell {
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            count = 1,
+            destination = SearchDestination.BATTLEFIELD,
+            shuffleAfter = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "177"
+        artist = "Darrell Riche"
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/28b08596-f6c7-4366-a4ed-21a11fbc901a.jpg?1783926824"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ArastaOfTheEndlessWebReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ArastaOfTheEndlessWebReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arasta of the Endless Web reprint in NCC. The canonical CardDefinition lives in
+ * Theros Beyond Death (`thb`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val ArastaOfTheEndlessWebReprint = Printing(
+    oracleId = "695eea46-1535-48c5-bbb6-0b8379e77bfc",
+    name = "Arasta of the Endless Web",
+    setCode = "NCC",
+    collectorNumber = "279",
+    scryfallId = "e905a310-02d5-4a86-bb58-2bb3502edba2",
+    artist = "Sam Rowan",
+    imageUri = "https://cards.scryfall.io/normal/front/e/9/e905a310-02d5-4a86-bb58-2bb3502edba2.jpg?1783923254",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+    frameEffects = listOf("legendary", "enchantment"),
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/CastleEmberethReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/CastleEmberethReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Castle Embereth reprint in NCC. The canonical CardDefinition lives in
+ * Throne of Eldraine (`eld`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val CastleEmberethReprint = Printing(
+    oracleId = "91fbb25b-8521-483f-88b0-77778d25f7fd",
+    name = "Castle Embereth",
+    setCode = "NCC",
+    collectorNumber = "392",
+    scryfallId = "a42a8db8-bc8d-47f6-a1d4-78adfcbdd19e",
+    artist = "Jaime Jones",
+    imageUri = "https://cards.scryfall.io/normal/front/a/4/a42a8db8-bc8d-47f6-a1d4-78adfcbdd19e.jpg?1783923204",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SunkenHollowReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SunkenHollowReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunken Hollow reprint in NCC. The canonical CardDefinition lives in
+ * Battle for Zendikar (`bfz`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val SunkenHollowReprint = Printing(
+    oracleId = "cd2c90ac-2b04-461c-92f3-939871b6b6a3",
+    name = "Sunken Hollow",
+    setCode = "NCC",
+    collectorNumber = "431",
+    scryfallId = "0fb2782e-6fe9-4383-9ba4-02d21b7cb4d7",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0fb2782e-6fe9-4383-9ba4-02d21b7cb4d7.jpg?1783923187",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/RavenousChupacabra.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/RavenousChupacabra.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ravenous Chupacabra
+ * {2}{B}{B}
+ * Creature — Beast Horror
+ * 2/2
+ * When this creature enters, destroy target creature an opponent controls.
+ *
+ * Unconditional removal stapled to a body: [Effects.Destroy] on a cast-time target. The "an
+ * opponent controls" restriction is carried entirely by [Targets.CreatureOpponentControls], whose
+ * filter adds the controller predicate — so no gating condition or extra effect is needed.
+ */
+val RavenousChupacabra = card("Ravenous Chupacabra") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Beast Horror"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, destroy target creature an opponent controls."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val victim = target("target", Targets.CreatureOpponentControls)
+        effect = Effects.Destroy(victim)
+        description = "When this creature enters, destroy target creature an opponent controls."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "82"
+        artist = "Daarken"
+        flavorText = "Opening Orazca unleashed more horrors than just the Immortal Sun."
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02551196-ecea-472f-9547-3c9658d0489e.jpg?1783935306"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/PrismariCampus.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/PrismariCampus.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Prismari Campus
+ *
+ * Land
+ * This land enters tapped.
+ * {T}: Add {U} or {R}.
+ * {4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ *
+ * The Campus cycle is the Coastal Tower shape: an unconditional [EntersTapped] plus "Add {U} or
+ * {R}" written as two separate one-colour mana abilities, which is how the SDK models a choice of
+ * colours — the player picks by choosing which ability to activate. The type line is bare `Land`
+ * with no basic land subtypes, so these written abilities are the land's only mana. The cycling
+ * payoff is plain [Effects.Scry].
+ */
+val PrismariCampus = card("Prismari Campus") {
+    manaCost = ""
+    colorIdentity = "RU"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {U} or {R}.\n" +
+        "{4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    replacementEffect(EntersTapped())
+
+    // {T}: Add {U} or {R}. — modeled as one ability per colour.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {4}, {T}: Scry 1.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap)
+        effect = Effects.Scry(1)
+        description = "{4}, {T}: Scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "270"
+        artist = "Adam Paquette"
+        flavorText = "Mage-students who see spellcraft as the highest form of expression choose Prismari, the college of elemental arts."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/768120f5-9401-4e52-924e-3374bde65b3d.jpg?1783927271"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ArastaOfTheEndlessWeb.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ArastaOfTheEndlessWeb.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Arasta of the Endless Web
+ * {2}{G}{G}
+ * Legendary Enchantment Creature — Spider
+ * 3/5
+ * Reach
+ * Whenever an opponent casts an instant or sorcery spell, create a 1/2 green Spider creature token with reach.
+ *
+ * A cast watcher narrowed on both axes at once: [Triggers.opponentCasts] supplies the
+ * `Player.EachOpponent` scope and [GameObjectFilter.InstantOrSorcery] the spell type, so the whole
+ * printed condition is the trigger and the body is a plain [Effects.CreateToken] — the token's own
+ * reach rides along as a `keywords` argument rather than a separate granting ability.
+ */
+val ArastaOfTheEndlessWeb = card("Arasta of the Endless Web") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Enchantment Creature — Spider"
+    power = 3
+    toughness = 5
+    oracleText = "Reach\n" +
+        "Whenever an opponent casts an instant or sorcery spell, create a 1/2 green Spider creature token with reach."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.opponentCasts(GameObjectFilter.InstantOrSorcery)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Spider"),
+            keywords = setOf(Keyword.REACH),
+        )
+        description = "Whenever an opponent casts an instant or sorcery spell, create a 1/2 green " +
+            "Spider creature token with reach."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "165"
+        artist = "Sam Rowan"
+        flavorText = "Her webs, spun from her own hair, reach from Nyx to the mortal world and even into the Underworld."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c38833a-96c5-48b5-8dd8-23f10e798537.jpg?1783931542"
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/ArastaOfTheEndlessWebReprint.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/ArastaOfTheEndlessWebReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.blc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arasta of the Endless Web reprint in BLC. The canonical CardDefinition lives in
+ * Theros Beyond Death (`thb`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val ArastaOfTheEndlessWebReprint = Printing(
+    oracleId = "695eea46-1535-48c5-bbb6-0b8379e77bfc",
+    name = "Arasta of the Endless Web",
+    setCode = "BLC",
+    collectorNumber = "205",
+    scryfallId = "6dda8d6b-fd31-4908-a953-20c180a33e56",
+    artist = "Sam Rowan",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6dda8d6b-fd31-4908-a953-20c180a33e56.jpg?1783910671",
+    releaseDate = "2024-08-02",
+    rarity = Rarity.RARE,
+    frameEffects = listOf("legendary", "enchantment"),
+)

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/ManagorgerHydraReprint.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/ManagorgerHydraReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.blc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Managorger Hydra reprint in BLC. The canonical CardDefinition lives in
+ * Magic Origins (`ori`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val ManagorgerHydraReprint = Printing(
+    oracleId = "b3f2265b-dd65-4b74-8b74-35ee0b147617",
+    name = "Managorger Hydra",
+    setCode = "BLC",
+    collectorNumber = "230",
+    scryfallId = "c91b574c-dc87-4994-9d7c-e1e8a20c1527",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/c/9/c91b574c-dc87-4994-9d7c-e1e8a20c1527.jpg?1783910664",
+    releaseDate = "2024-08-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/PropagandaReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/PropagandaReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Propaganda reprint in MSC. The canonical CardDefinition lives in
+ * Tempest (`tmp`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val PropagandaReprint = Printing(
+    oracleId = "ea9709b6-4c37-4d5a-b04d-cd4c42e4f9dd",
+    name = "Propaganda",
+    setCode = "MSC",
+    collectorNumber = "151",
+    scryfallId = "ac943e31-26bc-4b54-b73f-460e6e402d86",
+    artist = "Borja Pindado",
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/ac943e31-26bc-4b54-b73f-460e6e402d86.jpg?1783903239",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.UNCOMMON,
+    frameEffects = listOf("enchantment"),
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/SunkenHollowReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/SunkenHollowReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunken Hollow reprint in MSC. The canonical CardDefinition lives in
+ * Battle for Zendikar (`bfz`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val SunkenHollowReprint = Printing(
+    oracleId = "cd2c90ac-2b04-461c-92f3-939871b6b6a3",
+    name = "Sunken Hollow",
+    setCode = "MSC",
+    collectorNumber = "271",
+    scryfallId = "3a8eef9b-9b03-42cd-a27a-07021bf0b33f",
+    artist = "Pavel Kolomeyets",
+    imageUri = "https://cards.scryfall.io/normal/front/3/a/3a8eef9b-9b03-42cd-a27a-07021bf0b33f.jpg?1783903191",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/TerramorphReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/TerramorphReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Terramorph reprint in MSC. The canonical CardDefinition lives in
+ * Modern Horizons 2 (`mh2`), the card's earliest real printing; this file
+ * contributes only per-printing presentation data.
+ */
+val TerramorphReprint = Printing(
+    oracleId = "17a34f8d-a80f-4331-8be5-06cbb9d10d7b",
+    name = "Terramorph",
+    setCode = "MSC",
+    collectorNumber = "180",
+    scryfallId = "1389d46e-956d-4be6-a519-9c8338007715",
+    artist = "Eglė Mosakaitė",
+    imageUri = "https://cards.scryfall.io/normal/front/1/3/1389d46e-956d-4be6-a519-9c8338007715.jpg?1783903226",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/AFR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AFR.json
@@ -43,6 +43,58 @@
     ]
 }
 
+// Priest of Ancient Lore
+{
+    "name": "Priest of Ancient Lore",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Dwarf Cleric",
+    "oracleText": "When this creature enters, you gain 1 life and draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, you gain 1 life and draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "35",
+        "artist": "Jarel Threat",
+        "flavorText": "\"We are a product of our ancestors, the apotheosis of countless noble generations. Speak their names with reverence, and they will guide your path.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b10caff0-701a-48d8-a943-f947482e795a.jpg?1783926524"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Vampire Spawn
 {
     "name": "Vampire Spawn",

--- a/mtg-sets/src/test/resources/snapshots/cards/ARB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARB.json
@@ -1,3 +1,39 @@
+// Bloodbraid Elf
+{
+    "name": "Bloodbraid Elf",
+    "manaCost": "{2}{R}{G}",
+    "typeLine": "Creature — Elf Berserker",
+    "oracleText": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE",
+        "CASCADE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": "Cascade",
+                "descriptionOverride": "Cascade"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "rarity": "UNCOMMON",
+        "artist": "Dominick Domingo",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7ef67487-c8e5-49bb-b0f7-e073ff2e31f1.jpg?1783942431"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
 // Grizzled Leotau
 {
     "name": "Grizzled Leotau",

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -999,6 +999,106 @@
     ]
 }
 
+// Desolate Lighthouse
+{
+    "name": "Desolate Lighthouse",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{1}{U}{R}, {T}: Draw a card, then discard a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "descriptionOverride": "{1}{U}{R}, {T}: Draw a card, then discard a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "rarity": "RARE",
+        "artist": "Scott Chou",
+        "flavorText": "A lonely sentinel facing gales, hurricanes, and tides of homicidal spirits.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/16fb45bc-6152-4b01-9831-a8e80b1c1852.jpg?1783940649"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
+}
+
 // Driver of the Dead
 {
     "name": "Driver of the Dead",

--- a/mtg-sets/src/test/resources/snapshots/cards/BFZ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BFZ.json
@@ -655,6 +655,45 @@
     ]
 }
 
+// Sunken Hollow
+{
+    "name": "Sunken Hollow",
+    "manaCost": "",
+    "typeLine": "Land — Island Swamp",
+    "oracleText": "({T}: Add {U} or {B}.)\nThis land enters tapped unless you control two or more basic lands.",
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "basicland"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "249",
+        "rarity": "RARE",
+        "artist": "Adam Paquette",
+        "flavorText": "On the continent of Tazeem, rushing waters plunge through narrow canyons into mist-cloaked lakes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0dd1726f-b899-491a-8b0e-8e3d25f17d3d.jpg?1783938172"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
 // Sure Strike
 {
     "name": "Sure Strike",

--- a/mtg-sets/src/test/resources/snapshots/cards/CHK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CHK.json
@@ -2271,6 +2271,68 @@
     ]
 }
 
+// Ryusei, the Falling Star
+{
+    "name": "Ryusei, the Falling Star",
+    "manaCost": "{5}{R}",
+    "typeLine": "Legendary Creature — Dragon Spirit",
+    "oracleText": "Flying\nWhen Ryusei dies, it deals 5 damage to each creature without flying.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotKeyword",
+                                        "keyword": "FLYING"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "When Ryusei dies, it deals 5 damage to each creature without flying."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "rarity": "RARE",
+        "artist": "Nottsuo",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/7/17898412-6275-4762-a03b-04daf30fee7f.jpg?1783944296"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Sachi, Daughter of Seshiro
 {
     "name": "Sachi, Daughter of Seshiro",

--- a/mtg-sets/src/test/resources/snapshots/cards/CLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CLB.json
@@ -1,3 +1,153 @@
+// Bonecaller Cleric
+{
+    "name": "Bonecaller Cleric",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{3}{B}, Sacrifice this creature: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{B}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "{3}{B}, Sacrifice this creature: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "rarity": "UNCOMMON",
+        "artist": "Jason A. Engle",
+        "flavorText": "The bell's unearthly chime slips into the ears of the dead, waking them rudely from their eternal slumber.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/87f411d0-c796-443f-b957-c632aa23deb0.jpg?1783922765"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Breath Weapon
+{
+    "name": "Breath Weapon",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Breath Weapon deals 2 damage to each non-Dragon creature.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotSubtype",
+                                "subtype": "Dragon"
+                            }
+                        ]
+                    }
+                }
+            },
+            "body": {
+                "type": "DealDamage",
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "artist": "Adam Vehige",
+        "flavorText": "\"In the name of Tempus, Lord of Battles, you will die honorably in righteous fire.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/0174e40a-0ef5-4439-91e6-3fc39f482520.jpg?1783922743"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Bronze Walrus
+{
+    "name": "Bronze Walrus",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Walrus",
+    "oracleText": "When this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)\n{T}: Add one mana of any color.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                },
+                "descriptionOverride": "When this creature enters, scry 2."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "302",
+        "artist": "James Paick",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b2cfd2c0-2110-47f1-809e-487b9b0a1043.jpg?1783922682"
+    },
+    "colorIdentityOverride": []
+}
+
 // Carnelian Orb of Dragonkind
 {
     "name": "Carnelian Orb of Dragonkind",
@@ -59,5 +209,573 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Chardalyn Dragon
+{
+    "name": "Chardalyn Dragon",
+    "manaCost": "{6}",
+    "typeLine": "Artifact Creature — Dragon",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "306",
+        "artist": "Sergey Glushakov",
+        "flavorText": "First discovered in ancient Netheril, chardalyn stones absorb and hold magical energy, enabling constructs to be infused with fearsome power and unnatural malice.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a950d8be-dcf7-4253-a3cc-c040ba632355.jpg?1783922678"
+    },
+    "colorIdentityOverride": []
+}
+
+// Cloak of the Bat
+{
+    "name": "Cloak of the Bat",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature has flying and haste.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "307",
+        "artist": "Dominik Mayer",
+        "flavorText": "\"How about the power of silent flight? Does that suit your needs, cutthroat?\"\n—Rivalen Blackhand, proprietor of Sorcerous Sundries",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2f508a65-ff32-480a-b9c6-075074d0c3c3.jpg?1783922679"
+    },
+    "colorIdentityOverride": []
+}
+
+// Draconic Lore
+{
+    "name": "Draconic Lore",
+    "manaCost": "{5}{U}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {2} less to cast if you control a Dragon.\nDraw three cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 3
+            }
+        },
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 2
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "Exists",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": "permanent Dragon"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "64",
+        "artist": "Tom Babbey",
+        "flavorText": "The wyrmling studied the ancient carvings and dreamed of a day when her own exploits would be immortalized in stone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/557f2aa6-0b82-4f60-9617-610b613c2a48.jpg?1783922792"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Draconic Muralists
+{
+    "name": "Draconic Muralists",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Dragon Bard",
+    "oracleText": "When this creature dies, you may search your library for a Dragon card, reveal it, put it into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "permanent Dragon"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                },
+                "descriptionOverride": "When this creature dies, you may search your library for a Dragon card, reveal it, put it into your hand, then shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "rarity": "UNCOMMON",
+        "artist": "Tom Babbey",
+        "flavorText": "\"We must never allow the deeds of our great ancestors to be forgotten.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c9bf864-1f93-4d73-a212-f71265411768.jpg?1783922717"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Dragonborn Looter
+{
+    "name": "Dragonborn Looter",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Dragon Rogue",
+    "oracleText": "{1}, {T}: Draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "descriptionOverride": "{1}, {T}: Draw a card, then discard a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "artist": "Julio Reyna",
+        "flavorText": "Erdur never thought of it as stealing. Treasure simply didn't deserve to be stuck underground where no one could admire it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/570e8aaa-5273-42f4-b151-51976ab7730c.jpg?1783922793"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Earth Tremor
+{
+    "name": "Earth Tremor",
+    "manaCost": "{3}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Earth Tremor deals damage to target creature or planeswalker equal to the number of lands you control.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land"
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "artist": "Borja Pindado",
+        "flavorText": "\"Every cave-in is Moradin telling you to leave the earth where it is.\"\n—Halgar, dwarven recluse",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5f700c6-7591-481d-b223-21f5b820e831.jpg?1783922742"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Pseudodragon Familiar
+{
+    "name": "Pseudodragon Familiar",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\n{2}{U}: Target creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{2}{U}: Target creature gains flying until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "artist": "Campbell White",
+        "flavorText": "Pseudodragons are favored companions of wizards, prized for their cunning and curiosity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/50d69ee8-a616-4191-b111-1330dfb24f72.jpg?1783922780"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Reckless Barbarian
+{
+    "name": "Reckless Barbarian",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Dragon Barbarian",
+    "oracleText": "Sacrifice this creature: Add {R}{R}.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "artist": "Oleksandr Kozachenko",
+        "flavorText": "The best defense is not even knowing what the word \"defense\" means.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c912e984-1d27-4da2-9733-d56e437bcf58.jpg?1783922731"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Roving Harper
+{
+    "name": "Roving Harper",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Elf Scout",
+    "oracleText": "When this creature enters, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "When this creature enters, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "The Harpers value peaceful coexistence, historical preservation, and harmony with nature, and each day they spread their ideals a little farther.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c6b0ed9c-9a99-4a50-80a9-396420a8dcf9.jpg?1783922804"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Steadfast Unicorn
+{
+    "name": "Steadfast Unicorn",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Unicorn",
+    "oracleText": "{3}{W}: Creatures you control get +1/+1 and gain vigilance until end of turn. Activate only during your turn. (Attacking doesn't cause them to tap.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "VIGILANCE",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                },
+                "restrictions": [
+                    "OnlyDuringYourTurn"
+                ],
+                "descriptionOverride": "{3}{W}: Creatures you control get +1/+1 and gain vigilance until end of turn. Activate only during your turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "artist": "John Thacker",
+        "flavorText": "Only the good-hearted may set foot in a unicorn's domain.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13762890-6c5e-44e4-9bd8-998bd054db20.jpg?1783922804"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Stoneskin
+{
+    "name": "Stoneskin",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash\nEnchant creature\nEnchanted creature gets +0/+10.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 0,
+                "toughnessBonus": 10
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "rarity": "UNCOMMON",
+        "artist": "Jake Murray",
+        "flavorText": "\"Ooh, nice shot! I almost felt that one.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/16b9fdaa-9da9-48ff-b271-e6a41aabf073.jpg?1783922802"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/CMD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CMD.json
@@ -41,6 +41,62 @@
     "colorIdentityOverride": []
 }
 
+// Hornet Queen
+{
+    "name": "Hornet Queen",
+    "manaCost": "{4}{G}{G}{G}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Flying, deathtouch\nWhen this creature enters, create four 1/1 green Insect creature tokens with flying and deathtouch.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Insect"
+                    ],
+                    "keywords": [
+                        "FLYING",
+                        "DEATHTOUCH"
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, create four 1/1 green Insect creature tokens with flying and deathtouch."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "159",
+        "rarity": "RARE",
+        "artist": "Martina Pilcerova",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/714cd47b-88f6-448d-9242-481935565250.jpg?1783941193"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Kaalia of the Vast
 {
     "name": "Kaalia of the Vast",

--- a/mtg-sets/src/test/resources/snapshots/cards/CMR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CMR.json
@@ -580,6 +580,53 @@
     ]
 }
 
+// Natural Reclamation
+{
+    "name": "Natural Reclamation",
+    "manaCost": "{4}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)\nDestroy target artifact or enchantment.",
+    "keywords": [
+        "CASCADE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target"
+            }
+        ],
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": "Cascade",
+                "descriptionOverride": "Cascade"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "245",
+        "artist": "Alayna Danner",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3e98fb7c-6962-4b57-b7b7-c71899564002.jpg?1783928787"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Pride of the Perfect
 {
     "name": "Pride of the Perfect",

--- a/mtg-sets/src/test/resources/snapshots/cards/ELD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ELD.json
@@ -44,6 +44,151 @@
     ]
 }
 
+// Castle Embereth
+{
+    "name": "Castle Embereth",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless you control a Mountain.\n{T}: Add {R}.\n{1}{R}{R}, {T}: Creatures you control get +1/+0 until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "{1}{R}{R}, {T}: Creatures you control get +1/+0 until end of turn."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "land Mountain"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "239",
+        "rarity": "RARE",
+        "artist": "Jaime Jones",
+        "flavorText": "Without Embereth's courage, the realm would falter and fall.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8bb8512e-6913-4be6-8828-24cfcbec042e.jpg?1783932580"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Castle Vantress
+{
+    "name": "Castle Vantress",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless you control an Island.\n{T}: Add {U}.\n{2}{U}{U}, {T}: Scry 2.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                },
+                "descriptionOverride": "{2}{U}{U}, {T}: Scry 2."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "land Island"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "242",
+        "rarity": "RARE",
+        "artist": "John Avon",
+        "flavorText": "Without Vantress's knowledge, the realm would lose itself in darkness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0a8b9d37-e89c-44ad-bd1b-51cb06ec3e0b.jpg?1783932578"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Charming Prince
 {
     "name": "Charming Prince",

--- a/mtg-sets/src/test/resources/snapshots/cards/ELD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ELD.json
@@ -196,6 +196,70 @@
     ]
 }
 
+// Castle Vantress
+{
+    "name": "Castle Vantress",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless you control an Island.\n{T}: Add {U}.\n{2}{U}{U}, {T}: Scry 2.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                },
+                "descriptionOverride": "{2}{U}{U}, {T}: Scry 2."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "land Island"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "242",
+        "rarity": "RARE",
+        "artist": "John Avon",
+        "flavorText": "Without Vantress's knowledge, the realm would lose itself in darkness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0a8b9d37-e89c-44ad-bd1b-51cb06ec3e0b.jpg?1783932578"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Charming Prince
 {
     "name": "Charming Prince",

--- a/mtg-sets/src/test/resources/snapshots/cards/FRF.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FRF.json
@@ -122,6 +122,53 @@
     ]
 }
 
+// Mardu Strike Leader
+{
+    "name": "Mardu Strike Leader",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Whenever this creature attacks, create a 2/1 black Warrior creature token.\nDash {3}{B} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Dash",
+            "cost": "{3}{B}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Warrior"
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature attacks, create a 2/1 black Warrior creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "RARE",
+        "artist": "Jason Rainville",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c93fd5f0-fb62-42cc-8c7d-c0368e191c4b.jpg?1783938696"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Monastery Mentor
 {
     "name": "Monastery Mentor",

--- a/mtg-sets/src/test/resources/snapshots/cards/GTC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GTC.json
@@ -498,6 +498,58 @@
     ]
 }
 
+// High Priest of Penance
+{
+    "name": "High Priest of Penance",
+    "manaCost": "{W}{B}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Whenever this creature is dealt damage, you may destroy target nonland permanent.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target nonland permanent"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "nonland permanent"
+                    },
+                    "id": "target nonland permanent"
+                },
+                "descriptionOverride": "Whenever this creature is dealt damage, you may destroy target nonland permanent."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "RARE",
+        "artist": "Mark Zug",
+        "flavorText": "\"All I require is faith, loyalty, obedience, trust, and complete and utter devotion.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/84a3ff8d-6d7e-49f0-8d30-7f8c23db568b.jpg?1783940106"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
 // Ivy Lane Denizen
 {
     "name": "Ivy Lane Denizen",

--- a/mtg-sets/src/test/resources/snapshots/cards/IKO.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/IKO.json
@@ -312,6 +312,56 @@
     ]
 }
 
+// Sprite Dragon
+{
+    "name": "Sprite Dragon",
+    "manaCost": "{U}{R}",
+    "typeLine": "Creature — Faerie Dragon",
+    "oracleText": "Flying, haste\nWhenever you cast a noncreature spell, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever you cast a noncreature spell, put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "UNCOMMON",
+        "artist": "Gabor Szikszai",
+        "flavorText": "Size of a pixie, rage of a hellkite.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/281f6118-adb8-4a7d-9c77-5570f3399e6e.jpg?1783931016"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
+}
+
 // Voracious Greatshark
 {
     "name": "Voracious Greatshark",

--- a/mtg-sets/src/test/resources/snapshots/cards/KHM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KHM.json
@@ -44,6 +44,51 @@
     ]
 }
 
+// Demon Bolt
+{
+    "name": "Demon Bolt",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Demon Bolt deals 4 damage to target creature or planeswalker.\nForetell {R} (During your turn, you may pay {2} and exile this card from your hand face down. Cast it on a later turn for its foretell cost.)",
+    "keywords": [
+        "FORETELL"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Foretell",
+            "cost": "{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "artist": "Campbell White",
+        "flavorText": "\"Burn them from the sky.\"\n—Varragoth",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f856b0e-b413-49b0-9aa7-d935ad40ae53.jpg?1783928232"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Esika's Chariot
 {
     "name": "Esika's Chariot",
@@ -260,6 +305,29 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Highland Forest
+{
+    "name": "Highland Forest",
+    "manaCost": "",
+    "typeLine": "Snow Land — Mountain Forest",
+    "oracleText": "({T}: Add {R} or {G}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "261",
+        "artist": "Alayna Danner",
+        "flavorText": "\"Tread carefully! The last time I walked this path, half the snowdrifts were, in fact, sleeping trolls. I've never run so fast in my life!\"\n—Iskene, Kannah storyteller",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/682eee5f-7986-45d3-910f-407303fdbcc4.jpg?1783928176"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
     ]
 }
 
@@ -508,6 +576,29 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Snowfield Sinkhole
+{
+    "name": "Snowfield Sinkhole",
+    "manaCost": "",
+    "typeLine": "Snow Land — Plains Swamp",
+    "oracleText": "({T}: Add {W} or {B}.)\nThis land enters tapped.",
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "269",
+        "artist": "Marta Nael",
+        "flavorText": "\"Young Vitima bellowed to the Cosmos, daring the gods to punish her hubris! Well, she got their attention, as you can see.\"\n—Iskene, Kannah storyteller",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/6611dc5e-6acc-48df-b8c4-4b327314578b.jpg?1783928172"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/M19.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M19.json
@@ -170,6 +170,50 @@
     ]
 }
 
+// Arcane Encyclopedia
+{
+    "name": "Arcane Encyclopedia",
+    "manaCost": "{3}",
+    "typeLine": "Artifact — Book",
+    "oracleText": "{3}, {T}: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "{3}, {T}: Draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "rarity": "UNCOMMON",
+        "artist": "Nic Klein",
+        "flavorText": "Knowledge itself is neither good nor evil. Just as the wrong book in the wrong hands could doom all existence, the same book in the right hands could save it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0ce4702d-f65b-413e-99da-112f632a0a63.jpg?1783934516"
+    },
+    "colorIdentityOverride": []
+}
+
 // Bogstomper
 {
     "name": "Bogstomper",

--- a/mtg-sets/src/test/resources/snapshots/cards/MH1.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MH1.json
@@ -110,6 +110,54 @@
     ]
 }
 
+// Irregular Cohort
+{
+    "name": "Irregular Cohort",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\nWhen this creature enters, create a 2/2 colorless Shapeshifter creature token with changeling.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "CHANGELING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Shapeshifter"
+                    ],
+                    "keywords": [
+                        "CHANGELING"
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, create a 2/2 colorless Shapeshifter creature token with changeling."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "artist": "Steve Argyle",
+        "flavorText": "Where fickle form meets lasting loyalty.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/2/92c46961-cf1a-4f20-83aa-3d256db2388f.jpg?1783933160"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // King of the Pride
 {
     "name": "King of the Pride",

--- a/mtg-sets/src/test/resources/snapshots/cards/MH2.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MH2.json
@@ -99,6 +99,64 @@
     ]
 }
 
+// Terramorph
+{
+    "name": "Terramorph",
+    "manaCost": "{3}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Search your library for a basic land card, put it onto the battlefield, then shuffle.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
+    "keywords": [
+        "REBOUND"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": "basicland"
+                    },
+                    "storeAs": "searchable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "searchable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "found"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "found",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    }
+                },
+                "ShuffleLibrary",
+                "EmitLibrarySearchedEvent"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "rarity": "UNCOMMON",
+        "artist": "Darrell Riche",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/28b08596-f6c7-4366-a4ed-21a11fbc901a.jpg?1783926824"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Vile Entomber
 {
     "name": "Vile Entomber",

--- a/mtg-sets/src/test/resources/snapshots/cards/ORI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ORI.json
@@ -777,6 +777,49 @@
     ]
 }
 
+// Managorger Hydra
+{
+    "name": "Managorger Hydra",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Hydra",
+    "oracleText": "Trample\nWhenever a player casts a spell, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever a player casts a spell, put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "rarity": "RARE",
+        "artist": "Lucas Graciano",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a08e5ab-1ff9-4470-ab28-fea19bb79845.jpg?1783938321"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Priest of the Blood Rite
 {
     "name": "Priest of the Blood Rite",

--- a/mtg-sets/src/test/resources/snapshots/cards/RIX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RIX.json
@@ -513,6 +513,56 @@
     ]
 }
 
+// Ravenous Chupacabra
+{
+    "name": "Ravenous Chupacabra",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Beast Horror",
+    "oracleText": "When this creature enters, destroy target creature an opponent controls.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "When this creature enters, destroy target creature an opponent controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "rarity": "UNCOMMON",
+        "artist": "Daarken",
+        "flavorText": "Opening Orazca unleashed more horrors than just the Immortal Sun.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02551196-ecea-472f-9547-3c9658d0489e.jpg?1783935306"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Seafloor Oracle
 {
     "name": "Seafloor Oracle",

--- a/mtg-sets/src/test/resources/snapshots/cards/S99.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/S99.json
@@ -87,6 +87,67 @@
     ]
 }
 
+// Thunder Dragon
+{
+    "name": "Thunder Dragon",
+    "manaCost": "{5}{R}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nWhen this creature enters, it deals 3 damage to each creature without flying.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotKeyword",
+                                        "keyword": "FLYING"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "When this creature enters, it deals 3 damage to each creature without flying."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "rarity": "RARE",
+        "artist": "Dana Knutson",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e9b06a8-c3f3-4174-b992-7da7ca163990.jpg?1783946025"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Tidings
 {
     "name": "Tidings",

--- a/mtg-sets/src/test/resources/snapshots/cards/STX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STX.json
@@ -410,6 +410,72 @@
     ]
 }
 
+// Prismari Campus
+{
+    "name": "Prismari Campus",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {U} or {R}.\n{4}, {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                },
+                "descriptionOverride": "{4}, {T}: Scry 1."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "270",
+        "artist": "Adam Paquette",
+        "flavorText": "Mage-students who see spellcraft as the highest form of expression choose Prismari, the college of elemental arts.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/768120f5-9401-4e52-924e-3374bde65b3d.jpg?1783927271"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
+}
+
 // Spined Karok
 {
     "name": "Spined Karok",

--- a/mtg-sets/src/test/resources/snapshots/cards/THB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THB.json
@@ -1,3 +1,66 @@
+// Arasta of the Endless Web
+{
+    "name": "Arasta of the Endless Web",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Legendary Enchantment Creature — Spider",
+    "oracleText": "Reach\nWhenever an opponent casts an instant or sorcery spell, create a 1/2 green Spider creature token with reach.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    },
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Spider"
+                    ],
+                    "keywords": [
+                        "REACH"
+                    ]
+                },
+                "descriptionOverride": "Whenever an opponent casts an instant or sorcery spell, create a 1/2 green Spider creature token with reach."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "RARE",
+        "artist": "Sam Rowan",
+        "flavorText": "Her webs, spun from her own hair, reach from Nyx to the mortal world and even into the Underworld.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c38833a-96c5-48b5-8dd8-23f10e798537.jpg?1783931542"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Archon of Sun's Grace
 {
     "name": "Archon of Sun's Grace",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -622,6 +622,45 @@
     ]
 }
 
+// Dauthi Horror
+{
+    "name": "Dauthi Horror",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Dauthi Horror",
+    "oracleText": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nThis creature can't be blocked by white creatures.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "SHADOW"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasColor",
+                            "color": "WHITE"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "artist": "Jeff Laubenstein",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5a8bb3a-3a84-442f-8e31-8af2f04408ab.jpg?1783946642"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Dauthi Slayer
 {
     "name": "Dauthi Slayer",
@@ -2305,6 +2344,35 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Propaganda
+{
+    "name": "Propaganda",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Creatures can't attack you unless their controller pays {2} for each creature they control that's attacking you.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "AttackTax",
+                "amountPerAttacker": {
+                    "type": "Fixed",
+                    "amount": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "rarity": "UNCOMMON",
+        "artist": "Jeff Miracola",
+        "flavorText": "\"You've failed Gerrard. You've failed the Legacy. You've failed yourself. I can do no more.\"\n—Volrath, to Karn",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f67dde4d-3df1-480d-a8b8-ab22c768bb12.jpg?1783946652"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/TSP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TSP.json
@@ -446,6 +446,70 @@
     ]
 }
 
+// Search for Tomorrow
+{
+    "name": "Search for Tomorrow",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Search your library for a basic land card, put it onto the battlefield, then shuffle.\nSuspend 2—{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)",
+    "keywords": [
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{G}",
+            "timeCounters": 2
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": "basicland"
+                    },
+                    "storeAs": "searchable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "searchable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "found"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "found",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    }
+                },
+                "ShuffleLibrary",
+                "EmitLibrarySearchedEvent"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "artist": "Randy Gallegos",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/56f739e8-b4ba-426a-a159-0e0d5a0ebb6f.jpg?1783943208"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Terramorphic Expanse
 {
     "name": "Terramorphic Expanse",


### PR DESCRIPTION
CLB's "Assay reads it whole and it isn't implemented yet" set is **78 cards**. The other 568 missing cards read 534 `LINE_DECLINED`, 31 `MULTI_FACE` and 3 `LINES_DO_NOT_FOLD` — a Commander-draft set whose identity is initiative, backgrounds, venture and die-rolling puts one of those words on most of what's left, so the grammar declines it.

**1 / 361 draft → 31 / 361, and 4 / 290 extras → 52 / 290.**

## The four-way split

This is the first sweep where all four buckets are large:

| | count | |
|---|---|---|
| reprint-row-only | 33 | canonical already in the repo; CLB needed only a `Printing(...)` row |
| canonical belongs to an earlier scaffolded set | 26 | Propaganda and Dauthi Horror → TMP (1997), Ryusei → CHK, Bloodbraid Elf → ARB, Sprite Dragon → IKO, +21 more |
| new canonical in CLB | 14 | CLB is the earliest real printing |
| basic lands | 5 names / 20 art variants | `basicLand(...)` vals, not `Printing` rows |

Zero cards whose earliest printing is an unscaffolded set — nothing had to be scaffolded and nothing left the batch.

Authoring the 26 relocated canonicals also owed **20 `Printing` rows in the *other* sets that print them** (NCC, C16, MSC, BLC, JMP, PC2, M15, C13, ARC, C17, CMD, CMR). That gap was invisible before this change: `check-card-printing` exits "card not implemented" for a card with no canonical anywhere, so creating the canonical is what let the gate see it.

## No new SDK vocabulary

All 73 non-basic cards compose existing primitives, so `docs/card-sdk-language-reference.md` is unchanged.

The mechanics were traced against `rules-engine` **before** the fan-out, which is what kept three display-only keywords from shipping inert:

- **cascade** (Bloodbraid Elf, Natural Reclamation) — `Keyword.CASCADE` for the printed line **plus** a `WhenYouCastThisSpell` trigger carrying `Effects.Cascade`
- **foretell** (Demon Bolt) — `KeywordAbility.foretell("{R}")`, not `Keyword.FORETELL`
- **suspend** (Search for Tomorrow) — `KeywordAbility.suspend("{G}", 2)`, cost first, counters second

Rebound (Terramorph), changeling (Irregular Cohort) and shadow (Dauthi Horror) *do* have real consumers, so the bare keyword is correct there. Dash (Mardu Strike Leader) is the `dash = "{3}{B}"` builder property — there is no `Keyword.DASH` at all.

## The snow duals

Highland Forest and Snowfield Sinkhole write **only** the enters-tapped replacement effect. Their `({T}: Add {R} or {G}.)` line is in reminder parentheses because the basic land subtypes grant it through `IntrinsicManaAbilities`; writing it as well would double-tap the land. `Supertype.SNOW` parses and renders but nothing in `rules-engine` reads it — fine for two lands that only enter tapped.

## Gates

| gate | result |
|---|---|
| `just build` | green — card snapshots re-blessed for the 23 sets that gained a canonical; **+2060 lines, 0 deletions**, so only the new cards moved |
| `just assay-differential` | **3282 / 3295 confirmed; DIVERGENT unchanged at the same 13 pre-existing cards** — zero new divergences across all 40 newly authored canonicals |
| `just check-card-printing` | clean for Propaganda, Sunken Hollow, Bloodbraid Elf, Ryusei, Stoneskin, Arcane Encyclopedia |

The zero-divergence result comes from authoring to `assay compile`'s JSON — each agent got that card's exact `CardDefinition` model as its spec rather than working from the Oracle text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
