### PR TITLE
Add three Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AgrusKosSpiritOfJustice.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AgrusKosSpiritOfJustice.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.TriggeredAbilityBuilder
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Agrus Kos, Spirit of Justice — Murders at Karlov Manor #184
+ * {2}{R}{W} · Legendary Creature — Spirit Detective · 2/4
+ *
+ * Double strike, vigilance
+ * Whenever Agrus Kos enters or attacks, choose up to one target creature. If it's suspected, exile
+ * it. Otherwise, suspect it.
+ *
+ * A two-stage removal engine: the first hit hangs a suspect designation on a blocker (menace plus
+ * "can't block", CR 701.60a), and any later hit — the same Agrus Kos attacking again, or a second
+ * copy entering — cashes that designation in for an exile. Because Agrus Kos has vigilance, the
+ * attack trigger costs nothing defensively, and double strike means the body it just disarmed is
+ * exactly the one it wanted out of the way.
+ *
+ * **"Enters or attacks" is two triggered abilities, not one.** The SDK has no combined
+ * enters-or-attacks trigger, so the ability is written twice over a shared effect factory — the same
+ * shape [BenthicCriminologists] uses for the identical clause — one `TriggeredAbilityBuilder`
+ * extension declaring the target and the rider, invoked from both blocks. That is also the rules-correct
+ * reading: they are separate abilities that each trigger and target independently, so a turn where
+ * Agrus Kos enters *and* attacks puts two abilities on the stack, each choosing its own target.
+ *
+ * **The branch reads the target at resolution, not at announcement.** `TargetMatchesFilter` over
+ * `Creature.suspected()` is evaluated when the ability resolves, so a creature that was suspected on
+ * announcement but had the designation stripped in between (Absolving Lammasu, Airtight Alibi) gets
+ * suspected again rather than exiled — and vice versa. Modelling this as two modes chosen up front
+ * would get that backwards. The condition is keyed on the *target index* rather than on the handle
+ * `target(…)` returns: `ConditionEvaluator` resolves `ContextTarget` but not a bound variable, so a
+ * handle-based condition would silently evaluate false and always take the suspect branch.
+ *
+ * `optional = true` carries the printed "up to one": declining is legal even with legal targets on
+ * the board, which matters because suspecting an opponent's creature *helps* it get through as an
+ * attacker. With no target chosen the ability resolves and does nothing.
+ *
+ * Suspect is deliberately permanent (`Effects.Suspect` defaults to `Duration.Permanent`) — per the
+ * rulings a creature stays suspected until it leaves the battlefield or an effect un-suspects it.
+ * Nothing about the exile branch refers to Agrus Kos, so it still happens if Agrus Kos dies to the
+ * blocker's damage before the ability resolves.
+ */
+val AgrusKosSpiritOfJustice = card("Agrus Kos, Spirit of Justice") {
+    manaCost = "{2}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Spirit Detective"
+    power = 2
+    toughness = 4
+    oracleText = "Double strike, vigilance\n" +
+        "Whenever Agrus Kos enters or attacks, choose up to one target creature. If it's suspected, " +
+        "exile it. Otherwise, suspect it. (A suspected creature has menace and can't block.)"
+
+    keywords(Keyword.DOUBLE_STRIKE, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        exileIfSuspectedOtherwiseSuspect()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        exileIfSuspectedOtherwiseSuspect()
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "184"
+        artist = "Jason A. Engle"
+        flavorText = "\"Eventually I'll give retirement another shot. But not today.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/58aeac7c-1275-49d4-9915-7604ae4bfdff.jpg?1783912857"
+
+        ruling(
+            "2024-02-02",
+            "When an effect suspects a creature, it becomes suspected. It gains menace and \"This " +
+                "creature can't block\" for as long as it's suspected. It stays suspected until it " +
+                "leaves the battlefield or another effect causes it to no longer be suspected."
+        )
+        ruling(
+            "2024-02-02",
+            "If a suspected creature loses all abilities, it will lose menace and \"This creature " +
+                "can't block\", but it won't stop being suspected."
+        )
+        ruling(
+            "2024-02-02",
+            "Being suspected isn't a copiable value. If a permanent becomes a copy of a suspected " +
+                "creature, it won't be suspected."
+        )
+        ruling(
+            "2024-02-02",
+            "If a creature is already suspected, suspecting it again won't have any effect."
+        )
+        ruling(
+            "2024-02-02",
+            "There's no limit to the number of creatures that can be suspected simultaneously. " +
+                "Suspecting a new creature doesn't cause other creatures to stop being suspected."
+        )
+    }
+}
+
+/** The rider shared by the enters and attacks triggers. */
+private fun TriggeredAbilityBuilder.exileIfSuspectedOtherwiseSuspect() {
+    val suspect = target("up to one target creature", TargetCreature(optional = true))
+    effect = ConditionalEffect(
+        condition = Conditions.TargetMatchesFilter(GameObjectFilter.Creature.suspected()),
+        effect = Effects.Exile(suspect),
+        elseEffect = Effects.Suspect(suspect)
+    )
+    description = "Choose up to one target creature. If it's suspected, exile it. Otherwise, " +
+        "suspect it."
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RakdosPatronOfChaos.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RakdosPatronOfChaos.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.EffectChoice
+import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rakdos, Patron of Chaos — Murders at Karlov Manor #224
+ * {4}{B}{R} · Legendary Creature — Demon · 6/6
+ *
+ * Flying, trample
+ * At the beginning of your end step, target opponent may sacrifice two nonland, nontoken permanents
+ * of their choice. If they don't, you draw two cards.
+ *
+ * A six-mana 6/6 flier that taxes the table every turn it survives: two real permanents or two cards,
+ * chosen by the victim, every end step. In multiplayer the target is re-chosen each turn, so the tax
+ * rotates.
+ *
+ * **The "may" is an opponent-side choice between two named actions**, which is exactly
+ * [Effects.ChooseAction] with `player` set to the targeted opponent — the same shape as Terrapact
+ * Intimidator's wording-identical "target opponent may … If they don't, …". Both halves are effects
+ * the choosing player selects between, not a cost they pay, and that distinction is load-bearing here:
+ *
+ * - A `MayEffect(decisionMaker = opponent, otherwise = draw)` would prompt the right player, but the
+ *   engine evaluates a gate's feasibility against the *ability's controller*, not the decision maker.
+ *   Rakdos's controller having two spare permanents would then wrongly enable the option.
+ * - Worse, `ForceSacrifice` auto-sacrifices when a player has at most `count` legal permanents, so an
+ *   opponent who accepted while holding a single permanent would lose that one — sacrificing *one*
+ *   where the card demands two. `ChooseAction` avoids both: its
+ *   [FeasibilityCheck.ControlsPermanentMatching] is tested against the chooser, so an opponent who
+ *   can't find two is never offered the option, the remaining choice auto-executes, and the draw
+ *   happens without a prompt. That is the rules-correct outcome — they can't sacrifice two, so they
+ *   don't, and "if they don't" fires.
+ *
+ * "Of their choice" is the default for `Effects.Sacrifice(…, target = opponent)`: the named player is
+ * both the sacrificer and the chooser, prompted for exactly two permanents. `NonlandPermanent
+ * .nontoken()` is the printed filter — tokens are excluded so a Clue-and-Treasure board can't buy its
+ * way out cheaply.
+ *
+ * The draw is `EffectTarget.Controller`, not the trigger's target: "you" is Rakdos's controller.
+ * Nothing in either branch refers back to Rakdos, so both still happen if it leaves the battlefield
+ * after the trigger goes on the stack.
+ */
+val RakdosPatronOfChaos = card("Rakdos, Patron of Chaos") {
+    manaCost = "{4}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Demon"
+    power = 6
+    toughness = 6
+    oracleText = "Flying, trample\n" +
+        "At the beginning of your end step, target opponent may sacrifice two nonland, nontoken " +
+        "permanents of their choice. If they don't, you draw two cards."
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        val opponent = target("target opponent", Targets.Opponent)
+        val fodder = GameObjectFilter.NonlandPermanent.nontoken()
+        effect = Effects.ChooseAction(
+            choices = listOf(
+                EffectChoice(
+                    label = "Sacrifice two nonland, nontoken permanents",
+                    effect = Effects.Sacrifice(fodder, count = 2, target = opponent),
+                    feasibilityCheck = FeasibilityCheck.ControlsPermanentMatching(fodder, count = 2)
+                ),
+                EffectChoice(
+                    label = "Let Rakdos's controller draw two cards",
+                    effect = Effects.DrawCards(2, EffectTarget.Controller)
+                )
+            ),
+            player = opponent
+        )
+        description = "At the beginning of your end step, target opponent may sacrifice two " +
+            "nonland, nontoken permanents of their choice. If they don't, you draw two cards."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "224"
+        artist = "Joshua Raphael"
+        flavorText = "\"Finally, a performance worthy of my applause!\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc6fd2d5-8eb2-4265-a1bf-d4ae635285af.jpg?1783912841"
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/WorldsoulsRage.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/WorldsoulsRage.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Worldsoul's Rage — Murders at Karlov Manor #244
+ * {X}{R}{G} · Sorcery
+ *
+ * Worldsoul's Rage deals X damage to any target. Put up to X land cards from your hand and/or
+ * graveyard onto the battlefield tapped.
+ *
+ * One X buys both halves, which is why the card is a ramp payoff rather than a burn spell: X=4 is a
+ * four-point Rolling Thunder *and* four lands, so every point spent on the removal is also a point of
+ * mana development. The lands come from either zone, so a stocked graveyard (fetch lands, Aftermath
+ * Analyst) fuels it as well as a hand full of them.
+ *
+ * The two halves are one resolution, in printed order — damage first, then the lands. That ordering is
+ * observable: the damage can kill a creature whose death fills the graveyard, but not in time to be
+ * selected here, because the collection is gathered after the damage has already been dealt.
+ *
+ * "From your hand **and/or** graveyard" is a single decision over both zones, not two prompts:
+ * `CardSource.FromMultipleZones` gathers them together and the client renders the choice with zone
+ * labels (`MultiZoneSelectionUI`). A flat list would leave the player unable to tell a land in hand
+ * from the same land in the graveyard.
+ *
+ * `SelectionMode.ChooseUpTo(DynamicAmount.XValue)` carries the printed "up to X" — fewer than X is
+ * legal, and X=0 makes the whole spell a legal cast that deals no damage and puts no lands. The X here
+ * is `XValue`, the transient cast-time payment read during this spell's own resolution, not the
+ * object-scoped `CastX` a permanent would need.
+ *
+ * `ZonePlacement.Tapped` on the move step is what "onto the battlefield tapped" means — the same
+ * placement MKM's own Aftermath Analyst uses for its graveyard-land return. Nothing here is a land
+ * *play*, so the once-per-turn land drop is untouched and any number of lands can arrive.
+ */
+val WorldsoulsRage = card("Worldsoul's Rage") {
+    manaCost = "{X}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Sorcery"
+    oracleText = "Worldsoul's Rage deals X damage to any target. Put up to X land cards from your " +
+        "hand and/or graveyard onto the battlefield tapped."
+
+    spell {
+        val victim = target("any target", AnyTarget())
+        effect = Effects.Composite(
+            Effects.DealXDamage(victim),
+            GatherCardsEffect(
+                source = CardSource.FromMultipleZones(
+                    zones = listOf(Zone.HAND, Zone.GRAVEYARD),
+                    player = Player.You,
+                    filter = GameObjectFilter.Land
+                ),
+                storeAs = "worldsoulLands"
+            ),
+            SelectFromCollectionEffect(
+                from = "worldsoulLands",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.XValue),
+                storeSelected = "worldsoulLandsChosen"
+            ),
+            MoveCollectionEffect(
+                from = "worldsoulLandsChosen",
+                destination = CardDestination.ToZone(
+                    zone = Zone.BATTLEFIELD,
+                    placement = ZonePlacement.Tapped
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "244"
+        artist = "Lius Lasahido"
+        flavorText = "\"Hoarding supplies, profiting from death and destruction, colluding with the " +
+            "invaders—every one of them betrayed Ravnica in its time of greatest need. They all " +
+            "deserved to die. And I'm not done yet!\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc3340bd-1d8c-4c21-a59d-e092fcbe02e3.jpg?1783912832"
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AgrusKosSpiritOfJusticeScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AgrusKosSpiritOfJusticeScenarioTest.kt
@@ -1,0 +1,153 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.AgrusKosSpiritOfJustice
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Agrus Kos, Spirit of Justice (MKM #184) — {2}{R}{W} 2/4 Legendary Spirit Detective.
+ *
+ * "Double strike, vigilance. Whenever Agrus Kos enters or attacks, choose up to one target creature.
+ *  If it's suspected, exile it. Otherwise, suspect it."
+ *
+ * Three claims worth proving, because each has a plausible wrong implementation:
+ *
+ *  - the branch is a **resolution-time** state test, so a clean creature takes the suspect arm and a
+ *    creature that is already suspected takes the exile arm;
+ *  - "enters **or** attacks" is genuinely two abilities — the attacks half must fire on its own, not
+ *    only as a side effect of the entry trigger;
+ *  - "up to one target" must let the ability resolve with nothing chosen, rather than being removed
+ *    from the stack for want of a legal target.
+ *
+ * The two-stage test doubles as the card's real gameplay loop: entry suspects the blocker, the next
+ * attack cashes the designation in for an exile.
+ */
+class AgrusKosSpiritOfJusticeScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + AgrusKosSpiritOfJustice)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.payForAgrusKos(player: EntityId) {
+        giveMana(player, Color.RED, 1)
+        giveMana(player, Color.WHITE, 1)
+        giveColorlessMana(player, 2)
+    }
+
+    /** Drain priority until the trigger's target choice is raised, however many passes that takes. */
+    fun GameTestDriver.advanceToTargetChoice() {
+        var guard = 0
+        while (guard++ < 12 && pendingDecision !is ChooseTargetsDecision) {
+            if (stackSize > 0 || priorityPlayer != null) bothPass() else break
+        }
+        withClue("the trigger asked for its 'up to one target creature'") {
+            (pendingDecision is ChooseTargetsDecision) shouldBe true
+        }
+    }
+
+    test("the enters trigger suspects a target that isn't suspected yet") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        val victim = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        withClue("the victim starts clean") {
+            StateProjector().project(driver.state).isSuspected(victim) shouldBe false
+        }
+
+        val card = driver.putCardInHand(player, "Agrus Kos, Spirit of Justice")
+        driver.payForAgrusKos(player)
+        driver.castSpell(player, card).error shouldBe null
+        driver.advanceToTargetChoice()
+        driver.submitTargetSelection(player, listOf(victim)).error shouldBe null
+        driver.bothPass()
+
+        val projected = StateProjector().project(driver.state)
+        withClue("the else arm applied the suspected designation (CR 701.60a)") {
+            projected.isSuspected(victim) shouldBe true
+        }
+        withClue("suspected carries menace and can't block (CR 701.60c)") {
+            projected.hasKeyword(victim, Keyword.MENACE) shouldBe true
+            projected.cantBlock(victim) shouldBe true
+        }
+        withClue("the exile arm must not have run — it wasn't suspected when the ability resolved") {
+            driver.findPermanent(opponent, "Grizzly Bears") shouldBe victim
+        }
+    }
+
+    test("the attacks trigger exiles a target the enters trigger already suspected") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        val victim = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        // Stage one: hard-cast Agrus Kos, whose entry trigger suspects the victim.
+        val card = driver.putCardInHand(player, "Agrus Kos, Spirit of Justice")
+        driver.payForAgrusKos(player)
+        driver.castSpell(player, card).error shouldBe null
+        driver.advanceToTargetChoice()
+        driver.submitTargetSelection(player, listOf(victim)).error shouldBe null
+        driver.bothPass()
+
+        val agrus = driver.findPermanent(player, "Agrus Kos, Spirit of Justice")
+        agrus.shouldNotBeNull()
+        StateProjector().project(driver.state).isSuspected(victim) shouldBe true
+
+        // Stage two: attack with it. This is the *second* ability, and the target is now suspected.
+        driver.removeSummoningSickness(agrus)
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(agrus), opponent).error shouldBe null
+        driver.advanceToTargetChoice()
+        driver.submitTargetSelection(player, listOf(victim)).error shouldBe null
+        driver.bothPass()
+
+        withClue("the attacks half fired on its own and took the exile arm") {
+            driver.findPermanent(opponent, "Grizzly Bears") shouldBe null
+            driver.getExileCardNames(opponent) shouldContain "Grizzly Bears"
+        }
+    }
+
+    test("'up to one target' lets the ability resolve with nothing chosen") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        val victim = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val card = driver.putCardInHand(player, "Agrus Kos, Spirit of Justice")
+        driver.payForAgrusKos(player)
+        driver.castSpell(player, card).error shouldBe null
+        driver.advanceToTargetChoice()
+
+        // Decline the optional target even though a legal one is on the board.
+        driver.submitTargetSelection(player, emptyList()).error shouldBe null
+        driver.bothPass()
+
+        val projected = StateProjector().project(driver.state)
+        withClue("neither arm touched anything") {
+            projected.isSuspected(victim) shouldBe false
+            driver.findPermanent(opponent, "Grizzly Bears") shouldBe victim
+        }
+        withClue("Agrus Kos itself still arrived, with both printed keywords") {
+            val agrus = driver.findPermanent(player, "Agrus Kos, Spirit of Justice")
+            agrus.shouldNotBeNull()
+            projected.hasKeyword(agrus, Keyword.DOUBLE_STRIKE) shouldBe true
+            projected.hasKeyword(agrus, Keyword.VIGILANCE) shouldBe true
+        }
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RakdosPatronOfChaosScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RakdosPatronOfChaosScenarioTest.kt
@@ -1,0 +1,160 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.RakdosPatronOfChaos
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Rakdos, Patron of Chaos (MKM #224) — {4}{B}{R} 6/6 Legendary Demon, flying and trample.
+ *
+ * "At the beginning of your end step, target opponent may sacrifice two nonland, nontoken permanents
+ *  of their choice. If they don't, you draw two cards."
+ *
+ * The whole card is the punisher branch, and the branch has three distinct outcomes that a naive
+ * implementation gets wrong in three different ways:
+ *
+ *  - **taking the sacrifice** must cost the *opponent* two permanents and draw the controller nothing
+ *    (a `Gate.MayPay` would have sacrificed the controller's permanents instead);
+ *  - **declining** must draw the controller exactly two;
+ *  - **being unable to sacrifice two** must fall through to the draw with no prompt at all. This is
+ *    the one that matters most: feasibility has to be judged against the *choosing* player, and the
+ *    force-sacrifice must not settle for one permanent when the card demands two.
+ *
+ * The first test also pins the "nonland" half of the filter: a land the opponent controls is never an
+ * eligible sacrifice, and must survive.
+ */
+class RakdosPatronOfChaosScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + RakdosPatronOfChaos)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /**
+     * Walk to the end step and resolve the trigger far enough to reach the opponent's choice —
+     * or, when the sacrifice option is infeasible, past it entirely. Targeting the sole opponent
+     * may or may not raise an explicit decision, so both paths are handled.
+     */
+    fun GameTestDriver.resolveEndStepTrigger(controller: EntityId, opponent: EntityId) {
+        passPriorityUntil(Step.END)
+        var guard = 0
+        while (guard++ < 16) {
+            when (pendingDecision) {
+                is ChooseTargetsDecision -> submitTargetSelection(controller, listOf(opponent))
+                is ChooseOptionDecision -> return
+                else -> if (stackSize > 0 || priorityPlayer != null) bothPass() else return
+            }
+        }
+    }
+
+    fun GameTestDriver.chooseOption(player: EntityId, needle: String) {
+        val decision = pendingDecision as ChooseOptionDecision
+        val index = decision.options.indexOfFirst { it.contains(needle, ignoreCase = true) }
+        withClue("the '$needle' option was offered (saw ${decision.options})") { (index >= 0) shouldBe true }
+        submitDecision(player, OptionChosenResponse(decision.id, index)).error shouldBe null
+    }
+
+    test("the opponent may sacrifice two nonland, nontoken permanents — and the controller draws nothing") {
+        val driver = createDriver()
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        driver.putCreatureOnBattlefield(controller, "Rakdos, Patron of Chaos")
+        driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(opponent, "Minotaur Warrior")
+        // A third eligible body, so the opponent gets a genuine choice rather than an
+        // auto-sacrifice of everything they have — which is what pins the filter.
+        driver.putCreatureOnBattlefield(opponent, "Savannah Lions")
+        // A land the opponent controls must never be an eligible sacrifice.
+        driver.putLandOnBattlefield(opponent, "Swamp")
+
+        val handBefore = driver.getHandSize(controller)
+        val creaturesBefore = driver.getCreatures(opponent).size
+        driver.resolveEndStepTrigger(controller, opponent)
+        driver.chooseOption(opponent, "Sacrifice")
+
+        val selection = driver.pendingDecision as SelectCardsDecision
+        withClue("only the three creatures are eligible — the land is filtered out") {
+            selection.options.mapNotNull { driver.getCardName(it) }.sorted() shouldBe
+                listOf("Grizzly Bears", "Minotaur Warrior", "Savannah Lions")
+        }
+        withClue("the card demands exactly two") {
+            selection.minSelections shouldBe 2
+            selection.maxSelections shouldBe 2
+        }
+        driver.submitCardSelection(opponent, selection.options.take(2)).error shouldBe null
+        repeat(4) { if (driver.stackSize > 0 || driver.pendingDecision != null) driver.bothPass() }
+
+        withClue("exactly two creatures were sacrificed") {
+            driver.getCreatures(opponent).size shouldBe creaturesBefore - 2
+        }
+        withClue("the land survived") {
+            driver.getLands(opponent).size shouldBe 1
+        }
+        withClue("they did sacrifice, so the controller draws nothing") {
+            driver.getHandSize(controller) shouldBe handBefore
+        }
+    }
+
+    test("declining draws the controller two cards") {
+        val driver = createDriver()
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        driver.putCreatureOnBattlefield(controller, "Rakdos, Patron of Chaos")
+        driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(opponent, "Minotaur Warrior")
+
+        val handBefore = driver.getHandSize(controller)
+        driver.resolveEndStepTrigger(controller, opponent)
+        driver.chooseOption(opponent, "draw")
+        repeat(4) { if (driver.stackSize > 0 || driver.pendingDecision != null) driver.bothPass() }
+
+        withClue("nothing was sacrificed") {
+            driver.getCreatures(opponent).size shouldBe 2
+        }
+        withClue("'if they don't' fired — exactly two cards") {
+            driver.getHandSize(controller) shouldBe handBefore + 2
+        }
+    }
+
+    test("an opponent who can't find two legal permanents is never asked, and the controller draws") {
+        val driver = createDriver()
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        driver.putCreatureOnBattlefield(controller, "Rakdos, Patron of Chaos")
+        // One legal permanent plus lands — which never add up to the two the card demands.
+        val lone = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        driver.putLandOnBattlefield(opponent, "Swamp")
+        driver.putLandOnBattlefield(opponent, "Swamp")
+
+        val handBefore = driver.getHandSize(controller)
+        driver.resolveEndStepTrigger(controller, opponent)
+
+        withClue("the sacrifice option was infeasible, so no choice was offered") {
+            (driver.pendingDecision is ChooseOptionDecision) shouldBe false
+        }
+        repeat(4) { if (driver.stackSize > 0 || driver.pendingDecision != null) driver.bothPass() }
+
+        withClue("the single permanent must NOT have been eaten — the card demands two") {
+            driver.findPermanent(opponent, "Grizzly Bears") shouldBe lone
+        }
+        withClue("they couldn't sacrifice, so they didn't, so the controller draws two") {
+            driver.getHandSize(controller) shouldBe handBefore + 2
+        }
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WorldsoulsRageScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WorldsoulsRageScenarioTest.kt
@@ -1,0 +1,152 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.WorldsoulsRage
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Worldsoul's Rage (MKM #244) — {X}{R}{G} Sorcery.
+ *
+ * "Worldsoul's Rage deals X damage to any target. Put up to X land cards from your hand and/or
+ *  graveyard onto the battlefield tapped."
+ *
+ * One X drives two unrelated effects, which is where this card can go wrong: the damage and the land
+ * count must read the *same* X, the land selection must span both zones in one decision, the lands
+ * must arrive tapped, and "up to X" must tolerate both a partial choice and X = 0.
+ */
+class WorldsoulsRageScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + WorldsoulsRage)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** {X}{R}{G} with the given X. */
+    fun GameTestDriver.payForRage(player: EntityId, x: Int) {
+        giveMana(player, Color.RED, 1)
+        giveMana(player, Color.GREEN, 1)
+        if (x > 0) giveColorlessMana(player, x)
+    }
+
+    test("X=2 deals 2 damage and puts two lands from hand and graveyard onto the battlefield tapped") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        // A 2/2 that exactly dies to X=2.
+        driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        // One land in each zone, so the selection has to span both.
+        driver.putCardInHand(player, "Forest")
+        driver.putCardInGraveyard(player, "Island")
+
+        val landsBefore = driver.getLands(player).size
+        val rage = driver.putCardInHand(player, "Worldsoul's Rage")
+        driver.payForRage(player, 2)
+        driver.castXSpell(
+            player,
+            rage,
+            xValue = 2,
+            targets = listOf(driver.findPermanent(opponent, "Grizzly Bears")!!)
+        ).error shouldBe null
+        driver.bothPass()
+
+        // The damage lands first, but the 2/2 only leaves the battlefield when state-based actions
+        // next run — which is after this resolution finishes, not while it is paused on the land
+        // selection. So the selection is what we see here.
+        val selection = driver.pendingDecision as SelectCardsDecision
+        val offered = selection.options.mapNotNull { driver.getCardName(it) }
+        withClue("one decision spans both zones: the Forest in hand and the Island in the graveyard") {
+            offered.contains("Forest") shouldBe true
+            offered.contains("Island") shouldBe true
+        }
+        val crossZone = selection.options.filter { driver.getCardName(it) in setOf("Forest", "Island") }
+        driver.submitCardSelection(player, crossZone).error shouldBe null
+        repeat(3) { if (driver.stackSize > 0 || driver.pendingDecision != null) driver.bothPass() }
+
+        withClue("X damage killed the 2/2 once state-based actions ran") {
+            driver.findPermanent(opponent, "Grizzly Bears") shouldBe null
+        }
+
+        val lands = driver.getLands(player)
+        withClue("both lands arrived") {
+            lands.size shouldBe landsBefore + 2
+        }
+        withClue("and both arrived tapped") {
+            val arrived = lands.filter { driver.getCardName(it) in setOf("Forest", "Island") }
+            arrived.size shouldBe 2
+            arrived.all { driver.isTapped(it) } shouldBe true
+        }
+    }
+
+    test("'up to X' allows putting fewer lands than X") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        driver.putCardInHand(player, "Forest")
+        driver.putCardInGraveyard(player, "Island")
+
+        val landsBefore = driver.getLands(player).size
+        val rage = driver.putCardInHand(player, "Worldsoul's Rage")
+        driver.payForRage(player, 2)
+        driver.castXSpell(
+            player,
+            rage,
+            xValue = 2,
+            targets = listOf(driver.findPermanent(opponent, "Grizzly Bears")!!)
+        ).error shouldBe null
+        driver.bothPass()
+
+        // Take only the one in hand, leaving the graveyard land behind.
+        val selection = driver.pendingDecision as SelectCardsDecision
+        val fromHand = selection.options.first { driver.getCardName(it) == "Forest" }
+        driver.submitCardSelection(player, listOf(fromHand)).error shouldBe null
+        repeat(3) { if (driver.stackSize > 0 || driver.pendingDecision != null) driver.bothPass() }
+
+        withClue("exactly the one chosen land arrived") {
+            driver.getLands(player).size shouldBe landsBefore + 1
+        }
+        withClue("the declined graveyard land stayed put") {
+            driver.getGraveyardCardNames(player).contains("Island") shouldBe true
+        }
+    }
+
+    test("X=0 is a legal cast that deals no damage and puts no lands") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val bear = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        driver.putCardInHand(player, "Forest")
+
+        val landsBefore = driver.getLands(player).size
+        val rage = driver.putCardInHand(player, "Worldsoul's Rage")
+        driver.payForRage(player, 0)
+        driver.castXSpell(player, rage, xValue = 0, targets = listOf(bear)).error shouldBe null
+        repeat(4) {
+            when (val decision = driver.pendingDecision) {
+                is SelectCardsDecision -> driver.submitCardSelection(player, emptyList())
+                else -> if (driver.stackSize > 0 || decision != null) driver.bothPass() else Unit
+            }
+        }
+
+        withClue("zero damage leaves the 2/2 alive") {
+            driver.findPermanent(opponent, "Grizzly Bears") shouldBe bear
+        }
+        withClue("and no land could be put onto the battlefield") {
+            driver.getLands(player).size shouldBe landsBefore
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -308,6 +308,206 @@
     ]
 }
 
+// Agrus Kos, Spirit of Justice
+{
+    "name": "Agrus Kos, Spirit of Justice",
+    "manaCost": "{2}{R}{W}",
+    "typeLine": "Legendary Creature — Spirit Detective",
+    "oracleText": "Double strike, vigilance\nWhenever Agrus Kos enters or attacks, choose up to one target creature. If it's suspected, exile it. Otherwise, suspect it. (A suspected creature has menace and can't block.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "DOUBLE_STRIKE",
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "filter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    "IsSuspected"
+                                ]
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "up to one target creature"
+                        },
+                        "destination": "Exile"
+                    },
+                    "otherwise": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SetSuspected",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one target creature"
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "MENACE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one target creature"
+                                },
+                                "duration": "Permanent"
+                            },
+                            {
+                                "type": "CantBlockTargetCreatures",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one target creature"
+                                },
+                                "duration": "Permanent"
+                            }
+                        ],
+                        "descriptionOverride": "target becomes suspected"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "up to one target creature"
+                },
+                "descriptionOverride": "Choose up to one target creature. If it's suspected, exile it. Otherwise, suspect it."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "filter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    "IsSuspected"
+                                ]
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "up to one target creature"
+                        },
+                        "destination": "Exile"
+                    },
+                    "otherwise": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SetSuspected",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one target creature"
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "MENACE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one target creature"
+                                },
+                                "duration": "Permanent"
+                            },
+                            {
+                                "type": "CantBlockTargetCreatures",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one target creature"
+                                },
+                                "duration": "Permanent"
+                            }
+                        ],
+                        "descriptionOverride": "target becomes suspected"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "up to one target creature"
+                },
+                "descriptionOverride": "Choose up to one target creature. If it's suspected, exile it. Otherwise, suspect it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "rarity": "MYTHIC",
+        "artist": "Jason A. Engle",
+        "flavorText": "\"Eventually I'll give retirement another shot. But not today.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/58aeac7c-1275-49d4-9915-7604ae4bfdff.jpg?1783912857",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "When an effect suspects a creature, it becomes suspected. It gains menace and \"This creature can't block\" for as long as it's suspected. It stays suspected until it leaves the battlefield or another effect causes it to no longer be suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a suspected creature loses all abilities, it will lose menace and \"This creature can't block\", but it won't stop being suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Being suspected isn't a copiable value. If a permanent becomes a copy of a suspected creature, it won't be suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a creature is already suspected, suspecting it again won't have any effect."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "There's no limit to the number of creatures that can be suspected simultaneously. Suspecting a new creature doesn't cause other creatures to stop being suspected."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Alley Assailant
 {
     "name": "Alley Assailant",
@@ -9693,6 +9893,86 @@
     ]
 }
 
