### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1311,7 +1311,12 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   at-least gate can never fire a second time — no dedicated "Nth counter" trigger event is needed),
   `Counters.INVASION` (Alien Invasion — a tally its begin-combat trigger reads via
   `DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.INVASION))` to size the +1/+1 counters
-  on the Alien token it just made, then increments).
+  on the Alien token it just made, then increments),
+  `Counters.UNLOCK` (MKM — Cryptex: its `{T}`, collect-evidence-3 **mana** ability adds one per activation
+  and its `Costs.SacrificeSelf` ability is gated on
+  `ActivationRestriction.OnlyIfCondition(Conditions.SourceCounterCountAtLeast(Counters.UNLOCK, 5))`; the
+  rider on a mana ability doesn't change its classification — CR 605.1a asks only whether the ability could
+  add mana and whether it targets, so the counter lands at a moment nobody can respond to).
 - `DistributeCountersFromSelf(type?, count?)` — split source's counters among creatures you control.
 - `DistributeCountersAmongTargets(total, type?, minPerTarget?)` — divvy N counters among chosen
   targets. `total` is a `DynamicAmount` (an `Int` overload wraps it in `Fixed`), evaluated once at

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -96,6 +96,7 @@ enum class CounterType {
     OMEN,
     PLAN,
     INVASION,
+    UNLOCK,
 
     /**
      * Harness counter (Marvel's Spider-Man Infinity Stones). A binary "harnessed" marker: the Stone's
@@ -531,6 +532,15 @@ object Counters {
      * NOT a keyword counter, so it is intentionally absent from `StateProjector.KEYWORD_COUNTER_MAP`.
      */
     const val INVASION = "invasion"
+
+    /**
+     * Unlock counter (MKM — Cryptex). Passive accumulate-then-threshold counter with no inherent
+     * rule of its own: Cryptex's mana ability adds one per activation, and its sacrifice ability is
+     * gated on `Conditions.SourceCounterCountAtLeast(Counters.UNLOCK, 5)`. Same shape as
+     * `Counters.POINT` / `Counters.PLAN`, and like them the payoff removes the source.
+     * NOT a keyword counter, so it is intentionally absent from `StateProjector.KEYWORD_COUNTER_MAP`.
+     */
+    const val UNLOCK = "unlock"
 
     /**
      * Wildcard sentinel for triggers/events that fire on counters of *any* type, e.g.

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ArchdruidsCharm.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ArchdruidsCharm.kt
@@ -1,0 +1,160 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.EmitLibrarySearchedEventEffect
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Archdruid's Charm — Murders at Karlov Manor #151
+ * {G}{G}{G} · Instant · Rare
+ *
+ * Choose one —
+ * • Search your library for a creature or land card and reveal it. Put it onto the battlefield
+ *   tapped if it's a land card. Otherwise, put it into your hand. Then shuffle.
+ * • Put a +1/+1 counter on target creature you control. It deals damage equal to its power to
+ *   target creature you don't control.
+ * • Exile target artifact or enchantment.
+ *
+ * Three modes, three existing rails — nothing here is new vocabulary.
+ *
+ * **Mode 1** is the only one that needed thought. The search is a single search with a *branching
+ * destination*, so it can't go through `Patterns.Library.searchLibrary` (one `SearchDestination`
+ * for the whole call). Instead it is an inline [Effects.Pipeline]: gather creature-or-land from the
+ * library, choose up to one, reveal, then `filterSplit` on [GameObjectFilter.Land] and move each
+ * half to its own zone. The split is the load-bearing detail — "if it's a **land** card" is not
+ * "if it isn't a creature card", so a land creature (Dryad Arbor, Ancient Tomb-style animations are
+ * irrelevant here since this reads the *card*) goes to the battlefield, not to hand. Filtering on
+ * `Creature` for the second half would double-move it.
+ *
+ * Both halves are `ChooseUpTo(1)`, so declining the search — or finding nothing — leaves both slots
+ * empty and every downstream step is a no-op; the shuffle and the CR 701.23 "a player searched
+ * their library" event still fire, because searching happened whether or not a card was found
+ * (CR 701.23b). The reveal is `revealToSelf = false`: the searcher just picked the card out of
+ * their own library, so only the opponents need to be shown it.
+ *
+ * **Mode 2** is [BiteDownOnCrime]'s shape exactly: two targets in one mode, and the damage reads
+ * `EntityProperty(Target(0), Power)` with `damageSource = yours`, so the +1/+1 counter placed by
+ * the first half is already on the creature when the power is read. Per the printed rulings, if the
+ * opposing creature has become an illegal target by resolution the counter is still placed; if
+ * *your* creature is gone, neither half happens. Both fall out of ordinary per-target legality
+ * checking — the counter effect and the damage effect each fizzle on their own target.
+ *
+ * **Mode 3** is a plain [Effects.Exile] over [Targets.ArtifactOrEnchantment].
+ */
+val ArchdruidsCharm = card("Archdruid's Charm") {
+    manaCost = "{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Search your library for a creature or land card and reveal it. Put it onto the " +
+        "battlefield tapped if it's a land card. Otherwise, put it into your hand. Then shuffle.\n" +
+        "• Put a +1/+1 counter on target creature you control. It deals damage equal to its power " +
+        "to target creature you don't control.\n" +
+        "• Exile target artifact or enchantment."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode(
+                "Search your library for a creature or land card and reveal it. Put it onto the " +
+                    "battlefield tapped if it's a land card. Otherwise, put it into your hand. " +
+                    "Then shuffle."
+            ) {
+                effect = Effects.Pipeline {
+                    val searchable = gather(
+                        CardSource.FromZone(
+                            Zone.LIBRARY,
+                            Player.You,
+                            GameObjectFilter.Creature or GameObjectFilter.Land,
+                        )
+                    )
+                    val found = chooseUpTo(
+                        1,
+                        from = searchable,
+                        prompt = "Search your library for a creature or land card",
+                    )
+                    reveal(found, revealToSelf = false)
+                    val (lands, others) = filterSplit(found, GameObjectFilter.Land)
+                    move(
+                        lands,
+                        CardDestination.ToZone(Zone.BATTLEFIELD, placement = ZonePlacement.Tapped),
+                    )
+                    toHand(others)
+                    run(ShuffleLibraryEffect())
+                    run(EmitLibrarySearchedEventEffect)
+                }
+            }
+
+            mode(
+                "Put a +1/+1 counter on target creature you control. It deals damage equal to its " +
+                    "power to target creature you don't control."
+            ) {
+                val yours = target(
+                    "target creature you control",
+                    TargetCreature(filter = TargetFilter.Creature.youControl()),
+                )
+                val theirs = target(
+                    "target creature you don't control",
+                    TargetCreature(filter = TargetFilter.Creature.opponentControls()),
+                )
+                effect = Effects.Composite(
+                    Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, yours),
+                    Effects.DealDamage(
+                        amount = DynamicAmount.EntityProperty(
+                            EntityReference.Target(0),
+                            EntityNumericProperty.Power,
+                        ),
+                        target = theirs,
+                        damageSource = yours,
+                    ),
+                )
+            }
+
+            mode("Exile target artifact or enchantment") {
+                val permanent = target(
+                    "target artifact or enchantment",
+                    Targets.ArtifactOrEnchantment,
+                )
+                effect = Effects.Exile(permanent)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "151"
+        artist = "Liiga Smilshkalne"
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5caae5ae-845f-42c2-b1ae-956df2739433.jpg?1783912870"
+
+        ruling(
+            "2024-02-02",
+            "You can't choose the second mode for Archdruid's Charm unless you and another player " +
+                "have creatures to target."
+        )
+        ruling(
+            "2024-02-02",
+            "If you choose the second mode and your creature is not a legal target as Archdruid's " +
+                "Charm resolves, you won't put a +1/+1 counter on it, and no damage will be dealt."
+        )
+        ruling(
+            "2024-02-02",
+            "If you choose the second mode and the creature you don't control is not a legal " +
+                "target as Archdruid's Charm resolves, you'll still put a +1/+1 counter on your " +
+                "creature."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/Cryptex.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/Cryptex.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cryptex — Murders at Karlov Manor #251
+ * {2} · Artifact · Rare
+ *
+ * {T}, Collect evidence 3: Add one mana of any color. Put an unlock counter on this artifact.
+ * Sacrifice this artifact: Surveil 3, then draw three cards. Activate only if this artifact has
+ * five or more unlock counters on it.
+ *
+ * A five-turn clock that pays rent the whole way: every tap is a Cabal Coffers-grade colour fixer
+ * that also advances the combination, and the fifth one opens it for three cards.
+ *
+ * **The first ability really is a mana ability**, and the printed ruling says so: it doesn't use the
+ * stack and can't be responded to. That is `manaAbility = true`, which also fixes the timing rule —
+ * the rider (a counter) doesn't change the classification, because CR 605.1a asks only whether the
+ * ability could add mana and whether it targets, not whether it does anything *else*. The counter
+ * therefore lands at a moment nobody can interact with, exactly like the ICE painlands' damage
+ * rider. Collect evidence sits in the cost alongside `{T}` as an ordinary cost atom, so CR 701.59b
+ * applies: a graveyard that can't reach total mana value 3 makes the whole ability unactivatable
+ * rather than offering a collection the player couldn't complete.
+ *
+ * **The unlock counter** is a new passive named counter ([Counters.UNLOCK]) with no inherent rule of
+ * its own — the same accumulate-then-threshold shape as `Counters.POINT` and `Counters.PLAN`, and
+ * like them the payoff sacrifices its own source, so the "five or more" gate can never fire twice.
+ * The gate is [ActivationRestriction.OnlyIfCondition] over
+ * [Conditions.SourceCounterCountAtLeast], which reads the source's counters live rather than at
+ * enters-time, so counters added by anything else (proliferate, a counter-doubler) count too.
+ *
+ * Note the second ability's cost is only the sacrifice — no mana, no tap. A Cryptex that is already
+ * tapped, or summoning-sick, can still be cracked; the five taps it took to get there are the cost.
+ */
+val Cryptex = card("Cryptex") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}, Collect evidence 3: Add one mana of any color. Put an unlock counter on " +
+        "this artifact. (To collect evidence 3, exile cards with total mana value 3 or greater " +
+        "from your graveyard.)\n" +
+        "Sacrifice this artifact: Surveil 3, then draw three cards. Activate only if this " +
+        "artifact has five or more unlock counters on it."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.CollectEvidence(3))
+        manaAbility = true
+        effect = Effects.Composite(
+            Effects.AddManaOfChoice(),
+            Effects.AddCounters(Counters.UNLOCK, 1, EffectTarget.Self),
+        )
+        description = "Add one mana of any color. Put an unlock counter on this artifact."
+    }
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.SourceCounterCountAtLeast(Counters.UNLOCK, 5)
+            )
+        )
+        effect = Effects.Composite(
+            Effects.Surveil(3),
+            Effects.DrawCards(3),
+        )
+        description = "Surveil 3, then draw three cards."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "251"
+        artist = "Yeong-Hao Han"
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f92a2563-6cfb-4d12-9513-b44d1a7a20ab.jpg?1783912829"
+
+        ruling(
+            "2024-02-02",
+            "Cryptex's first ability is a mana ability. It doesn't use the stack and can't be " +
+                "responded to."
+        )
+        ruling(
+            "2024-02-02",
+            "If you can't exile enough cards to meet or exceed the required mana value, you can't " +
+                "choose to collect evidence at all."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/InsidiousRoots.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/InsidiousRoots.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Insidious Roots — Murders at Karlov Manor #208
+ * {B}{G} · Enchantment · Uncommon
+ *
+ * Creature tokens you control have "{T}: Add one mana of any color."
+ * Whenever one or more creature cards leave your graveyard, create a 0/1 green Plant creature
+ * token, then put a +1/+1 counter on each Plant you control.
+ *
+ * Two mana for an engine that turns graveyard recursion into a widening board *and* a mana base:
+ * every Plant it makes is a Cryptolith Rite land, and every subsequent trigger grows all of them at
+ * once. Note the counters go on **Plants**, not on all creature tokens — the Plant tokens it made
+ * itself are the ones that compound.
+ *
+ * The first ability is [CryptolithRite]'s [GrantActivatedAbility] narrowed to `token()`; the
+ * granted ability is `isManaAbility = true` with `TimingRule.ManaAbility` so the raw
+ * [ActivatedAbility] constructor carries the classification the card-DSL builder's `manaAbility`
+ * flag would set. The printed ruling about Insidious Roots granting *itself* the ability when it is
+ * somehow a creature token falls out of the filter — it says "creature tokens you control", not
+ * "other", so nothing excludes the source.
+ *
+ * The trigger is [Triggers.CardsLeaveYourGraveyard], the CR 603.2c batch shape [ChalkOutline] uses:
+ * a mass reanimation, a flashback cast and a graveyard-exiling sweep each fire it exactly once no
+ * matter how many creature cards moved or where they went — which is what the second printed ruling
+ * says in as many words. The filter matches the *card*, so a creature card cast from the graveyard
+ * counts on its way to the stack.
+ *
+ * The payoff is ordered, not simultaneous: the token is created first and then the counters land, so
+ * the new Plant gets a counter too and enters play as a 1/2. [Effects.ForEachInGroup] snapshots the
+ * group before iterating, and the snapshot is taken after the token exists.
+ *
+ * The Plant token takes its art from MKM's `tokenArt` layer, so no `imageUri` is baked in here.
+ */
+val InsidiousRoots = card("Insidious Roots") {
+    manaCost = "{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Enchantment"
+    oracleText = "Creature tokens you control have \"{T}: Add one mana of any color.\"\n" +
+        "Whenever one or more creature cards leave your graveyard, create a 0/1 green Plant " +
+        "creature token, then put a +1/+1 counter on each Plant you control."
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Tap,
+                effect = Effects.AddManaOfChoice(),
+                isManaAbility = true,
+                timing = TimingRule.ManaAbility,
+            ),
+            filter = GroupFilter(GameObjectFilter.Creature.token().youControl()),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.CardsLeaveYourGraveyard(GameObjectFilter.Creature)
+        effect = Effects.Composite(
+            Effects.CreateToken(
+                power = 0,
+                toughness = 1,
+                colors = setOf(Color.GREEN),
+                creatureTypes = setOf("Plant"),
+            ),
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature.withSubtype("Plant").youControl()),
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            ),
+        )
+        description = "Whenever one or more creature cards leave your graveyard, create a 0/1 " +
+            "green Plant creature token, then put a +1/+1 counter on each Plant you control."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "208"
+        artist = "Jeremy Wilson"
+        flavorText = "The roots of Vitu-Ghazi allowed Trostani to reach every crack and crevice " +
+            "in the city."
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0bb91a22-2040-4a37-85f8-5f22de8c5907.jpg?1783912846"
+
+        ruling(
+            "2024-02-02",
+            "In the rare case where Insidious Roots is a creature token, it will grant itself the " +
+                "ability \"{T}: Add one mana of any color.\""
+        )
+        ruling(
+            "2024-02-02",
+            "If multiple creature cards leave your graveyard at the same time, Insidious Roots's " +
+                "last ability will trigger only once."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ProftsEideticMemory.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ProftsEideticMemory.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.NoMaximumHandSize
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.TurnTracker
+
+/**
+ * Proft's Eidetic Memory — Murders at Karlov Manor #67
+ * {1}{U} · Legendary Enchantment · Rare
+ *
+ * When Proft's Eidetic Memory enters, draw a card.
+ * You have no maximum hand size.
+ * At the beginning of combat on your turn, if you've drawn more than one card this turn, put X
+ * +1/+1 counters on target creature you control, where X is the number of cards you've drawn this
+ * turn minus one.
+ *
+ * A two-mana enchantment that turns any second draw into a combat trick you never have to hold up
+ * mana for. It replaces itself, so the turn it lands it has already done half the work of switching
+ * itself on for *next* turn.
+ *
+ * Three abilities, three plain rails. The interesting one is the third, and it hinges on the
+ * distinction between the gate and the amount:
+ *
+ * - **The gate** is `interveningIf` ([Conditions.YouDrewCardsThisTurn]`(2)` — "more than one" is
+ *   "two or more"), not a `triggerRestriction`. That matters in both directions per CR 603.4: the
+ *   ability doesn't even go on the stack if the count isn't there at the start of combat (the first
+ *   printed ruling), and it is re-checked on resolution, so a Stifle-adjacent effect that somehow
+ *   un-drew a card would still fizzle it.
+ * - **The amount** is read separately, once, as the ability resolves (the third ruling), so a draw
+ *   made in response to the trigger *does* grow X even though it came too late to matter for the
+ *   gate. `DynamicAmount.Subtract(TurnTracking(You, CARDS_DRAWN), Fixed(1))` is exactly that:
+ *   the same per-player `CardsDrawnThisTurnComponent` the gate reads, evaluated at resolution.
+ *
+ * The tracker is a turn-scoped count, not a "since this entered" one, so the second ruling falls
+ * out for free — draws made before the enchantment hit the battlefield are already in the tally.
+ *
+ * [Triggers.BeginCombat] is already scoped to `Step.BEGIN_COMBAT, Player.You`, so "on your turn"
+ * needs no extra condition.
+ */
+val ProftsEideticMemory = card("Proft's Eidetic Memory") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Enchantment"
+    oracleText = "When Proft's Eidetic Memory enters, draw a card.\n" +
+        "You have no maximum hand size.\n" +
+        "At the beginning of combat on your turn, if you've drawn more than one card this turn, " +
+        "put X +1/+1 counters on target creature you control, where X is the number of cards " +
+        "you've drawn this turn minus one."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+        description = "When Proft's Eidetic Memory enters, draw a card."
+    }
+
+    staticAbility {
+        ability = NoMaximumHandSize
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        interveningIf = Conditions.YouDrewCardsThisTurn(2)
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmount.Subtract(
+                DynamicAmount.TurnTracking(Player.You, TurnTracker.CARDS_DRAWN),
+                DynamicAmount.Fixed(1),
+            ),
+            creature,
+        )
+        description = "At the beginning of combat on your turn, if you've drawn more than one " +
+            "card this turn, put X +1/+1 counters on target creature you control, where X is the " +
+            "number of cards you've drawn this turn minus one."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "67"
+        artist = "Julie Dillon"
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/af5b29b3-974c-4200-8df8-b072c11e1600.jpg?1783912906"
+
+        ruling(
+            "2024-02-02",
+            "If you haven't drawn more than one card by the time a beginning of combat step " +
+                "begins on your turn, Proft's Eidetic Memory's last ability won't trigger at all."
+        )
+        ruling(
+            "2024-02-02",
+            "Proft's Eidetic Memory's last ability looks at how many cards you've drawn this " +
+                "turn, even if it wasn't on the battlefield when you drew those cards."
+        )
+        ruling(
+            "2024-02-02",
+            "The value of X is determined only once, as Proft's Eidetic Memory's last ability " +
+                "resolves."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/UnyieldingGatekeeper.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/UnyieldingGatekeeper.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Unyielding Gatekeeper — Murders at Karlov Manor #35
+ * {1}{W} · Creature — Elephant Cleric · 3/2 · Rare
+ *
+ * Disguise {1}{W}
+ * When this creature is turned face up, exile another target nonland permanent. If you controlled
+ * it, return it to the battlefield tapped. Otherwise, its controller creates a 2/2 white and blue
+ * Detective creature token.
+ *
+ * Two cards in one trigger: a blink for your own enters-the-battlefield permanent, or unconditional
+ * exile removal for an opponent's — bought at the price of handing them a 2/2. Both halves are
+ * bought at instant speed and can't be responded to, because turning a permanent face up is a
+ * special action (CR 701.34a); the only window an opponent gets is with the trigger already on the
+ * stack and its target locked in.
+ *
+ * **The branch is decided before the exile, not after.** "If you controlled it" is read as the
+ * ability resolves, and both printed rulings turn on that: controlling the permanent earlier in the
+ * turn doesn't count, and one you *do* control returns under **your** control regardless of who
+ * owns it. [ConditionalEffect] evaluates its condition up front as a synchronous state test, so
+ * [Conditions.TargetMatchesFilter] still sees the permanent on the battlefield with its controller
+ * intact. Each branch then does its own exile — hoisting the exile out of the conditional and
+ * testing afterwards would be testing a controller that no longer exists.
+ *
+ * The return is [RestorationAngel]'s two-move blink with [ZonePlacement.Tapped], plus an explicit
+ * `controllerOverride = EffectTarget.Controller`: the default return is under the card's *owner's*
+ * control, which is the wrong player for the one case the second ruling calls out — a permanent you
+ * control but don't own. A card that changes zones is a new object, so nothing survives the trip;
+ * that is correct here, the printed card wants a fresh permanent.
+ *
+ * The consolation token uses [EffectTarget.TargetController], which reads last-known information
+ * after the exile (the Bovine Intervention shape), so the opponent creates their own Detective per
+ * CR 111.1. It takes its art from MKM's `tokenArt` layer, so no `imageUri` is baked in — the same
+ * shape [ChalkOutline] and [InsideSource] use for theirs.
+ */
+val UnyieldingGatekeeper = card("Unyielding Gatekeeper") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elephant Cleric"
+    oracleText = "Disguise {1}{W} (You may cast this card face down for {3} as a 2/2 creature " +
+        "with ward {2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this creature is turned face up, exile another target nonland permanent. If you " +
+        "controlled it, return it to the battlefield tapped. Otherwise, its controller creates a " +
+        "2/2 white and blue Detective creature token."
+    power = 3
+    toughness = 2
+
+    disguise = "{1}{W}"
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        val permanent = target("another target nonland permanent", Targets.OtherNonlandPermanent)
+        effect = ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(
+                GameObjectFilter.NonlandPermanent.youControl()
+            ),
+            effect = Effects.Move(permanent, Zone.EXILE)
+                .then(
+                    Effects.Move(
+                        permanent,
+                        Zone.BATTLEFIELD,
+                        placement = ZonePlacement.Tapped,
+                        controllerOverride = EffectTarget.Controller,
+                    )
+                ),
+            elseEffect = Effects.Composite(
+                Effects.Exile(permanent),
+                Effects.CreateToken(
+                    power = 2,
+                    toughness = 2,
+                    colors = setOf(Color.WHITE, Color.BLUE),
+                    creatureTypes = setOf("Detective"),
+                    controller = EffectTarget.TargetController,
+                ),
+            ),
+        )
+        description = "When this creature is turned face up, exile another target nonland " +
+            "permanent. If you controlled it, return it to the battlefield tapped. Otherwise, " +
+            "its controller creates a 2/2 white and blue Detective creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "35"
+        artist = "Borja Pindado"
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f3a0d597-d2df-4aaf-8084-c8eeda64ce60.jpg?1783912917"
+
+        ruling(
+            "2024-02-02",
+            "If you controlled the target permanent earlier in the turn but not at the time " +
+                "Unyielding Gatekeeper's last ability resolves, you won't return it to the " +
+                "battlefield tapped. The player who controlled that permanent at the time it was " +
+                "exiled will create a Detective."
+        )
+        ruling(
+            "2024-02-02",
+            "If the controller of Unyielding Gatekeeper's last ability controlled the target " +
+                "permanent at the time the ability began to resolve, the permanent will return to " +
+                "the battlefield tapped under that player's control, regardless of who its owner is."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to."
+        )
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ArchdruidsCharmScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ArchdruidsCharmScenarioTest.kt
@@ -1,0 +1,170 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Archdruid's Charm (MKM #151) — {G}{G}{G} instant, three modes.
+ *
+ * Mode 1 is the reason this file exists. It is a *single* search whose destination branches on the
+ * found card's type — "onto the battlefield tapped if it's a land card. Otherwise, put it into your
+ * hand" — which no `SearchDestination` can express, so it is an inline pipeline that splits the
+ * one-card result on `GameObjectFilter.Land`. Both arms are exercised from the same board, because
+ * a `filterSplit` wired backwards (or a `Creature`-vs-`Land` split instead of land-vs-rest) passes
+ * whichever arm you test alone.
+ *
+ * Mode 2's damage must read the *boosted* power: the counter resolves first, so a 2/2 hits for 3,
+ * not 2. Asserting the victim merely died would pass at either amount, so the survivor case pins it
+ * — a 2/4 blocker takes exactly 3 and lives with 3 damage marked.
+ */
+class ArchdruidsCharmScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 30, "Grizzly Bears" to 10),
+            skipMulligans = true,
+        )
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.castCharm(
+        player: EntityId,
+        modeIndex: Int,
+        modeTargets: List<ChosenTarget> = emptyList(),
+    ) = run {
+        val card = putCardInHand(player, "Archdruid's Charm")
+        giveMana(player, Color.GREEN, 3)
+        submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                targets = modeTargets,
+                chosenModes = listOf(modeIndex),
+                modeTargetsOrdered = listOf(modeTargets),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+    }
+
+    test("mode 1 puts a found land onto the battlefield tapped, and shuffles") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val landsBefore = driver.getLands(player).size
+
+        driver.castCharm(player, 0).error shouldBe null
+        driver.bothPass()
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        val forest = decision.options.first { driver.getCardName(it) == "Forest" }
+        driver.submitCardSelection(player, listOf(forest)).error shouldBe null
+
+        withClue("the land arm ran: onto the battlefield, and tapped") {
+            driver.getLands(player).size shouldBe landsBefore + 1
+            driver.getLands(player) shouldContain forest
+            driver.isTapped(forest) shouldBe true
+        }
+        withClue("the land arm ran, so the hand arm must not have") {
+            driver.getHand(player) shouldNotContain forest
+        }
+    }
+
+    test("mode 1 puts a found nonland card into hand instead") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.castCharm(player, 0).error shouldBe null
+        driver.bothPass()
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        val bears = decision.options.first { driver.getCardName(it) == "Grizzly Bears" }
+        driver.submitCardSelection(player, listOf(bears)).error shouldBe null
+
+        withClue("a creature card takes the 'otherwise' arm — hand, not battlefield") {
+            driver.getHand(player) shouldContain bears
+            driver.findPermanent(player, "Grizzly Bears") shouldBe null
+        }
+    }
+
+    test("mode 1 resolves with nothing found — the search is 'up to one'") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val handBefore = driver.getHandSize(player)
+        val landsBefore = driver.getLands(player).size
+
+        driver.castCharm(player, 0).error shouldBe null
+        driver.bothPass()
+
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitCardSelection(player, emptyList()).error shouldBe null
+
+        withClue("declining the search moves nothing, and doesn't error out downstream") {
+            driver.getHandSize(player) shouldBe handBefore
+            driver.getLands(player).size shouldBe landsBefore
+        }
+    }
+
+    test("mode 2 counters first, then deals the boosted power as damage") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        val mine = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val theirs = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        driver.castCharm(
+            player,
+            1,
+            listOf(ChosenTarget.Permanent(mine), ChosenTarget.Permanent(theirs)),
+        ).error shouldBe null
+        driver.bothPass()
+
+        withClue("the +1/+1 counter landed on my creature") {
+            driver.state.getEntity(mine)?.get<CountersComponent>()
+                ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+            driver.state.projectedState.getPower(mine) shouldBe 3
+        }
+        withClue("a 3/3 died, so the damage was 3 — the counter resolved before power was read") {
+            driver.findPermanent(opponent, "Centaur Courser") shouldBe null
+            driver.getGraveyardCardNames(opponent) shouldContain "Centaur Courser"
+        }
+        withClue("my creature survived — the damage went one way only") {
+            driver.findPermanent(player, "Grizzly Bears").shouldNotBeNull()
+        }
+    }
+
+    test("mode 3 exiles an enchantment") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        val enchantment = driver.putPermanentOnBattlefield(opponent, "Chalk Outline")
+
+        driver.castCharm(player, 2, listOf(ChosenTarget.Permanent(enchantment))).error shouldBe null
+        driver.bothPass()
+
+        withClue("'exile target artifact or enchantment' accepted the enchantment half") {
+            driver.findPermanent(opponent, "Chalk Outline") shouldBe null
+            driver.getExileCardNames(opponent) shouldContain "Chalk Outline"
+        }
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CryptexScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CryptexScenarioTest.kt
@@ -1,0 +1,151 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.Cryptex
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cryptex (MKM #251) — {2} artifact.
+ *
+ * "{T}, Collect evidence 3: Add one mana of any color. Put an unlock counter on this artifact."
+ * "Sacrifice this artifact: Surveil 3, then draw three cards. Activate only if this artifact has
+ *  five or more unlock counters on it."
+ *
+ * Three claims, each with a plausible wrong implementation:
+ *
+ *  - the first ability is a **mana ability** (the printed ruling says so), so it must resolve
+ *    immediately without going on the stack — and its non-mana rider has to survive that path,
+ *    which a naive `isManaAbility` executor that only knows how to add mana would drop;
+ *  - collect evidence is a genuine *cost*, so CR 701.59b makes the whole ability unactivatable with
+ *    a graveyard that can't reach total mana value 3 — not activatable-then-fizzling;
+ *  - the sacrifice ability's gate reads counters **live**, so it is illegal at four and legal at
+ *    five. Testing only the legal side would pass against no gate at all.
+ */
+class CryptexScenarioTest : FunSpec({
+
+    val tapAndUnlock = Cryptex.activatedAbilities[0].id
+    val crack = Cryptex.activatedAbilities[1].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.unlockCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.UNLOCK) ?: 0
+
+    test("the mana ability adds a chosen colour and an unlock counter, off the stack") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val cryptex = driver.putPermanentOnBattlefield(player, "Cryptex")
+        // Centaur Courser is mana value 3 — exactly the collect-evidence threshold on its own.
+        driver.putCardInGraveyard(player, "Centaur Courser")
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = cryptex,
+                abilityId = tapAndUnlock,
+                manaColorChoice = Color.GREEN,
+                paymentStrategy = PaymentStrategy.AutoPay,
+            )
+        )
+        result.error shouldBe null
+        (driver.pendingDecision as? ChooseColorDecision)?.let {
+            driver.submitDecision(player, ColorChosenResponse(it.id, Color.GREEN))
+        }
+
+        withClue("a mana ability never uses the stack (CR 605.3a)") {
+            driver.stackSize shouldBe 0
+        }
+        withClue("the mana half ran") {
+            driver.state.getEntity(player)?.get<ManaPoolComponent>()?.green shouldBe 1
+        }
+        withClue("the rider ran too — the counter isn't dropped by the mana-ability path") {
+            driver.unlockCounters(cryptex) shouldBe 1
+        }
+        withClue("the cost was paid: tapped, and the evidence exiled") {
+            driver.isTapped(cryptex) shouldBe true
+            driver.getExileCardNames(player) shouldBe listOf("Centaur Courser")
+        }
+    }
+
+    test("an empty graveyard makes the ability unactivatable, not merely ineffective") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val cryptex = driver.putPermanentOnBattlefield(player, "Cryptex")
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = cryptex,
+                abilityId = tapAndUnlock,
+                manaColorChoice = Color.GREEN,
+                paymentStrategy = PaymentStrategy.AutoPay,
+            )
+        )
+
+        withClue("CR 701.59b: you can't choose to collect evidence you can't pay for") {
+            (result.error != null) shouldBe true
+            driver.isTapped(cryptex) shouldBe false
+            driver.unlockCounters(cryptex) shouldBe 0
+        }
+    }
+
+    test("the sacrifice ability is gated at five unlock counters") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val cryptex = driver.putPermanentOnBattlefield(player, "Cryptex")
+
+        driver.addComponent(cryptex, CountersComponent(mapOf(CounterType.UNLOCK to 4)))
+        val tooEarly = driver.submit(
+            ActivateAbility(playerId = player, sourceId = cryptex, abilityId = crack)
+        )
+        withClue("four counters is not five") {
+            (tooEarly.error != null) shouldBe true
+            driver.findPermanent(player, "Cryptex") shouldBe cryptex
+        }
+
+        driver.addComponent(cryptex, CountersComponent(mapOf(CounterType.UNLOCK to 5)))
+        val handBefore = driver.getHandSize(player)
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = cryptex, abilityId = crack)
+        ).error shouldBe null
+        // Unlike the first ability this one uses the stack, so it has to resolve before the
+        // surveil prompt appears. Keeping every surveiled card on top means the three cards drawn
+        // are exactly the three that were looked at.
+        driver.bothPass()
+        var guard = 0
+        while (driver.isPaused && guard++ < 6) {
+            when (val decision = driver.pendingDecision) {
+                is SelectCardsDecision -> driver.submitCardSelection(player, emptyList())
+                is ReorderLibraryDecision -> driver.submitOrderedResponse(player, decision.cards)
+                else -> break
+            }
+        }
+
+        withClue("the fifth counter opened it: sacrificed, and three cards drawn") {
+            driver.findPermanent(player, "Cryptex") shouldBe null
+            driver.getHandSize(player) shouldBe handBefore + 3
+        }
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/InsidiousRootsScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/InsidiousRootsScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Insidious Roots (MKM #208) — {B}{G} enchantment.
+ *
+ * "Creature tokens you control have '{T}: Add one mana of any color.'"
+ * "Whenever one or more creature cards leave your graveyard, create a 0/1 green Plant creature
+ *  token, then put a +1/+1 counter on each Plant you control."
+ *
+ * Two things worth pinning down:
+ *
+ *  - the payoff is **ordered**, not simultaneous. The token is created first and the counters land
+ *    second, so the brand-new Plant gets one too and arrives as a 1/2. An implementation that
+ *    snapshots the group before creating the token leaves it a 0/1.
+ *  - the counters go on **Plants**, not on all creature tokens — a Detective token sitting next to
+ *    them must stay untouched, which a filter copied from the first ability would get wrong.
+ *
+ * The second trigger fires exactly once per batch (CR 603.2c) by construction — that is
+ * `Triggers.CardsLeaveYourGraveyard`, shared with Chalk Outline and covered by its test — so this
+ * file drives it once and spends its assertions on the payoff instead.
+ */
+class InsidiousRootsScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.plants(player: EntityId): List<EntityId> =
+        getCreatures(player).filter { getCardName(it) == "Plant Token" }
+
+    fun GameTestDriver.counters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Raise Dead a creature card out of the graveyard, which is what fires the trigger. */
+    fun GameTestDriver.raiseDead(player: EntityId, target: EntityId) {
+        val spell = putCardInHand(player, "Raise Dead")
+        giveMana(player, com.wingedsheep.sdk.core.Color.BLACK, 1)
+        submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Card(target, player, Zone.GRAVEYARD)),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        ).error shouldBe null
+        bothPass()
+    }
+
+    test("the new Plant is included in its own counter sweep, arriving as a 1/2") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.putPermanentOnBattlefield(player, "Insidious Roots")
+        val corpse = driver.putCardInGraveyard(player, "Grizzly Bears")
+
+        driver.plants(player) shouldBe emptyList()
+        driver.raiseDead(player, corpse)
+        driver.bothPass()
+
+        val plants = driver.plants(player)
+        withClue("one creature card left the graveyard, so one Plant was created") {
+            plants.size shouldBe 1
+        }
+        withClue("the counter sweep ran after the token existed — 0/1 plus a counter is 1/2") {
+            driver.counters(plants.single()) shouldBe 1
+            driver.state.projectedState.getPower(plants.single()) shouldBe 1
+            driver.state.projectedState.getToughness(plants.single()) shouldBe 2
+        }
+    }
+
+    test("a second trigger grows every Plant, and leaves non-Plant tokens alone") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.putPermanentOnBattlefield(player, "Insidious Roots")
+        // Chalk Outline shares the trigger and makes a Detective — a creature token that is not a
+        // Plant, so it proves the counter filter is narrower than the mana-grant filter.
+        driver.putPermanentOnBattlefield(player, "Chalk Outline")
+
+        val first = driver.putCardInGraveyard(player, "Grizzly Bears")
+        driver.raiseDead(player, first)
+        while (driver.stackSize > 0) driver.bothPass()
+
+        val second = driver.putCardInGraveyard(player, "Centaur Courser")
+        driver.raiseDead(player, second)
+        while (driver.stackSize > 0) driver.bothPass()
+
+        val plants = driver.plants(player)
+        withClue("two triggers, two Plants") {
+            plants.size shouldBe 2
+        }
+        withClue("the first Plant caught both sweeps; the second caught only its own") {
+            plants.map { driver.counters(it) }.sorted() shouldBe listOf(1, 2)
+        }
+        withClue("Detective tokens are creature tokens but not Plants — no counters") {
+            driver.getCreatures(player)
+                .filter { driver.getCardName(it) == "Detective Token" }
+                .map { driver.counters(it) } shouldBe listOf(0, 0)
+        }
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ProftsEideticMemoryScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ProftsEideticMemoryScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Proft's Eidetic Memory (MKM #67) — {1}{U} legendary enchantment.
+ *
+ * "At the beginning of combat on your turn, if you've drawn more than one card this turn, put X
+ *  +1/+1 counters on target creature you control, where X is the number of cards you've drawn this
+ *  turn minus one."
+ *
+ * The gate and the amount read the same tracker but are **not** the same number, which is where a
+ * wrong implementation lands: X is the count *minus one*, so two draws is one counter, not two. And
+ * "more than one" is a real threshold — at one draw the ability must not trigger at all (the first
+ * printed ruling), which an `interveningIf` of `YouDrewCardsThisTurn(1)` would silently pass.
+ *
+ * Draws are made with a free test instant rather than `putCardInHand`, because only a genuine draw
+ * increments `CardsDrawnThisTurnComponent`. Note the enchantment's own enters trigger draws one, so
+ * the turn it lands it has already banked a draw toward next turn's threshold.
+ */
+class ProftsEideticMemoryScenarioTest : FunSpec({
+
+    val drawOne = card("Proft Draw One Test") {
+        manaCost = "{0}"
+        typeLine = "Instant"
+        oracleText = "Draw a card."
+        spell { effect = Effects.DrawCards(1) }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + drawOne)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.drawWithSpell(player: EntityId) {
+        val card = putCardInHand(player, "Proft Draw One Test")
+        castSpell(player, card).error shouldBe null
+        bothPass()
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("one draw is not 'more than one' — the trigger never goes on the stack") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val bears = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.putPermanentOnBattlefield(player, "Proft's Eidetic Memory")
+
+        driver.drawWithSpell(player)
+        driver.passPriorityUntil(Step.BEGIN_COMBAT)
+
+        withClue("CR 603.4: the intervening-if failed, so nothing was put on the stack") {
+            driver.stackSize shouldBe 0
+            driver.plusOneCounters(bears) shouldBe 0
+        }
+    }
+
+    test("three draws put two counters on the target — X is the count minus one") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val bears = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.putPermanentOnBattlefield(player, "Proft's Eidetic Memory")
+
+        repeat(3) { driver.drawWithSpell(player) }
+        driver.passPriorityUntil(Step.BEGIN_COMBAT)
+        driver.submitTargetSelection(player, listOf(bears)).error shouldBe null
+        driver.bothPass()
+
+        withClue("three drawn cards, minus one, is two counters — not three") {
+            driver.plusOneCounters(bears) shouldBe 2
+            driver.state.projectedState.getPower(bears) shouldBe 4
+            driver.state.projectedState.getToughness(bears) shouldBe 4
+        }
+    }
+
+    test("the enters trigger draws a card, so it replaces itself") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val card = driver.putCardInHand(player, "Proft's Eidetic Memory")
+        val handHolding = driver.getHandSize(player)
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.giveColorlessMana(player, 1)
+        driver.submit(
+            CastSpell(playerId = player, cardId = card, paymentStrategy = PaymentStrategy.FromPool)
+        ).error shouldBe null
+        driver.bothPass()
+        driver.bothPass()
+
+        withClue("it resolved onto the battlefield") {
+            driver.findPermanent(player, "Proft's Eidetic Memory").shouldNotBeNull()
+        }
+        withClue("one card left the hand to cast it, one came back from the draw") {
+            driver.getHandSize(player) shouldBe handHolding
+        }
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/UnyieldingGatekeeperScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/UnyieldingGatekeeperScenarioTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unyielding Gatekeeper (MKM #35) — {1}{W} 3/2 with Disguise {1}{W}.
+ *
+ * "When this creature is turned face up, exile another target nonland permanent. If you controlled
+ *  it, return it to the battlefield tapped. Otherwise, its controller creates a 2/2 white and blue
+ *  Detective creature token."
+ *
+ * One trigger, two opposite outcomes, and the branch is chosen by a state test that must be read
+ * **before** the exile — a naive implementation that exiles first and then asks "did you control
+ * it?" always takes the else arm, because an exiled card has no controller. So both arms are driven
+ * from the same trigger, and each asserts the *other* arm didn't fire:
+ *
+ *  - my own permanent comes back tapped and **no** Detective appears;
+ *  - the opponent's stays exiled and exactly one Detective appears **under their control**.
+ *
+ * The whole thing only happens on a flip, so each case goes through the real disguise loop: cast
+ * face down for {3}, then pay {1}{W} to turn it face up.
+ */
+class UnyieldingGatekeeperScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Cast the Gatekeeper face down for {3} and return the resulting face-down permanent. */
+    fun GameTestDriver.castFaceDown(player: EntityId): EntityId {
+        val card = putCardInHand(player, "Unyielding Gatekeeper")
+        giveColorlessMana(player, 3)
+        submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        ).error shouldBe null
+        bothPass()
+        return getPermanents(player).single {
+            state.getEntity(it)?.has<FaceDownComponent>() == true
+        }
+    }
+
+    /** Pay the {1}{W} disguise cost, then let the turned-face-up trigger resolve. */
+    fun GameTestDriver.flipUp(player: EntityId, gatekeeper: EntityId) {
+        giveColorlessMana(player, 1)
+        giveMana(player, Color.WHITE, 1)
+        submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = gatekeeper,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        ).error shouldBe null
+    }
+
+    fun GameTestDriver.detectivesOf(player: EntityId): List<EntityId> =
+        getCreatures(player).filter { getCardName(it) == "Detective Token" }
+
+    test("a permanent you control is blinked back tapped, with no consolation Detective") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        val mine = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.untapPermanent(mine)
+        // A counter is the observable "same object or not?" probe: a permanent that genuinely left
+        // the battlefield and came back is a new object and keeps nothing (CR 400.7).
+        driver.addComponent(mine, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 2)))
+
+        val gatekeeper = driver.castFaceDown(player)
+        driver.flipUp(player, gatekeeper)
+        driver.submitTargetSelection(player, listOf(mine)).error shouldBe null
+        driver.bothPass()
+
+        val returned = driver.findPermanent(player, "Grizzly Bears")
+        withClue("it came back under my control rather than staying in exile") {
+            returned.shouldNotBeNull()
+            driver.getExileCardNames(player) shouldBe emptyList()
+        }
+        withClue("it came back *tapped*") {
+            driver.isTapped(returned!!) shouldBe true
+        }
+        withClue("it really left and came back — a new object keeps none of its counters") {
+            driver.state.getEntity(returned!!)?.get<CountersComponent>()
+                ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0 shouldBe 0
+        }
+        withClue("the else arm must not have run for a permanent I controlled") {
+            driver.detectivesOf(player) shouldBe emptyList()
+            driver.detectivesOf(opponent) shouldBe emptyList()
+        }
+    }
+
+    test("an opponent's permanent stays exiled and hands them one Detective") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        val theirs = driver.findPermanent(opponent, "Grizzly Bears")!!
+
+        val gatekeeper = driver.castFaceDown(player)
+        driver.flipUp(player, gatekeeper)
+        driver.submitTargetSelection(player, listOf(theirs)).error shouldBe null
+        driver.bothPass()
+
+        withClue("the exile stuck — nothing returned it") {
+            driver.findPermanent(opponent, "Grizzly Bears") shouldBe null
+            driver.getExileCardNames(opponent) shouldContain "Grizzly Bears"
+        }
+        withClue("'its controller' is the opponent, not me (CR 111.1)") {
+            driver.detectivesOf(opponent).size shouldBe 1
+            driver.detectivesOf(player) shouldBe emptyList()
+        }
+        withClue("the Gatekeeper itself is face up and on the battlefield") {
+            driver.findPermanent(player, "Unyielding Gatekeeper").shouldNotBeNull()
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -813,6 +813,177 @@
     ]
 }
 
