### PR TITLE
Add two Mirrodin cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/PlatinumAngelReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/PlatinumAngelReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.`10e`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Platinum Angel reprint in 10E. Canonical CardDefinition lives in Mirrodin (its earliest real
+ * printing), `com.wingedsheep.mtg.sets.definitions.mrd.cards.PlatinumAngel`.
+ */
+val PlatinumAngel10eReprint = Printing(
+    oracleId = "b148578c-c0bf-4785-b97c-4b6f83028008",
+    name = "Platinum Angel",
+    setCode = "10E",
+    collectorNumber = "339",
+    scryfallId = "698f66ac-dae6-4b42-ae6f-d468b69b25be",
+    artist = "Brom",
+    imageUri = "https://cards.scryfall.io/normal/front/6/9/698f66ac-dae6-4b42-ae6f-d468b69b25be.jpg?1783942980",
+    releaseDate = "2007-07-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/PlatinumAngel.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/PlatinumAngel.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantCantLoseGame
+import com.wingedsheep.sdk.scripting.GrantOpponentsCantWinGame
+
+/**
+ * Platinum Angel — Mirrodin #228
+ * {7} · Artifact Creature — Angel · 4/4 · Rare
+ *
+ * Flying
+ * You can't lose the game and your opponents can't win the game.
+ *
+ * The printed sentence is two independent restrictions, so it is two static abilities — the same
+ * pair Herald of Eternal Dawn (FDN) and Lich's Mastery (DOM) use. [GrantCantLoseGame] suppresses
+ * every loss condition for the controller (0-or-less life, poison, drawing from an empty library,
+ * and "you lose the game" effects), while [GrantOpponentsCantWinGame] makes any effect that would
+ * hand an opponent the win do nothing at all.
+ *
+ * Both are anchored to the permanent, so the lock ends the instant the Angel leaves the battlefield
+ * — a player at -20 life loses to the state-based action on the very next check.
+ */
+val PlatinumAngel = card("Platinum Angel") {
+    manaCost = "{7}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Angel"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "You can't lose the game and your opponents can't win the game."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = GrantCantLoseGame
+    }
+    staticAbility {
+        ability = GrantOpponentsCantWinGame
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "228"
+        artist = "Brom"
+        flavorText = "In its heart lies the secret of immortality."
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/59bb5aee-b334-4c24-875b-56751d4add02.jpg?1783944508"
+
+        ruling(
+            "2009-10-01",
+            "No game effect can cause you to lose the game or cause any opponent to win the game " +
+                "while you control Platinum Angel. It doesn't matter whether you have 0 or less life, " +
+                "you're forced to draw a card while your library is empty, or you have ten or more " +
+                "poison counters. You keep playing."
+        )
+        ruling(
+            "2004-12-01",
+            "Effects that say the game is a draw are not affected by Platinum Angel. They'll still work."
+        )
+        ruling(
+            "2004-12-01",
+            "You can concede a game while Platinum Angel is on the battlefield. A concession causes " +
+                "you to leave the game, which then causes you to lose the game."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SecondSunrise.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SecondSunrise.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Second Sunrise — Mirrodin #20
+ * {1}{W}{W} · Instant · Rare
+ *
+ * Each player returns to the battlefield all artifact, creature, enchantment, and land cards in
+ * their graveyard that were put there from the battlefield this turn.
+ *
+ * One Gather → Move pipeline over `Player.Each` (the same all-graveyards sweep Rise of the Dark
+ * Realms uses), with two details that carry the card's whole meaning:
+ *
+ *  - **`putIntoGraveyardFromBattlefieldThisTurn()`** is the "put there from the battlefield this
+ *    turn" clause. The predicate reads the per-card `PutIntoGraveyardThisTurnComponent` that
+ *    `ZoneTransitionService` stamps on every graveyard arrival and strips when the card leaves, so a
+ *    creature milled this turn — or one that died two turns ago — is correctly skipped. The
+ *    component is wiped at each untap step, which is what makes it per-turn.
+ *  - **`underOwnersControl = true`** is "*each player* returns … in *their* graveyard". Unlike a
+ *    reanimation spell, Second Sunrise hands nothing to its caster: every card comes back under its
+ *    own owner's control (CR 610.3c), including the opponents' dead.
+ *
+ * The type list is spelled out as an explicit union rather than `GameObjectFilter.Permanent`
+ * because the printed text names exactly four types — a planeswalker or battle card that hit the
+ * graveyard from the battlefield this turn stays there.
+ */
+val SecondSunrise = card("Second Sunrise") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Each player returns to the battlefield all artifact, creature, enchantment, and " +
+        "land cards in their graveyard that were put there from the battlefield this turn."
+
+    spell {
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.GRAVEYARD,
+                        player = Player.Each,
+                        filter = (
+                            GameObjectFilter.Artifact or
+                                GameObjectFilter.Creature or
+                                GameObjectFilter.Enchantment or
+                                GameObjectFilter.Land
+                            ).putIntoGraveyardFromBattlefieldThisTurn()
+                    ),
+                    storeAs = "returningCards"
+                ),
+                MoveCollectionEffect(
+                    from = "returningCards",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                    underOwnersControl = true
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "20"
+        artist = "Greg Staples"
+        flavorText = "The bright tunnel sometimes leads back to life."
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4e50ee7c-f2a2-4d49-a1cc-8233fd8dd0c5.jpg?1783944558"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PlatinumAngelScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PlatinumAngelScenarioTest.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Platinum Angel (MRD #228) — {7} 4/4 Artifact Creature — Angel.
+ *
+ * "Flying
+ *  You can't lose the game and your opponents can't win the game."
+ *
+ * Both halves are pinned, plus the thing neither static says out loud: the lock is anchored to the
+ * permanent, so it ends the moment the Angel does. A card that only ever tested the "still alive at
+ * -5" case would pass just as well if the grant had been made permanent.
+ */
+class PlatinumAngelScenarioTest : FunSpec({
+
+    // Instants, so the non-active player can cast them while holding priority.
+    val angelTestVictory = card("Angel Test Instant Victory") {
+        manaCost = "{1}"
+        typeLine = "Instant"
+        oracleText = "You win the game."
+        spell { effect = Effects.WinGame(EffectTarget.Controller) }
+    }
+
+    val angelTestLoseTen = card("Angel Test Lifeloss Ten") {
+        manaCost = "{1}"
+        typeLine = "Instant"
+        oracleText = "You lose 10 life."
+        spell { effect = Effects.LoseLife(10, EffectTarget.Controller) }
+    }
+
+    fun driver(startingLife: Int = 20): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(angelTestVictory, angelTestLoseTen))
+        d.initMirrorMatch(
+            deck = Deck.of("Plains" to 30),
+            skipMulligans = true,
+            startingLife = startingLife,
+        )
+        return d
+    }
+
+    fun GameTestDriver.settle() {
+        var guard = 0
+        while (!state.gameOver && state.stack.isNotEmpty() && guard++ < 20) bothPass()
+    }
+
+    fun GameTestDriver.castCheap(player: EntityId, cardName: String) {
+        val holder = state.priorityPlayerId
+        if (holder != null && holder != player) passPriority(holder)
+
+        val spell = putCardInHand(player, cardName)
+        giveColorlessMana(player, 1)
+        castSpell(player, spell).isSuccess shouldBe true
+        settle()
+    }
+
+    test("controller doesn't lose the game at 0 or less life") {
+        val d = driver(startingLife = 5)
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.putCreatureOnBattlefield(p1, "Platinum Angel")
+
+        d.castCheap(p1, "Angel Test Lifeloss Ten")
+
+        d.getLifeTotal(p1) shouldBe -5
+        d.state.gameOver.shouldBeFalse()
+    }
+
+    // The grant lives on the permanent, not on the player: once the Angel is destroyed the
+    // life-total state-based action catches up on the very next check. Platinum Angel is an
+    // *artifact* creature, so Shatter is legal removal for it.
+    test("the loss lands as soon as the Angel leaves the battlefield") {
+        val d = driver(startingLife = 5)
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val angel = d.putCreatureOnBattlefield(p1, "Platinum Angel")
+
+        d.castCheap(p1, "Angel Test Lifeloss Ten")
+        d.getLifeTotal(p1) shouldBe -5
+        d.state.gameOver.shouldBeFalse()
+
+        val holder = d.state.priorityPlayerId
+        if (holder != null && holder != p2) d.passPriority(holder)
+        val shatter = d.putCardInHand(p2, "Shatter")
+        d.giveMana(p2, Color.RED, 2)
+        d.castSpellWithTargets(p2, shatter, listOf(ChosenTarget.Permanent(angel))).isSuccess shouldBe true
+        d.settle()
+
+        d.state.gameOver.shouldBeTrue()
+        d.state.winnerId shouldBe p2
+    }
+
+    test("an opponent's 'you win the game' effect does nothing") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.putCreatureOnBattlefield(p1, "Platinum Angel")
+
+        d.castCheap(p2, "Angel Test Instant Victory")
+
+        // Fizzled outright — nobody won, nobody lost, the game goes on.
+        d.state.gameOver.shouldBeFalse()
+        d.state.winnerId shouldBe null
+    }
+
+    test("without the Angel, the same win effect ends the game") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.castCheap(p2, "Angel Test Instant Victory")
+
+        d.state.gameOver.shouldBeTrue()
+        d.state.winnerId shouldBe p2
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SecondSunriseScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SecondSunriseScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Second Sunrise (MRD #20) — {1}{W}{W} Instant.
+ *
+ * "Each player returns to the battlefield all artifact, creature, enchantment, and land cards in
+ *  their graveyard that were put there from the battlefield this turn."
+ *
+ * Two clauses carry the card and each has a way of silently doing nothing, so each gets its own
+ * assertion:
+ *
+ *  - *each player … their graveyard* — the opponent's dead come back too, and they come back on the
+ *    **opponent's** side. A gather scoped to the caster, or a move that forgot `underOwnersControl`,
+ *    would look almost right: the caster's own creature returns either way.
+ *  - *put there from the battlefield this turn* — a creature card sitting in a graveyard for any
+ *    other reason stays there. Drop the predicate and this reads as a mass reanimation spell.
+ */
+class SecondSunriseScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 30))
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.settle() {
+        var guard = 0
+        while (!state.gameOver && state.stack.isNotEmpty() && guard++ < 20) bothPass()
+    }
+
+    /** Pyroclasm wipes both 2/2s off the battlefield in one resolution, with no decisions. */
+    fun GameTestDriver.wipeBoard(caster: com.wingedsheep.sdk.model.EntityId) {
+        val pyroclasm = putCardInHand(caster, "Pyroclasm")
+        giveMana(caster, Color.RED, 2)
+        castSpell(caster, pyroclasm).isSuccess shouldBe true
+        settle()
+    }
+
+    fun GameTestDriver.castSecondSunrise(caster: com.wingedsheep.sdk.model.EntityId) {
+        val sunrise = putCardInHand(caster, "Second Sunrise")
+        giveMana(caster, Color.WHITE, 3)
+        castSpell(caster, sunrise).isSuccess shouldBe true
+        settle()
+    }
+
+    test("both players' creatures return, each under its own owner's control") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+
+        d.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        d.putCreatureOnBattlefield(p2, "Grizzly Bears")
+
+        d.wipeBoard(p1)
+        d.getGraveyardCardNames(p1) shouldContain "Grizzly Bears"
+        d.getGraveyardCardNames(p2) shouldContain "Grizzly Bears"
+
+        d.castSecondSunrise(p1)
+
+        // Back on the battlefield — and the opponent's is on the opponent's side, not the caster's.
+        d.findPermanent(p1, "Grizzly Bears").shouldNotBeNull()
+        d.findPermanent(p2, "Grizzly Bears").shouldNotBeNull()
+        d.getGraveyardCardNames(p1) shouldNotContain "Grizzly Bears"
+        d.getGraveyardCardNames(p2) shouldNotContain "Grizzly Bears"
+    }
+
+    test("a creature card that reached the graveyard some other way stays there") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+
+        d.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        // Never on the battlefield — a discard or a mill, as far as the graveyard is concerned.
+        d.putCardInGraveyard(p1, "Centaur Courser")
+
+        d.wipeBoard(p1)
+        d.castSecondSunrise(p1)
+
+        d.findPermanent(p1, "Grizzly Bears").shouldNotBeNull()
+        d.getGraveyardCardNames(p1) shouldContain "Centaur Courser"
+        d.findPermanent(p1, "Centaur Courser") shouldBe null
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/PlatinumAngelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/PlatinumAngelReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Platinum Angel reprint in M10. Canonical CardDefinition lives in Mirrodin (its earliest real
+ * printing), `com.wingedsheep.mtg.sets.definitions.mrd.cards.PlatinumAngel`.
+ */
+val PlatinumAngelM10Reprint = Printing(
+    oracleId = "b148578c-c0bf-4785-b97c-4b6f83028008",
+    name = "Platinum Angel",
+    setCode = "M10",
+    collectorNumber = "218",
+    scryfallId = "7b782865-b9d1-41ed-8a7b-a36c17022190",
+    artist = "Brom",
+    imageUri = "https://cards.scryfall.io/normal/front/7/b/7b782865-b9d1-41ed-8a7b-a36c17022190.jpg?1783942354",
+    releaseDate = "2009-07-17",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/PlatinumAngelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/PlatinumAngelReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Platinum Angel reprint in M11. Canonical CardDefinition lives in Mirrodin (its earliest real
+ * printing), `com.wingedsheep.mtg.sets.definitions.mrd.cards.PlatinumAngel`.
+ */
+val PlatinumAngelM11Reprint = Printing(
+    oracleId = "b148578c-c0bf-4785-b97c-4b6f83028008",
+    name = "Platinum Angel",
+    setCode = "M11",
+    collectorNumber = "212",
+    scryfallId = "a9a561bf-bddc-4ea7-bf71-9cdc07a71456",
+    artist = "Brom",
+    imageUri = "https://cards.scryfall.io/normal/front/a/9/a9a561bf-bddc-4ea7-bf71-9cdc07a71456.jpg?1783941789",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -7769,6 +7769,75 @@
     ]
 }
 