+// Rakdos, Patron of Chaos
+{
+    "name": "Rakdos, Patron of Chaos",
+    "manaCost": "{4}{B}{R}",
+    "typeLine": "Legendary Creature — Demon",
+    "oracleText": "Flying, trample\nAt the beginning of your end step, target opponent may sacrifice two nonland, nontoken permanents of their choice. If they don't, you draw two cards.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ChooseAction",
+                    "choices": [
+                        {
+                            "label": "Sacrifice two nonland, nontoken permanents",
+                            "effect": {
+                                "type": "ForceSacrifice",
+                                "filter": "nonland permanent nontoken",
+                                "count": 2,
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target opponent"
+                                }
+                            },
+                            "feasibilityCheck": {
+                                "type": "ControlsPermanentMatching",
+                                "filter": "nonland permanent nontoken",
+                                "count": 2
+                            }
+                        },
+                        {
+                            "label": "Let Rakdos's controller draw two cards",
+                            "effect": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            }
+                        }
+                    ],
+                    "player": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "At the beginning of your end step, target opponent may sacrifice two nonland, nontoken permanents of their choice. If they don't, you draw two cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "rarity": "MYTHIC",
+        "artist": "Joshua Raphael",
+        "flavorText": "\"Finally, a performance worthy of my applause!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc6fd2d5-8eb2-4265-a1bf-d4ae635285af.jpg?1783912841"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Rakish Scoundrel
 {
     "name": "Rakish Scoundrel",
@@ -13517,6 +13797,76 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Worldsoul's Rage
+{
+    "name": "Worldsoul's Rage",
+    "manaCost": "{X}{R}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Worldsoul's Rage deals X damage to any target. Put up to X land cards from your hand and/or graveyard onto the battlefield tapped.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": "XValue",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromMultipleZones",
+                        "zones": [
+                            "Hand",
+                            "Graveyard"
+                        ],
+                        "filter": "land"
+                    },
+                    "storeAs": "worldsoulLands"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "worldsoulLands",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": "XValue"
+                    },
+                    "storeSelected": "worldsoulLandsChosen"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "worldsoulLandsChosen",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield",
+                        "placement": "Tapped"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "any target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "244",
+        "rarity": "RARE",
+        "artist": "Lius Lasahido",
+        "flavorText": "\"Hoarding supplies, profiting from death and destruction, colluding with the invaders—every one of them betrayed Ravnica in its time of greatest need. They all deserved to die. And I'm not done yet!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc3340bd-1d8c-4c21-a59d-e092fcbe02e3.jpg?1783912832"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
     ]
 }
 


