### PR TITLE
Close the printing-row drift behind the BLC sweep: 47 rows across 17 sets

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BalefulStrixReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BalefulStrixReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Baleful Strix reprint in Commander 2013. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `pc2` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val BalefulStrixReprint = Printing(
+    oracleId = "37688720-03de-4eca-a82d-a0afe8d58adc",
+    name = "Baleful Strix",
+    setCode = "C13",
+    collectorNumber = "177",
+    scryfallId = "47ac0f77-1294-4de9-93d1-141a9f314f98",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/4/7/47ac0f77-1294-4de9-93d1-141a9f314f98.jpg?1783939654",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GrimBackwoodsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GrimBackwoodsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grim Backwoods reprint in Commander 2013. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `dka` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val GrimBackwoodsReprint = Printing(
+    oracleId = "5effaa94-7f87-4485-8959-473d584c5034",
+    name = "Grim Backwoods",
+    setCode = "C13",
+    collectorNumber = "292",
+    scryfallId = "7586de16-1341-4c6c-a30c-a3a8f4655411",
+    artist = "Vincent Proce",
+    imageUri = "https://cards.scryfall.io/normal/front/7/5/7586de16-1341-4c6c-a30c-a3a8f4655411.jpg?1783939629",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SeasideCitadelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SeasideCitadelReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seaside Citadel reprint in Commander 2013. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `ala` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SeasideCitadelReprint = Printing(
+    oracleId = "2ae77795-6a80-498b-bf69-6fd612f601e4",
+    name = "Seaside Citadel",
+    setCode = "C13",
+    collectorNumber = "318",
+    scryfallId = "d3bc73ed-812f-4cf1-b32e-38cc06a55ae5",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/d/3/d3bc73ed-812f-4cf1-b32e-38cc06a55ae5.jpg?1783939622",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SwiftfootBootsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SwiftfootBootsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftfoot Boots reprint in Commander 2013. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m12` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SwiftfootBootsReprint = Printing(
+    oracleId = "c8b143ad-43ec-4e0d-a440-e348daa31391",
+    name = "Swiftfoot Boots",
+    setCode = "C13",
+    collectorNumber = "263",
+    scryfallId = "da8ac93d-3377-4768-8152-d988a090de2a",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/d/a/da8ac93d-3377-4768-8152-d988a090de2a.jpg?1783939634",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SwiftfootBootsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SwiftfootBootsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftfoot Boots reprint in Commander 2014. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m12` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SwiftfootBootsReprint = Printing(
+    oracleId = "c8b143ad-43ec-4e0d-a440-e348daa31391",
+    name = "Swiftfoot Boots",
+    setCode = "C14",
+    collectorNumber = "275",
+    scryfallId = "4b224614-6374-4c42-8715-daa0b73ca05c",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/4/b/4b224614-6374-4c42-8715-daa0b73ca05c.jpg?1783938815",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/GrimBackwoodsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/GrimBackwoodsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grim Backwoods reprint in Commander 2015. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `dka` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val GrimBackwoodsReprint = Printing(
+    oracleId = "5effaa94-7f87-4485-8959-473d584c5034",
+    name = "Grim Backwoods",
+    setCode = "C15",
+    collectorNumber = "288",
+    scryfallId = "de99df2a-61de-4c4a-938f-8cf45aa91c9e",
+    artist = "Vincent Proce",
+    imageUri = "https://cards.scryfall.io/normal/front/d/e/de99df2a-61de-4c4a-938f-8cf45aa91c9e.jpg?1783938041",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/SwiftfootBootsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/SwiftfootBootsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftfoot Boots reprint in Commander 2015. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m12` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SwiftfootBootsReprint = Printing(
+    oracleId = "c8b143ad-43ec-4e0d-a440-e348daa31391",
+    name = "Swiftfoot Boots",
+    setCode = "C15",
+    collectorNumber = "271",
+    scryfallId = "b79b931d-93b6-46fa-8dff-87abe6dd7170",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/b/7/b79b931d-93b6-46fa-8dff-87abe6dd7170.jpg?1783938047",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/BalefulStrixReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/BalefulStrixReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Baleful Strix reprint in Commander 2016. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `pc2` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val BalefulStrixReprint = Printing(
+    oracleId = "37688720-03de-4eca-a82d-a0afe8d58adc",
+    name = "Baleful Strix",
+    setCode = "C16",
+    collectorNumber = "181",
+    scryfallId = "8b088449-2968-4f11-91b5-5e1f0a833725",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8b088449-2968-4f11-91b5-5e1f0a833725.jpg?1783937053",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/ManagorgerHydraReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/ManagorgerHydraReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Managorger Hydra reprint in Commander 2016. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `ori` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val ManagorgerHydraReprint = Printing(
+    oracleId = "b3f2265b-dd65-4b74-8b74-35ee0b147617",
+    name = "Managorger Hydra",
+    setCode = "C16",
+    collectorNumber = "157",
+    scryfallId = "f2e4ab33-150e-4004-a346-4842f4e701cc",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/f/2/f2e4ab33-150e-4004-a346-4842f4e701cc.jpg?1783937058",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/SeasideCitadelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/SeasideCitadelReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seaside Citadel reprint in Commander 2016. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `ala` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SeasideCitadelReprint = Printing(
+    oracleId = "2ae77795-6a80-498b-bf69-6fd612f601e4",
+    name = "Seaside Citadel",
+    setCode = "C16",
+    collectorNumber = "322",
+    scryfallId = "a43910f1-303d-4214-9404-cabee59b65bd",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/a/4/a43910f1-303d-4214-9404-cabee59b65bd.jpg?1783937022",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/SunpetalGroveReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/SunpetalGroveReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunpetal Grove reprint in Commander 2016. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m10` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SunpetalGroveReprint = Printing(
+    oracleId = "402ec768-76fb-474e-ae74-babc90d833c4",
+    name = "Sunpetal Grove",
+    setCode = "C16",
+    collectorNumber = "329",
+    scryfallId = "ee06bee0-912f-49ae-98ca-a30246de1a5a",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/ee06bee0-912f-49ae-98ca-a30246de1a5a.jpg?1783937021",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/SwiftfootBootsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/SwiftfootBootsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftfoot Boots reprint in Commander 2016. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m12` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SwiftfootBootsReprint = Printing(
+    oracleId = "c8b143ad-43ec-4e0d-a440-e348daa31391",
+    name = "Swiftfoot Boots",
+    setCode = "C16",
+    collectorNumber = "276",
+    scryfallId = "db9337e8-3315-4821-a08a-b04bb00d4b05",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/d/b/db9337e8-3315-4821-a08a-b04bb00d4b05.jpg?1783937032",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/GlacialFortressReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/GlacialFortressReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glacial Fortress reprint in Magic 2011. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m10` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val GlacialFortressReprint = Printing(
+    oracleId = "027dd013-baa7-4111-b3c9-f4d1414e9c45",
+    name = "Glacial Fortress",
+    setCode = "M11",
+    collectorNumber = "225",
+    scryfallId = "b9d18532-2247-4e33-a760-bc42a727e9f5",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/b/9/b9d18532-2247-4e33-a760-bc42a727e9f5.jpg?1783941787",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/SunpetalGroveReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/SunpetalGroveReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunpetal Grove reprint in Magic 2011. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m10` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SunpetalGroveReprint = Printing(
+    oracleId = "402ec768-76fb-474e-ae74-babc90d833c4",
+    name = "Sunpetal Grove",
+    setCode = "M11",
+    collectorNumber = "228",
+    scryfallId = "eeee9597-674f-4f72-90f4-5491f4432ec5",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/eeee9597-674f-4f72-90f4-5491f4432ec5.jpg?1783941786",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/GlacialFortressReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/GlacialFortressReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glacial Fortress reprint in Magic 2012. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m10` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val GlacialFortressReprint = Printing(
+    oracleId = "027dd013-baa7-4111-b3c9-f4d1414e9c45",
+    name = "Glacial Fortress",
+    setCode = "M12",
+    collectorNumber = "227",
+    scryfallId = "8b3601d4-4091-465e-8c18-0cd717258211",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8b3601d4-4091-465e-8c18-0cd717258211.jpg?1783941045",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/SunpetalGroveReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/SunpetalGroveReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunpetal Grove reprint in Magic 2012. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m10` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SunpetalGroveReprint = Printing(
+    oracleId = "402ec768-76fb-474e-ae74-babc90d833c4",
+    name = "Sunpetal Grove",
+    setCode = "M12",
+    collectorNumber = "229",
+    scryfallId = "0c0e02be-e41f-49b4-8393-c4cd2992e380",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/0/c/0c0e02be-e41f-49b4-8393-c4cd2992e380.jpg?1783941046",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/GlacialFortressReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/GlacialFortressReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glacial Fortress reprint in Magic 2013. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m10` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val GlacialFortressReprint = Printing(
+    oracleId = "027dd013-baa7-4111-b3c9-f4d1414e9c45",
+    name = "Glacial Fortress",
+    setCode = "M13",
+    collectorNumber = "225",
+    scryfallId = "bc9d29ee-1a21-4c3e-99c1-f815d40e8f19",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/b/c/bc9d29ee-1a21-4c3e-99c1-f815d40e8f19.jpg?1783940458",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/SunpetalGroveReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/SunpetalGroveReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunpetal Grove reprint in Magic 2013. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m10` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SunpetalGroveReprint = Printing(
+    oracleId = "402ec768-76fb-474e-ae74-babc90d833c4",
+    name = "Sunpetal Grove",
+    setCode = "M13",
+    collectorNumber = "229",
+    scryfallId = "15663129-9deb-4c34-84a0-f94cf1a723f0",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/1/5/15663129-9deb-4c34-84a0-f94cf1a723f0.jpg?1783940453",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/InkEyesServantOfOniReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/InkEyesServantOfOniReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ink-Eyes, Servant of Oni reprint in Planechase 2012. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `bok` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val InkEyesServantOfOniReprint = Printing(
+    oracleId = "5d520476-740a-4005-801e-472b24fa6497",
+    name = "Ink-Eyes, Servant of Oni",
+    setCode = "PC2",
+    collectorNumber = "33",
+    scryfallId = "e103987b-3c88-44ce-bc97-2efb92620347",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e103987b-3c88-44ce-bc97-2efb92620347.jpg?1783940624",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/SeasideCitadelReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/SeasideCitadelReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seaside Citadel reprint in Commander 2017. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `ala` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SeasideCitadelReprint = Printing(
+    oracleId = "2ae77795-6a80-498b-bf69-6fd612f601e4",
+    name = "Seaside Citadel",
+    setCode = "C17",
+    collectorNumber = "277",
+    scryfallId = "c3e6f255-2d5a-4ba1-92e7-41a19216d816",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/c/3/c3e6f255-2d5a-4ba1-92e7-41a19216d816.jpg?1783935842",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/SunscorchRegentReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/SunscorchRegentReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunscorch Regent reprint in Commander 2017. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `dtk` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SunscorchRegentReprint = Printing(
+    oracleId = "c8ff464f-0059-4055-a2f2-556fe6db8fbf",
+    name = "Sunscorch Regent",
+    setCode = "C17",
+    collectorNumber = "74",
+    scryfallId = "27c4da08-3f62-4945-9cf0-44749002fa6c",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/27c4da08-3f62-4945-9cf0-44749002fa6c.jpg?1783935923",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/SwiftfootBootsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/SwiftfootBootsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftfoot Boots reprint in Commander 2017. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m12` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SwiftfootBootsReprint = Printing(
+    oracleId = "c8b143ad-43ec-4e0d-a440-e348daa31391",
+    name = "Swiftfoot Boots",
+    setCode = "C17",
+    collectorNumber = "226",
+    scryfallId = "505c3777-71ef-425e-9dc6-539a8e11e7cd",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/505c3777-71ef-425e-9dc6-539a8e11e7cd.jpg?1783935862",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ArastaOfTheEndlessWebReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ArastaOfTheEndlessWebReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arasta of the Endless Web reprint in Commander Legends: Battle for Baldur's Gate. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `thb` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val ArastaOfTheEndlessWebReprint = Printing(
+    oracleId = "695eea46-1535-48c5-bbb6-0b8379e77bfc",
+    name = "Arasta of the Endless Web",
+    setCode = "CLB",
+    collectorNumber = "817",
+    scryfallId = "558b6db8-4a54-4d25-98e7-e27efc1cab38",
+    artist = "Sam Rowan",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/558b6db8-4a54-4d25-98e7-e27efc1cab38.jpg?1783922411",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ManagorgerHydraReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ManagorgerHydraReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Managorger Hydra reprint in Commander Legends: Battle for Baldur's Gate. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `ori` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val ManagorgerHydraReprint = Printing(
+    oracleId = "b3f2265b-dd65-4b74-8b74-35ee0b147617",
+    name = "Managorger Hydra",
+    setCode = "CLB",
+    collectorNumber = "828",
+    scryfallId = "330aefb9-629f-4d07-94d4-7252f17f85ba",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/3/3/330aefb9-629f-4d07-94d4-7252f17f85ba.jpg?1783922407",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SelflessSpiritReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SelflessSpiritReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Selfless Spirit reprint in Commander Legends: Battle for Baldur's Gate. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `emn` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SelflessSpiritReprint = Printing(
+    oracleId = "71d785a9-ddc8-472e-a778-a551b444a4bd",
+    name = "Selfless Spirit",
+    setCode = "CLB",
+    collectorNumber = "706",
+    scryfallId = "ef8d8d0c-cb0e-4745-a0fb-d556c9324428",
+    artist = "Seb McKinnon",
+    imageUri = "https://cards.scryfall.io/normal/front/e/f/ef8d8d0c-cb0e-4745-a0fb-d556c9324428.jpg?1783922481",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SwiftfootBootsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/SwiftfootBootsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftfoot Boots reprint in Commander Legends: Battle for Baldur's Gate. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m12` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SwiftfootBootsReprint = Printing(
+    oracleId = "c8b143ad-43ec-4e0d-a440-e348daa31391",
+    name = "Swiftfoot Boots",
+    setCode = "CLB",
+    collectorNumber = "339",
+    scryfallId = "16c23cde-e1c0-4cdf-ae59-18d64db518d4",
+    artist = "Manuel Castañón",
+    imageUri = "https://cards.scryfall.io/normal/front/1/6/16c23cde-e1c0-4cdf-ae59-18d64db518d4.jpg?1783922663",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/SwiftfootBootsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/SwiftfootBootsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftfoot Boots reprint in Commander Legends. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m12` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SwiftfootBootsReprint = Printing(
+    oracleId = "c8b143ad-43ec-4e0d-a440-e348daa31391",
+    name = "Swiftfoot Boots",
+    setCode = "CMR",
+    collectorNumber = "474",
+    scryfallId = "b5c45f3d-cf12-4db7-b161-9539ed969ca7",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b5c45f3d-cf12-4db7-b161-9539ed969ca7.jpg?1783928686",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/CasualtiesOfWarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/CasualtiesOfWarReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Casualties of War reprint in Kaldheim Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `war` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val CasualtiesOfWarReprint = Printing(
+    oracleId = "5c6c8fe7-3520-423b-a224-1c0af516871a",
+    name = "Casualties of War",
+    setCode = "KHC",
+    collectorNumber = "83",
+    scryfallId = "e5a2a709-0273-48a3-874b-13aff4872b0a",
+    artist = "Tomasz Jedruszek",
+    imageUri = "https://cards.scryfall.io/normal/front/e/5/e5a2a709-0273-48a3-874b-13aff4872b0a.jpg?1783928305",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/CloudblazerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/CloudblazerReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cloudblazer reprint in Kaldheim Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `kld` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val CloudblazerReprint = Printing(
+    oracleId = "f84d1291-1f82-4b67-a26e-b79624b4ce1d",
+    name = "Cloudblazer",
+    setCode = "KHC",
+    collectorNumber = "84",
+    scryfallId = "edab81f0-dd20-45bd-946d-75b682e1d3d0",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/edab81f0-dd20-45bd-946d-75b682e1d3d0.jpg?1783928306",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/SwiftfootBootsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/SwiftfootBootsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftfoot Boots reprint in Kaldheim Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m12` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SwiftfootBootsReprint = Printing(
+    oracleId = "c8b143ad-43ec-4e0d-a440-e348daa31391",
+    name = "Swiftfoot Boots",
+    setCode = "KHC",
+    collectorNumber = "105",
+    scryfallId = "bf700ec0-1fd3-4971-ab03-51365dc8f4f4",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/b/f/bf700ec0-1fd3-4971-ab03-51365dc8f4f4.jpg?1783928298",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ArastaOfTheEndlessWebReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ArastaOfTheEndlessWebReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arasta of the Endless Web reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `thb` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val ArastaOfTheEndlessWebReprint = Printing(
+    oracleId = "695eea46-1535-48c5-bbb6-0b8379e77bfc",
+    name = "Arasta of the Endless Web",
+    setCode = "NCC",
+    collectorNumber = "279",
+    scryfallId = "e905a310-02d5-4a86-bb58-2bb3502edba2",
+    artist = "Sam Rowan",
+    imageUri = "https://cards.scryfall.io/normal/front/e/9/e905a310-02d5-4a86-bb58-2bb3502edba2.jpg?1783923254",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/CanopyVistaReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/CanopyVistaReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Canopy Vista reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `bfz` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val CanopyVistaReprint = Printing(
+    oracleId = "dcb7e046-f01b-497c-88e5-57794eb30ce5",
+    name = "Canopy Vista",
+    setCode = "NCC",
+    collectorNumber = "389",
+    scryfallId = "79dffd83-05c8-4698-9677-5decb997e29f",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/7/9/79dffd83-05c8-4698-9677-5decb997e29f.jpg?1783923205",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/CastleArdenvaleReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/CastleArdenvaleReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Castle Ardenvale reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `eld` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val CastleArdenvaleReprint = Printing(
+    oracleId = "f8f4fc60-725d-46d8-8e8f-e68e00d20589",
+    name = "Castle Ardenvale",
+    setCode = "NCC",
+    collectorNumber = "391",
+    scryfallId = "eed204e1-45bd-4160-aaef-dde33bd9884a",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/eed204e1-45bd-4160-aaef-dde33bd9884a.jpg?1783923205",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/PrairieStreamReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/PrairieStreamReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prairie Stream reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `bfz` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val PrairieStreamReprint = Printing(
+    oracleId = "5330e24a-8568-446e-840a-594cd08bd1bc",
+    name = "Prairie Stream",
+    setCode = "NCC",
+    collectorNumber = "421",
+    scryfallId = "40e52996-863b-46ee-893a-6ecb29f23106",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/4/0/40e52996-863b-46ee-893a-6ecb29f23106.jpg?1783923191",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SeasideCitadelReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SeasideCitadelReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seaside Citadel reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `ala` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SeasideCitadelReprint = Printing(
+    oracleId = "2ae77795-6a80-498b-bf69-6fd612f601e4",
+    name = "Seaside Citadel",
+    setCode = "NCC",
+    collectorNumber = "425",
+    scryfallId = "816ce96f-9180-4f95-a7cd-334f4a159fa7",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/816ce96f-9180-4f95-a7cd-334f4a159fa7.jpg?1783923190",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SwiftfootBootsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SwiftfootBootsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftfoot Boots reprint in New Capenna Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m12` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SwiftfootBootsReprint = Printing(
+    oracleId = "c8b143ad-43ec-4e0d-a440-e348daa31391",
+    name = "Swiftfoot Boots",
+    setCode = "NCC",
+    collectorNumber = "382",
+    scryfallId = "3cb171ef-42eb-466e-b425-e3c16301c0ca",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3cb171ef-42eb-466e-b425-e3c16301c0ca.jpg?1783923208",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/HangedExecutionerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/HangedExecutionerReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hanged Executioner reprint in Innistrad: Crimson Vow Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m20` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val HangedExecutionerReprint = Printing(
+    oracleId = "6ff4ff67-ad08-447f-a112-1a071c1474a4",
+    name = "Hanged Executioner",
+    setCode = "VOC",
+    collectorNumber = "89",
+    scryfallId = "7676deeb-b80d-49c9-b810-5ed0a68fa618",
+    artist = "Johann Bodin",
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/7676deeb-b80d-49c9-b810-5ed0a68fa618.jpg?1783924973",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/PrairieStreamReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/PrairieStreamReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prairie Stream reprint in Innistrad: Crimson Vow Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `bfz` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val PrairieStreamReprint = Printing(
+    oracleId = "5330e24a-8568-446e-840a-594cd08bd1bc",
+    name = "Prairie Stream",
+    setCode = "VOC",
+    collectorNumber = "179",
+    scryfallId = "ae6bf73b-c70b-4b19-ac00-7317d5fcea7c",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/a/e/ae6bf73b-c70b-4b19-ac00-7317d5fcea7c.jpg?1783924932",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/SwiftfootBootsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/SwiftfootBootsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftfoot Boots reprint in Innistrad: Crimson Vow Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m12` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SwiftfootBootsReprint = Printing(
+    oracleId = "c8b143ad-43ec-4e0d-a440-e348daa31391",
+    name = "Swiftfoot Boots",
+    setCode = "VOC",
+    collectorNumber = "169",
+    scryfallId = "99d75dbd-6fd2-479d-a5c7-272b4be21d8b",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/9/9/99d75dbd-6fd2-479d-a5c7-272b4be21d8b.jpg?1783924937",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/GlacialFortressReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/GlacialFortressReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glacial Fortress reprint in Ixalan. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m10` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val GlacialFortressReprint = Printing(
+    oracleId = "027dd013-baa7-4111-b3c9-f4d1414e9c45",
+    name = "Glacial Fortress",
+    setCode = "XLN",
+    collectorNumber = "255",
+    scryfallId = "cef133d9-26d2-4a1e-8d6a-829f1067c169",
+    artist = "James Paick",
+    imageUri = "https://cards.scryfall.io/normal/front/c/e/cef133d9-26d2-4a1e-8d6a-829f1067c169.jpg?1783935697",
+    releaseDate = "2017-09-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SunpetalGroveReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SunpetalGroveReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunpetal Grove reprint in Ixalan. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m10` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SunpetalGroveReprint = Printing(
+    oracleId = "402ec768-76fb-474e-ae74-babc90d833c4",
+    name = "Sunpetal Grove",
+    setCode = "XLN",
+    collectorNumber = "257",
+    scryfallId = "0f234312-00e8-49f7-a489-f4c316b0a81a",
+    artist = "Dimitar Marinski",
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0f234312-00e8-49f7-a489-f4c316b0a81a.jpg?1783935696",
+    releaseDate = "2017-09-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/SwiftfootBootsReprint.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/SwiftfootBootsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.tle.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftfoot Boots reprint in Avatar: The Last Airbender Eternal. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m12` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SwiftfootBootsReprint = Printing(
+    oracleId = "c8b143ad-43ec-4e0d-a440-e348daa31391",
+    name = "Swiftfoot Boots",
+    setCode = "TLE",
+    collectorNumber = "317",
+    scryfallId = "aff074f2-6ad9-4c0c-88e2-fc622772d2a1",
+    artist = "Barbara Rosiak",
+    imageUri = "https://cards.scryfall.io/normal/front/a/f/aff074f2-6ad9-4c0c-88e2-fc622772d2a1.jpg?1783904750",
+    releaseDate = "2025-11-21",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/CanopyVistaReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/CanopyVistaReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Canopy Vista reprint in Marvel Super Heroes Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `bfz` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val CanopyVistaReprint = Printing(
+    oracleId = "dcb7e046-f01b-497c-88e5-57794eb30ce5",
+    name = "Canopy Vista",
+    setCode = "MSC",
+    collectorNumber = "227",
+    scryfallId = "369e6485-fbc7-45f9-ac9d-2e26dd94f2d5",
+    artist = "Anthony Devine",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/369e6485-fbc7-45f9-ac9d-2e26dd94f2d5.jpg?1783903209",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/GlacialFortressReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/GlacialFortressReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glacial Fortress reprint in Marvel Super Heroes Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m10` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val GlacialFortressReprint = Printing(
+    oracleId = "027dd013-baa7-4111-b3c9-f4d1414e9c45",
+    name = "Glacial Fortress",
+    setCode = "MSC",
+    collectorNumber = "248",
+    scryfallId = "d673a2d5-0c61-48dc-8c8d-06f0c7b6b8bf",
+    artist = "Eugene Maslovski",
+    imageUri = "https://cards.scryfall.io/normal/front/d/6/d673a2d5-0c61-48dc-8c8d-06f0c7b6b8bf.jpg?1783903199",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/PrairieStreamReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/PrairieStreamReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prairie Stream reprint in Marvel Super Heroes Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `bfz` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val PrairieStreamReprint = Printing(
+    oracleId = "5330e24a-8568-446e-840a-594cd08bd1bc",
+    name = "Prairie Stream",
+    setCode = "MSC",
+    collectorNumber = "257",
+    scryfallId = "b2e133b4-2263-4ac2-8d16-7bf307d5e104",
+    artist = "Rockey Chen",
+    imageUri = "https://cards.scryfall.io/normal/front/b/2/b2e133b4-2263-4ac2-8d16-7bf307d5e104.jpg?1783903196",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/SunpetalGroveReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/SunpetalGroveReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunpetal Grove reprint in Marvel Super Heroes Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m10` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SunpetalGroveReprint = Printing(
+    oracleId = "402ec768-76fb-474e-ae74-babc90d833c4",
+    name = "Sunpetal Grove",
+    setCode = "MSC",
+    collectorNumber = "272",
+    scryfallId = "e83092ee-4a90-4eac-915f-3fd01b7d9bd0",
+    artist = "Rafater",
+    imageUri = "https://cards.scryfall.io/normal/front/e/8/e83092ee-4a90-4eac-915f-3fd01b7d9bd0.jpg?1783903191",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/SwiftfootBootsReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/SwiftfootBootsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swiftfoot Boots reprint in Marvel Super Heroes Commander. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in the `m12` `cards/` package
+ * (the card's earliest real printing); this file contributes only per-printing presentation data.
+ */
+val SwiftfootBootsReprint = Printing(
+    oracleId = "c8b143ad-43ec-4e0d-a440-e348daa31391",
+    name = "Swiftfoot Boots",
+    setCode = "MSC",
+    collectorNumber = "216",
+    scryfallId = "6675632d-d74a-4b1e-8539-ac678d5545a5",
+    artist = "Immanuela Crovius",
+    imageUri = "https://cards.scryfall.io/normal/front/6/6/6675632d-d74a-4b1e-8539-ac678d5545a5.jpg?1783903212",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.UNCOMMON,
+)


### PR DESCRIPTION
Follow-up to #1870, **stacked on it** (base branch is `worktree-blc-assay-ready`; merge that first).

#1870 disclosed that `check-card-printing` still reported drift on 17 of its 30 cards: each had a scaffolded *other* set with no `Printing(...)` row. That drift predates the sweep — it was invisible before, because the gate used to exit 2 with "card not implemented" for cards with no canonical anywhere. Implementing the canonical is what made the rest of each card's printing layout legible, so this closes it in the same series.

## What's here

**47 rows, one per (card, scaffolded set) pair, across 17 sets**: `c13 c14 c15 c16 c17 clb cmr khc m11 m12 m13 msc ncc pc2 tle voc xln`.

The long tail is what you'd expect from a Commander staple — Swiftfoot Boots alone owed 12 rows; Sunpetal Grove 6; Glacial Fortress 5.

Two things worth knowing about the shape:

- **One row per set, not per art treatment.** The gate keys `reprint_rows` by set code, so a card printed twice in one set — Canopy Vista, Glacial Fortress, Prairie Stream and Sunpetal Grove in MSC; Swiftfoot Boots in CMR — takes a single row against that set's primary collector number.
- **c16, msc and tle had no `Printing(...)` row at all before this.** All three already wire `CardDiscovery.findPrintingsIn`, so the rows are picked up with no set-object change anywhere.

## Scope

Deliberately the 30 cards from #1870. A corpus-wide sweep of this drift class is a much larger separate job and is not attempted here.

## Verification

- `just build` — green
- `check-card-printing` now exits 0 for **all 30** cards (was 17 failing)
- **no snapshot re-bless needed** — `Printing` rows are presentation data and the per-set card goldens hold `CardDefinition` trees, so `just rebless-cards` produced an empty diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