+// Archdruid's Charm
+{
+    "name": "Archdruid's Charm",
+    "manaCost": "{G}{G}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Search your library for a creature or land card and reveal it. Put it onto the battlefield tapped if it's a land card. Otherwise, put it into your hand. Then shuffle.\n• Put a +1/+1 counter on target creature you control. It deals damage equal to its power to target creature you don't control.\n• Exile target artifact or enchantment.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "creature|land"
+                                },
+                                "storeAs": "gathered0"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "gathered0",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "selected1",
+                                "prompt": "Search your library for a creature or land card"
+                            },
+                            {
+                                "type": "RevealCollection",
+                                "from": "selected1",
+                                "revealToSelf": false
+                            },
+                            {
+                                "type": "FilterCollection",
+                                "from": "selected1",
+                                "filter": {
+                                    "type": "MatchesFilter",
+                                    "filter": "land"
+                                },
+                                "storeMatching": "matching3",
+                                "storeNonMatching": "rest3"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "matching3",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield",
+                                    "placement": "Tapped"
+                                }
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "rest3",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                }
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    },
+                    "description": "Search your library for a creature or land card and reveal it. Put it onto the battlefield tapped if it's a land card. Otherwise, put it into your hand. Then shuffle."
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature you control"
+                                }
+                            },
+                            {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "EntityProperty",
+                                    "entity": "Target",
+                                    "numericProperty": "Power"
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature you don't control"
+                                },
+                                "damageSource": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature you control"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            },
+                            "id": "target creature you control"
+                        },
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            },
+                            "id": "target creature you don't control"
+                        }
+                    ],
+                    "description": "Put a +1/+1 counter on target creature you control. It deals damage equal to its power to target creature you don't control."
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact or enchantment"
+                        },
+                        "destination": "Exile"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact|enchantment"
+                            },
+                            "id": "target artifact or enchantment"
+                        }
+                    ],
+                    "description": "Exile target artifact or enchantment"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "RARE",
+        "artist": "Liiga Smilshkalne",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5caae5ae-845f-42c2-b1ae-956df2739433.jpg?1783912870",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "You can't choose the second mode for Archdruid's Charm unless you and another player have creatures to target."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If you choose the second mode and your creature is not a legal target as Archdruid's Charm resolves, you won't put a +1/+1 counter on it, and no damage will be dealt."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If you choose the second mode and the creature you don't control is not a legal target as Archdruid's Charm resolves, you'll still put a +1/+1 counter on your creature."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Assemble the Players
 {
     "name": "Assemble the Players",
@@ -2912,6 +3083,111 @@
         "GREEN",
         "WHITE"
     ]
