### PR TITLE
Add a verify-set skill for proving a set is actually finished

### DIFF
--- a/.agents/skills/verify-set/SKILL.md
+++ b/.agents/skills/verify-set/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: verify-set
+description: Prove a Magic set is actually finished — card-for-card complete, field-for-field faithful to Scryfall, and behaviourally sound — then archive its backlog. Builds the set's Scryfall dump and `<Set>CardFieldVerificationTest`, fixes what they surface, and writes the completion report. Use when asked to "verify set X is done", "field-verify a set against Scryfall", "is set X really complete", or when a set's backlog hits N/N and needs closing out.
+argument-hint: <SET name or code>
+---
+
+# Verify a set is finished
+
+`cards.md` reading `286 / 286` is a claim, not a proof. It says every name has *a* `CardDefinition` — not
+that the definitions carry the right power, the right color identity, the right oracle text, or that the
+cards work when played. This skill closes that gap and then archives the backlog.
+
+
+## The four claims
+
+Finished means all four hold. Do them in order — each is cheap relative to the next, and a failure early
+saves the later work.
+
+| # | Claim | Proven by | Stage |
+|---|---|---|---|
+| 1 | Every card that should exist, exists | `scripts/card-status --set <CODE>`, `just check-backlog*` | [1](#stage-1--completeness) |
+| 2 | Every compiled `CardDefinition` matches Scryfall field for field | `<Set>CardFieldVerificationTest` | [2](#stage-2--field-fidelity) |
+| 3 | The cards behave as printed when played | scenario tests + a self-play pass | [3](#stage-3--behaviour) |
+| 4 | The repo says so | snapshot re-bless, backlog archived, report written | [4](#stage-4--land-it) |
+
+Claim 2 is the one this skill exists for, and the one no other gate in the repo covers.
+`CardDefinitionSnapshotTest` pins what we compiled against *what we compiled last time*; it is blind to
+Scryfall. `CardLintTest` checks internal hygiene. Nothing else compares a card to the printed card.
+
+## Stage 0 — the dump
+
+Everything downstream reads one committed artifact: a full Scryfall dump of the set.
+
+```bash
+CODE=msh                     # lowercase set code
+SLUG=marvel-super-heroes     # the backlog/sets/<slug> directory
+curl -s "https://api.scryfall.com/cards/search?order=set&unique=prints&q=e%3A$CODE" \
+  -H 'User-Agent: ArgentumEngine/1.0 (card data verification)' > /tmp/p1.json
+# follow `next_page` until it's absent, concatenating `data` into one {"data":[...]} object
+```
+
+- **`unique=prints`, not `unique=cards`.** One card can have several printings inside a single set
+  (showcase, borderless, Beginner Box); the per-card row Scryfall serves is an arbitrary one of them.
+  Reprint rows and variant art are matched by collector number, which only `unique=prints` gives you.
+- **Do not commit** This changes, so this is a snapshot for this test.
+- **Do not reuse `~/.cache/scryfall/<code>.json`.** `scripts/card-status` writes it, but it keeps only
+  names plus a flattened per-card subset — no `type_line`, no `mana_cost`, no P/T, no per-face objects. It
+  cannot support Stage 2.
+
+`scripts/card-status` also decides *which* cards are in scope: it partitions on Scryfall `booster` into
+draft cards and extras, and drops `coverage/card-exclusions.json` entries (ante, subgames, dexterity) out
+of the denominator. Take its numbers as the set's definition of done, not the raw dump size.
+
+## Stage 1 — completeness
+
+```bash
+scripts/card-status --set <SET code> --list        # implemented vs missing, missing names listed
+just check-backlog                          # cards.md headers match actual [x] counts
+just check-backlog-implementations           # every [ ] is genuinely unimplemented
+```
+
+Then the two lists `card-status` does *not* diff, both of which a modern set has and none of the five
+existing harnesses ever checked:
+
+```bash
+grep -n 'printings\|basicLands' mtg-sets/*/src/main/kotlin/**/definitions/$CODE/*Set.kt
+```
+
+- **`MtgSet.printings`** — reprint and variant rows. These are `Printing` vals, not `CardDefinition`s, so
+  they are absent from `set.cards` and invisible to every gate in Stage 2 unless you add the reprint block
+  from the template. Their `collectorNumber`, `artist`, `imageUri`, `rarity` are per-printing data that
+  can be wrong independently of the canonical card.
+- **`MtgSet.basicLands`** — also outside `set.cards`. `BasicLandArtOrderTest` covers art ordering;
+  presence and collector numbers are yours to check.
+
+If the set is genuinely short of cards, stop — that's `add-card` / `set-loop` work, not verification.
+Report the gap and don't proceed to Stage 2 on a partial set.
+
+## Stage 2 — field fidelity
+
+**Read [`field-verification.md`](field-verification.md)** — it holds the test template, the loader, the
+DFC face-pairing, and the taxonomy of what the five prior runs actually found. Do not write this test from
+memory; the false-positive handling is the hard part and it's all in there.
+
+The shape:
+
+1. Add `mtg-sets/src/test/kotlin/com/wingedsheep/mtg/sets/<Xxx>CardFieldVerificationTest.kt` from the
+   template, with the set code, dump path and class name substituted. 
+2. Run it. It collects *every* discrepancy and asserts the list is empty, so one run gives you the whole
+   worklist rather than the first failure.
+3. Triage each line into **fix the card**, **fix the SDK**, or **normalize the comparison** — the taxonomy
+   table tells you which, and it matters: three of the eleven classes are the harness being wrong, not the
+   card.
+4. Fix, re-run to zero, re-bless the snapshot (Stage 4).
+5. Remove the `CardFieldVerificationTest.kt`. It's just part of this test. Should not be commited.
+
+Field discrepancies are their own commit, separate from the harness that found them — that's what
+`tla-verify` and `tmt-field-verification` both did, and it keeps the card diff reviewable without the
+40k-line dump in the way.
+
+## Stage 3 — behaviour
+
+Fields being right does not make a card work.
+
+1. **Important cards must have scenario test.** , all special cards and
+   cards with tricky behaviour. `<CardName>ScenarioTest.kt` — `AGENTS.md`'s 
+2. **Play the set.** Follow [`docs/gym-self-play-testing.md`](../../../docs/gym-self-play-testing.md):
+   `just gym-server`, then build an Explicit deck that concentrates the set's cards and drive the step
+   loop for both seats. This is what surfaces the class of bug a scenario test can't — a card that
+   produces no legal action, a trigger that never fires, a state that can't legally exist.
+3. **Route what you find.** A card-shaped fix is `add-card` territory. A missing engine capability is
+   `add-feature`.
+
+
+## Stage 4 - DSL
+
+
+## Stage 5 - Tokens
+
+
+## Stage 6 — land it
+
+```bash
+just rebless-cards                       # Stage 2's card fixes moved the golden — expected
+git diff mtg-sets/src/test/resources/snapshots/cards/<CODE>.json
+```
+
+Only your set's cards should have moved. **An unrelated card in the diff means you changed shared SDK
+behaviour** — stop and investigate (`verify` skill, "Expected: a card-snapshot diff").
+
+Gate by what the diff reaches, per the [`verify`](../verify/SKILL.md) skill's table — card-only fixes plus
+a new `mtg-sets` test is `just test`; anything that touched `rules-engine` is `just test-rules`.
+
+Then close the backlog out:
+
+Read and update all files in backlogs/sets/<slug>
+
+Ensure that the Set file is no longer incomplete. 
+`com.wingedsheep.mtg.sets.definitions.<setcode>.<SetName>Set.kt` should not have this: `override val incomplete = true`
+
+
+```bash
+git mv backlog/sets/<slug> backlog/archived/sets/<slug>      # dump included
+# cards.md header: "**Implemented:** N / N" + a Status line saying the set is complete
+just check-backlog
+```
+
+Keep `<slug>-engine-gaps.md` alongside it if the set left anything genuinely infeasible — TLA's archive
+does. An "engine gap" is a documented decision, not an excuse: say what's missing and why.
+
+## The report
+
+A set is verified when you can state all four claims with the evidence attached. Write it into the PR body:
+
+```
+Set:              MSH — Marvel Super Heroes
+Completeness:     276/276 draft cards, 0 missing, N reprint rows, 20 basic lands  (scripts/card-status)
+Field fidelity:   276 cards × 13 fields vs Scryfall — 0 discrepancies  (MshCardFieldVerificationTest)
+                  <N> fixed on the way: <one line per class from the taxonomy>
+Behaviour:        <N> scenario tests, <M> cards without one (<reason>); self-play: <what you played, what broke>
+Waived:           <card, field, why, and where the follow-up is tracked>  — or "none"
+Gate:             just test — green  (does not cover: <what it doesn't>)
+```
+
+**State what the gate does not cover.** "0 discrepancies" means: against the dump, on those thirteen
+fields, for the cards in `set.cards`. It says nothing about rulings, legalities, or whether the card plays
+correctly. Claiming more than that is worse than claiming nothing.
+
+## Traps
+
+- **Zero discrepancies on a modern set is a result to distrust before you trust it.** ARN legitimately came
+  back clean (78 cards, all vanilla-ish, hand-checked). A 280-card set coming back clean on the first run
+  more often means the harness matched nothing — check the reported card count in the test's own output
+  against `card-status` before believing it.
+- **The waiver set is not a way to reach green.** `WAIVED` is keyed to an exact (card, field) pair so a
+  *new* discrepancy still fails. Every entry needs a reason and a tracked follow-up in the report. A
+  waiver on `power` is almost certainly a real bug wearing a disguise.
+- **`checkFace` on a single-faced card is the whole object.** Don't special-case; the template's `faces()`
+  returns `listOf(this)` and the same code path covers both.
+- **Don't fix a card to match a false positive.** Image cache-busters, `*+N` P/T render order, and the
+  back-face mana cost are the harness's problem. See the taxonomy.
+- **Verification is not a licence to touch other people's work.** A failure in a card or module outside
+  your set is another agent's in-flight change — report and stop (`AGENTS.md` → Hard rules).

--- a/.agents/skills/verify-set/SKILL.md
+++ b/.agents/skills/verify-set/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-set
-description: Prove a Magic set is actually finished — card-for-card complete, field-for-field faithful to Scryfall, and behaviourally sound — then archive its backlog. Builds the set's Scryfall dump and `<Set>CardFieldVerificationTest`, fixes what they surface, and writes the completion report. Use when asked to "verify set X is done", "field-verify a set against Scryfall", "is set X really complete", or when a set's backlog hits N/N and needs closing out.
+description: Prove a Magic set is actually finished — card-for-card complete, field-for-field faithful to Scryfall, scripts that match their oracle text, tokens that resolve the set's own art, behaviourally sound — then archive its backlog. Builds the Scryfall dump and `<Set>CardFieldVerificationTest`, fans the per-card DSL and token review out to subagents, fixes what they surface, and writes the completion report. Use when asked to "verify set X is done", "field-verify a set against Scryfall", "check a set's cards match their oracle text", "check a set's token art", "is set X really complete", or when a set's backlog hits N/N and needs closing out.
 argument-hint: <SET name or code>
 ---
 
@@ -11,9 +11,9 @@ that the definitions carry the right power, the right color identity, the right 
 cards work when played. This skill closes that gap and then archives the backlog.
 
 
-## The four claims
+## The six claims
 
-Finished means all four hold. Do them in order — each is cheap relative to the next, and a failure early
+Finished means all six hold. Do them in order — each is cheap relative to the next, and a failure early
 saves the later work.
 
 | # | Claim | Proven by | Stage |
@@ -21,11 +21,37 @@ saves the later work.
 | 1 | Every card that should exist, exists | `scripts/card-status --set <CODE>`, `just check-backlog*` | [1](#stage-1--completeness) |
 | 2 | Every compiled `CardDefinition` matches Scryfall field for field | `<Set>CardFieldVerificationTest` | [2](#stage-2--field-fidelity) |
 | 3 | The cards behave as printed when played | scenario tests + a self-play pass | [3](#stage-3--behaviour) |
-| 4 | The repo says so | snapshot re-bless, backlog archived, report written | [4](#stage-4--land-it) |
+| 4 | Every card's *script* says what its oracle text says | `assay-differential` + a per-card review | [4](#stage-4---dsl) |
+| 5 | Every token the set mints resolves *this set's* art | `token-art-gaps`, `TokenArtCoverageTest` | [5](#stage-5---tokens) |
+| 6 | The repo says so | snapshot re-bless, backlog archived, report written | [6](#stage-6--land-it) |
 
 Claim 2 is the one this skill exists for, and the one no other gate in the repo covers.
 `CardDefinitionSnapshotTest` pins what we compiled against *what we compiled last time*; it is blind to
 Scryfall. `CardLintTest` checks internal hygiene. Nothing else compares a card to the printed card.
+
+Claims 4 and 5 are the ones that don't fit in one context: they're per-card judgement across 200–290
+cards. **Read [`per-card-review.md`](per-card-review.md) before starting either** — it holds the subagent
+fan-out protocol, the reviewer prompts with their fixed verdict blocks, and both checklists.
+
+## You are the orchestrator
+
+A set is 200–290 cards. Read serially in one session, the useful signal is gone by card 40 and the session
+is compacting by card 80 — and a compacted reviewer gets quietly worse without telling you. So for every
+per-card stage: **dispatch, aggregate, record. Never open a card file yourself.**
+
+- Subagents read the cards; you hold only their verdict blocks. Insist on a fixed `Return only:` shape so a
+  batch costs you four lines, not four hundred.
+- Batch 8–12 cards per reviewer, grouped by mechanic or cycle rather than alphabetically — a reviewer
+  holding a whole cycle catches the one card that renders the shared ability differently.
+- Run batches concurrently; they're read-only and independent.
+- Review and fix are separate dispatches. A reviewer that also edits rationalises its own findings.
+- Keep a scratch ledger, one line per batch. Across a pass this long it's your memory; the conversation
+  isn't.
+
+The test of whether you're doing it right: a 280-card set costs your context roughly what a 20-card set
+costs. If you're about to open a `.kt` file to "just check one thing", that's a subagent's job. Same
+doctrine as `set-loop` —
+[How the driving session stays flat](../../../docs/agent-loops/set-implementation-loop.md#how-the-driving-session-stays-flat).
 
 ## Stage 0 — the dump
 
@@ -91,7 +117,7 @@ The shape:
 3. Triage each line into **fix the card**, **fix the SDK**, or **normalize the comparison** — the taxonomy
    table tells you which, and it matters: three of the eleven classes are the harness being wrong, not the
    card.
-4. Fix, re-run to zero, re-bless the snapshot (Stage 4).
+4. Fix, re-run to zero, re-bless the snapshot (Stage 6).
 5. Remove the `CardFieldVerificationTest.kt`. It's just part of this test. Should not be commited.
 
 Field discrepancies are their own commit, separate from the harness that found them — that's what
@@ -114,9 +140,64 @@ Fields being right does not make a card work.
 
 ## Stage 4 - DSL
 
+Stage 2 proved the card's *text* matches Scryfall. This stage asks the harder question: does the
+`cardDef { }` **do** what that text says? A card can carry a byte-perfect `oracleText` and a script that
+implements three of its four clauses — Stage 2 passes it, the snapshot passes it, and nothing else looks.
+
+Fan this out. It's ~200–290 cards of judgement and it does not fit in one context —
+**[`per-card-review.md`](per-card-review.md)** holds the batching, the reviewer prompt and its verdict
+block. Run the machines first; they shrink what humans have to read:
+
+```bash
+just assay-differential --set <CODE>    # read EVERY divergent row
+just assay-gate --set <CODE>            # declines are coverage, not failures
+just test-class CardLintTest            # dataflow hygiene
+just test-class FacadeBoundaryTest      # facades, not raw constructors
+```
+
+`assay-differential` is the one that matters. It is Argentum Assay's *independent* reading of each oracle
+text set against the card a human wrote from the same text — which is precisely this stage's question,
+decided by a parser instead of a reviewer. Its own recipe says to classify every `DIVERGENT` row as parser
+bug / card bug / known fold and read all of them; its history is that it keeps finding real bugs in
+hand-written cards (the batch-trigger band exposed five at once).
+
+Its limit is honest and important: the differential only sees the class of card Assay's grammar reads
+*whole*, so on a modern set most cards decline and are simply not covered. A green differential is a floor,
+not the pass. The per-card review is the pass.
+
+What the reviewers are looking for, in rough order of how often it's wrong: a clause in the oracle text
+with nothing in the script implementing it; targeting quantifiers (`target` vs "each" vs "any number of");
+optional vs mandatory (`you may`); trigger event, zone, and intervening-if vs on-resolution condition;
+durations (end of turn / end of combat / until your next turn); last-known-information reads on dies
+triggers; and a one-off effect written where a `Patterns.*` composition already exists.
 
 ## Stage 5 - Tokens
 
+Nothing about a wrong token fails. A token with no resolvable art doesn't render blank — it falls through
+to a Scryfall **name guess** (`cards/named?exact=<name>`) and shows whatever printing comes back. That's
+how Arahbo's Foundations Cat ended up showing Dominaria Remastered art: nothing was missing, so nothing
+failed. Tokens are therefore the part of a finished set most likely to be quietly wrong.
+
+```bash
+just token-art-gaps                       # -> backlog/token-art-gaps.md; must list nothing for your set
+just test-class TokenArtCoverageTest      # the floor: nothing renders via a Scryfall name-guess
+```
+
+Art resolves in three steps — an explicit `imageUri` on the `CreateToken` effect, then **this set's rows
+for the set the creating card was printed in** (hand-authored `MtgSet.tokenArt` ahead of synced
+`tokens.json`), then the generic by-creature-type fallback. Step 2 is the correct-creator rule, and it's
+why art belongs on the set and not the card: keying on the creating card's printing is what makes a reprint
+mint the *reprint's* token.
+
+The two checks above are not the same strength. `TokenArtCoverageTest` only proves nothing falls to a name
+guess; **`token-art-gaps` proves the property you actually want** — that no token of yours is showing
+generic stand-in art instead of its own set's. Read the rows for your set code; the file is global and
+generated, so don't hand-edit it.
+
+[`per-card-review.md`](per-card-review.md) has the full checklist: enumerating token sites with
+`TokenCreationSites.of(card)` rather than grepping for `CreateToken`, why `imageUri` must be the Scryfall
+`normal` URL and not `art_crop`, when a set needs hand-authored rows at all (mostly pre-2001), and the
+explicit-`imageUri` anti-pattern that both gates deliberately skip.
 
 ## Stage 6 — land it
 
@@ -150,7 +231,7 @@ does. An "engine gap" is a documented decision, not an excuse: say what's missin
 
 ## The report
 
-A set is verified when you can state all four claims with the evidence attached. Write it into the PR body:
+A set is verified when you can state all six claims with the evidence attached. Write it into the PR body:
 
 ```
 Set:              MSH — Marvel Super Heroes
@@ -158,6 +239,9 @@ Completeness:     276/276 draft cards, 0 missing, N reprint rows, 20 basic lands
 Field fidelity:   276 cards × 13 fields vs Scryfall — 0 discrepancies  (MshCardFieldVerificationTest)
                   <N> fixed on the way: <one line per class from the taxonomy>
 Behaviour:        <N> scenario tests, <M> cards without one (<reason>); self-play: <what you played, what broke>
+DSL fidelity:     276 cards reviewed in <B> batches — <N> divergent, all fixed
+                  assay-differential: <D> divergent of <C> cards read whole (<rest> declined, not covered)
+Tokens:           <T> tokens from <N> cards — all resolve MSH art (token-art-gaps: none; TokenArtCoverageTest green)
 Waived:           <card, field, why, and where the follow-up is tracked>  — or "none"
 Gate:             just test — green  (does not cover: <what it doesn't>)
 ```
@@ -165,6 +249,11 @@ Gate:             just test — green  (does not cover: <what it doesn't>)
 **State what the gate does not cover.** "0 discrepancies" means: against the dump, on those thirteen
 fields, for the cards in `set.cards`. It says nothing about rulings, legalities, or whether the card plays
 correctly. Claiming more than that is worse than claiming nothing.
+
+The same applies to the two fanned-out stages, and it's easier to overclaim there because the numbers look
+absolute. A DSL pass is *N reviewers' judgement*, not a proof — report how many cards each batch held and
+how many `assay-differential` actually read whole versus declined. A clean `token-art-gaps` means no token
+falls back to generic art; it does not mean the art is the one printed on the card you meant.
 
 ## Traps
 
@@ -179,5 +268,12 @@ correctly. Claiming more than that is worse than claiming nothing.
   returns `listOf(this)` and the same code path covers both.
 - **Don't fix a card to match a false positive.** Image cache-busters, `*+N` P/T render order, and the
   back-face mana cost are the harness's problem. See the taxonomy.
+- **A card's own `metadata { imageUri = … }` is card art and correct.** Only an `imageUri` argument *inside
+  a token effect* is the anti-pattern. A loose grep for `imageUri` in a set's card files hits every card and
+  says nothing.
+- **`assay-differential` declining a card is not a pass.** Declines are coverage, not verdicts. A set whose
+  cards mostly decline got almost no signal from the differential, however green the run looked.
+- **Don't let a reviewer subagent fix what it found.** It will rationalise. Collect verdicts, triage
+  yourself, dispatch fixes separately.
 - **Verification is not a licence to touch other people's work.** A failure in a card or module outside
   your set is another agent's in-flight change — report and stop (`AGENTS.md` → Hard rules).

--- a/.agents/skills/verify-set/field-verification.md
+++ b/.agents/skills/verify-set/field-verification.md
@@ -1,0 +1,315 @@
+# Field verification: the harness and what it finds
+
+Stage 2 of [`SKILL.md`](SKILL.md). Read this before writing the test.
+
+The test compares the **compiled `CardDefinition`s the engine actually loads** — not the DSL source, not
+the backlog — against a committed Scryfall dump, on thirteen fields:
+
+```
+name  mana_cost  color_identity  type_line  oracle_text  power  toughness  loyalty
+rarity  collector_number  artist  flavor_text  image_uris
+```
+
+It collects every discrepancy and asserts the list is empty at the end, so one run yields the whole
+worklist. That property is the point — don't convert it to a fail-fast.
+
+---
+
+## The template
+
+`mtg-sets/src/test/kotlin/com/wingedsheep/mtg/sets/<Xxx>CardFieldVerificationTest.kt`. Substitute the set
+code, the class name, and the dump slug. 
+
+It belongs in the aggregator module `mtg-sets`, **not** in an era module or its `tests` child — that's
+where the whole-corpus tests live (`CardDefinitionSnapshotTest`, `CardLintTest`), where `MtgSetCatalog`
+can see every set, and where `kotlinx-serialization-json` is already on the test classpath.
+
+Delete it when finished running the validation.
+
+```kotlin
+package com.wingedsheep.mtg.sets
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import java.io.File
+
+private const val SET_CODE = "MSH"
+private const val DUMP_RELATIVE = "sets/marvel-super-heroes/msh_set.json"
+
+/**
+ * Field-level verification of every registered Marvel Super Heroes card against authoritative
+ * Scryfall data.
+ *
+ * Checks the **compiled [CardDefinition]s** the engine loads — the real source of truth for play —
+ * against the committed Scryfall dump, field by field: name, mana_cost, color_identity, type_line,
+ * oracle_text, power, toughness, loyalty, rarity, collector_number, artist, flavor_text, image_uris.
+ *
+ * Double-faced cards are checked **face by face**: our front face against Scryfall `card_faces[0]`
+ * and [CardDefinition.backFace] against `card_faces[1]` for the per-face fields. color_identity,
+ * rarity and collector_number are whole-card and come from the top-level object.
+ *
+ * Reprint rows ([com.wingedsheep.sdk.model.MtgSet.printings]) and basic lands are outside
+ * `set.cards`, so they get their own passes below.
+ */
+class MshCardFieldVerificationTest : FunSpec({
+
+    val dump = Json.parseToJsonElement(dumpFile().readText()).jsonObject
+    val scryfall = dump["data"]!!.jsonArray.map { it.jsonObject }
+    val byCollector = scryfall.associateBy { it.str("collector_number") }
+    val byId = scryfall.associateBy { it.str("id") }
+    val set = MtgSetCatalog.requireByCode(SET_CODE)
+
+    test("$SET_CODE: every registered card matches authoritative Scryfall on all requested fields") {
+        val cards = set.cards.sortedBy { it.name }
+        val problems = mutableListOf<String>()
+
+        for (card in cards) {
+            val cn = card.metadata.collectorNumber
+            val a = byCollector[cn] ?: byId[card.scryfallId()]
+            if (a == null) {
+                problems += "${card.name} (cn=$cn): no authoritative Scryfall match"
+                continue
+            }
+
+            // Whole-card fields — never per-face on Scryfall.
+            check(problems, card.name, "color_identity", card.colorIdentityString(), a.colorIdentityString())
+            check(problems, card.name, "rarity", card.metadata.rarity.scryfall(), a.str("rarity"))
+            check(problems, card.name, "collector_number", cn ?: "", a.str("collector_number"))
+
+            // Per-face fields: pair our faces with Scryfall's card_faces, or the whole object when
+            // the card is single-faced.
+            val ourFaces = if (card.isDoubleFaced) listOf(card, card.backFace!!) else listOf(card)
+            val authFaces = a.faces()
+            if (ourFaces.size != authFaces.size) {
+                problems += "${card.name}: face-count mismatch ours=${ourFaces.size} auth=${authFaces.size}"
+                continue
+            }
+            for ((idx, pair) in ourFaces.zip(authFaces).withIndex()) {
+                val (ourFace, authFace) = pair
+                val label = if (card.isDoubleFaced) "${card.name}[$idx:${ourFace.name}]" else card.name
+                // The back face of a *nonmodal* DFC (CR 712.2) is reached only by transforming, and
+                // has no mana symbols where a mana cost would go — it has no mana cost (CR 202.1b),
+                // its colors coming from a color indicator instead (CR 204). Scryfall still lists a
+                // printed mana_cost for that face. Don't flag it. A *modal* DFC back face has a real
+                // mana cost and no indicator, so this correctly leaves it checked.
+                val nonmodalBack = card.isDoubleFaced && idx == 1 && ourFace.colorIndicator != null
+                checkFace(problems, label, ourFace, authFace, skipManaCost = nonmodalBack)
+            }
+        }
+
+        report(problems, "$SET_CODE cards", cards.size)
+        problems shouldBe emptyList()
+    }
+
+    // Reprint / variant rows carry their own per-printing metadata and are absent from set.cards.
+    test("$SET_CODE: every reprint row matches its Scryfall printing") {
+        val problems = mutableListOf<String>()
+        for (p in set.printings.sortedBy { it.collectorNumber }) {
+            val a = byCollector[p.collectorNumber] ?: byId[p.scryfallId]
+            if (a == null) {
+                problems += "${p.name} (cn=${p.collectorNumber}): no authoritative Scryfall match"
+                continue
+            }
+            val label = "${p.name}#${p.collectorNumber}"
+            check(problems, label, "name", p.name, a.faces().first().str("name"))
+            check(problems, label, "rarity", p.rarity.scryfall(), a.str("rarity"))
+            check(problems, label, "artist", p.artist, a.faces().first().str("artist"))
+            check(problems, label, "image_uris", p.imageUri?.substringBefore("?"),
+                a.faces().first().imageNormal()?.substringBefore("?"))
+        }
+        report(problems, "$SET_CODE reprints", set.printings.size)
+        problems shouldBe emptyList()
+    }
+
+    // Basic lands are also outside set.cards. Art *ordering* is BasicLandArtOrderTest's job; this
+    // only asserts each declared land is a real printing in the set at the collector number we claim.
+    test("$SET_CODE: every basic land maps to a real printing in the dump") {
+        val problems = mutableListOf<String>()
+        for (land in set.basicLands) {
+            val cn = land.metadata.collectorNumber
+            val a = byCollector[cn]
+            when {
+                a == null -> problems += "${land.name} (cn=$cn): no printing at that collector number"
+                a.faces().first().str("name") != land.name ->
+                    problems += "${land.name} (cn=$cn): collector number belongs to " +
+                        "${a.faces().first().str("name")}"
+            }
+        }
+        report(problems, "$SET_CODE basic lands", set.basicLands.size)
+        problems shouldBe emptyList()
+    }
+})
+
+/**
+ * Known SDK-level *rendering* gaps, waived and tracked for follow-up: the card is right, the compiled
+ * rendering isn't. Keyed to the exact (label, field) pair so any **new** discrepancy still fails.
+ * Every entry needs a reason in the commit message and a tracked follow-up. A waiver on power,
+ * toughness, type_line or color_identity is almost certainly a real bug — don't add one.
+ */
+private val WAIVED: Set<Pair<String, String>> = emptySet()
+
+/** Compare every per-face field of one of our faces against its Scryfall face object. */
+private fun checkFace(
+    problems: MutableList<String>,
+    label: String,
+    def: CardDefinition,
+    a: JsonObject,
+    skipManaCost: Boolean = false,
+) {
+    check(problems, label, "name", def.name, a.str("name"))
+    if (!skipManaCost) check(problems, label, "mana_cost", def.manaCost.toString(), a.str("mana_cost") ?: "")
+    check(problems, label, "type_line", def.typeLine.toString(), a.str("type_line"))
+    check(problems, label, "oracle_text", def.oracleText, a.str("oracle_text") ?: "")
+    check(problems, label, "power", def.creatureStats?.power?.description, a.str("power"))
+    check(problems, label, "toughness", def.creatureStats?.toughness?.description, a.str("toughness"))
+    check(problems, label, "loyalty", def.startingLoyalty?.toString(), a.str("loyalty"))
+    check(problems, label, "artist", def.metadata.artist, a.str("artist"))
+    check(problems, label, "flavor_text", def.metadata.flavorText, a.str("flavor_text"))
+    // Compare image URIs without Scryfall's volatile `?<timestamp>` cache-buster — the image identity
+    // is the path (…/<scryfall-id>.jpg); the query bumps on every re-host.
+    check(problems, label, "image_uris",
+        def.metadata.imageUri?.substringBefore("?"), a.imageNormal()?.substringBefore("?"))
+}
+
+/** A field matches when the two normalized values are equal, treating null/blank as the empty string. */
+private fun check(problems: MutableList<String>, label: String, field: String, ours: String?, auth: String?) {
+    if ((label to field) in WAIVED) return
+    val o = canon(field, ours)
+    val a = canon(field, auth)
+    if (o != a) problems += "$label.$field: ours=${o.q()} auth=${a.q()}"
+}
+
+/**
+ * Normalize for comparison. Beyond trim and null-as-empty: a dynamic P/T with a fixed offset renders
+ * as `*+N` from [com.wingedsheep.sdk.model.CharacteristicValue], while Scryfall writes `N+*`. Same
+ * value, different word order — canonicalize rather than editing the card.
+ */
+private fun canon(field: String, s: String?): String {
+    val v = s?.trim().orEmpty()
+    if (field == "power" || field == "toughness") {
+        Regex("""^\*\+(\d+)$""").find(v)?.let { return "${it.groupValues[1]}+*" }
+    }
+    return v
+}
+
+private fun report(problems: List<String>, what: String, total: Int) {
+    if (problems.isEmpty()) {
+        println("$what: all $total match Scryfall on every requested field.")
+    } else {
+        println("$what: ${problems.size} discrepancy(ies) across $total")
+        problems.forEach { println("  - $it") }
+    }
+}
+
+private fun String.q(): String = "\"" + replace("\n", "\\n") + "\""
+
+private fun Rarity.scryfall(): String = name.lowercase()
+
+/** Our color identity in Scryfall's canonical WUBRG order, e.g. {W}{U} -> "W,U". */
+private fun CardDefinition.colorIdentityString(): String =
+    colorIdentity.sortedBy { Color.entries.indexOf(it) }.joinToString(",") { it.symbol.toString() }
+
+private fun JsonObject.colorIdentityString(): String {
+    val arr = this["color_identity"] as? JsonArray ?: return ""
+    return arr.map { (it as JsonPrimitive).content }
+        .sortedBy { sym -> Color.entries.indexOfFirst { it.symbol == sym.firstOrNull() } }
+        .joinToString(",")
+}
+
+/** Prefer the recorded Scryfall id; fall back to the one embedded in the image URI path. */
+private fun CardDefinition.scryfallId(): String? =
+    metadata.scryfallId
+        ?: metadata.imageUri?.let { Regex("""/([0-9a-f-]{36})\.""").find(it)?.groupValues?.get(1) }
+
+/** Scryfall's per-face objects, or the whole object when the card is single-faced. */
+private fun JsonObject.faces(): List<JsonObject> {
+    val arr = this["card_faces"] as? JsonArray
+    if (arr != null && arr.size >= 2) return arr.map { it.jsonObject }
+    return listOf(this)
+}
+
+private fun JsonObject.imageNormal(): String? =
+    (this["image_uris"] as? JsonObject)?.get("normal")?.let { (it as JsonPrimitive).content }
+
+private fun JsonObject.str(key: String): String? =
+    (this[key] as? JsonPrimitive)?.takeIf { !it.isString || it.content.isNotEmpty() }?.content
+
+/**
+ * Walk up from the working directory to the dump. Checks the archived root too, so the test keeps
+ * working after Stage 4 moves the backlog directory under `backlog/archived/`.
+ */
+private fun dumpFile(): File {
+    var dir: File? = File(System.getProperty("user.dir")).absoluteFile
+    while (dir != null) {
+        for (root in listOf("backlog", "backlog/archived")) {
+            val f = File(dir, "$root/$DUMP_RELATIVE")
+            if (f.exists()) return f
+        }
+        dir = dir.parentFile
+    }
+    error("Could not locate $DUMP_RELATIVE under backlog/ or backlog/archived/ " +
+        "from ${System.getProperty("user.dir")}")
+}
+```
+
+Run it alone while iterating — it's seconds against a warm daemon:
+
+```bash
+just test-class MshCardFieldVerificationTest
+```
+
+---
+
+## The taxonomy: what these runs actually found
+
+Ordered by how much it matters. **Gameplay** classes change how the card plays and are the reason this
+stage exists. **Display** classes are cosmetic but land in the client and the snapshot. **Harness**
+classes are false positives — fixing the card there makes the card wrong.
+
+| # | Class | Kind | Signature | Do |
+|---|---|---|---|---|
+| 1 | Wrong power/toughness | gameplay | `power: ours="4" auth="5"` | Fix the card. TMT's Leatherhead, Swamp Stalker shipped a 4/5 as a 4/4 behind a green backlog. |
+| 2 | Wrong color identity | gameplay | `color_identity: ours="G" auth="G,U"` | Set `colorIdentity = "GU"` explicitly. The heuristic derives identity from the mana cost, so it misses symbols in *activated-ability* costs (TMT Venus's pay-`{U}`) and on a **DFC back face** (TLA Avatar Aang, RGWU → WUBRG). Both were real. |
+| 3 | Missing supertype / wrong type line | gameplay | `type_line: ours="Creature — …" auth="Legendary Creature — …"` | Fix the type line. Legendary is load-bearing (the "legend rule", CR 704.5j). |
+| 4 | Reminder text inlined that Oracle doesn't have | display | `oracle_text` ours carries `(Whenever this creature attacks, add {R}{R}…)` | Strip it. Scryfall's `oracle_text` includes reminder text only where the printed card does — a bare `Firebending 2` on the card stays bare. Hit TLA's Bumi/Iroh/Ozai and TMT's Leonardo (Sneak). |
+| 5 | Reminder text missing that Oracle *does* have | display | inverse of 4 | Add it verbatim. TLA's Saber-Tooth Moose-Lion (forestcycling), TMT's Equip / Scry / Menace. |
+| 6 | Missing flavor text | display | `flavor_text: ours="" auth="…"` | Add it. Nine on TLA alone — the single highest-count line item. |
+| 7 | Mis-quoted flavor text | display | spurious wrapping `"…"`, or wrong attribution dash | Match Scryfall byte for byte, including `\n—Speaker`. TLA's Turtle-Duck had invented outer quotes. |
+| 8 | Wrong artist | display | `artist: ours="X" auth="Y"` | Fix. Three on TMT. Easy to get wrong when a card was drafted from a sibling printing. |
+| 9 | Line breaks | display | text equal but for `\n` placement | Match Scryfall's breaks exactly — TMT's Class level lines. `\n` vs joined-with-space is a real diff in the snapshot. |
+| 10 | Dynamic P/T word order | **harness** | `power: ours="*+1" auth="1+*"` | Leave the card alone; `canon()` normalizes it. `CharacteristicValue` renders offset-last. |
+| 11 | Image cache-buster / back-face mana cost | **harness** | `?1764121885` differing; a mana cost on a transformed back face | Leave the card alone; the template strips the query and skips the nonmodal back face (CR 202.1b / 204). |
+
+Two notes on citing rules here, since the prior harnesses got one wrong:
+
+- Double-faced cards are **CR 712**, not 711 — 711 is Leveler Cards. `SpmCardFieldVerificationTest`'s
+  comment says 711; it's stale. Nonmodal (transforming) DFCs are 712.2, modal DFCs 712.3.
+- The back face having no mana cost is **CR 202.1b** (objects with no mana symbols where the cost would
+  appear have no mana cost), with its colors coming from the color indicator, **CR 204**. CR 202.3a is the
+  related mana-*value* carve-out.
+
+Verified against `MagicCompRules_20260808.txt`. Re-check if a newer dated file appears in the repo root.
+
+---
+
+## The live cross-check (optional)
+
+The Kotlin test proves *compiled cards == dump*. A python script proves *dump == live Scryfall*, which
+matters once — when you first commit the dump — and then only if you suspect the dump is stale. All five
+branches shipped one (`verify_<code>_set.py`, ~80 lines, next to the dump). Its extra value over the
+Kotlin test is the **presence** assertion: for each required field it checks the field is either present
+in the dump *or* legitimately empty on **both** sides, which catches "Scryfall has a flavor text we never
+recorded" as distinct from "neither has one".
+
+Write it only if you want that property re-runnable. Otherwise a one-off diff of the fresh fetch against
+the committed dump is the same evidence, and `SKILL.md` Stage 0's fetch is already that.
+

--- a/.agents/skills/verify-set/per-card-review.md
+++ b/.agents/skills/verify-set/per-card-review.md
@@ -1,0 +1,154 @@
+# Reviewing every card, without drowning
+
+Stages 3–4 of [`SKILL.md`](SKILL.md): the DSL fidelity pass and the token pass. Both are *per card*, and
+a modern set is 200–290 of them. This file is the fan-out protocol and the two checklists.
+
+## Why this can't be one agent's job
+
+Stage 2's field check is a string compare — one test run, one list of failures, no reading required.
+Stages 3 and 4 are judgement: *does this `cardDef { }` do what the oracle text says?* That means reading
+the card file, the oracle text, and often an SDK primitive's KDoc. Call it 200–600 lines of context per
+card. At 280 cards, read serially in one session, the useful signal is long gone by card 40 and the
+session is compacting by card 80 — and a compacted reviewer silently gets worse without saying so.
+
+So the driving session **never reads a card file**. It dispatches, aggregates verdict blocks, and keeps a
+ledger. This is the same doctrine `set-loop` runs on — see
+[How the driving session stays flat](../../../docs/agent-loops/set-implementation-loop.md#how-the-driving-session-stays-flat)
+— with one difference: verification is read-only, so batches can run wide and no worktree is needed
+unless you start fixing.
+
+**The test of whether you're doing it right:** a 280-card set must cost your context roughly what a
+20-card set costs. If you're about to open a `.kt` file to "just check one thing", that's a subagent's job.
+
+## Dispatch shape
+
+```
+enumerate cards  →  batch into units of 8–12  →  one reviewer subagent per batch  →  aggregate
+                                                 (several in flight at once)
+```
+
+- **Batch size 8–12.** One card per agent wastes a whole context on a vanilla creature and floods you with
+  verdict blocks; 30 puts the agent in the same drowning position as the driving session. 8–12 fits
+  comfortably and keeps a red batch small enough to re-dispatch.
+- **Group by mechanic or cycle, not alphabetically.** A reviewer holding all five cards of a cycle catches
+  the one that renders the shared ability differently — the highest-value finding in the pass, and
+  invisible to an alphabetical split.
+- **Run several batches concurrently.** They're read-only and independent, so dispatch them in one message.
+- **Fixes are a separate dispatch.** A reviewer that also edits will rationalise its own findings. Collect
+  every verdict first, triage yourself, then dispatch fixers against the specific findings.
+- **Enumerate before you dispatch**, so the batch list is real:
+  ```bash
+  ls mtg-sets/*/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/$CODE/cards/*.kt | wc -l
+  just where $CODE          # the era module and its tests/ child
+  ```
+
+Keep a ledger — a scratch file, one line per batch (`[ ] pending · [~] running · [x] verdict recorded`).
+It is your memory across a pass this long; the conversation is not.
+
+## The DSL reviewer prompt
+
+Substitute the batch. The **Return only** block is what keeps your context flat — insist on it.
+
+```
+Review the DSL fidelity of these <SET> cards. Read-only: change no files, run no builds.
+
+Cards: <CardA.kt; CardB.kt; …>   (mtg-sets/<era>/src/main/kotlin/.../definitions/<code>/cards/)
+
+For each card:
+1. Read the card file and its `oracleText`.
+2. Read the scenario test if one exists (<era>/tests/.../<CardName>ScenarioTest.kt).
+3. Answer: does the script do what the oracle text says — every clause, in the right order,
+   with the right timing, targets, durations and controller? Check especially:
+   - a clause in the oracle text with nothing in the script that implements it
+   - a script doing something the oracle text doesn't say
+   - "target" vs "each" vs "any number of"; "you may" vs mandatory
+   - triggers: the right event, the right zone, intervening-if vs on-resolution condition
+   - durations: end of turn vs end of combat vs permanent; "until your next turn"
+   - last-known-information reads on dies/leaves triggers
+4. Check it composes existing vocabulary: `Effects.*` / `Patterns.*` facades, no raw
+   constructors (FacadeBoundaryTest's rule), no one-off effect where a composition exists.
+   Consult docs/card-sdk-language-reference.md for what already exists.
+5. Note whether the card has a scenario test at all, and whether that test would actually
+   fail if the ability were broken (an assertion on the real effect, not just "it resolved").
+
+Return only, one block per card, nothing else:
+CARD / VERDICT (ok|divergent|no-test|both) / FINDING (one line, or -) /
+SEVERITY (gameplay|display|style|-) / SUGGESTED (one line fix, or -)
+```
+
+Aggregate: count verdicts, keep only `divergent` and `no-test` rows, and re-dispatch anything the
+reviewer flagged as uncertain to a second reviewer with a different framing before you act on it.
+
+## What the machines can check first
+
+Run these before dispatching anybody — they're cheap and they shrink the human-judgement surface.
+
+| Tool | What it proves | Limit |
+|---|---|---|
+| `just assay-differential --set <CODE>` | Assay's independent reading of each oracle text against the card we hand-wrote from the same text. A `DIVERGENT` row is a *semantic* disagreement — exactly the Stage 3 question, decided by a parser instead of a reviewer. | Only over the class the grammar reads whole. A modern set declines most cards, so this is a floor, not the pass. |
+| `just assay-gate --set <CODE>` | Every oracle text in the set normalizes and re-prints invertibly. | Declines aren't failures — they're the coverage number. |
+| `just check-backlog-implementations` | Every `[ ]` in the backlog is genuinely unimplemented. | Names only. |
+| `CardLintTest` | Pipeline-variable dataflow, `ContextTarget` / `BoundVariable` resolution, choice-slot declarations. | Internal hygiene, not fidelity to the printed card. |
+| `FacadeBoundaryTest` | Cards use the facades, not raw constructors. | Style, not semantics. |
+
+**Read every `DIVERGENT` row from the differential.** The recipe's own comment says to classify each as
+parser bug / card bug / known fold — and its history is that it found real bugs in hand-written cards
+(the batch-trigger band exposed five at once). It is the single highest-yield DSL check in the repo.
+
+## The token checklist
+
+Tokens are the part of a set most likely to be quietly wrong, because nothing about a wrong token fails.
+A token with no art doesn't render blank — it falls through to a Scryfall *name guess*
+(`cards/named?exact=<name>`) and shows whatever printing comes back. That's how Arahbo's Foundations Cat
+ended up showing Dominaria Remastered art: nothing was missing, so nothing failed.
+
+**Resolution order** (`TokenArtRegistry`, mirrored by the token executors):
+
+1. An explicit `imageUri` on the `CreateToken` effect — always wins.
+2. This set's rows, for **the set the creating card was printed in** — hand-authored `MtgSet.tokenArt`
+   ahead of synced `TokenArtData` (`mtg-sets/core/src/main/resources/tokens.json`, keyed by set code).
+3. The engine-wide generic fallback by creature type (`TokenArt.IMAGES`).
+
+Step 2 is the "correct creator" rule, and it's why art belongs on the set rather than the card: keying on
+the creating card's printing is what makes a reprint mint the *reprint's* token. `resolve()` prefers
+`sourcePrintingSetCode` (the printing the player actually brought) over the canonical
+`sourceCardDefinitionId`.
+
+Checks, in order:
+
+```bash
+just token-art-gaps     # -> backlog/token-art-gaps.md; must list nothing for your set
+just test-class TokenArtCoverageTest
+```
+
+- **`token-art-gaps` is the real check.** `TokenArtCoverageTest` is only the floor — it proves nothing
+  renders via a Scryfall name-guess. `token-art-gaps` proves the stronger property: no token of yours is
+  showing *generic stand-in* art instead of its own set's. The file is generated; don't hand-edit it, and
+  note it's global — read the rows for your set code.
+- **Every token the set's cards can mint needs a row.** Enumerate with `TokenCreationSites.of(card)`, which
+  walks the serialised card tree and so finds a `CreateToken` nested in a composite, a mode, a pipeline, a
+  reflexive trigger, a granted ability or a `ConvertCountersToTokens` — a grep for `CreateToken` will not.
+- **Synced rows are usually enough.** `just token-art-sync` regenerates `tokens.json` wholesale from
+  Scryfall's `t<code>` token sets, so a modern set typically needs no hand-authored `tokenArt` at all. MSH
+  is like this: 21 synced rows, no override. Hand-author only what the sync can't supply — mostly pre-2001
+  sets, which have no `t<code>` set to draw from and fall back to `/images/tokens/`.
+- **`imageUri` must be the Scryfall `normal` URL**, the whole token card. An `art_crop` URL still *works*
+  but takes the legacy path: the client sees `/art_crop/` and draws the art inside a frame it generates
+  itself, which is how a token with a real printed card ends up looking like a placeholder.
+- **Hunt explicit `imageUri` on token effects** — resolution step 1 wins over everything, and
+  `TokenArtCoverageTest` deliberately skips those sites, so they are a blind spot in both gates. It is the
+  documented anti-pattern (`TokenPrinting` KDoc): baking art into the card mints the same art from every
+  printing and is wrong the moment the card is reprinted. Beware the false positive — a card's own
+  `metadata { imageUri = … }` is card art and entirely correct; only an `imageUri` argument *inside a token
+  effect* is the smell.
+- **Discriminators.** A bare `TokenPrinting("Cat", art)` matches every Cat the set mints. Pin `power` /
+  `toughness` / `colors` only when the set prints two tokens sharing a name. One token printed with several
+  illustrations is several rows differing only in `imageUri`; the engine deals them out in order.
+
+Verdict block for a token reviewer, if you dispatch one:
+
+```
+Return only:
+TOKEN / CREATED-BY (cards) / SOURCE (explicit|set-tokenArt|synced|generic-fallback) /
+IMAGE (normal|art_crop|self-hosted|none) / VERDICT (ok|wrong-set|wrong-form|missing) / NOTE (one line)
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,9 @@ docs it points at; load those when the work needs them.
   - Working autonomously through a whole set, one PR at a time, until it's done → **`set-loop`** (launches
     the harness's own loop — Claude Code `/loop`, Codex `/goal`; every PR it opens is titled
     `[agent-loop: <model-id>]`).
+  - Proving a set is *actually* finished once its backlog reads N/N, and archiving it → **`verify-set`**
+    (Scryfall field verification of every compiled card, reprint and basic-land coverage, self-play pass).
+    A green backlog is a claim; that skill is the proof.
 - **Verify MTG rule numbers before citing them** in code, comments, commit messages, PR bodies, or chat.
   613.8 vs 613.7 and 704.5 vs 704.6 are easy to swap. Check the official Comprehensive Rules
   <https://magic.wizards.com/en/rules> — the plain-text `.txt` is too large to fetch into context, so


### PR DESCRIPTION
# Add a `verify-set` skill

A backlog reading `286 / 286` is a claim, not a proof. It says every name has *a* `CardDefinition` — not
that the definition carries the right power, colour identity, or oracle text, not that the script means
what the printed text says, and not that the card works when played. Nothing in the repo closes that gap
today: `CardDefinitionSnapshotTest` pins what we compiled against *what we compiled last time* and is
blind to Scryfall; `CardLintTest` checks internal hygiene. This skill is the proof step, and it archives
the backlog once the proof holds.

## What it adds

`.agents/skills/verify-set/` — a three-file skill, plus the routing line in `AGENTS.md` that points at it.

The skill organises the work as six claims, cheapest first so an early failure saves the later stages:

| # | Claim | Proven by |
|---|---|---|
| 1 | Every card that should exist, exists | `scripts/card-status`, `just check-backlog*` |
| 2 | Every compiled `CardDefinition` matches Scryfall field for field | generated `<Set>CardFieldVerificationTest` |
| 3 | The cards behave as printed when played | scenario tests + a self-play pass |
| 4 | Every card's *script* says what its oracle text says | `assay-differential` + per-card review |
| 5 | Every token the set mints resolves *this set's* art | `token-art-gaps`, `TokenArtCoverageTest` |
| 6 | The repo says so | snapshot re-bless, backlog archived, report written |

- **`SKILL.md`** — the orchestration: the six claims, the stage order, and the rule that the driving
  session dispatches and aggregates rather than reading card files itself.
- **`field-verification.md`** — building the Scryfall dump and generating the per-set field-verification
  test (claim 2), including reprint and basic-land coverage.
- **`per-card-review.md`** — the subagent fan-out protocol for claims 4 and 5: reviewer prompts with fixed
  verdict blocks, and both checklists.

## Why the fan-out

Claims 4 and 5 are per-card judgement across 200–290 cards. Read serially in one session the useful signal
is gone by card 40 and the session is compacting by card 80 — and a compacted reviewer degrades without
saying so. The skill therefore mandates dispatch/aggregate/record with a fixed verdict format, so the
orchestrator's context holds verdicts rather than card text.

## Scope and verification

Documentation only — three new Markdown files under `.agents/skills/` and three lines in `AGENTS.md`. No
Kotlin, TypeScript, or build files are touched, so no build or test gate applies and none was run. The
card work these instructions were developed against ships separately in the Marvel Super Heroes branch;
this PR carries none of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
