### PR TITLE
Make CostAtom.excludeSelf the one candidate rule on every payment path

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -724,8 +724,12 @@ preview — in the turn-face-up handler.)
   the source excluded.
 
 The word **"another"** is the only thing that decides self-exclusion, and it lives on the cost atom
-(`excludeSelf`). Both `PayOrSufferExecutor` and `CostPaymentService` read that flag; neither applies
-a blanket exclusion.
+(`excludeSelf`). Every path that asks "which objects could pay this?" reads that flag and nothing
+else — `PayOrSufferExecutor`, `AnyPlayerMayPayExecutor` (and the continuation that asks the next
+player), `CostHandler`, both enumerators, and `CostPaymentService.selectionCandidates`, the single
+candidate-domain helper behind the last one's affordability *and* prompt. None of them applies a
+blanket exclusion: a self-inclusive cost stays payable on a board holding only the source, and a
+self-exclusive one is never offered the source in the first place.
 - `Costs.pay.Choice(options)` — present several `PayCost`s; player picks one (or the suffer effect).
   Unaffordable options are hidden. "...unless they sacrifice a nonland permanent or discard a card."
 - `Costs.pay.ReturnToHand(filter, count = 1)` — return permanents you control to their owner's hand.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
@@ -205,6 +205,11 @@ class CostPaymentContinuationResumer(
         if (selectedCount < paymentService.requiredCount(cost)) {
             return declined(state, continuation, checkForMore)
         }
+        // No domain re-check here: `DecisionValidators.validateSelectCards` already rejects anything
+        // outside the decision's `options`, and those options come from
+        // `CostPaymentService.selectionCandidates` — the same source-relative rule affordability
+        // counted. So a pick outside the domain (the source itself under an `excludeSelf` cost)
+        // never reaches this payment.
         // "Sacrifice N ... with different names" — reject selections that repeat a name (CR 601.2g costs
         // must be paid in full and legally). The chosen permanents must be pairwise distinctly named.
         if (atom is CostAtom.Sacrifice && atom.distinctNames &&

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -9,7 +9,7 @@ import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PipelineState
 import com.wingedsheep.engine.handlers.PredicateContext
-import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
 import com.wingedsheep.engine.mechanics.mana.ManaPaymentWindow
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
@@ -21,6 +21,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
@@ -649,7 +650,10 @@ class SacrificeAndPayContinuationResumer(
                 if (selectedPermanents.size < continuation.requiredCount) {
                     return askNextPlayerForAnyPlayerMayPay(state, continuation, checkForMore)
                 }
-
+                // No domain re-check here: `DecisionValidators.validateSelectCards` already rejects
+                // anything outside the decision's `options`, and those options come from
+                // [anyPlayerSacrificeCandidates] on both the initial and the next-player path — so an
+                // `excludeSelf` source can never reach this payment.
                 var newState = state
                 val events = mutableListOf<GameEvent>()
                 events.add(PermanentsSacrificedEvent(playerId, selectedPermanents))
@@ -709,6 +713,31 @@ class SacrificeAndPayContinuationResumer(
     }
 
     /**
+     * The permanents [playerId] may sacrifice to pay an "any player may sacrifice …" [cost] whose
+     * source is [sourceId].
+     *
+     * The same rule the initial prompt uses (`AnyPlayerMayPayExecutor`), applied here so the
+     * continuation can't widen or narrow the domain between players:
+     *
+     * - the atom's own `excludeSelf` — and nothing else — decides whether the source is in the pool;
+     * - control comes from *projected* state via [BattlefieldFilterUtils], not from a raw
+     *   `ZoneKey(playerId, BATTLEFIELD)` scan, so a permanent whose controller was changed by a
+     *   continuous effect is offered to the player who actually controls it.
+     */
+    private fun anyPlayerSacrificeCandidates(
+        state: GameState,
+        playerId: EntityId,
+        cost: CostAtom.Sacrifice,
+        sourceId: EntityId
+    ): List<EntityId> =
+        BattlefieldFilterUtils.findMatchingOnBattlefield(
+            state,
+            cost.filter.youControl(),
+            PredicateContext(controllerId = playerId),
+            excludeSelfId = if (cost.excludeSelf) sourceId else null
+        )
+
+    /**
      * Find and ask the next eligible player for "any player may [cost]" effects.
      * If no player can pay, runs the "none paid" consequence (e.g., reanimate the discarded card).
      */
@@ -717,20 +746,16 @@ class SacrificeAndPayContinuationResumer(
         continuation: AnyPlayerMayPayContinuation,
         checkForMore: CheckForMore
     ): ExecutionResult {
-        val predicateEvaluator = PredicateEvaluator()
         val cost = continuation.cost
-        val projected = state.projectedState
         val decisionHandler = DecisionHandler()
 
         for ((index, nextPlayerId) in continuation.remainingPlayers.withIndex()) {
             val remainingAfter = continuation.remainingPlayers.drop(index + 1)
             when (val atom = (cost as? PayCost.Atom)?.atom) {
                 is CostAtom.Sacrifice -> {
-                    val battlefield = state.getZone(ZoneKey(nextPlayerId, Zone.BATTLEFIELD))
-                    val context = PredicateContext(controllerId = nextPlayerId)
-                    val validPermanents = battlefield.filter { permanentId ->
-                        predicateEvaluator.matches(state, projected, permanentId, atom.filter, context)
-                    }
+                    val validPermanents = anyPlayerSacrificeCandidates(
+                        state, nextPlayerId, atom, continuation.sourceId
+                    )
                     if (validPermanents.size >= atom.count) {
                         val prompt = "You may sacrifice ${atom.count} ${atom.filter.description}s to cause ${continuation.sourceName} to be sacrificed, or skip"
                         val decisionResult = decisionHandler.createCardSelectionDecision(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AnyPlayerMayPayExecutor.kt
@@ -130,7 +130,7 @@ class AnyPlayerMayPayExecutor(
     ): Boolean {
         return when (val atom = (cost as? PayCost.Atom)?.atom) {
             is CostAtom.Sacrifice -> {
-                val validPermanents = findValidPermanentsOnBattlefield(state, playerId, atom.filter, sourceId)
+                val validPermanents = findValidPermanentsOnBattlefield(state, playerId, atom, sourceId)
                 validPermanents.size >= atom.count
             }
             // CR 119.4: a player may pay life only if their life total is at least the amount.
@@ -153,7 +153,7 @@ class AnyPlayerMayPayExecutor(
         playerOrder: List<EntityId>,
         currentIndex: Int
     ): EffectResult {
-        val validPermanents = findValidPermanentsOnBattlefield(state, playerId, cost.filter, sourceId)
+        val validPermanents = findValidPermanentsOnBattlefield(state, playerId, cost, sourceId)
 
         val prompt = "You may sacrifice ${cost.count} ${cost.filter.description}s to cause $sourceName to be sacrificed, or skip"
 
@@ -298,14 +298,22 @@ class AnyPlayerMayPayExecutor(
         return executor(state, consequence, context)
     }
 
+    /**
+     * The permanents [playerId] may sacrifice to pay a [CostAtom.Sacrifice] whose source is
+     * [sourceId] — the same source-relative rule the resumer applies when it asks the *next* player
+     * (see `SacrificeAndPayContinuationResumer.askNextPlayerForAnyPlayerMayPay`): the atom's own
+     * `excludeSelf` decides whether the source is in the pool, and nothing else does.
+     */
     private fun findValidPermanentsOnBattlefield(
         state: GameState,
         playerId: EntityId,
-        filter: com.wingedsheep.sdk.scripting.GameObjectFilter,
+        cost: CostAtom.Sacrifice,
         sourceId: EntityId
-    ): List<EntityId> {
-        return BattlefieldFilterUtils.findMatchingOnBattlefield(
-            state, filter.youControl(), PredicateContext(controllerId = playerId)
+    ): List<EntityId> =
+        BattlefieldFilterUtils.findMatchingOnBattlefield(
+            state,
+            cost.filter.youControl(),
+            PredicateContext(controllerId = playerId),
+            excludeSelfId = if (cost.excludeSelf) sourceId else null
         )
-    }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -674,9 +674,7 @@ class PayOrSufferExecutor(
                 targets = context.targets,
                 namedTargets = context.pipeline.namedTargets,
                 storedCollections = context.pipeline.storedCollections
-            ),
-            // "Remove counters from among creatures you control" does not say "another".
-            excludeSource = false
+            )
         )
         return when (payment) {
             is PaymentResult.Pending ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -290,8 +290,10 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                         }
                         is CostAtom.TapPermanents -> {
                             tapCost = atom
-                            tapTargets = context.costUtils.findAbilityTapTargets(state, playerId, atom.filter)
-                                .let { targets -> if (atom.excludeSelf) targets.filter { it != entityId } else targets }
+                            tapTargets = context.costUtils.findAbilityTapTargets(
+                                state, playerId, atom.filter,
+                                if (atom.excludeSelf) entityId else null
+                            )
                             if (tapTargets.size < atom.count) continue
                         }
                         is CostAtom.Discard -> {
@@ -460,8 +462,10 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                     }
                                     is CostAtom.TapPermanents -> {
                                         tapCost = atom
-                                        tapTargets = context.costUtils.findAbilityTapTargets(state, playerId, atom.filter)
-                                            .let { targets -> if (atom.excludeSelf) targets.filter { it != entityId } else targets }
+                                        tapTargets = context.costUtils.findAbilityTapTargets(
+                                            state, playerId, atom.filter,
+                                            if (atom.excludeSelf) entityId else null
+                                        )
                                         if (tapTargets.size < atom.count) {
                                             costCanBePaid = false
                                             break

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
@@ -157,7 +157,10 @@ class ManaAbilityEnumerator : ActionEnumerator {
                     is AbilityCost.Atom -> when (val atom = effectiveCost.atom) {
                         is CostAtom.TapPermanents -> {
                             tapCost = atom
-                            tapTargets = context.costUtils.findAbilityTapTargets(state, playerId, atom.filter)
+                            tapTargets = context.costUtils.findAbilityTapTargets(
+                                state, playerId, atom.filter,
+                                if (atom.excludeSelf) entityId else null
+                            )
                             if (tapTargets.size < atom.count) affordable = false
                         }
                         is CostAtom.Sacrifice -> {
@@ -223,7 +226,10 @@ class ManaAbilityEnumerator : ActionEnumerator {
                                     }
                                     is CostAtom.TapPermanents -> {
                                         tapCost = atom
-                                        tapTargets = context.costUtils.findAbilityTapTargets(state, playerId, atom.filter)
+                                        tapTargets = context.costUtils.findAbilityTapTargets(
+                                            state, playerId, atom.filter,
+                                            if (atom.excludeSelf) entityId else null
+                                        )
                                         if (tapTargets.size < atom.count) {
                                             affordable = false; break
                                         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
@@ -100,14 +100,25 @@ class CostEnumerationUtils(
 
     // --- Tap targets ---
 
+    /**
+     * Untapped battlefield permanents [playerId] controls that match a tap cost's [filter].
+     *
+     * [excludeEntityId] is the cost's own source when
+     * [CostAtom.TapPermanents.excludeSelf][com.wingedsheep.sdk.scripting.costs.CostAtom.TapPermanents.excludeSelf]
+     * is set — "tap another untapped …". Pass `if (atom.excludeSelf) sourceId else null` from every
+     * enumeration site so the offered pool matches what payment validation will accept; a plain
+     * "tap two untapped …" may tap the source itself, so null is correct there.
+     */
     fun findAbilityTapTargets(
         state: GameState,
         playerId: EntityId,
-        filter: GameObjectFilter
+        filter: GameObjectFilter,
+        excludeEntityId: EntityId? = null
     ): List<EntityId> {
         val predicateContext = PredicateContext(controllerId = playerId)
         val projected = state.projectedState
         return projected.getBattlefieldControlledBy(playerId).filter { entityId ->
+            if (entityId == excludeEntityId) return@filter false
             val container = state.getEntity(entityId) ?: return@filter false
             container.get<CardComponent>() ?: return@filter false
             if (container.has<TappedComponent>()) return@filter false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/SelectionCostPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/SelectionCostPresentation.kt
@@ -60,8 +60,9 @@ object SelectionCostPresentation {
                     .filter { it != castCardId }
                 is CostAtom.Discard -> handCandidates(state, playerId, castCardId, atom.filter, predicateEvaluator)
                 is CostAtom.RevealFromHand -> handCandidates(state, playerId, castCardId, atom.filter, predicateEvaluator)
-                is CostAtom.TapPermanents -> costUtils.findAbilityTapTargets(state, playerId, atom.filter)
-                    .let { if (atom.excludeSelf) it.filter { id -> id != castCardId } else it }
+                is CostAtom.TapPermanents -> costUtils.findAbilityTapTargets(
+                    state, playerId, atom.filter, if (atom.excludeSelf) castCardId else null
+                )
                 is CostAtom.ReturnToHand -> costUtils.findAbilityBounceTargets(state, playerId, atom.filter)
                 else -> emptyList()
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -73,8 +73,13 @@ class CostPaymentService(private val services: EngineServices) {
     // ---------------------------------------------------------------------------------------------
 
     /**
-     * Whether [payerId] can pay [cost]. For battlefield selection costs the [sourceId] is excluded
-     * from the candidate pool (you can't sacrifice/return/tap the very permanent whose cost this is).
+     * Whether [payerId] can pay [cost].
+     *
+     * The candidate domain for a battlefield selection cost is *source-relative*: the atom's own
+     * `excludeSelf` flag decides whether [sourceId] is in it ("sacrifice **another** creature" vs
+     * "sacrifice a creature", which the source itself may pay — CR 601.2h). Affordability, the
+     * prompt this service builds, and final payment validation all read that one rule, so they can
+     * never disagree about which permanents are payable.
      *
      * Delegates to the [companion][Companion] form so legal-action enumerators
      * (e.g. `TurnFaceUpEnumerator`) can call affordability directly with just a [ManaSolver] —
@@ -84,9 +89,8 @@ class CostPaymentService(private val services: EngineServices) {
         state: GameState,
         payerId: EntityId,
         cost: PayCost,
-        sourceId: EntityId,
-        excludeSource: Boolean = true
-    ): Boolean = canAfford(state, payerId, cost, sourceId, services.manaSolver, excludeSource)
+        sourceId: EntityId
+    ): Boolean = canAfford(state, payerId, cost, sourceId, services.manaSolver)
 
     // ---------------------------------------------------------------------------------------------
     // Pay — build the right prompt and push a single continuation.
@@ -103,14 +107,16 @@ class CostPaymentService(private val services: EngineServices) {
         payerId: EntityId,
         cost: PayCost,
         sourceId: EntityId,
-        ctx: CostPaymentContext = CostPaymentContext(),
-        excludeSource: Boolean = true
+        ctx: CostPaymentContext = CostPaymentContext()
     ): PaymentResult {
         val resolved = resolve(state, cost, sourceId)
-        if (!canAfford(state, payerId, resolved, sourceId, excludeSource)) {
+        if (!canAfford(state, payerId, resolved, sourceId)) {
             return PaymentResult.Unaffordable(state)
         }
         val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "the source"
+        // The one source-relative candidate domain — the same list affordability counted above and
+        // the resumer validates the response against.
+        val candidates = selectionCandidates(state, payerId, resolved, sourceId).orEmpty()
 
         return when (resolved) {
             is PayCost.Choice -> choicePrompt(state, payerId, resolved, sourceId, sourceName, ctx)
@@ -126,32 +132,29 @@ class CostPaymentService(private val services: EngineServices) {
                         val word = if (atom.count == 1) "a card" else "${atom.count} cards"
                         yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "Discard $word at random?", "Discard")
                     } else {
-                        selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, cardsInHand(state, payerId, atom.filter), atom.count, useTargetingUI = false)
+                        selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, candidates, atom.count, useTargetingUI = false)
                     }
                 is CostAtom.ExileFrom ->
-                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, cardsInZone(state, payerId, atom.filter, atom.zone), atom.count, useTargetingUI = atom.zone == Zone.BATTLEFIELD)
+                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, candidates, atom.count, useTargetingUI = atom.zone == Zone.BATTLEFIELD)
                 // Collect evidence N (CR 701.59a) — the whole graveyard is selectable and the gate
                 // is the summed mana value, so the count cap is simply "all of them".
-                is CostAtom.CollectEvidence -> {
-                    val graveyard = com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver
-                        .candidates(state, payerId).cards
+                is CostAtom.CollectEvidence ->
                     selectionPrompt(
-                        state, payerId, resolved, sourceId, sourceName, ctx, graveyard, graveyard.size,
+                        state, payerId, resolved, sourceId, sourceName, ctx, candidates, candidates.size,
                         useTargetingUI = false, minTotalManaValue = atom.amount
                     )
-                }
                 // Milling takes no selection — the cards are the top of the library — so this is a
                 // plain yes/no like paying life.
                 is CostAtom.Mill ->
                     yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "${atom.description.replaceFirstChar { it.uppercase() }}?", atom.description.replaceFirstChar { it.uppercase() })
                 is CostAtom.RevealFromHand ->
-                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, cardsInHand(state, payerId, atom.filter), atom.count, useTargetingUI = false)
+                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, candidates, atom.count, useTargetingUI = false)
                 is CostAtom.Sacrifice ->
-                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledMatching(state, payerId, atom.filter, sourceId), atom.count, useTargetingUI = true)
+                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, candidates, atom.count, useTargetingUI = true)
                 is CostAtom.ReturnToHand ->
-                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledMatching(state, payerId, atom.filter, sourceId), atom.count, useTargetingUI = true)
+                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, candidates, atom.count, useTargetingUI = true)
                 is CostAtom.TapPermanents ->
-                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledUntapped(state, payerId, atom.filter, if (atom.excludeSelf) sourceId else null), atom.count, useTargetingUI = true)
+                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, candidates, atom.count, useTargetingUI = true)
                 // Activated-ability-scoped (see canAfford below, which reports it unaffordable as a
                 // PayCost) — unreachable, but a yes/no is its shape if it is ever wired up.
                 is CostAtom.PutCountersOnSelf ->
@@ -166,9 +169,6 @@ class CostPaymentService(private val services: EngineServices) {
                         val prompt = atom.description
                         yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, prompt, prompt)
                     } else {
-                        val candidates = controlledMatching(
-                            state, payerId, atom.filter, if (excludeSource) sourceId else null
-                        )
                         if (candidates.isEmpty()) {
                             return PaymentResult.Unaffordable(state)
                         }
@@ -644,8 +644,7 @@ class CostPaymentService(private val services: EngineServices) {
             payerId: EntityId,
             cost: PayCost,
             sourceId: EntityId,
-            manaSolver: ManaSolver,
-            excludeSource: Boolean = true
+            manaSolver: ManaSolver
         ): Boolean {
             return when (val c = resolve(state, cost, sourceId)) {
                 // Only unresolvable own-mana-costs reach here (missing source/card component) — unpayable.
@@ -656,8 +655,8 @@ class CostPaymentService(private val services: EngineServices) {
                     // CR 119.4 — a player may pay life only if their life total is at least the amount; paying
                     // life that would reduce them to 0 or less is legal (they then lose as a state-based action).
                     is CostAtom.PayLife -> life(state, payerId) >= atom.amount
-                    is CostAtom.Discard -> cardsInHand(state, payerId, atom.filter).size >= atom.count
-                    is CostAtom.ExileFrom -> cardsInZone(state, payerId, atom.filter, atom.zone).size >= atom.count
+                    is CostAtom.Discard -> domain(state, payerId, c, sourceId).size >= atom.count
+                    is CostAtom.ExileFrom -> domain(state, payerId, c, sourceId).size >= atom.count
                     // CR 701.59b — unpayable unless the graveyard's *total mana value* reaches N.
                     // Card count says nothing here: five lands total 0 and pay nothing.
                     is CostAtom.CollectEvidence ->
@@ -665,16 +664,14 @@ class CostPaymentService(private val services: EngineServices) {
                             .canCollect(state, payerId, atom.amount)
                     // CR 701.17b — a mill cost is unpayable when the library holds fewer cards.
                     is CostAtom.Mill -> state.getZone(ZoneKey(payerId, Zone.LIBRARY)).size >= atom.count
-                    is CostAtom.RevealFromHand -> cardsInHand(state, payerId, atom.filter).size >= atom.count
+                    is CostAtom.RevealFromHand -> domain(state, payerId, c, sourceId).size >= atom.count
                     is CostAtom.Sacrifice -> {
-                        val candidates = controlledMatching(
-                            state, payerId, atom.filter, if (excludeSource) sourceId else null
-                        )
+                        val candidates = domain(state, payerId, c, sourceId)
                         if (atom.distinctNames) distinctNameCount(state, candidates) >= atom.count
                         else candidates.size >= atom.count
                     }
-                    is CostAtom.ReturnToHand -> controlledMatching(state, payerId, atom.filter, sourceId).size >= atom.count
-                    is CostAtom.TapPermanents -> controlledUntapped(state, payerId, atom.filter, if (atom.excludeSelf) sourceId else null).size >= atom.count
+                    is CostAtom.ReturnToHand -> domain(state, payerId, c, sourceId).size >= atom.count
+                    is CostAtom.TapPermanents -> domain(state, payerId, c, sourceId).size >= atom.count
                     // Activated-ability cost only: no printed morph / "unless you …" cost puts
                     // counters on a permanent, and CostHandler owns the placement path.
                     is CostAtom.PutCountersOnSelf -> false
@@ -692,10 +689,7 @@ class CostPaymentService(private val services: EngineServices) {
                             else counters.counters.values.sum() >= needed
                         } else {
                             val counterType = atom.counterType?.let { resolveCounterType(it) }
-                            val projected = state.projectedState
-                            val candidates = projected.getBattlefieldControlledBy(payerId).filter {
-                                predicateEvaluator.matches(state, projected, it, atom.filter, PredicateContext(controllerId = payerId))
-                            }
+                            val candidates = domain(state, payerId, c, sourceId)
                             val total = candidates.sumOf { entityId ->
                                 val counters = state.getEntity(entityId)?.get<CountersComponent>() ?: return@sumOf 0
                                 if (counterType != null) counters.getCount(counterType)
@@ -709,6 +703,57 @@ class CostPaymentService(private val services: EngineServices) {
                 }
             }
         }
+
+        /**
+         * The objects [payerId] may pick to pay [cost] — the **one** source-relative candidate rule,
+         * shared by [canAfford], the prompt [pay] builds, and the resumer's final validation, so
+         * those three can never disagree about which objects are legal.
+         *
+         * The source-relative part is the atom's own `excludeSelf`: "sacrifice **another** creature"
+         * excludes the cost's source, a plain "sacrifice a creature" does not — the source may pay
+         * its own cost (CR 601.2h). A blanket source exclusion here is what made a self-inclusive
+         * cost falsely unaffordable on a board holding only the source, and what let a self-exclusive
+         * one be offered and then rejected at payment.
+         *
+         * Null for a cost with no object domain at all (mana, life, mill, self counter removal, the
+         * activated-ability-only atoms, and the option pick of a [PayCost.Choice]). A domain is not
+         * the same as a prompt: a random discard has a domain (the matching cards in hand) but is
+         * paid with a yes/no.
+         */
+        fun selectionCandidates(
+            state: GameState,
+            payerId: EntityId,
+            cost: PayCost,
+            sourceId: EntityId
+        ): List<EntityId>? = when (val c = resolve(state, cost, sourceId)) {
+            is PayCost.OwnManaCost, is PayCost.Choice -> null
+            is PayCost.Atom -> when (val atom = c.atom) {
+                is CostAtom.Discard -> cardsInHand(state, payerId, atom.filter)
+                is CostAtom.RevealFromHand -> cardsInHand(state, payerId, atom.filter)
+                is CostAtom.ExileFrom -> cardsInZone(state, payerId, atom.filter, atom.zone)
+                // Collect evidence N (CR 701.59a) — the whole graveyard is selectable; the gate is
+                // the summed mana value, checked in [canAfford].
+                is CostAtom.CollectEvidence ->
+                    com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver.candidates(state, payerId).cards
+                is CostAtom.Sacrifice ->
+                    controlledMatching(state, payerId, atom.filter, if (atom.excludeSelf) sourceId else null)
+                // ReturnToHand carries no `excludeSelf` axis, so the source stays out of the pool —
+                // one rule, applied identically by affordability, prompt, and validation.
+                is CostAtom.ReturnToHand -> controlledMatching(state, payerId, atom.filter, sourceId)
+                is CostAtom.TapPermanents ->
+                    controlledUntapped(state, payerId, atom.filter, if (atom.excludeSelf) sourceId else null)
+                // "Remove a counter from among permanents you control" never says "another", so the
+                // source is in the pool. Self-removal picks nothing at all.
+                is CostAtom.RemoveCounters ->
+                    if (atom.self) null else controlledMatching(state, payerId, atom.filter)
+                is CostAtom.Mana, is CostAtom.PayLife, is CostAtom.Mill,
+                is CostAtom.PutCountersOnSelf, is CostAtom.VariablePermanents -> null
+            }
+        }
+
+        /** [selectionCandidates] for a cost whose branch already knows it has a domain. */
+        private fun domain(state: GameState, payerId: EntityId, cost: PayCost, sourceId: EntityId): List<EntityId> =
+            selectionCandidates(state, payerId, cost, sourceId).orEmpty()
 
         /**
          * Lowers [PayCost.OwnManaCost] to a concrete [PayCost.Atom] (CostAtom.Mana) against the source's printed cost so

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -2397,10 +2397,9 @@ class ManaSolver(
             payerId = playerId,
             cost = PayCost.Atom(cost.atom),
             sourceId = sourceId,
-            manaSolver = this,
-            // The source pays its own cost unless the atom says otherwise (CR 601.2h) — mirrors
-            // ManaAbilityEnumerator, which only excludes self for an excludeSelf sacrifice.
-            excludeSource = (cost.atom as? CostAtom.Sacrifice)?.excludeSelf == true
+            // The source pays its own cost unless the atom's own `excludeSelf` says otherwise
+            // (CR 601.2h); canAfford reads that flag itself.
+            manaSolver = this
         )
         is AbilityCost.Composite -> cost.costs.all {
             nonManaAbilityCostIsPayable(state, playerId, sourceId, it)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/ManaAbilityEnumeratorTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/ManaAbilityEnumeratorTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.legalactions
 
 import com.wingedsheep.engine.legalactions.support.EnumerationFixtures
+import com.wingedsheep.engine.legalactions.support.EnumerationTestDriver
 import com.wingedsheep.engine.legalactions.support.setupP1
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
@@ -10,6 +11,7 @@ import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
@@ -126,6 +128,78 @@ class ManaAbilityEnumeratorTest : FunSpec({
         abilities shouldHaveSize 1
         abilities.single().isManaAbility shouldBe true
         abilities.single().affordable shouldBe true
+    }
+
+    // -------------------------------------------------------------------------
+    // CostAtom.TapPermanents.excludeSelf — the enumerated pool must be the one
+    // payment validation accepts. Enumeration used to offer every matching
+    // untapped permanent, so an "another"-shaped mana ability was reported legal
+    // with only the source untapped, and listed the source in validTapTargets
+    // for a tap the payment path then rejected (issue #1880).
+
+    val TapAnotherManaCreature = card("Test Tap-Another Mana Creature") {
+        typeLine = "Creature — Elf Druid"
+        power = 1; toughness = 1
+        activatedAbility {
+            cost = Costs.TapAnotherPermanent(GameObjectFilter.Creature)
+            effect = Effects.AddMana(Color.GREEN)
+            manaAbility = true
+        }
+    }
+
+    val TapAnyManaCreature = card("Test Tap-Any Mana Creature") {
+        typeLine = "Creature — Elf Druid"
+        power = 1; toughness = 1
+        activatedAbility {
+            cost = Costs.TapPermanents(1, GameObjectFilter.Creature)
+            effect = Effects.AddMana(Color.GREEN)
+            manaAbility = true
+        }
+    }
+
+    fun bf(driver: EnumerationTestDriver, name: String) =
+        driver.game.state.getBattlefield(driver.player1).first { id ->
+            driver.game.state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+
+    test("excludeSelf=false — the source is a legal tap target for its own mana ability") {
+        val driver = setupP1(
+            battlefield = listOf("Test Tap-Any Mana Creature"),
+            extraSetCards = listOf(TapAnyManaCreature)
+        )
+        val sourceId = bf(driver, "Test Tap-Any Mana Creature")
+
+        val abilities = driver.enumerateFor(driver.player1).activatedAbilityActionsFor(sourceId)
+        abilities shouldHaveSize 1
+        abilities.single().affordable shouldBe true
+        abilities.single().additionalCostInfo?.validTapTargets shouldBe listOf(sourceId)
+    }
+
+    test("excludeSelf=true — the source alone doesn't make the mana ability affordable") {
+        val driver = setupP1(
+            battlefield = listOf("Test Tap-Another Mana Creature"),
+            extraSetCards = listOf(TapAnotherManaCreature)
+        )
+        val sourceId = bf(driver, "Test Tap-Another Mana Creature")
+
+        val abilities = driver.enumerateFor(driver.player1).activatedAbilityActionsFor(sourceId)
+        abilities shouldHaveSize 1
+        abilities.single().affordable shouldBe false
+        abilities.single().additionalCostInfo?.validTapTargets?.shouldBeEmpty()
+    }
+
+    test("excludeSelf=true — validTapTargets offers the other creature, never the source") {
+        val driver = setupP1(
+            battlefield = listOf("Test Tap-Another Mana Creature", "Test Tap-Any Mana Creature"),
+            extraSetCards = listOf(TapAnotherManaCreature, TapAnyManaCreature)
+        )
+        val sourceId = bf(driver, "Test Tap-Another Mana Creature")
+        val otherId = bf(driver, "Test Tap-Any Mana Creature")
+
+        val ability = driver.enumerateFor(driver.player1)
+            .activatedAbilityActionsFor(sourceId).single()
+        ability.affordable shouldBe true
+        ability.additionalCostInfo?.validTapTargets shouldBe listOf(otherId)
     }
 
     test("two Forests in play produce two distinct mana ability actions") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnyPlayerMayPayCandidateDomainTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnyPlayerMayPayCandidateDomainTest.kt
@@ -1,0 +1,222 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AnyPlayerMayPayEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * The candidate domain of an "any player may [cost]" effect
+ * ([com.wingedsheep.engine.handlers.effects.player.AnyPlayerMayPayExecutor], and the next-player
+ * path in [com.wingedsheep.engine.handlers.continuations.SacrificeAndPayContinuationResumer]).
+ *
+ * Two properties, both broken before
+ * [issue #1880](https://github.com/wingedsheep/argentum-engine/issues/1880):
+ *
+ * - the atom's own `excludeSelf` — and nothing else — decides whether the effect's source is a
+ *   legal pick. The helper took a `sourceId` and ignored it, so a "sacrifice **another** creature"
+ *   cost offered the source and reported a source-only board payable.
+ * - both the initial prompt and the continuation read *projected* control. The continuation used a
+ *   raw `ZoneKey(player, BATTLEFIELD)` scan, which is keyed by **ownership**, so a stolen creature
+ *   was offered to its owner rather than to the player who actually controls it.
+ */
+class AnyPlayerMayPayCandidateDomainTest : FunSpec({
+
+    /** "When this enters, any player may sacrifice a creature. If a player does, they gain 3 life." */
+    val SacrificeAny = card("Test Any-Player Sacrifice") {
+        manaCost = "{0}"
+        typeLine = "Creature — Test"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = AnyPlayerMayPayEffect(
+                cost = Costs.pay.Sacrifice(GameObjectFilter.Creature, count = 1),
+                consequence = Effects.GainLife(3)
+            )
+        }
+    }
+
+    /** The same, printed "another" — the source is out of the pool. */
+    val SacrificeAnother = card("Test Any-Player Sacrifice Another") {
+        manaCost = "{0}"
+        typeLine = "Creature — Test"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = AnyPlayerMayPayEffect(
+                cost = Costs.pay.SacrificeAnother(GameObjectFilter.Creature, count = 1),
+                consequence = Effects.GainLife(3)
+            )
+        }
+    }
+
+    /**
+     * The "another" shape with flash, so the *non-active* player can be the one who controls the
+     * source — the only way the continuation's next-player path meets the source at all, since the
+     * active player is always asked first.
+     */
+    val SacrificeAnotherFlash = card("Test Any-Player Sacrifice Another Flash") {
+        manaCost = "{0}"
+        typeLine = "Creature — Test"
+        power = 1
+        toughness = 1
+        keywords(Keyword.FLASH)
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = AnyPlayerMayPayEffect(
+                cost = Costs.pay.SacrificeAnother(GameObjectFilter.Creature, count = 1),
+                consequence = Effects.GainLife(3)
+            )
+        }
+    }
+
+    val Bear = card("Test Bear") {
+        manaCost = "{0}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    /** {0} sorcery: "Gain control of target creature." Used to split control from ownership. */
+    val StealCreature = card("Test Steal Creature") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        spell {
+            val t = target("creature", Targets.Creature)
+            effect = Effects.GainControl(t, Duration.Permanent)
+        }
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCards(listOf(SacrificeAny, SacrificeAnother, SacrificeAnotherFlash, Bear, StealCreature))
+        d.initMirrorMatch(deck = Deck.of("Forest" to 20), startingLife = 20)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** Put [cardName] into [playerId]'s hand, cast it, and let it resolve onto the battlefield. */
+    fun GameTestDriver.resolveCreature(playerId: EntityId, cardName: String): EntityId {
+        val cardId = putCardInHand(playerId, cardName)
+        giveMana(playerId, Color.GREEN, 1)
+        castSpell(playerId, cardId)
+        bothPass()
+        return cardId
+    }
+
+    test("excludeSelf=false — the source alone is offered and can pay its own cost") {
+        val d = driver()
+        val active = d.activePlayer!!
+        val source = d.resolveCreature(active, "Test Any-Player Sacrifice")
+
+        d.bothPass() // resolve the ETB trigger
+
+        val decision = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.playerId shouldBe active
+        decision.options shouldContainExactly listOf(source)
+
+        d.submitCardSelection(active, listOf(source))
+        d.getGraveyardCardNames(active) shouldContain "Test Any-Player Sacrifice"
+        d.getLifeTotal(active) shouldBe 23 // the consequence ran
+    }
+
+    test("excludeSelf=true — a board holding only the source is skipped, not prompted") {
+        val d = driver()
+        val active = d.activePlayer!!
+        d.resolveCreature(active, "Test Any-Player Sacrifice Another")
+
+        d.bothPass() // resolve the ETB trigger
+
+        // Neither player can pay: the source is excluded and nobody else has a creature.
+        d.pendingDecision shouldBe null
+        d.findPermanent(active, "Test Any-Player Sacrifice Another") shouldNotBe null
+    }
+
+    test("excludeSelf=true — the source is kept out of the prompt's options") {
+        val d = driver()
+        val active = d.activePlayer!!
+        val bear = d.putCreatureOnBattlefield(active, "Test Bear")
+        val source = d.resolveCreature(active, "Test Any-Player Sacrifice Another")
+
+        d.bothPass() // resolve the ETB trigger
+
+        val decision = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.playerId shouldBe active
+        decision.options shouldContainExactly listOf(bear)
+        decision.options shouldNotContain source
+    }
+
+    test("continuation — the next player's options exclude the source they control") {
+        val d = driver()
+        val active = d.activePlayer!!
+        val opponent = if (active == d.player1) d.player2 else d.player1
+
+        // The active player has a creature (so they are asked first and can decline); the opponent
+        // flashes in the source, so they control it and are asked second — the continuation path.
+        d.putCreatureOnBattlefield(active, "Test Bear")
+        val oppBear = d.putCreatureOnBattlefield(opponent, "Test Bear")
+
+        val source = d.putCardInHand(opponent, "Test Any-Player Sacrifice Another Flash")
+        d.giveMana(opponent, Color.GREEN, 1)
+        d.passPriority(active)
+        d.castSpell(opponent, source)
+        d.bothPass() // resolve the creature
+        d.bothPass() // resolve the ETB trigger
+
+        d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>().playerId shouldBe active
+        d.submitCardSelection(active, emptyList()) // decline → continuation asks the opponent
+
+        val next = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        next.playerId shouldBe opponent
+        next.options shouldContainExactly listOf(oppBear)
+        next.options shouldNotContain source
+    }
+
+    test("continuation — the next player's options follow projected control, not ownership") {
+        val d = driver()
+        val active = d.activePlayer!!
+        val opponent = if (active == d.player1) d.player2 else d.player1
+
+        // The opponent owns a Bear; the active player steals it. Ownership still puts that Bear in
+        // the opponent's battlefield zone, so a raw zone scan would offer it back to them.
+        val stolen = d.putCreatureOnBattlefield(opponent, "Test Bear")
+        val steal = d.putCardInHand(active, "Test Steal Creature")
+        d.giveMana(active, Color.GREEN, 1)
+        d.castSpell(active, steal, listOf(stolen))
+        d.bothPass()
+        d.state.projectedState.getController(stolen) shouldBe active
+
+        d.resolveCreature(active, "Test Any-Player Sacrifice Another")
+        d.bothPass() // resolve the ETB trigger
+
+        // The active player is asked and declines; the opponent now controls nothing, so the
+        // continuation must skip them rather than offer the Bear they merely own.
+        d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>().playerId shouldBe active
+        d.submitCardSelection(active, emptyList())
+
+        d.pendingDecision shouldBe null
+        d.state.getBattlefield() shouldContain stolen // never sacrificed
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostPaymentServiceTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostPaymentServiceTest.kt
@@ -31,6 +31,7 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
 import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
 import com.wingedsheep.engine.core.SelectManaSourcesDecision
 import io.kotest.matchers.shouldBe
@@ -317,9 +318,9 @@ class CostPaymentServiceTest : ScenarioTestBase() {
         // Sacrifice
         // -----------------------------------------------------------------------------------------
 
-        test("Sacrifice: excludes the source; paying sacrifices the chosen permanent") {
+        test("Sacrifice: paying sacrifices the chosen permanent") {
             val game = scenario().withPlayers()
-                .withCardOnBattlefield(1, "Goblin Guide") // source — must be excluded
+                .withCardOnBattlefield(1, "Goblin Guide") // the cost's source
                 .withCardOnBattlefield(1, "Savannah Lions") // the fodder
                 .build()
             val service = CostPaymentService(EngineServices(cardRegistry))
@@ -336,11 +337,80 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             game.state.getZone(ZoneKey(game.player1Id, Zone.GRAVEYARD)) shouldContain fodder
         }
 
-        test("Sacrifice: unaffordable when only the source is on the battlefield") {
+        // The `excludeSelf` contract, checked on the three paths that must agree about it:
+        // affordability, the prompt's candidate options, and the resumer's final validation.
+        // A blanket source exclusion used to make a self-inclusive cost falsely unaffordable on a
+        // board holding only the source (github.com/wingedsheep/argentum-engine/issues/1880).
+
+        test("Sacrifice: excludeSelf=false — the source alone can pay its own cost") {
             val game = scenario().withPlayers().withCardOnBattlefield(1, "Goblin Guide").build()
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
-            service.canAfford(game.state, game.player1Id, Costs.pay.Sacrifice(GameObjectFilter.Any, 1), source).shouldBeFalse()
+            val cost = Costs.pay.Sacrifice(GameObjectFilter.Any, 1)
+
+            service.canAfford(game.state, game.player1Id, cost, source).shouldBeTrue()
+            val pending = service.pay(game.state, game.player1Id, cost, source) as PaymentResult.Pending
+            pending.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+                .options shouldBe listOf(source)
+
+            game.state = pending.state
+            game.submitDecision(CardsSelectedResponse(pending.pendingDecision.id, listOf(source)))
+            game.state.getBattlefield(game.player1Id) shouldNotContain source
+            game.state.getZone(ZoneKey(game.player1Id, Zone.GRAVEYARD)) shouldContain source
+        }
+
+        test("Sacrifice: excludeSelf=true — the source is unaffordable and never offered") {
+            val game = scenario().withPlayers().withCardOnBattlefield(1, "Goblin Guide").build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val cost = Costs.pay.SacrificeAnother(GameObjectFilter.Any, 1)
+
+            service.canAfford(game.state, game.player1Id, cost, source).shouldBeFalse()
+            service.pay(game.state, game.player1Id, cost, source)
+                .shouldBeInstanceOf<PaymentResult.Unaffordable>()
+        }
+
+        test("Sacrifice: excludeSelf=true keeps the source out of the prompt's options") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .withCardOnBattlefield(1, "Savannah Lions")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val fodder = bfCardByName(game.state, game.player1Id, "Savannah Lions")
+
+            val pending = service.pay(
+                game.state, game.player1Id, Costs.pay.SacrificeAnother(GameObjectFilter.Any, 1), source
+            ) as PaymentResult.Pending
+            pending.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+                .options shouldBe listOf(fodder)
+        }
+
+        test("Sacrifice: excludeSelf=true rejects a client picking the source anyway") {
+            // Final validation and the offered domain are the same rule: because the prompt's
+            // options come from the source-relative candidate list, a response naming the excluded
+            // source is rejected and the decision stays pending instead of being paid.
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .withCardOnBattlefield(1, "Savannah Lions")
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val fodder = bfCardByName(game.state, game.player1Id, "Savannah Lions")
+
+            val pending = service.pay(
+                game.state, game.player1Id, Costs.pay.SacrificeAnother(GameObjectFilter.Any, 1), source
+            ) as PaymentResult.Pending
+            game.state = pending.state
+            val rejected = game.submitDecision(CardsSelectedResponse(pending.pendingDecision.id, listOf(source)))
+
+            rejected.error.shouldNotBeNull()
+            game.state.getBattlefield(game.player1Id) shouldContain source // not sacrificed
+            game.state.pendingDecision?.id shouldBe pending.pendingDecision.id // still pending
+
+            // The same decision accepts the candidate it *did* offer.
+            game.submitDecision(CardsSelectedResponse(pending.pendingDecision.id, listOf(fodder)))
+            game.state.getZone(ZoneKey(game.player1Id, Zone.GRAVEYARD)) shouldContain fodder
         }
 
         // -----------------------------------------------------------------------------------------
@@ -408,6 +478,20 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
             service.canAfford(game.state, game.player1Id, Costs.pay.Tap(GameObjectFilter.Any, 1), source).shouldBeTrue()
+        }
+
+        test("Tap: excludeSelf=true — the untapped source is unaffordable and never offered") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide")
+                .withCardOnBattlefield(1, "Savannah Lions", tapped = true)
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            val cost = Costs.pay.TapAnother(GameObjectFilter.Any, 1)
+
+            service.canAfford(game.state, game.player1Id, cost, source).shouldBeFalse()
+            service.pay(game.state, game.player1Id, cost, source)
+                .shouldBeInstanceOf<PaymentResult.Unaffordable>()
         }
 
         // -----------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1880.

## The contract

`CostAtom.Sacrifice.excludeSelf` / `CostAtom.TapPermanents.excludeSelf` is the *only* thing that decides whether a cost's own source is a legal way to pay it. The word is "another": without it the source may pay its own cost (CR 601.2h — Vulshok War Boar's ruling is the printed example, "sacrifice an artifact" on an artifact creature). The SDK facades already say so (`Costs.pay.Sacrifice` vs `Costs.pay.SacrificeAnother`), and `docs/card-sdk-language-reference.md` already claimed the engine read the flag. Four paths didn't.

## What was wrong

- **`CostPaymentService`** applied a blanket `excludeSource = true` to sacrifice in both `canAfford` and the prompt. A self-inclusive "sacrifice a creature" was reported **unaffordable** on a board holding only the source. The `excludeSource` parameter also let a caller make the two disagree: with `excludeSource = false` affordability included the source but the prompt still dropped it.
- **`AnyPlayerMayPayExecutor`**'s candidate helper took a `sourceId` and never used it, so an `excludeSelf` cost offered the source and reported it payable.
- **`SacrificeAndPayContinuationResumer`** rebuilt the domain independently after a decline: no `excludeSelf`, and a raw `ZoneKey(player, BATTLEFIELD)` scan. That zone is keyed by **ownership**, so a permanent whose control had changed was offered to its owner instead of to the player who actually controls it.
- **`ManaAbilityEnumerator`** never removed the source for a `TapPermanents` cost, in either the single-atom or the composite branch. An "another"-shaped mana ability was enumerated as legal with only the source untapped, and listed the source in `validTapTargets` for a tap that payment validation then rejected.

## The fix

One source-relative rule per layer instead of four ad-hoc ones.

- `CostPaymentService.selectionCandidates` is the single candidate-domain helper: `canAfford` counts it, `pay` prompts with it, and `DecisionValidators.validateSelectCards` enforces membership against exactly those options — so affordability, presentation, and final validation cannot diverge. The `excludeSource` parameter is deleted from `canAfford`/`pay`; `RemoveCounters` now reads the same (non-excluding) domain on both paths, which is what `PayOrSufferExecutor` was overriding the parameter to get.
- `AnyPlayerMayPayExecutor` and the continuation resumer share the same helper shape, both driven by `atom.excludeSelf` and both reading projected control through `BattlefieldFilterUtils`.
- `CostEnumerationUtils.findAbilityTapTargets` gains an `excludeEntityId` parameter, mirroring `findAbilitySacrificeTargets`. `ManaAbilityEnumerator` passes it in both branches; the three call sites that filtered inline afterwards (`ActivatedAbilityEnumerator` x2, `SelectionCostPresentation`) now use it instead.
- `ManaSolver`'s `AbilityCost.Atom` call site no longer computes the flag for `canAfford` — `canAfford` reads it itself.

`CostHandler`, `ActivateAbilityHandler`, and `PayOrSufferExecutor` already threaded the flag correctly and are unchanged apart from the dropped override.

## Behavior change worth calling out

One shipped card actually changes: **Vulshok War Boar** ("At the beginning of your upkeep, sacrifice an artifact. If you can't, sacrifice Vulshok War Boar.") is itself an artifact, so it is now offered as a legal way to pay — which matches its ruling. Every other card using a `PayCost` sacrifice has a filter the source can't match, so nothing else moves.

## Tests

- `CostPaymentServiceTest` — sacrifice and tap for both flag values: affordability, the pending/unaffordable result, the prompt's options, the actual payment, and a client response naming an excluded source (rejected, decision stays pending, then the offered candidate is accepted). The old test asserting "unaffordable when only the source is on the battlefield" encoded the bug and was rewritten to the contract.
- `AnyPlayerMayPayCandidateDomainTest` (new) — initial affordability/options for both flag values, the next-player continuation with the source under that player's control (reached via a flash source, since the active player is always asked first), and the continuation reading projected control rather than ownership after a creature is stolen.
- `ManaAbilityEnumeratorTest` — direct `TapPermanents` for both flag values: legal-action presence, `affordable`, and `validTapTargets`.

Gate: `just test-rules` (engine tests + every card scenario) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