### PR DESCRIPTION
Three MKM cards, each composed entirely from existing `Effects.*` / `Triggers.*` / `Conditions.*` primitives — no new SDK vocabulary. One scenario test file per card (9 tests, all passing).

## Cards

- **Agrus Kos, Spirit of Justice** — {2}{R}{W} 2/4 Legendary Spirit Detective, double strike + vigilance. "Whenever Agrus Kos enters or attacks, choose up to one target creature. If it's suspected, exile it. Otherwise, suspect it." Two `triggeredAbility` blocks sharing one `TriggeredAbilityBuilder` extension (the Benthic Criminologists shape — there is no combined enters-or-attacks trigger, and two abilities is also what the rules describe), `TargetCreature(optional = true)`, and `ConditionalEffect` over `Conditions.TargetMatchesFilter(Creature.suspected())` branching to `Effects.Exile` / `Effects.Suspect`.

- **Rakdos, Patron of Chaos** — {4}{B}{R} 6/6 Legendary Demon, flying + trample. "At the beginning of your end step, target opponent may sacrifice two nonland, nontoken permanents of their choice. If they don't, you draw two cards." `Triggers.YourEndStep` + `Targets.Opponent` + `Effects.ChooseAction(player = opponent)` over `Effects.Sacrifice(NonlandPermanent.nontoken(), 2, target = opponent)` and `Effects.DrawCards(2, Controller)` — the Terrapact Intimidator / Thornplate Intimidator shape.