+}
+
+// Cryptex
+{
+    "name": "Cryptex",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}, Collect evidence 3: Add one mana of any color. Put an unlock counter on this artifact. (To collect evidence 3, exile cards with total mana value 3 or greater from your graveyard.)\nSacrifice this artifact: Surveil 3, then draw three cards. Activate only if this artifact has five or more unlock counters on it.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomCollectEvidence",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        "AddManaOfChoice",
+                        {
+                            "type": "AddCounters",
+                            "counterType": "unlock",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "Add one mana of any color. Put an unlock counter on this artifact."
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Surveil",
+                            "count": 3
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": {
+                                    "type": "CounterCount",
+                                    "counterType": {
+                                        "type": "Named",
+                                        "name": "unlock"
+                                    }
+                                }
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 5
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "Surveil 3, then draw three cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "251",
+        "rarity": "RARE",
+        "artist": "Yeong-Hao Han",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f92a2563-6cfb-4d12-9513-b44d1a7a20ab.jpg?1783912829",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Cryptex's first ability is a mana ability. It doesn't use the stack and can't be responded to."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If you can't exile enough cards to meet or exceed the required mana value, you can't choose to collect evidence at all."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Culvert Ambusher
@@ -6758,6 +7034,94 @@
     ]
 }
 
+// Insidious Roots
+{
+    "name": "Insidious Roots",
+    "manaCost": "{B}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Creature tokens you control have \"{T}: Add one mana of any color.\"\nWhenever one or more creature cards leave your graveyard, create a 0/1 green Plant creature token, then put a +1/+1 counter on each Plant you control.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "CardsLeftYourGraveyardEvent",
+                    "filter": "creature"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 0,
+                            "toughness": 1,
+                            "colors": [
+                                "GREEN"
+                            ],
+                            "creatureTypes": [
+                                "Plant"
+                            ]
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature Plant ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever one or more creature cards leave your graveyard, create a 0/1 green Plant creature token, then put a +1/+1 counter on each Plant you control."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": "AddManaOfChoice",
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                "filter": {
+                    "baseFilter": "creature token ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "208",
+        "rarity": "UNCOMMON",
+        "artist": "Jeremy Wilson",
+        "flavorText": "The roots of Vitu-Ghazi allowed Trostani to reach every crack and crevice in the city.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0bb91a22-2040-4a37-85f8-5f22de8c5907.jpg?1783912846",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "In the rare case where Insidious Roots is a creature token, it will grant itself the ability \"{T}: Add one mana of any color.\""
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If multiple creature cards leave your graveyard at the same time, Insidious Roots's last ability will trigger only once."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // It Doesn't Add Up
 {
     "name": "It Doesn't Add Up",
@@ -9617,6 +9981,99 @@
     },
     "colorIdentityOverride": [
         "WHITE",
+        "BLUE"
+    ]
+}
+
+// Proft's Eidetic Memory
+{
+    "name": "Proft's Eidetic Memory",
+    "manaCost": "{1}{U}",
+    "typeLine": "Legendary Enchantment",
+    "oracleText": "When Proft's Eidetic Memory enters, draw a card.\nYou have no maximum hand size.\nAt the beginning of combat on your turn, if you've drawn more than one card this turn, put X +1/+1 counters on target creature you control, where X is the number of cards you've drawn this turn minus one.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "When Proft's Eidetic Memory enters, draw a card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "Subtract",
+                        "left": {
+                            "type": "TurnTracking",
+                            "player": "You",
+                            "tracker": "CARDS_DRAWN"
+                        },
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "interveningIf": {
+                    "type": "PlayerDrewCardsThisTurn",
+                    "atLeast": 2
+                },
+                "descriptionOverride": "At the beginning of combat on your turn, if you've drawn more than one card this turn, put X +1/+1 counters on target creature you control, where X is the number of cards you've drawn this turn minus one."
+            }
+        ],
+        "staticAbilities": [
+            "NoMaximumHandSize"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "67",
+        "rarity": "RARE",
+        "artist": "Julie Dillon",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/af5b29b3-974c-4200-8df8-b072c11e1600.jpg?1783912906",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If you haven't drawn more than one card by the time a beginning of combat step begins on your turn, Proft's Eidetic Memory's last ability won't trigger at all."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Proft's Eidetic Memory's last ability looks at how many cards you've drawn this turn, even if it wasn't on the battlefield when you drew those cards."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "The value of X is determined only once, as Proft's Eidetic Memory's last ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
         "BLUE"
     ]
 }