+// Second Sunrise
+{
+    "name": "Second Sunrise",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Each player returns to the battlefield all artifact, creature, enchantment, and land cards in their graveyard that were put there from the battlefield this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Graveyard",
+                        "player": "Each",
+                        "filter": {
+                            "cardPredicates": [
+                                {
+                                    "type": "Or",
+                                    "predicates": [
+                                        {
+                                            "type": "Or",
+                                            "predicates": [
+                                                {
+                                                    "type": "Or",
+                                                    "predicates": [
+                                                        "IsArtifact",
+                                                        "IsCreature"
+                                                    ]
+                                                },
+                                                "IsEnchantment"
+                                            ]
+                                        },
+                                        "IsLand"
+                                    ]
+                                }
+                            ],
+                            "statePredicates": [
+                                "PutIntoGraveyardFromBattlefieldThisTurn"
+                            ]
+                        }
+                    },
+                    "storeAs": "returningCards"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "returningCards",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    },
+                    "underOwnersControl": true
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "rarity": "RARE",
+        "artist": "Greg Staples",
+        "flavorText": "The bright tunnel sometimes leads back to life.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4e50ee7c-f2a2-4d49-a1cc-8233fd8dd0c5.jpg?1783944558"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Seething Song
 {
     "name": "Seething Song",

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -6776,6 +6776,49 @@
     ]
 }
 