- **Worldsoul's Rage** — {X}{R}{G} Sorcery. "Deals X damage to any target. Put up to X land cards from your hand and/or graveyard onto the battlefield tapped." `Effects.DealXDamage` plus the Gather → Select → Move pipeline with `CardSource.FromMultipleZones(HAND, GRAVEYARD)`, `SelectionMode.ChooseUpTo(DynamicAmount.XValue)` and `ZonePlacement.Tapped` — the Bonny Pall, Clearcutter shape.

## Two notes worth a reviewer's eye

**Agrus Kos's condition is keyed on the target index, not the handle.** `Conditions.TargetMatchesFilter(filter)` (i.e. `ContextTarget(0)`) rather than `Conditions.EntityMatches(handle, filter)`: `ConditionEvaluator` resolves `ContextTarget` but falls through to `false` for a bound variable, so the handle form would silently always take the suspect arm. Covered by the two-stage test (entry suspects, the later attack exiles).

**Rakdos is `ChooseAction`, not a `MayEffect` gate.** `GatedEffectExecutor` evaluates a gate's `feasibility` against the ability's *controller*, not the `decisionMaker`; and `ForceSacrificeExecutor` auto-sacrifices when a player has at most `count` legal permanents. Together those would let an opponent holding a single permanent lose it where the card demands two. `ChooseAction`'s `FeasibilityCheck` is tested against the *choosing* player, so an opponent who can't find two is never offered the option and "if they don't" fires. There's a test for exactly that case.