@@ -13333,6 +13790,137 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Unyielding Gatekeeper
+{
+    "name": "Unyielding Gatekeeper",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Elephant Cleric",
+    "oracleText": "Disguise {1}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, exile another target nonland permanent. If you controlled it, return it to the battlefield tapped. Otherwise, its controller creates a 2/2 white and blue Detective creature token.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{W}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "filter": "nonland permanent ctrl:you"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "another target nonland permanent"
+                                },
+                                "destination": "Exile"
+                            },
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "another target nonland permanent"
+                                },
+                                "destination": "Battlefield",
+                                "placement": "Tapped",
+                                "controllerOverride": "Controller"
+                            }
+                        ]
+                    },
+                    "otherwise": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "another target nonland permanent"
+                                },
+                                "destination": "Exile"
+                            },
+                            {
+                                "type": "CreateToken",
+                                "power": 2,
+                                "toughness": 2,
+                                "colors": [
+                                    "WHITE",
+                                    "BLUE"
+                                ],
+                                "creatureTypes": [
+                                    "Detective"
+                                ],
+                                "controller": "TargetController"
+                            }
+                        ]
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "nonland permanent",
+                        "excludeSelf": true
+                    },
+                    "id": "another target nonland permanent"
+                },
+                "descriptionOverride": "When this creature is turned face up, exile another target nonland permanent. If you controlled it, return it to the battlefield tapped. Otherwise, its controller creates a 2/2 white and blue Detective creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "35",
+        "rarity": "RARE",
+        "artist": "Borja Pindado",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f3a0d597-d2df-4aaf-8084-c8eeda64ce60.jpg?1783912917",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If you controlled the target permanent earlier in the turn but not at the time Unyielding Gatekeeper's last ability resolves, you won't return it to the battlefield tapped. The player who controlled that permanent at the time it was exiled will create a Detective."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If the controller of Unyielding Gatekeeper's last ability controlled the target permanent at the time the ability began to resolve, the permanent will return to the battlefield tapped under that player's control, regardless of who its owner is."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -141,5 +141,6 @@ export const counterManaClass: Record<string, string> = {
   HARNESS: 'counter-devotion',
   PLAN: 'counter-lore',
   INVASION: 'counter-charge',
