### PR TITLE
Make Vanishing N engine-live (CR 702.62)

### DIFF
--- a/backlog/mtgish-tooling-engine-gaps.md
+++ b/backlog/mtgish-tooling-engine-gaps.md
@@ -360,6 +360,9 @@ Madness / Impending / Firebending ones.
 `absorb`, `afflict`, `annihilator`, `bushido`, `casualty`, `devour` / `devourLand`, `fabricate`,
 `fading`, `hideaway`, `mobilize`, `modular`, `rampage`, `renown`, `toxic`, `tribute`, `vanishing`
 
+(`vanishing` is now engine-live — declaring `KeywordAbility.vanishing(n)` is the whole
+implementation, so the emitter can render it as a bare keyword line with no hand-lowering.)
+
 These are the cheapest wins in the whole document — the shape is identical to the already-rendered
 `saddle(N)` / `firebending(N)`, just a different factory name.
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -77,7 +77,9 @@ doubt, leave it out — the planner will conservatively schedule a rule-plan.
 
 ### Numeric keywords (printed text + payload; engine wires them where used)
 - Annihilator N, Bushido N, Rampage N, Absorb N, Afflict N, Modular N,
-  Fading N, Vanishing N, Renown N, Fabricate N, Tribute N
+  Fading N, Renown N, Fabricate N, Tribute N
+- Vanishing N — fully wired (CR 702.62): declaring the keyword ability is the whole
+  implementation; the engine supplies the enters-with-counters replacement and both triggers.
   (catalog entries with display text and N; only the ones above with their own
   bullets have full mechanical wiring beyond what `KeywordAbility.Numeric` carries.
   When a card's only behaviour is the keyword itself, prefer to confirm via an

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7307,8 +7307,24 @@ composite abilities).
   last-known **+1/+1** count specifically rather than reaching for `Effects.MoveAllLastKnownCounters`
   (Servant of the Scale): that moves every counter kind, so a modular creature killed by -1/-1
   counters would hand its leftover -1/-1 counters to the target too.