## Dropped from the batch

Two of the five cards I set out to implement need engine work and so get their own PRs rather than growing this one:

- **Repulsive Mutation** ({X}{G}{U}) — needs a required creature target *first* and an optional spell target *second*. `CounterEffect` reads the countered spell off `context.targets.firstOrNull()` and has no target selector, while cast-time target↔slot matching is positional with no placeholder for a declined slot. So the spell must be slot 0, and making it `optional` there means a cast that declines it sends `[creature]`, which slot 0 rejects — i.e. the card could never be cast without a spell to counter, which is its most common mode. Wants either `CounterTargetSource.ChosenAt(index)` or `resolveCounterTarget` picking `targets.filterIsInstance<ChosenTarget.Spell>().firstOrNull()`.

- **Lamplight Phoenix** ({1}{R}{R}) — "you may exile it and collect evidence 4. If you do, return this card to the battlefield tapped." The faithful shape is `MayEffect(IfYouDoEffect(...))` ("if you do", not "when you do", so not a reflexive trigger). But nothing checks CR 701.59b feasibility for that shape: `GatedEffectExecutor` pre-checks `canCollect` only when `then` *is* directly a `CollectEvidenceEffect`, and `canAfford` fails open for costs it doesn't recognise. A player could accept with an unreachable graveyard, the exile would happen, the collect would silently no-op, and the Phoenix would return for free. Wants a `FeasibilityCheck.CanCollectEvidence(amount)` (`ReflexiveTriggerEffectExecutor.isActionFeasible` already does this correctly and could be shared).