+  UNLOCK: 'counter-charge',
   HONE: 'counter-arrow',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -820,6 +820,7 @@ export const PASSIVE_COUNTER_TYPES: readonly CounterType[] = [
   CounterType.HARNESS,
   CounterType.PLAN,
   CounterType.INVASION,
+  CounterType.UNLOCK,
   CounterType.HONE,
   CounterType.PLUS_ONE_PLUS_ZERO,
   CounterType.PLUS_ZERO_PLUS_ONE,

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -2229,6 +2229,7 @@ const passiveCounterPalette: Record<string, CounterBadgePalette> = {
   HARNESS: { bg: 'rgba(48, 26, 12, 0.95)', border: 'rgba(240, 180, 80, 0.8)', color: '#ffc860', glow: 'rgba(240, 180, 80, 0.7)' },
   PLAN: { bg: 'rgba(24, 40, 62, 0.95)', border: 'rgba(120, 175, 230, 0.7)', color: '#a8cdee', glow: 'rgba(120, 175, 230, 0.55)' },
   INVASION: { bg: 'rgba(52, 22, 20, 0.95)', border: 'rgba(230, 110, 90, 0.7)', color: '#f0a090', glow: 'rgba(230, 110, 90, 0.55)' },
+  UNLOCK: { bg: 'rgba(44, 36, 16, 0.95)', border: 'rgba(214, 182, 96, 0.75)', color: '#efd694', glow: 'rgba(214, 182, 96, 0.6)' },
   HONE: { bg: 'rgba(36, 42, 50, 0.95)', border: 'rgba(196, 214, 228, 0.8)', color: '#e4eef8', glow: 'rgba(196, 214, 228, 0.65)' },
   PLUS_ONE_PLUS_ZERO: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   PLUS_ZERO_PLUS_ONE: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -479,6 +479,7 @@ export enum CounterType {
   HARNESS = 'HARNESS',
   PLAN = 'PLAN',
   INVASION = 'INVASION',
+  UNLOCK = 'UNLOCK',
   HONE = 'HONE',
 }
 
@@ -558,6 +559,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.HARNESS]: 'Harness',
   [CounterType.PLAN]: 'Plan',
   [CounterType.INVASION]: 'Invasion',
+  [CounterType.UNLOCK]: 'Unlock',
   [CounterType.HONE]: 'Hone',
 }
 