+// Platinum Angel
+{
+    "name": "Platinum Angel",
+    "manaCost": "{7}",
+    "typeLine": "Artifact Creature — Angel",
+    "oracleText": "Flying\nYou can't lose the game and your opponents can't win the game.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            "GrantCantLoseGame",
+            "GrantOpponentsCantWinGame"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "rarity": "RARE",
+        "artist": "Brom",
+        "flavorText": "In its heart lies the secret of immortality.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/59bb5aee-b334-4c24-875b-56751d4add02.jpg?1783944508",
+        "rulings": [
+            {
+                "date": "2009-10-01",
+                "text": "No game effect can cause you to lose the game or cause any opponent to win the game while you control Platinum Angel. It doesn't matter whether you have 0 or less life, you're forced to draw a card while your library is empty, or you have ten or more poison counters. You keep playing."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "Effects that say the game is a draw are not affected by Platinum Angel. They'll still work."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "You can concede a game while Platinum Angel is on the battlefield. A concession causes you to leave the game, which then causes you to lose the game."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Power Conduit
 {
     "name": "Power Conduit",


### PR DESCRIPTION
Two cards from Mirrodin's missing list, both built entirely from existing SDK primitives — no engine or SDK changes.

## Cards

**Platinum Angel** (#228) — `{7}` 4/4 Artifact Creature — Angel. Flying; "You can't lose the game and your opponents can't win the game."
The printed sentence is two independent restrictions, so it is two static abilities: `GrantCantLoseGame` + `GrantOpponentsCantWinGame`, the pair Herald of Eternal Dawn (FDN) and Lich's Mastery (DOM) already use. `Printing(...)` rows added for the 10E, M10 and M11 reprints, whose sets are already scaffolded.

**Second Sunrise** (#20) — `{1}{W}{W}` Instant. "Each player returns to the battlefield all artifact, creature, enchantment, and land cards in their graveyard that were put there from the battlefield this turn."
One Gather → Move pipeline over `Player.Each` (the all-graveyards sweep Rise of the Dark Realms uses), plus the two riders that carry the card's meaning: `putIntoGraveyardFromBattlefieldThisTurn()` for the timing clause, and `underOwnersControl = true` so every card returns on its own owner's side rather than the caster's. The four card types are spelled out as an explicit union rather than `GameObjectFilter.Permanent`, so a planeswalker or battle card stays dead.

## Tests

Both cards get their own scenario test even though neither adds vocabulary — each composition has a way of silently doing nothing, and a snapshot diff wouldn't catch it.

- `PlatinumAngelScenarioTest` — survives at −5 life; an opponent's "you win the game" fizzles; the same effect ends the game without the Angel; and the loss lands the moment Shatter kills the Angel (the grant is anchored to the permanent, not the player).
- `SecondSunriseScenarioTest` — both players' Pyroclasm'd creatures return, each on its own owner's side; a creature card that reached the graveyard another way stays there.

## Cards evaluated and dropped

Mirrodin's 64-card tail is mostly blocked on mechanics the engine doesn't have. Each of these was checked against the SDK and left out because it needs new vocabulary, which `AGENTS.md` requires be its own PR:

| Card | Blocker |
|---|---|
| Dream's Grip, Blinding Beam, Roar of the Kha, Wail of the Nim, Journey of Discovery, Betrayal of Flesh, Incite War, Solar Tide, One Dozen Eyes, Promise of Power, Temporal Cascade, Tooth and Nail, Grab the Reins | **Entwine** is unimplemented — no `Keyword.ENTWINE` anywhere in `mtg-sdk` or `rules-engine` |
| Duplicant, Mirror Golem, Chrome Mox, Extraplanar Lens, Isochron Scepter, Soul Foundry, Spellweaver Helix, Thought Prison, Mourner's Shield | **Imprint** — no linked-imprint vocabulary; each also needs a distinct payoff (`SetPower`/`SetToughness`, dynamic protection, cast-a-copy) |
| **Mesmeric Orb** | Needs a `Player` reference for "controller of the triggering entity". `Patterns.Library.mill(count, target)` maps `EffectTarget` → `Player` through a `when` whose `else` is `Player.You`, and `UntapEvent`'s `TriggerContext` stamps only `triggeringEntityId`, so `Player.TriggeringPlayer` resolves to the permanent, not its controller. Everything else about it works — `Triggers.becomesUntapped(binding = ANY)` fires per permanent including untap-step untaps. Closest to shippable of the lot. |
| **Arc-Slogger** | Cost is "exile the top ten cards of your library". `CostAtom` has `Mill(count)` (graveyard) and `ExileFrom(zone, filter, count)` (a *selection*, wrong for a hidden zone) but no exile-top-N atom. |
| **Awe Strike** | Needs next-instance-only source-side prevention plus "gain life equal to the damage prevented". `PreventDamageExecutor`'s `FromTarget` + `amount = null` branch produces `PreventAllDamageDealtBy` (all damage, all turn) and never reads `nextInstanceOnly` or fires `onPrevented`. |
| **Hum of the Radix** | "costs {1} more for each artifact **its controller** controls" — `CostModification` has no `IncreaseGenericBy(source)`, and every `CostReductionSource` count is scoped to the *static's* controller, not the caster's. |
| **Lightning Coils** | "**Exile** them at the beginning of the next end step" — `CreateToken` has `sacrificeAtStep`, not an exile equivalent, and sacrifice vs exile differ observably (dies triggers). |
| Culling Scales | No "lowest mana value" filter. |
| Myr Prototype | No "can't attack or block unless you pay {N}" tax static. |
| Psychogenic Probe | No shuffle trigger. |
| Blinkmoth Urn, Gate to the Aether | "each player's main phase … **that player** adds/reveals" — `AddMana` and the reveal pipelines have no recipient other than the ability's controller. |
| Brown Ouphe | No counter-target-activated-ability. |
| Oblivion Stone | Needs a `FATE` `CounterType` enum entry (load-bearing — `CounterTypeFilter.Named` fails open to +1/+1). |
| Fiery Gambit, Krark's Thumb, Liar's Pendulum | Coin flips. |
| Fractured Loyalty | `BecomesTarget` is SELF-bound; also needs control-gain to the triggering spell's controller. |

## Verification

- `just build` — green (full compile + all module tests)
- `just test-class PlatinumAngelScenarioTest` — 4/4 pass
- `just test-class SecondSunriseScenarioTest` — 2/2 pass
- `just rebless-cards` — `MRD.json` diff is two additions, only these cards
- `just check-card-printing` — clean for both

🤖 Generated with [Claude Code](https://claude.com/claude-code)