## A pre-existing engine bug found on the way

I also drafted **Krenko, Baron of Tin Street** and dropped it, because its "create a 1/1 red Goblin creature token. It gains haste until end of turn" exposed what looks like an existing bug rather than anything about that card:

**`Effects.GrantKeyword` targeting `EffectTarget.PipelineTarget(CREATED_TOKENS, 0)` never applies.** I isolated it with a control card — a plain, ungated `{0}` sorcery doing `Composite(CreateToken, GrantKeyword(HASTE, PipelineTarget(CREATED_TOKENS, 0)), GrantKeyword(MENACE, same))`. The token is created; both grants read back `false` on the projected state. So it is not haste-specific, and not about the may-pay gate Krenko wraps it in.

This is the shape used by shipped cards — Windcrag Siege (`tdm`), Artistic Process (`sos`), Old Hob Alleycat Blues (`tmt`), Underfoot Underdogs and Frontline Rush — so those cards' until-end-of-turn grants on their tokens are likely inert too. I have not touched it (AGENTS.md → report, don't work around), and no card in this PR depends on it.

## Verification

- `just build` — BUILD SUCCESSFUL (full suite).
- `just test-scenarios 2024` — 9/9 new tests passing.
- `just rebless-cards` — MKM golden shows **only** these three cards added, no deletions and no unrelated card moved.
- `just check-card-printing` — ok for all three (MKM is the earliest real printing for each; `pmkm` promos and `eoc` correctly skipped/rowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