### PR DESCRIPTION
Five MKM cards, all built from existing primitives. One SDK addition — a new passive counter type — rides along with the card that needs it.

- **Archdruid's Charm** {G}{G}{G} — three-mode instant. Mode 1 is a *single* search whose destination branches on the found card's type, which no `SearchDestination` can express, so it's an inline `Effects.Pipeline`: gather creature-or-land, `chooseUpTo(1)`, reveal, then `filterSplit` on `Land` — lands to the battlefield tapped, everything else to hand. Splitting on `Land` rather than on `Creature` is load-bearing: a land creature belongs on the battlefield, and a `Creature` split would move it twice. Mode 2 is Bite Down on Crime's two-target shape with `damageSource` set to the pumped creature. Mode 3 is `Effects.Exile` over `Targets.ArtifactOrEnchantment`.

- **Unyielding Gatekeeper** {1}{W} — disguise plus a turned-face-up trigger that blinks your own permanent or exiles an opponent's. The branch must be decided *before* the exile: both printed rulings turn on who controlled the permanent as the ability began to resolve, and an exiled card has no controller left to read. `ConditionalEffect` evaluates its condition up front, so each arm does its own exile. The return needs an explicit `controllerOverride` — the default is the card's *owner*, which is the wrong player for a permanent you control but don't own, exactly the case the second ruling calls out.

