### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BurdenOfProof.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BurdenOfProof.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CanOnlyBlockCreaturesWith
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
+
+/**
+ * "as long as it's a Detective you control" — shared by all three of the Aura's statics. Declared
+ * ahead of the card because top-level properties initialize in file order.
+ */
+private val IsDetectiveYouControl = Conditions.EnchantedPermanentMatches(
+    GameObjectFilter.Creature.withSubtype(Subtype.DETECTIVE).youControl()
+)
+
+/**
+ * Burden of Proof — Murders at Karlov Manor #42
+ * {1}{U} · Enchantment — Aura
+ *
+ * Flash
+ * Enchant creature
+ * Enchanted creature gets +2/+2 as long as it's a Detective you control. Otherwise, it has base
+ * power and toughness 1/1 and can't block Detectives.
+ *
+ * One condition drives all three statics, so it is written once and negated for the "otherwise"
+ * branch: [Conditions.EnchantedPermanentMatches] over a Detective-you-control filter. Both branches
+ * stay live continuously — the Aura can move, the enchanted creature can gain or lose the Detective
+ * type, and control can change; each recheck flips which branch projects.
+ *
+ * The two stat lines sit in different layers and never fight: `+2/+2` is [ModifyStats] (Layer 7c)
+ * and `base power and toughness 1/1` is [SetBasePowerToughnessStatic] (Layer 7b). Because the
+ * conditions are exact complements, only one is ever contributing.
+ *
+ * "Can't block Detectives" is expressed as its complement, [CanOnlyBlockCreaturesWith] over
+ * non-Detective creatures. The two are the same restriction — every creature is either a Detective
+ * or not — and this shape scopes the restriction to the enchanted creature itself, where the oracle
+ * text puts it, rather than making it a property of every Detective on the battlefield. Per the
+ * ruling, this is checked when blockers are declared: attaching the Aura to a creature that has
+ * *already* blocked a Detective doesn't undo the block.
+ */
+val BurdenOfProof = card("Burden of Proof") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\n" +
+        "Enchant creature\n" +
+        "Enchanted creature gets +2/+2 as long as it's a Detective you control. Otherwise, it has " +
+        "base power and toughness 1/1 and can't block Detectives."
+
+    keywords(Keyword.FLASH)
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        condition = IsDetectiveYouControl
+        ability = ModifyStats(+2, +2, Filters.EnchantedCreature)
+    }
+
+    staticAbility {
+        condition = Conditions.Not(IsDetectiveYouControl)
+        ability = SetBasePowerToughnessStatic(1, 1, Filters.EnchantedCreature)
+    }
+
+    staticAbility {
+        condition = Conditions.Not(IsDetectiveYouControl)
+        ability = CanOnlyBlockCreaturesWith(
+            blockerFilter = GameObjectFilter.Creature.notSubtype(Subtype.DETECTIVE),
+            filter = Filters.EnchantedCreature
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "42"
+        artist = "Deruchenko Alexander"
+        flavorText = "\"You must have known all those lies would catch up to you eventually.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4ea29c34-4b55-4170-9120-0a8dda61f2eb.jpg?1783912915"
+        ruling(
+            "2024-02-02",
+            "Once a Detective has been blocked, attaching Burden of Proof to a creature blocking it " +
+                "won't cause that Detective to become unblocked."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BuriedInTheGarden.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BuriedInTheGarden.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalManaOnTap
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Buried in the Garden — Murders at Karlov Manor #191
+ * {2}{G}{W} · Enchantment — Aura
+ *
+ * Enchant land
+ * When this Aura enters, exile target nonland permanent you don't control until this Aura leaves
+ * the battlefield.
+ * Whenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.
+ *
+ * A Banishing Light stapled to a Fertile Ground, and both halves already have their shape here.
+ * The removal is the standard [Effects.ExileUntilLeaves] / [Effects.ReturnLinkedExileUnderOwnersControl]
+ * pair — the enters trigger links the exiled permanent to this Aura and the leaves trigger returns
+ * it, which is what makes the three rulings fall out for free: the exile never happens if the Aura
+ * is gone before the trigger resolves, the returning card is a new object (so counters and Auras on
+ * it are lost), and an exiled token simply ceases to exist with nothing to return.
+ *
+ * The mana half is [AdditionalManaOnTap] with `anyColor = true` — the Fertile Ground shape, where
+ * the controller picks the colour on each manual tap and the auto-tapper treats the bonus as
+ * flexible when paying a cost. Note who gets the mana: the ability says *its controller*, so
+ * enchanting an opponent's land hands them the bonus. That falls out of the static being keyed to
+ * the tap rather than to this Aura's controller.
+ */
+val BuriedInTheGarden = card("Buried in the Garden") {
+    manaCost = "{2}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant land\n" +
+        "When this Aura enters, exile target nonland permanent you don't control until this Aura " +
+        "leaves the battlefield.\n" +
+        "Whenever enchanted land is tapped for mana, its controller adds an additional one mana of " +
+        "any color."
+
+    auraTarget = Targets.Land
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val exiled = target("exiled", TargetPermanent(filter = TargetFilter.NonlandPermanentOpponentControls))
+        effect = Effects.ExileUntilLeaves(exiled)
+        description = "When this Aura enters, exile target nonland permanent you don't control " +
+            "until this Aura leaves the battlefield."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    staticAbility {
+        ability = AdditionalManaOnTap(amount = DynamicAmount.Fixed(1), anyColor = true)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "191"
+        artist = "Tom Babbey"
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e144609-e1f6-4bdc-8d14-b735ef4140d3.jpg?1783912854"
+        ruling(
+            "2024-02-02",
+            "If Buried in the Garden leaves the battlefield before its first triggered ability " +
+                "resolves, the target permanent won't be exiled."
+        )
+        ruling(
+            "2024-02-02",
+            "Auras attached to the exiled permanent will be put into their owners' graveyards. Any " +
+                "Equipment will become unattached and remain on the battlefield. Any counters on the " +
+                "exiled permanent will cease to exist. When the card returns to the battlefield, it " +
+                "will be a new object with no connection to the card that was exiled."
+        )
+        ruling(
+            "2024-02-02",
+            "If a token is exiled this way, it will cease to exist and won't return to the battlefield."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ConnectingTheDots.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ConnectingTheDots.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Connecting the Dots — Murders at Karlov Manor #118
+ * {1}{R} · Enchantment
+ *
+ * Whenever a creature you control attacks, exile the top card of your library face down.
+ * {1}{R}, Discard your hand, Sacrifice this enchantment: Put all cards exiled with this
+ * enchantment into their owners' hands.
+ *
+ * The two halves are one mechanism: the exile side stamps `linkToSource`, and the payoff reads that
+ * same linked pile back with [Effects.ReturnLinkedExileToHand]. That link is what makes the first
+ * ruling true without any extra wiring — each copy of this enchantment owns its own pile, so a
+ * second Connecting the Dots can't cash in the first one's cards. It's also why the second ruling
+ * holds: sacrificing or bouncing the enchantment destroys the link, and the cards stay in exile
+ * face down forever.
+ *
+ * `FaceDownMode.HIDDEN` is the "face down in exile" mode (the hideaway shape), so the cards are
+ * genuinely unlookable rather than merely unrevealed — the parenthetical "(You can't look at it.)"
+ * is load-bearing, and hidden exile is what masks them from their own controller.
+ *
+ * The trigger is per-attacker (`binding = ANY` over creatures you control), not a
+ * once-per-declaration `YouAttack`: attacking with three creatures exiles three cards.
+ *
+ * Discarding your hand is [Costs.DiscardHand], which is payable with an empty hand — the third
+ * ruling — because it discards whatever is there rather than requiring a card.
+ */
+val ConnectingTheDots = card("Connecting the Dots") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a creature you control attacks, exile the top card of your library " +
+        "face down. (You can't look at it.)\n" +
+        "{1}{R}, Discard your hand, Sacrifice this enchantment: Put all cards exiled with this " +
+        "enchantment into their owners' hands."
+
+    triggeredAbility {
+        trigger = Triggers.attacks(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(count = DynamicAmount.Fixed(1), player = Player.You),
+                    storeAs = "clue"
+                ),
+                MoveCollectionEffect(
+                    from = "clue",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                    faceDown = FaceDownMode.HIDDEN,
+                    linkToSource = true
+                )
+            )
+        )
+        description = "Whenever a creature you control attacks, exile the top card of your " +
+            "library face down."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{R}"), Costs.DiscardHand, Costs.SacrificeSelf)
+        effect = Effects.ReturnLinkedExileToHand()
+        description = "Put all cards exiled with this enchantment into their owners' hands."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "118"
+        artist = "Aaron J. Riley"
+        flavorText = "\"How could I have missed it? The answer was right in front of me all along!\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e02731a-8698-4b41-99c3-f0a19fc31430.jpg?1783912884"
+        ruling(
+            "2024-02-02",
+            "Each Connecting the Dots you control has its own set of face-down exiled cards. " +
+                "Connecting the Dots's last ability puts only those cards into your hand, not those of " +
+                "any other Connecting the Dots."
+        )
+        ruling(
+            "2024-02-02",
+            "If Connecting the Dots leaves the battlefield before you activate its last ability, any " +
+                "cards exiled by its triggered ability remain exiled face down for the rest of the game."
+        )
+        ruling("2024-02-02", "You can pay the cost of \"discard your hand\" even if your hand contains zero cards.")
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ForensicGadgeteer.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ForensicGadgeteer.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ReduceActivatedAbilityCost
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Forensic Gadgeteer — Murders at Karlov Manor #57
+ * {2}{U} · Creature — Vedalken Artificer Detective · 2/3
+ *
+ * Whenever you cast an artifact spell, investigate.
+ * Activated abilities of artifacts you control cost {1} less to activate. This effect can't reduce
+ * the mana in that cost to less than one mana.
+ *
+ * Both halves are existing vocabulary. The trigger is `youCastSpell` filtered to artifact spells —
+ * the *spell* filter, not a battlefield one, so an artifact creature spell counts too (its type line
+ * on the stack is still Artifact Creature).
+ *
+ * The static is [ReduceActivatedAbilityCost] with `manaFloor = 1`, which is the whole second
+ * sentence: the reduction only eats generic mana and stops once one mana is left, so a Clue's
+ * `{2}, Sacrifice this token` becomes `{1}` and never free. Two rulings shape what the filter must
+ * *not* say. It's `GameObjectFilter.Artifact.youControl()` scoped to the battlefield group, because
+ * the ability reaches only artifacts you control in play — cycling and other abilities that
+ * function from hand or graveyard are untouched. And triggered abilities aren't activated
+ * abilities, so nothing here needs to exclude them; `ReduceActivatedAbilityCost` only ever sees the
+ * activated rail.
+ */
+val ForensicGadgeteer = card("Forensic Gadgeteer") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Vedalken Artificer Detective"
+    power = 2
+    toughness = 3
+    oracleText = "Whenever you cast an artifact spell, investigate. (Create a Clue token. It's an " +
+        "artifact with \"{2}, Sacrifice this token: Draw a card.\")\n" +
+        "Activated abilities of artifacts you control cost {1} less to activate. This effect can't " +
+        "reduce the mana in that cost to less than one mana."
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Artifact)
+        effect = Effects.Investigate()
+        description = "Whenever you cast an artifact spell, investigate."
+    }
+
+    staticAbility {
+        ability = ReduceActivatedAbilityCost(
+            filter = GroupFilter(GameObjectFilter.Artifact.youControl()),
+            amount = DynamicAmount.Fixed(1),
+            manaFloor = 1
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "57"
+        artist = "Volkan Baǵa"
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/97d08a15-e61c-4421-a541-c68a4f87cb74.jpg?1783912910"
+        ruling(
+            "2024-02-02",
+            "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" " +
+                "Triggered abilities (starting with \"when,\" \"whenever,\" or \"at\") are unaffected by " +
+                "the cost reduction ability of Forensic Gadgeteer."
+        )
+        ruling(
+            "2024-02-02",
+            "Forensic Gadgeteer's last ability affects only abilities of artifacts you control on " +
+                "the battlefield. The costs of activated abilities of artifact cards that work in other " +
+                "zones, such as cycling, won't be reduced."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PompousGadabout.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PompousGadabout.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Pompous Gadabout — Murders at Karlov Manor #171
+ * {2}{G} · Creature — Human Citizen · 4/2
+ *
+ * During your turn, this creature has hexproof.
+ * This creature can't be blocked by creatures that don't have a name.
+ *
+ * Hexproof is a [GrantKeyword] gated by [Conditions.IsYourTurn] — the `condition` field on the
+ * `staticAbility { }` block auto-wraps it in a `ConditionalStaticAbility`, so the keyword is simply
+ * absent from projected state on opponents' turns rather than being granted and then stripped.
+ *
+ * "Creatures that don't have a name" is the face-down set. CR 708.2 gives a face-down permanent no
+ * name, and this card's own ruling states it outright: *"Face-down creatures don't have names unless
+ * an effect says otherwise."* In an MKM context that means disguised and cloaked creatures, which is
+ * the whole point of the design. So the blocker filter is `Creature.faceDown()`, reading the
+ * projected face-down state rather than the underlying card — a face-down creature turned face up
+ * mid-combat has a name again and the restriction stops applying to it, exactly as the rules want.
+ *
+ * The restriction is checked when blockers are declared, so per the second ruling, turning an
+ * already-declared blocker face down doesn't retroactively remove it from combat.
+ */
+val PompousGadabout = card("Pompous Gadabout") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Citizen"
+    power = 4
+    toughness = 2
+    oracleText = "During your turn, this creature has hexproof.\n" +
+        "This creature can't be blocked by creatures that don't have a name."
+
+    staticAbility {
+        condition = Conditions.IsYourTurn
+        ability = GrantKeyword(Keyword.HEXPROOF, Filters.Self)
+    }
+
+    staticAbility {
+        ability = CantBeBlockedBy(blockerFilter = GameObjectFilter.Creature.faceDown())
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "171"
+        artist = "Scott Murphy"
+        flavorText = "\"Stand aside, nobodies.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6d803b93-c1df-4a02-9dbb-d347c841d4d7.jpg?1783912863"
+        ruling("2024-02-02", "Face-down creatures don't have names unless an effect says otherwise.")
+        ruling(
+            "2024-02-02",
+            "Once Pompous Gadabout has been blocked by a creature, turning that creature face down " +
+                "or otherwise causing it to lose its name won't cause it to stop blocking Pompous Gadabout."
+        )
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BurdenOfProofScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BurdenOfProofScenarioTest.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.BurdenOfProof
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Burden of Proof — "Enchanted creature gets +2/+2 as long as it's a Detective you control.
+ * Otherwise, it has base power and toughness 1/1 and can't block Detectives."
+ *
+ * Three statics share one condition and its negation, so the tests exist to prove the condition
+ * really splits them rather than one branch quietly always applying. The three cases are the three
+ * ways the condition can resolve:
+ *
+ *  1. a Detective **you** control — the buff branch, and the debuff must be absent;
+ *  2. a creature you control that isn't a Detective — the "otherwise" branch, base 1/1;
+ *  3. an opponent's Detective — still the "otherwise" branch. This is the case that separates
+ *     `Detective` from `Detective you control`; a filter that dropped `youControl` would hand an
+ *     opposing Detective +2/+2 instead of shrinking it, which is the opposite of what the card does.
+ *
+ * The blocking restriction is checked against a real declaration rather than a projected flag,
+ * because a restriction that projects but is never enforced is indistinguishable from nothing.
+ */
+class BurdenOfProofScenarioTest : FunSpec({
+
+    val testDetective = CardDefinition.creature(
+        name = "Test Detective",
+        manaCost = ManaCost.parse("{1}{U}"),
+        subtypes = setOf(Subtype.DETECTIVE),
+        power = 2,
+        toughness = 2,
+    )
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(BurdenOfProof)
+        driver.registerCard(testDetective)
+        return driver
+    }
+
+    /** Cast Burden of Proof from [caster]'s hand onto [victim] and resolve it. */
+    fun enchant(driver: GameTestDriver, caster: EntityId, victim: EntityId) {
+        val aura = driver.putCardInHand(caster, "Burden of Proof")
+        driver.giveMana(caster, Color.BLUE, 2)
+        driver.castSpell(caster, aura, listOf(victim))
+        driver.bothPass()
+    }
+
+    test("a Detective you control gets +2/+2") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val detective = driver.putCreatureOnBattlefield(active, "Test Detective")
+        enchant(driver, active, detective)
+
+        withClue("2/2 Detective + the buff branch") {
+            projector.getProjectedPower(driver.state, detective) shouldBe 4
+            projector.getProjectedToughness(driver.state, detective) shouldBe 4
+        }
+    }
+
+    test("a non-Detective you control is shrunk to a base 1/1") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+        enchant(driver, active, bears)
+
+        withClue("base power and toughness are set, not modified — a 2/2 becomes 1/1, not 3/3") {
+            projector.getProjectedPower(driver.state, bears) shouldBe 1
+            projector.getProjectedToughness(driver.state, bears) shouldBe 1
+        }
+    }
+
+    test("an opponent's Detective takes the 'otherwise' branch — the condition is 'you control'") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val theirDetective = driver.putCreatureOnBattlefield(opponent, "Test Detective")
+        enchant(driver, active, theirDetective)
+
+        withClue("it is a Detective, but not one the Aura's controller controls") {
+            projector.getProjectedPower(driver.state, theirDetective) shouldBe 1
+            projector.getProjectedToughness(driver.state, theirDetective) shouldBe 1
+        }
+    }
+
+    test("the enchanted non-Detective can't block a Detective, but can block anything else") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val attackingDetective = driver.putCreatureOnBattlefield(active, "Test Detective")
+        driver.removeSummoningSickness(attackingDetective)
+        val attackingBears = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+        driver.removeSummoningSickness(attackingBears)
+
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        enchant(driver, active, blocker)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(attackingDetective, attackingBears), opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        withClue("the restriction names Detectives specifically") {
+            driver.declareBlockers(opponent, mapOf(blocker to listOf(attackingDetective))).error shouldNotBe null
+        }
+        withClue("a non-Detective attacker is still blockable — it isn't a blanket can't-block") {
+            driver.declareBlockers(opponent, mapOf(blocker to listOf(attackingBears))).error shouldBe null
+        }
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ConnectingTheDotsScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ConnectingTheDotsScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.ConnectingTheDots
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Connecting the Dots — "Whenever a creature you control attacks, exile the top card of your
+ * library face down. … {1}{R}, Discard your hand, Sacrifice this enchantment: Put all cards exiled
+ * with this enchantment into their owners' hands."
+ *
+ * The two halves only work if they agree on *which* pile: the trigger stamps `linkToSource` and the
+ * activated ability reads that same linked pile back. A round trip is the only assertion that
+ * catches a mismatch — an exile that isn't linked looks perfectly correct until the payoff returns
+ * nothing.
+ *
+ * The trigger is per-attacker, so the second test attacks with two creatures and expects two cards
+ * exiled. Wiring it to the once-per-declaration `YouAttack` event instead would pass the first test
+ * and fail only here.
+ */
+class ConnectingTheDotsScenarioTest : FunSpec({
+
+    val cashInAbility = ConnectingTheDots.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ConnectingTheDots)
+        return driver
+    }
+
+    test("attacking exiles the top card, and the payoff returns exactly that card to hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val dots = driver.putPermanentOnBattlefield(active, "Connecting the Dots")
+        val attacker = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+        driver.removeSummoningSickness(attacker)
+        driver.putCardOnTopOfLibrary(active, "Serra Angel")
+
+        val exileBefore = driver.getExile(active).size
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(attacker), opponent).error shouldBe null
+        driver.bothPass() // resolve the attack trigger
+
+        withClue("one attacker, one card off the top into exile") {
+            driver.getExile(active).size shouldBe exileBefore + 1
+            driver.getExileCardNames(active) shouldContain "Serra Angel"
+        }
+
+        // Cash in. The cost discards the opening hand, so whatever is left is what the ability put there.
+        driver.giveMana(active, Color.RED, 2)
+        driver.submitSuccess(ActivateAbility(active, dots, cashInAbility))
+        driver.bothPass() // resolve the ability
+
+        withClue("the linked pile — and only it — comes back to hand") {
+            driver.getHand(active).map { driver.getCardName(it) } shouldBe listOf("Serra Angel")
+        }
+        withClue("the enchantment was sacrificed as part of the cost") {
+            driver.getPermanents(active) shouldNotContain dots
+        }
+    }
+
+    test("the trigger is per attacker — two attackers exile two cards") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(active, "Connecting the Dots")
+        val first = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+        val second = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+        driver.removeSummoningSickness(first)
+        driver.removeSummoningSickness(second)
+
+        val exileBefore = driver.getExile(active).size
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(first, second), opponent).error shouldBe null
+        driver.bothPass() // resolve the first trigger
+        driver.bothPass() // resolve the second
+
+        withClue("'whenever a creature you control attacks' fires once per attacker (CR 603.2c)") {
+            driver.getExile(active).size shouldBe exileBefore + 2
+        }
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PompousGadaboutScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PompousGadaboutScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.PompousGadabout
+import com.wingedsheep.mtg.sets.definitions.scg.cards.ZombieCutthroat
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Pompous Gadabout — "During your turn, this creature has hexproof. This creature can't be blocked
+ * by creatures that don't have a name."
+ *
+ * The second line is the one worth pinning down, because "creatures that don't have a name" has no
+ * literal spelling in the SDK: it is modeled as the face-down set (CR 708.2, and the card's own
+ * ruling — *"Face-down creatures don't have names unless an effect says otherwise"*). A filter that
+ * silently matched *every* creature would make the Gadabout unblockable and every test that only
+ * checked the face-down case would still pass, so both directions are asserted here: the face-down
+ * blocker is rejected and the face-up one is accepted, in the same combat.
+ *
+ * The hexproof half is a conditional static, so the interesting assertion is the turn it is *not*
+ * active — a `GrantKeyword` wired without its condition looks identical on your own turn.
+ */
+class PompousGadaboutScenarioTest : FunSpec({
+
+    val allCards = TestCards.all + listOf(PompousGadabout, ZombieCutthroat)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(allCards)
+        return driver
+    }
+
+    /** A face-down (hence nameless) creature on [playerId]'s battlefield, ready to block. */
+    fun GameTestDriver.putFaceDownCreature(playerId: EntityId, cardName: String): EntityId {
+        val creatureId = putCreatureOnBattlefield(playerId, cardName)
+        val cardDef = allCards.first { it.name == cardName }
+        val morphAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Morph>().firstOrNull()
+        replaceState(
+            state.updateEntity(creatureId) { container ->
+                var c = container.with(FaceDownComponent)
+                if (morphAbility != null) {
+                    c = c.with(MorphDataComponent(morphAbility.morphCost, cardDef.name))
+                }
+                c
+            }
+        )
+        removeSummoningSickness(creatureId)
+        return creatureId
+    }
+
+    test("a face-down creature can't block it, but a face-up one can") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40, "Swamp" to 40), skipMulligans = true)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gadabout = driver.putCreatureOnBattlefield(active, "Pompous Gadabout")
+        driver.removeSummoningSickness(gadabout)
+
+        val nameless = driver.putFaceDownCreature(opponent, "Zombie Cutthroat")
+        val named = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(gadabout), opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        withClue("a face-down creature has no name, so it can't block the Gadabout") {
+            driver.declareBlockers(opponent, mapOf(nameless to listOf(gadabout))).error shouldNotBe null
+        }
+        withClue("a face-up creature has a name and blocks normally — the filter isn't 'any creature'") {
+            driver.declareBlockers(opponent, mapOf(named to listOf(gadabout))).error shouldBe null
+        }
+    }
+
+    test("hexproof is present on your turn and gone on the opponent's") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gadabout = driver.putCreatureOnBattlefield(active, "Pompous Gadabout")
+
+        withClue("during its controller's turn the conditional static grants hexproof") {
+            driver.state.projectedState.hasKeyword(gadabout, Keyword.HEXPROOF) shouldBe true
+        }
+
+        // Roll into the next turn — the next upkeep belongs to the opponent.
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.activePlayer shouldNotBe active
+
+        withClue("on anyone else's turn the condition is false and the keyword is simply absent") {
+            driver.state.projectedState.hasKeyword(gadabout, Keyword.HEXPROOF) shouldBe false
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -1917,6 +1917,199 @@
     ]
 }
 