-- `Fading(n)` — ETB with N fade counters; removes one each upkeep, sacrifice if can't.
-- `Vanishing(n)` — same idea with time counters.
+- `Fading(n)` — ETB with N fade counters; removes one each upkeep, sacrifice if can't. **Display-only
+  — nothing in the engine reads `Keyword.FADING`**, and unlike vanishing it cannot simply borrow the
+  time-counter machinery: fading counts a distinct fade counter type this codebase does not have, and
+  its third ability is "if you *can't* remove a counter, sacrifice it" — one turn earlier than
+  vanishing's. Hand-lower it, or add the counter type first.
+- `Vanishing(n)` — **engine-live.** Declare it and nothing else: `keywordAbility(KeywordAbility.vanishing(3))`
+  (Deep Forest Hermit). The engine supplies all three CR 702.62 abilities from
+  [`Vanishing`](../mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Vanishing.kt) — the
+  "enters with N time counters" replacement is synthesized at the entry seam from the printed `n`
+  (so it runs through `placeEntryCounters` and honours Hardened Scales / Solemnity), and the upkeep
+  countdown plus the "when the last time counter is removed, sacrifice it" trigger are granted from
+  the **projected** keyword, the same way flanking and the Siege defeat trigger are. Deriving from
+  the projection is what makes a token created *with* vanishing, or a creature that *gains* it,
+  count down as well — and what makes "loses all abilities" stop the clock. Do **not** hand-write
+  the three parts; they would stack with the engine's. Note 702.62b and 702.62c stay two separate
+  abilities (unlike suspend, which fuses them): a vanishing permanent sits where instant-speed
+  counter removal can reach it, and it is sacrificed whenever the last counter leaves, not only on
+  an upkeep.
 - `Renown(n)` — first combat damage to a player grants renown counters.
 - `Fabricate(n)` — ETB choose +1/+1 counters or Servo tokens.
 - `Tribute(n)` — opponent chooses ETB bonus.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -1471,6 +1471,11 @@ sealed interface KeywordAbility {
         fun saddle(n: Int): KeywordAbility = Numeric(Keyword.SADDLE, n)
         fun modular(n: Int): KeywordAbility = Numeric(Keyword.MODULAR, n)
         fun fading(n: Int): KeywordAbility = Numeric(Keyword.FADING, n)
+        /**
+         * Vanishing N (CR 702.62) — engine-live. Declaring this is the whole implementation;
+         * [Vanishing] supplies the enters-with-N-time-counters replacement and both triggers.
+         * Do not also hand-write those three parts, or they will stack with the engine's.
+         */
         fun vanishing(n: Int): KeywordAbility = Numeric(Keyword.VANISHING, n)
         fun renown(n: Int): KeywordAbility = Numeric(Keyword.RENOWN, n)
         fun fabricate(n: Int): KeywordAbility = Numeric(Keyword.FABRICATE, n)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Vanishing.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Vanishing.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.sdk.scripting
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.scripting.conditions.EntityMatches
+import com.wingedsheep.sdk.scripting.effects.RemoveCountersEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeTargetEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.predicates.StatePredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vanishing N (CR 702.62) as pure data — the three abilities every vanishing permanent has and
+ * none of them prints as separate lines.
+ *
+ * A card carrying `Vanishing 3` shows one keyword line plus its reminder text; the rules give it
+ * three distinct abilities:
+ *
+ *  1. **"This permanent enters with N time counters on it."** A replacement effect, and the only
+ *     one of the three that needs `N` — hence [entersWithCounters], a factory rather than a
+ *     singleton. The engine reads `N` back off the card's [KeywordAbility.Numeric] at entry.
+ *  2. **"At the beginning of your upkeep, if this permanent has a time counter on it, remove a
+ *     time counter from it."** [upkeepCountdown]. The intervening-`if` is what CR 702.62b prints,
+ *     and it also makes the ability inert once something else has drained the counters.
+ *  3. **"When the last time counter is removed from this permanent, sacrifice it."**
+ *     [lastCounterSacrifice].
+ *
+ * Parts 2 and 3 are deliberately **two abilities, not one fused countdown**. Suspend
+ * ([Suspend.countdownAbility]) folds its "when the last is removed" clause into a
+ * [com.wingedsheep.sdk.scripting.effects.ConditionalEffect] inside the upkeep trigger because
+ * nothing else ever removes a suspended card's time counters. A vanishing permanent sits on the
+ * battlefield where Vampire Hexmage, Hex Parasite and friends can strip its counters at instant
+ * speed — and CR 702.62c says it is sacrificed *whenever* the last one leaves, not only on an
+ * upkeep. Fusing them would silently ignore every off-turn removal.
+ *
+ * Both triggers are singletons granted by the engine to any permanent whose *projected* keywords
+ * include [Keyword.VANISHING], the same shape as [Flanking.blockedByNonFlankerTrigger] and
+ * [Sieges.defeatAbility]. Deriving from the projection rather than from the printed card is what
+ * makes *granted* vanishing work — a token created "with vanishing 3", or a creature that gains
+ * vanishing — and what makes a "loses all abilities" effect strip it.
+ *
+ * Fading (CR 702.30) is a near neighbour and is deliberately **not** covered here: it counts a
+ * distinct fade counter type that this codebase does not have, and its third ability is "if you
+ * can't remove a counter, sacrifice it" — a different rule from vanishing's, and one turn earlier.
+ */
+object Vanishing {
+
+    /** "this permanent has a time counter on it" — the CR 702.62b intervening-`if` gate. */
+    private val hasTimeCounter = EntityMatches(
+        EffectTarget.Self,
+        GameObjectFilter.Any.copy(
+            statePredicates = listOf(StatePredicate.HasCounter(Counters.TIME.uppercase()))
+        )
+    )
+
+    /**
+     * CR 702.62b — "At the beginning of your upkeep, if this permanent has a time counter on it,
+     * remove a time counter from it."
+     */
+    val upkeepCountdown: TriggeredAbility = TriggeredAbility(
+        id = AbilityId("vanishing_countdown"),
+        trigger = EventPattern.StepEvent(Step.UPKEEP, Player.You),
+        binding = TriggerBinding.SELF,
+        activeZones = setOf(Zone.BATTLEFIELD),
+        interveningIf = hasTimeCounter,
+        effect = RemoveCountersEffect(Counters.TIME, 1, EffectTarget.Self),
+        descriptionOverride = "At the beginning of your upkeep, remove a time counter from " +
+            "this permanent.",
+    )
+
+    /**
+     * CR 702.62c — "When the last time counter is removed from this permanent, sacrifice it."
+     *
+     * `lastRemoved` fires it only for the removal that empties the pile, so counting 3 → 2 → 1 is
+     * silent and the removal that reaches 0 sacrifices exactly once — however that removal
+     * happened.
+     */
+    val lastCounterSacrifice: TriggeredAbility = TriggeredAbility(
+        id = AbilityId("vanishing_sacrifice"),
+        trigger = EventPattern.CountersRemovedEvent(
+            counterType = Counters.TIME,
+            lastRemoved = true,
+        ),
+        binding = TriggerBinding.SELF,
+        activeZones = setOf(Zone.BATTLEFIELD),
+        effect = SacrificeTargetEffect(EffectTarget.Self),
+        descriptionOverride = "When the last time counter is removed from this permanent, " +
+            "sacrifice it.",
+    )
+
+    /**
+     * CR 702.62a — "This permanent enters with N time counters on it."
+     *
+     * `selfOnly` because the replacement applies to the vanishing permanent itself, never to
+     * other things entering under its controller.
+     */
+    fun entersWithCounters(n: Int): EntersWithCounters = EntersWithCounters(
+        counterType = CounterTypeFilter.Named(Counters.TIME),
+        count = n,
+        selfOnly = true,
+    )
+
+    /**
+     * The N on a card's printed `Vanishing N`, or `null` if it has none.
+     *
+     * Multiple instances would each set up their own counters (CR 702.62d), so the printed values
+     * are summed rather than taking the first — a permanent with vanishing 2 and vanishing 3
+     * enters with five time counters.
+     */
+    fun printedCount(cardDef: CardDefinition): Int? {
+        val total = cardDef.keywordAbilities
+            .filterIsInstance<KeywordAbility.Numeric>()
+            .filter { it.keyword == Keyword.VANISHING }
+            .sumOf { it.n }
+        return total.takeIf { it > 0 }
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/DeepForestHermit.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/DeepForestHermit.kt
@@ -1,20 +1,15 @@
 package com.wingedsheep.mtg.sets.definitions.mh1.cards
 
 import com.wingedsheep.sdk.core.Color
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Subtype
-import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.ModifyStats
-import com.wingedsheep.sdk.scripting.TriggerBinding
-import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
  * Deep Forest Hermit
@@ -26,15 +21,8 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * When this creature enters, create four 1/1 green Squirrel creature tokens.
  * Squirrels you control get +1/+1.
  *
- * Vanishing (CR 702.62) is spelled out from its three parts rather than declared as a keyword:
- * `Keyword.VANISHING` / `KeywordAbility.vanishing(n)` exist for rendering only — no engine
- * executor reads them — so a declared-only vanishing creature would enter with no time counters
- * and never be sacrificed. The three printed abilities are:
- *  - "enters with three time counters on it" → [EntersWithCounters] over [Counters.TIME]
- *  - "at the beginning of your upkeep, if it has a time counter on it, remove one" → an
- *    intervening-"if" upkeep trigger
- *  - "when the last is removed, sacrifice it" → [Triggers.countersRemovedFrom] with
- *    `lastRemoved = true` bound to the source
+ * Vanishing is declared, not spelled out: the engine supplies all three of CR 702.62's abilities
+ * from the keyword — see [com.wingedsheep.sdk.scripting.Vanishing].
  *
  * "Squirrels you control" carries no card type, so it is every Squirrel *permanent* you control —
  * [GameObjectFilter.Permanent], not `.Creature`. The Hermit is an Elf Druid, so it never pumps
@@ -52,34 +40,7 @@ val DeepForestHermit = card("Deep Forest Hermit") {
     power = 1
     toughness = 1
 
-    // Vanishing 3, part 1 — enters with three time counters on it.
-    replacementEffect(
-        EntersWithCounters(
-            counterType = CounterTypeFilter.Named(Counters.TIME),
-            count = 3,
-            selfOnly = true
-        )
-    )
-
-    // Vanishing 3, part 2 — at the beginning of your upkeep, if it has a time counter on it,
-    // remove a time counter from it.
-    triggeredAbility {
-        trigger = Triggers.YourUpkeep
-        interveningIf = Conditions.SourceCounterCountAtLeast(Counters.TIME, 1)
-        effect = Effects.RemoveCounters(Counters.TIME, 1, EffectTarget.Self)
-        description = "At the beginning of your upkeep, remove a time counter from this creature."
-    }
-
-    // Vanishing 3, part 3 — when the last time counter is removed, sacrifice it.
-    triggeredAbility {
-        trigger = Triggers.countersRemovedFrom(
-            counterType = Counters.TIME,
-            lastRemoved = true,
-            binding = TriggerBinding.SELF
-        )
-        effect = Effects.SacrificeTarget(EffectTarget.Self)
-        description = "When the last time counter is removed from this creature, sacrifice it."
-    }
+    keywordAbility(KeywordAbility.vanishing(3))
 
     triggeredAbility {
         trigger = Triggers.EntersBattlefield

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DeepForestHermitScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DeepForestHermitScenarioTest.kt
@@ -24,11 +24,12 @@ import io.kotest.matchers.shouldBe
  *  When this creature enters, create four 1/1 green Squirrel creature tokens.
  *  Squirrels you control get +1/+1."
  *
- * Vanishing (CR 702.62) has no engine executor — `Keyword.VANISHING` and
- * `KeywordAbility.vanishing(n)` exist for rendering only — so the card spells its three printed
- * abilities out of existing primitives. These tests are the proof that the composition behaves:
- * the Hermit enters with three time counters, sheds exactly one per *its controller's* upkeep, and
- * is sacrificed when the last one leaves. The Squirrel lord is asserted alongside, because the
+ * The card declares `KeywordAbility.vanishing(3)` and nothing else for it: all three of CR 702.62's
+ * abilities come from the engine ([com.wingedsheep.sdk.scripting.Vanishing]). These tests are the
+ * card-level proof that the declaration is enough — the Hermit enters with three time counters,
+ * sheds exactly one per *its controller's* upkeep, and is sacrificed when the last one leaves. The
+ * mechanic itself, including granted vanishing and off-turn counter removal, is pinned by
+ * `VanishingKeywordTest` in `rules-engine`. The Squirrel lord is asserted alongside, because the
  * tokens it makes are the reason the countdown matters.
  *
  * The countdown test drives a real [GameTestDriver] game rather than a static scenario board: it

--- a/mtg-sets/src/test/resources/snapshots/cards/MH1.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MH1.json
@@ -8,57 +8,20 @@
         "power": 1,
         "toughness": 1
     },
+    "keywords": [
+        "VANISHING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "VANISHING",
+            "n": 3
+        }
+    ],
     "script": {
         "triggeredAbilities": [
             {
                 "id": "ability_1",
-                "trigger": {
-                    "type": "StepEvent",
-                    "step": "UPKEEP"
-                },
-                "binding": "ANY",
-                "effect": {
-                    "type": "RemoveCounters",
-                    "counterType": "time",
-                    "count": 1,
-                    "target": "Self"
-                },
-                "interveningIf": {
-                    "type": "Compare",
-                    "left": {
-                        "type": "EntityProperty",
-                        "entity": "Source",
-                        "numericProperty": {
-                            "type": "CounterCount",
-                            "counterType": {
-                                "type": "Named",
-                                "name": "time"
-                            }
-                        }
-                    },
-                    "operator": "GTE",
-                    "right": {
-                        "type": "Fixed",
-                        "amount": 1
-                    }
-                },
-                "descriptionOverride": "At the beginning of your upkeep, remove a time counter from this creature."
-            },
-            {
-                "id": "ability_2",
-                "trigger": {
-                    "type": "CountersRemovedEvent",
-                    "counterType": "time",
-                    "lastRemoved": true
-                },
-                "effect": {
-                    "type": "SacrificeTarget",
-                    "target": "Self"
-                },
-                "descriptionOverride": "When the last time counter is removed from this creature, sacrifice it."
-            },
-            {
-                "id": "ability_3",
                 "trigger": {
                     "type": "ZoneChangeEvent",
                     "to": "Battlefield"
@@ -88,17 +51,6 @@
                 "filter": {
                     "baseFilter": "permanent Squirrel ctrl:you"
                 }
-            }
-        ],
-        "replacementEffects": [
-            {
-                "type": "EntersWithCounters",
-                "counterType": {
-                    "type": "Named",
-                    "name": "time"
-                },
-                "count": 3,
-                "selfOnly": true
             }
         ]
     },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -105,9 +105,14 @@ class TriggerAbilityResolver(
         // and one that stops being a Siege loses it.
         val siegeAbilities = getSiegeDefeatAbilities(entityId, state)
 
+        // Vanishing N (CR 702.62) — the upkeep countdown and the last-counter sacrifice are
+        // intrinsic to the keyword, printed on no card as separate lines. Derived from the
+        // projected keywords, so granted vanishing works and "loses all abilities" strips it.
+        val vanishingAbilities = getVanishingTriggeredAbilities(entityId, state)
+
         val allGranted = grantedAbilities + staticGrantedAbilities + attachedGrantedAbilities +
             selfGrantedAbilities + wardAbilities + flankingAbilities + ringBearerAbilities +
-            suspendAbilities + paradigmAbilities + siegeAbilities
+            suspendAbilities + paradigmAbilities + siegeAbilities + vanishingAbilities
         val combined = if (allGranted.isNotEmpty()) base + allGranted else base
 
         // Apply text replacement if the entity has one
@@ -287,9 +292,14 @@ class TriggerAbilityResolver(
         // and one that stops being a Siege loses it.
         val siegeAbilities = getSiegeDefeatAbilities(entityId, state)
 
+        // Vanishing N (CR 702.62) — the upkeep countdown and the last-counter sacrifice are
+        // intrinsic to the keyword, printed on no card as separate lines. Derived from the
+        // projected keywords, so granted vanishing works and "loses all abilities" strips it.
+        val vanishingAbilities = getVanishingTriggeredAbilities(entityId, state)
+
         val allGranted = grantedAbilities + staticGrantedAbilities + attachedGrantedAbilities +
             selfGrantedAbilities + wardAbilities + flankingAbilities + ringBearerAbilities +
-            suspendAbilities + paradigmAbilities + siegeAbilities
+            suspendAbilities + paradigmAbilities + siegeAbilities + vanishingAbilities
         val combined = if (allGranted.isNotEmpty()) base + allGranted else base
 
         val textReplacement = state.getEntity(entityId)?.get<TextReplacementComponent>()
@@ -680,6 +690,31 @@ class TriggerAbilityResolver(
     private fun getFlankingTriggeredAbilities(entityId: EntityId, state: GameState): List<TriggeredAbility> =
         if (state.projectedState.hasKeyword(entityId, com.wingedsheep.sdk.core.Keyword.FLANKING)) {
             listOf(com.wingedsheep.sdk.scripting.Flanking.blockedByNonFlankerTrigger)
+        } else {
+            emptyList()
+        }
+
+    /**
+     * Vanishing N (CR 702.62) as two keyword-derived triggered abilities: the upkeep countdown
+     * (702.62b) and the last-time-counter sacrifice (702.62c). A vanishing card prints one keyword
+     * line and a reminder, never these two abilities, so the engine supplies them — the same shape
+     * as flanking, ward and the Siege defeat trigger.
+     *
+     * Keyed on the *projected* keyword, which buys three things at once: a token created "with
+     * vanishing 3" and a creature that *gains* vanishing both count down, and a permanent that has
+     * lost all abilities stops counting down (the keyword is stripped in projection) — matching
+     * CR 702.62, where all three vanishing abilities are abilities of the permanent.
+     *
+     * The N-carrying half — "enters with N time counters" — is not here: it is a replacement
+     * effect applied at entry from the printed [com.wingedsheep.sdk.scripting.KeywordAbility.Numeric],
+     * see `EntersWithReplacements`.
+     */
+    private fun getVanishingTriggeredAbilities(entityId: EntityId, state: GameState): List<TriggeredAbility> =
+        if (state.projectedState.hasKeyword(entityId, com.wingedsheep.sdk.core.Keyword.VANISHING)) {
+            listOf(
+                com.wingedsheep.sdk.scripting.Vanishing.upkeepCountdown,
+                com.wingedsheep.sdk.scripting.Vanishing.lastCounterSacrifice,
+            )
         } else {
             emptyList()
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithReplacements.kt
@@ -25,6 +25,7 @@ import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
 import com.wingedsheep.sdk.scripting.EntersWithKeywords
+import com.wingedsheep.sdk.scripting.Vanishing
 import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
@@ -156,7 +157,15 @@ object EntersWithReplacements {
         val events = mutableListOf<GameEvent>()
         val entityName = newState.getEntity(entityId)?.get<CardComponent>()?.name ?: ""
 
-        for (effect in cardDef.script.replacementEffects) {
+        // Vanishing N (CR 702.62a) — "this permanent enters with N time counters on it" is an
+        // ability of the keyword, not a line any vanishing card prints, so synthesize the
+        // replacement from the printed `Vanishing N` and run it through the same path as an
+        // authored one. Same `printed + listOfNotNull(synthetic)` shape as granted Riot's
+        // enters-with choice in StackResolver.
+        val vanishingEntry = Vanishing.printedCount(cardDef)?.let { Vanishing.entersWithCounters(it) }
+        val replacementEffects = cardDef.script.replacementEffects + listOfNotNull(vanishingEntry)
+
+        for (effect in replacementEffects) {
             when (effect) {
                 is EntersWithCounters -> {
                     // Skip "other only" effects when applying to self (Metallic Mimic's "each other

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VanishingKeywordTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VanishingKeywordTest.kt
@@ -1,0 +1,205 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.ActiveFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.FloatingEffectData
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffects
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mechanic-level tests for Vanishing N (CR 702.62).
+ *
+ * A vanishing card declares one keyword ability; the engine supplies all three printed abilities
+ * from [com.wingedsheep.sdk.scripting.Vanishing] — the enters-with-N-time-counters replacement
+ * (702.62a) at the entry seam, and the upkeep countdown (702.62b) plus the last-counter sacrifice
+ * (702.62c) as keyword-derived triggers.
+ *
+ * Three things are worth pinning beyond the happy path:
+ *  - the countdown is **yours**, not every upkeep;
+ *  - the sacrifice fires on the removal that empties the counters **whatever removed them**, which
+ *    is why 702.62b and 702.62c are two abilities here rather than suspend's single fused
+ *    countdown;
+ *  - the triggers are derived from the **projected** keyword, so a creature that merely *gains*
+ *    vanishing counts down too.
+ */
+class VanishingKeywordTest : FunSpec({
+
+    val vanishingBear = card("Vanishing Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+        oracleText = "Vanishing 2"
+        keywordAbility(KeywordAbility.vanishing(2))
+    }
+
+    /** A plain 2/2 with no vanishing, used as the "gains vanishing" subject. */
+    val plainBear = card("Plain Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    /** Removes a time counter at instant speed — the off-turn drain CR 702.62c must notice. */
+    val timeSiphon = card("Time Siphon") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        oracleText = "Remove a time counter from target creature."
+        spell {
+            val victim = target("target creature", Targets.Creature)
+            effect = Effects.RemoveCounters(Counters.TIME, 1, victim)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(vanishingBear, plainBear, timeSiphon))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun timeCounters(driver: GameTestDriver, perm: EntityId): Int =
+        driver.state.getEntity(perm)?.get<CountersComponent>()?.getCount(CounterType.TIME) ?: 0
+
+    /** Cast [cardName] from hand with mana granted, and resolve it. */
+    fun castAndResolve(driver: GameTestDriver, player: EntityId, cardName: String, targets: List<EntityId> = emptyList()) {
+        driver.giveMana(player, Color.GREEN, 3)
+        driver.giveMana(player, Color.BLUE, 3)
+        val cardId = driver.putCardInHand(player, cardName)
+        val result = driver.submit(
+            CastSpell(player, cardId, targets.map { ChosenTarget.Permanent(it) })
+        )
+        if (!result.isSuccess) throw AssertionError("cast of $cardName failed: ${result.error}")
+        driver.bothPass()
+    }
+
+    /** Advance to [owner]'s next upkeep, resolving the countdown trigger that fires there. */
+    fun resolveNextOwnerUpkeep(driver: GameTestDriver, owner: EntityId) {
+        do {
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+            driver.passPriorityUntil(Step.UPKEEP)
+        } while (driver.activePlayer != owner)
+        driver.bothPass()
+    }
+
+    test("a declared Vanishing N enters the battlefield with N time counters") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        castAndResolve(driver, player, "Vanishing Bear")
+
+        val bear = driver.findPermanent(player, "Vanishing Bear")!!
+        timeCounters(driver, bear) shouldBe 2
+    }
+
+    test("the countdown is the controller's upkeep only, and the last removal sacrifices it") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        castAndResolve(driver, player, "Vanishing Bear")
+        val bear = driver.findPermanent(player, "Vanishing Bear")!!
+
+        // The opponent's upkeep comes first and must not count anything down.
+        driver.passPriorityUntil(Step.UPKEEP)
+        (driver.activePlayer == player) shouldBe false
+        timeCounters(driver, bear) shouldBe 2
+
+        resolveNextOwnerUpkeep(driver, player)
+        timeCounters(driver, bear) shouldBe 1
+        (driver.findPermanent(player, "Vanishing Bear") != null) shouldBe true
+
+        // The countdown and the sacrifice are two abilities, so the emptying upkeep needs two
+        // resolutions: the countdown removes the last counter, which queues the sacrifice trigger.
+        resolveNextOwnerUpkeep(driver, player)
+        driver.bothPass()
+        driver.findPermanent(player, "Vanishing Bear").shouldBeNull()
+        driver.getGraveyardCardNames(player).contains("Vanishing Bear") shouldBe true
+    }
+
+    test("draining the last counter off-turn sacrifices it immediately, not at the next upkeep") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        castAndResolve(driver, player, "Vanishing Bear")
+        val bear = driver.findPermanent(player, "Vanishing Bear")!!
+
+        // Take it to one counter the ordinary way, then strip the last one with an instant.
+        resolveNextOwnerUpkeep(driver, player)
+        timeCounters(driver, bear) shouldBe 1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        castAndResolve(driver, player, "Time Siphon", targets = listOf(bear))
+        driver.bothPass() // resolve the sacrifice trigger
+
+        driver.findPermanent(player, "Vanishing Bear").shouldBeNull()
+    }
+
+    test("a creature that merely gains vanishing counts down too") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        castAndResolve(driver, player, "Plain Bear")
+        val bear = driver.findPermanent(player, "Plain Bear")!!
+
+        // Grant the keyword and hand it counters — the shape a "it gains vanishing 2" effect
+        // produces. The triggers are derived from the projected keyword, so this is enough.
+        var s = driver.state.updateEntity(bear) { container ->
+            container.with(CountersComponent().withAdded(CounterType.TIME, 1))
+        }
+        s = s.addFloatingEffects(
+            listOf(
+                ActiveFloatingEffect(
+                    id = EntityId.generate(),
+                    effect = FloatingEffectData(
+                        layer = Layer.ABILITY,
+                        modification = SerializableModification.GrantKeyword(Keyword.VANISHING.name),
+                        affectedEntities = setOf(bear),
+                    ),
+                    duration = Duration.Permanent,
+                    sourceId = bear,
+                    sourceName = "Plain Bear",
+                    controllerId = player,
+                    timestamp = s.timestamp,
+                )
+            )
+        )
+        driver.replaceState(s)
+        driver.state.projectedState.hasKeyword(bear, Keyword.VANISHING) shouldBe true
+
+        resolveNextOwnerUpkeep(driver, player)
+        driver.bothPass() // resolve the sacrifice trigger the emptying removal queued
+
+        driver.findPermanent(player, "Plain Bear").shouldBeNull()
+    }
+
+    test("Vanishing.printedCount sums multiple printed instances (CR 702.62d)") {
+        val doubled = card("Doubly Vanishing Bear") {
+            manaCost = "{1}{G}"
+            typeLine = "Creature — Bear"
+            power = 2
+            toughness = 2
+            keywordAbilities(KeywordAbility.vanishing(2), KeywordAbility.vanishing(3))
+        }
+        com.wingedsheep.sdk.scripting.Vanishing.printedCount(doubled) shouldBe 5
+        com.wingedsheep.sdk.scripting.Vanishing.printedCount(plainBear).shouldBeNull()
+    }
+})


### PR DESCRIPTION
Follow-up to #1870, **stacked on #1873** (base branch is `worktree-blc-printing-drift`; merge #1870 then #1873 first).

#1870 flagged that vanishing is a dead enum: `Keyword.VANISHING` and `KeywordAbility.vanishing(n)` exist only so the keyword line renders, and nothing in `rules-engine` reads either — so a card that *declared* vanishing would enter with no time counters and never be sacrificed. Deep Forest Hermit worked around it by spelling the three abilities out by hand. This makes the declaration itself the implementation.

## The mechanic as data

New `mtg-sdk/.../scripting/Vanishing.kt`, in the shape of the existing `Suspend` / `Sieges` / `Flanking` objects:

| | CR | |
|---|---|---|
| `upkeepCountdown` | 702.62b | `StepEvent(UPKEEP, You)`, intervening-`if` "has a time counter" |
| `lastCounterSacrifice` | 702.62c | `CountersRemovedEvent(TIME, lastRemoved = true)` → sacrifice |
| `entersWithCounters(n)` | 702.62a | the only part that needs `N` |
| `printedCount(cardDef)` | 702.62d | sums printed instances |

## Where it's wired, and why there

**The two triggers are granted from the *projected* keyword** in `TriggerAbilityResolver` — in **both** `getTriggeredAbilities` and `getTriggeredAbilitiesWithProviders`, since the latter is the hot path behind `TriggerIndex` and patching only one would work in tests and quietly not in real games.

Reading the projection rather than the printed card is the whole point of this seam: it means a token created *with* vanishing and a creature that *gains* vanishing count down too, and that "loses all abilities" stops the clock. There is already latent demand for that — Maelstrom Djinn ("it gains vanishing") and The Girl in the Fireplace (a token *with* vanishing 3) are both sitting in the Assay verdict ledger.

**The enters-with-counters half is synthesized in `EntersWithReplacements.applyFromDefinition`**, using the same `printed + listOfNotNull(synthetic)` shape granted Riot already uses in `StackResolver`. That function is shared by stack resolution *and* `applyOnEntry`, so a reanimated or token-copied vanishing creature gets its counters too — and routing through `placeEntryCounters` means Hardened Scales and Solemnity are honoured, which Impending's ad-hoc counter stamping does not do.

## Two abilities, not one fused countdown

Suspend folds its "when the last is removed" clause into a `ConditionalEffect` inside the upkeep trigger. Vanishing must not: suspend can fuse because nothing else ever drains an exiled card's time counters, whereas a vanishing permanent sits on the battlefield where Vampire Hexmage and friends strip counters at instant speed, and CR 702.62c sacrifices it *whenever* the last one leaves — not only on an upkeep. `VanishingKeywordTest` pins exactly that case.

## The payoff

Deep Forest Hermit goes from 47 lines of hand-rolled machinery to one line:

```kotlin
keywordAbility(KeywordAbility.vanishing(3))
```

and **its existing scenario test passes unchanged** — that test is the regression oracle for this change. Its snapshot golden loses 58 lines and gains 10.

The Assay differential improves too: the card's golden now matches Assay's compiled model exactly, so it moves *into* comparison — `script slot not modelled yet` 118 → 117, compared 3278 → 3279, confirmed 3265 → 3266, divergences unchanged at the same pre-existing 13.

## Fading is deliberately left alone

Fading (CR 702.30) is a near neighbour but not the same job: it counts a fade counter type this codebase does not have, and its third ability is "if you *can't* remove a counter, sacrifice it" — a different rule, one turn earlier. Rather than implying it works, both docs now say it is display-only and why.

## Verification

- `just build` — green
- `VanishingKeywordTest` — 5 tests: entry counters, controller's-upkeep-only countdown, off-turn drain, **granted** vanishing, multi-instance sum
- `DeepForestHermitScenarioTest` — passes **unchanged**
- `just assay-differential` — same 13 divergences, one card gained into comparison
- MH1 snapshot re-blessed

Docs updated in the same change per the SDK-reference rule: `card-sdk-language-reference.md` (vanishing documented as engine-live with a "don't hand-write the parts, they'd stack" warning; fading marked display-only), `docs/RULES.md`, `backlog/mtgish-tooling-engine-gaps.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