- **Cryptex** {2} — a mana ability with a counter rider, plus a sacrifice ability gated at five counters. Adds `Counters.UNLOCK` on the documented path (`CounterType` enum, `Counters` constants, and the four client wiring sites). The rider doesn't change the classification: CR 605.1a asks only whether the ability could add mana and whether it targets.

- **Proft's Eidetic Memory** {1}{U} — enters-draw, `NoMaximumHandSize`, and a begin-combat trigger whose gate and amount read the same tracker but are *not* the same number. The gate is `interveningIf = YouDrewCardsThisTurn(2)`; X is `Subtract(TurnTracking(CARDS_DRAWN), 1)`, read once at resolution, so a draw made in response still grows X.

- **Insidious Roots** {B}{G} — Cryptolith Rite's `GrantActivatedAbility` narrowed to creature tokens, plus `Triggers.CardsLeaveYourGraveyard` (the CR 603.2c batch shape). The payoff is ordered, not simultaneous: the Plant is created first, so it's in its own counter sweep and arrives a 1/2. Counters go on Plants, a narrower filter than the mana grant's.

No card was dropped from the batch.

## Verification

- `just build` green.
- 15 scenario tests across five files, all passing. Each targets the assertion a plausible wrong implementation would fail: both arms of the Gatekeeper branch (each asserting the *other* arm didn't fire); both destinations of the Charm's search; Cryptex illegal at four counters and legal at five; Proft's not triggering at one draw and giving two counters at three; the new Plant catching its own sweep.
- `just check-card-printing` clean for all five (MKM is the canonical printing for each).
- Card snapshot reblessed — only the five added cards move in the golden, no existing card changed.
- The web-client TypeScript changes are four mechanical additions mirroring the existing `INVASION` rows; `just client-typecheck` couldn't run here because this worktree has no `node_modules`, so CI is the first typecheck of those four lines. Only `CounterTypeDisplayNames` is an exhaustive `Record<CounterType, …>`, and it has the new key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)