+// Burden of Proof
+{
+    "name": "Burden of Proof",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash\nEnchant creature\nEnchanted creature gets +2/+2 as long as it's a Detective you control. Otherwise, it has base power and toughness 1/1 and can't block Detectives.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "EnchantedPermanent",
+                    "filter": "creature Detective ctrl:you"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "SetBasePowerToughnessStatic",
+                    "power": 1,
+                    "toughness": 1
+                },
+                "condition": {
+                    "type": "Not",
+                    "condition": {
+                        "type": "EntityMatches",
+                        "entity": "EnchantedPermanent",
+                        "filter": "creature Detective ctrl:you"
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "CanOnlyBlockCreaturesWith",
+                    "blockerFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotSubtype",
+                                "subtype": "Detective"
+                            }
+                        ]
+                    },
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "AttachedTo"
+                    }
+                },
+                "condition": {
+                    "type": "Not",
+                    "condition": {
+                        "type": "EntityMatches",
+                        "entity": "EnchantedPermanent",
+                        "filter": "creature Detective ctrl:you"
+                    }
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "rarity": "UNCOMMON",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "\"You must have known all those lies would catch up to you eventually.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4ea29c34-4b55-4170-9120-0a8dda61f2eb.jpg?1783912915",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Once a Detective has been blocked, attaching Burden of Proof to a creature blocking it won't cause that Detective to become unblocked."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Buried in the Garden
+{
+    "name": "Buried in the Garden",
+    "manaCost": "{2}{G}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant land\nWhen this Aura enters, exile target nonland permanent you don't control until this Aura leaves the battlefield.\nWhenever enchanted land is tapped for mana, its controller adds an additional one mana of any color.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ExileUntilLeaves",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "exiled"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "nonland permanent ctrl:opponent"
+                    },
+                    "id": "exiled"
+                },
+                "descriptionOverride": "When this Aura enters, exile target nonland permanent you don't control until this Aura leaves the battlefield."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "AdditionalManaOnTap",
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "anyColor": true
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "land"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "191",
+        "rarity": "UNCOMMON",
+        "artist": "Tom Babbey",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e144609-e1f6-4bdc-8d14-b735ef4140d3.jpg?1783912854",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If Buried in the Garden leaves the battlefield before its first triggered ability resolves, the target permanent won't be exiled."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Auras attached to the exiled permanent will be put into their owners' graveyards. Any Equipment will become unattached and remain on the battlefield. Any counters on the exiled permanent will cease to exist. When the card returns to the battlefield, it will be a new object with no connection to the card that was exiled."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a token is exiled this way, it will cease to exist and won't return to the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Call a Surprise Witness
 {
     "name": "Call a Surprise Witness",
@@ -2691,6 +2884,115 @@
             {
                 "date": "2024-02-02",
                 "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Connecting the Dots
+{
+    "name": "Connecting the Dots",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a creature you control attacks, exile the top card of your library face down. (You can't look at it.)\n{1}{R}, Discard your hand, Sacrifice this enchantment: Put all cards exiled with this enchantment into their owners' hands.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "filter": "creature ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "clue"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "clue",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true,
+                            "faceDown": "HIDDEN"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever a creature you control attacks, exile the top card of your library face down."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
+                        },
+                        "CostDiscardHand",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return_hand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return_hand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Put all cards exiled with this enchantment into their owners' hands."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "rarity": "RARE",
+        "artist": "Aaron J. Riley",
+        "flavorText": "\"How could I have missed it? The answer was right in front of me all along!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8e02731a-8698-4b41-99c3-f0a19fc31430.jpg?1783912884",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Each Connecting the Dots you control has its own set of face-down exiled cards. Connecting the Dots's last ability puts only those cards into your hand, not those of any other Connecting the Dots."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If Connecting the Dots leaves the battlefield before you activate its last ability, any cards exiled by its triggered ability remain exiled face down for the rest of the game."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "You can pay the cost of \"discard your hand\" even if your hand contains zero cards."
             }
         ]
     },
@@ -5172,6 +5474,71 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Forensic Gadgeteer
+{
+    "name": "Forensic Gadgeteer",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Vedalken Artificer Detective",
+    "oracleText": "Whenever you cast an artifact spell, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\nActivated abilities of artifacts you control cost {1} less to activate. This effect can't reduce the mana in that cost to less than one mana.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsArtifact"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                },
+                "descriptionOverride": "Whenever you cast an artifact spell, investigate."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ReduceActivatedAbilityCost",
+                "filter": {
+                    "baseFilter": "artifact ctrl:you"
+                },
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "manaFloor": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "rarity": "RARE",
+        "artist": "Volkan Baǵa",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/97d08a15-e61c-4421-a541-c68a4f87cb74.jpg?1783912910",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Triggered abilities (starting with \"when,\" \"whenever,\" or \"at\") are unaffected by the cost reduction ability of Forensic Gadgeteer."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Forensic Gadgeteer's last ability affects only abilities of artifacts you control on the battlefield. The costs of activated abilities of artifact cards that work in other zones, such as cycling, won't be reduced."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -9809,6 +10176,65 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Pompous Gadabout
+{
+    "name": "Pompous Gadabout",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Citizen",
+    "oracleText": "During your turn, this creature has hexproof.\nThis creature can't be blocked by creatures that don't have a name.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HEXPROOF",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "IsYourTurn"
+            },
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature"
+                    ],
+                    "statePredicates": [
+                        "IsFaceDown"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "UNCOMMON",
+        "artist": "Scott Murphy",
+        "flavorText": "\"Stand aside, nobodies.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6d803b93-c1df-4a02-9dbb-d347c841d4d7.jpg?1783912863",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Face-down creatures don't have names unless an effect says otherwise."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Once Pompous Gadabout has been blocked by a creature, turning that creature face down or otherwise causing it to lose its name won't cause it to stop blocking Pompous Gadabout."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 


### PR DESCRIPTION
Five Murders at Karlov Manor cards, all built from existing SDK vocabulary — no new effects, executors, conditions, or keywords. MKM is the earliest real expansion printing for all five (promo `pmkm` and masterpiece `otp` skipped), so each gets a canonical `card(...)` here.

| Card | Cost | Composed from |
|---|---|---|
| **Forensic Gadgeteer** | `{2}{U}` | `Triggers.youCastSpell(Artifact)` + `Effects.Investigate()`; `ReduceActivatedAbilityCost` over artifacts you control with `manaFloor = 1` |
| **Burden of Proof** | `{1}{U}` | one `Conditions.EnchantedPermanentMatches` + its negation driving `ModifyStats`, `SetBasePowerToughnessStatic`, `CanOnlyBlockCreaturesWith` |
| **Connecting the Dots** | `{1}{R}` | `Triggers.attacks(Creature.youControl(), ANY)` → gather/move with `FaceDownMode.HIDDEN` + `linkToSource`; `Costs.DiscardHand` + `Costs.SacrificeSelf` → `Effects.ReturnLinkedExileToHand()` |
| **Pompous Gadabout** | `{2}{G}` | `GrantKeyword(HEXPROOF)` under `Conditions.IsYourTurn`; `CantBeBlockedBy(Creature.faceDown())` |
| **Buried in the Garden** | `{2}{G}{W}` | `ExileUntilLeaves` / `ReturnLinkedExileUnderOwnersControl` (Banishing Light family) + `AdditionalManaOnTap(anyColor = true)` (Fertile Ground) |

### The two modelling decisions worth a reviewer's eye

**"Creatures that don't have a name"** (Pompous Gadabout) has no literal spelling in the SDK, so it is modelled as the face-down set. CR 708.2 gives a face-down permanent no name, and the card's own ruling states it: *"Face-down creatures don't have names unless an effect says otherwise."* In an MKM context that is precisely the disguised and cloaked creatures the design is aimed at. The mtgish draft rendered this as a bare `CantBeBlockedBy(GameObjectFilter.Creature)` — it dropped the constraint and would have made the Gadabout unblockable, so the scenario test asserts *both* directions in one combat.

**"Can't block Detectives"** (Burden of Proof) is written as its complement, `CanOnlyBlockCreaturesWith(Creature.notSubtype(DETECTIVE))`. Every creature is either a Detective or not, so the two are the same restriction — and this shape scopes it to the enchanted creature, where the oracle text puts it, instead of turning it into a property of every Detective on the battlefield.

### Cards considered and dropped

Triaged the other 71 missing MKM cards for primitives first; these needed engine work and are not in scope here:

- **Slime Against Humanity** — no name filter or exile+graveyard zone-count `DynamicAmount`.
- **Cease // Desist**, **Push // Pull** — need a "from a single graveyard" cross-target constraint.
- **Delney, Streetwise Lookout** — needs trigger doubling.
- Every **Case of the …** — the "to solve" mechanic doesn't exist at all.

### Tests

Three scenario tests, one file per card, for the cards whose wiring could silently be wrong:

- `PompousGadaboutScenarioTest` — face-down blocker rejected *and* face-up blocker accepted in the same combat; hexproof present on your turn, absent on the opponent's.
- `BurdenOfProofScenarioTest` — all three ways the condition resolves, including an opponent's Detective (the case separating `Detective` from `Detective you control`); plus the block restriction against a real declaration, not a projected flag.
- `ConnectingTheDotsScenarioTest` — the full linked-exile round trip (an exile that isn't linked looks correct until the payoff returns nothing), and that the trigger fires per attacker.

Forensic Gadgeteer and Buried in the Garden ride the snapshot: their card-specific choices (`manaFloor = 1`, `anyColor = true`, which filter) are visible in the golden, and the primitives themselves are already pinned by `PowerArtifactScenarioTest` and `FertileGroundAnyColorAffordabilityTest`.

### Verification

- `just build` — green.
- `just test-class` on all three new scenario tests — 8/8 passing.
- `just rebless-cards` — MKM golden is insertions only; no existing card moved.
- `just check-card-printing` — ok for all five.
- Every mechanical field (name, mana cost, type line, oracle text, P/T, rarity, collector number, artist, flavor, image URI) re-verified field-by-field against the Scryfall MKM printing: all match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
