### PR TITLE
Fix Syphon Mind in multiplayer

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2400,7 +2400,13 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   Every space snapshots its items before the first iteration (entities destroyed mid-loop stay in
   the list) and every space is **pause-safe**: a body that pauses for a decision resumes the
   remaining iterations via the shared `ForEachContinuation`. Multi-effect bodies lower to a
-  `CompositeEffect`.
+  `CompositeEffect`. `ForEachPlayerCollectingEffect(players, effects, collectCollections)` is the
+  player-loop facade for a following effect that needs outputs from every fresh per-player
+  sub-pipeline. Its map is `body-local collection → aggregate collection`; each iteration's output
+  is appended in player order and published only outside the loop. Accumulation is pause-safe and
+  does not leak one player's working collections into the next player's body. Syphon Mind maps each
+  opponent's `discarded_this_opponent` output into `discarded_by_opponents`, then draws from that
+  aggregate.
 - `ConditionalEffect(condition, ifTrue, ifFalse?)` / `Branch(...)` — conditional branch. Facade
   preserved for existing cards; it now **lowers to `GatedEffect(Gate.WhenCondition(condition), then =
   ifTrue, otherwise = ifFalse)`** (compiled form is `Gated`, not a distinct `Conditional` type). It is
@@ -2670,7 +2676,11 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
   to decouple the payoff from the discard ("discard up to two cards, then draw three").
 - `discardRandom(count, target)` — random discards.
 - `discardHand(target)` — discard entire hand.
-- `eachOpponentDiscards(count, controllerDrawsPerDiscard?)` — Mind Twist-style.
+- `eachOpponentDiscards(count, controllerDrawsPerDiscard?)` — each opponent independently chooses
+  and discards `count` cards. When `controllerDrawsPerDiscard > 0`, the per-player pipelines collect
+  the cards that actually reached graveyards and the controller draws that many times the multiplier
+  in one draw instruction (Syphon Mind); this covers every opponent and naturally counts fewer cards
+  when an opponent's hand is short.
 - `eachPlayerDiscards(count)` — each player *including you* discards N, each from their own hand (facade `Effects.EachPlayerDiscards(count)`). Rankle's Prank's first mode, Lore Broker's second half. One `ForEachPlayer(Player.ActivePlayerFirst)` iteration per player so the choices happen in APNAP order (CR 101.4); iterations run sequentially, so a later player chooses after an earlier player's cards have already hit the graveyard, where the rules would have every player choose face down (CR 101.4a) and discard simultaneously. The mtgish emitter renders `EachPlayerAction(AnyPlayer, Discard…)` to this pattern when the discard is the player's sole action.
 - `eachPlayerDiscardsDraws(controllerBonusDraw?)` — Windfall / Wheel of Fortune.
 - `eachPlayerDrawsX(includeController?, includeOpponents?)` — Howling Mine shape.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
@@ -18,6 +18,7 @@ import com.wingedsheep.sdk.scripting.effects.EffectChoice
 import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
 import com.wingedsheep.sdk.scripting.effects.ForEachEffect
 import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerCollectingEffect
 import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
@@ -43,29 +44,37 @@ object HandPatterns {
     fun eachOpponentDiscards(count: Int, controllerDrawsPerDiscard: Int = 0): Effect {
         if (controllerDrawsPerDiscard > 0) {
             val drawCount: DynamicAmount = if (controllerDrawsPerDiscard == 1) {
-                DynamicAmount.VariableReference("discarded_count")
+                DynamicAmount.DistinctEntitiesInCollections(listOf("discarded_by_opponents"))
             } else {
-                DynamicAmount.Multiply(DynamicAmount.VariableReference("discarded_count"), controllerDrawsPerDiscard)
+                DynamicAmount.Multiply(
+                    DynamicAmount.DistinctEntitiesInCollections(listOf("discarded_by_opponents")),
+                    controllerDrawsPerDiscard
+                )
             }
             return CompositeEffect(listOf(
-                GatherCardsEffect(
-                    // TODO(multiplayer Phase 1, backlog/multiplayer.md): "each opponent discards,
-                    //  you draw per discard" needs cross-iteration count accumulation; until then
-                    //  this hits one opponent (identical in two-player games).
-                    source = CardSource.FromZone(Zone.HAND, Player.AnOpponent),
-                    storeAs = "hand"
-                ),
-                SelectFromCollectionEffect(
-                    from = "hand",
-                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(count)),
-                    chooser = Chooser.Opponent,
-                    storeSelected = "discarded",
-                    prompt = "Choose ${if (count == 1) "a card" else "$count cards"} to discard"
-                ),
-                MoveCollectionEffect(
-                    from = "discarded",
-                    destination = CardDestination.ToZone(Zone.GRAVEYARD, player = Player.AnOpponent),
-                    moveType = MoveType.Discard
+                ForEachPlayerCollectingEffect(
+                    players = Player.EachOpponent,
+                    effects = listOf(
+                        GatherCardsEffect(
+                            source = CardSource.FromZone(Zone.HAND, Player.You),
+                            storeAs = "hand"
+                        ),
+                        SelectFromCollectionEffect(
+                            from = "hand",
+                            selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(count)),
+                            storeSelected = "discarded",
+                            prompt = "Choose ${if (count == 1) "a card" else "$count cards"} to discard"
+                        ),
+                        MoveCollectionEffect(
+                            from = "discarded",
+                            destination = CardDestination.ToZone(Zone.GRAVEYARD),
+                            moveType = MoveType.Discard,
+                            storeMovedAs = "discarded_this_opponent"
+                        )
+                    ),
+                    collectCollections = mapOf(
+                        "discarded_this_opponent" to "discarded_by_opponents"
+                    )
                 ),
                 DrawCardsEffect(count = drawCount)
             ))

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ForEachEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ForEachEffects.kt
@@ -125,7 +125,18 @@ sealed interface IterationSpace {
 @Serializable
 data class ForEachEffect(
     val space: IterationSpace,
-    val body: Effect
+    val body: Effect,
+    /**
+     * Per-iteration collection outputs to append into an outer result collection.
+     * The key is the collection written by [body]; the value is the collection
+     * published after every iteration completes.
+     *
+     * Player and target iterations still start with fresh collections. This reducer
+     * is the explicit bridge for effects such as "each opponent discards ...; draw
+     * for each card discarded this way", where every opponent makes an independent
+     * choice but the following effect needs the combined set of moved cards.
+     */
+    val collectCollections: Map<String, String> = emptyMap()
 ) : Effect {
     override val description: String = render { it.description }
 
@@ -218,6 +229,22 @@ fun ForEachTargetEffect(effects: List<Effect>): ForEachEffect =
 @Suppress("FunctionName")
 fun ForEachPlayerEffect(players: Player, effects: List<Effect>): ForEachEffect =
     ForEachEffect(IterationSpace.Players(players), effects.asBody())
+
+/**
+ * Execute a fresh sub-pipeline once per matching player and append selected collection
+ * outputs across every iteration. [collectCollections] maps each body-local output name
+ * to the aggregate name exposed to following effects.
+ */
+@Suppress("FunctionName")
+fun ForEachPlayerCollectingEffect(
+    players: Player,
+    effects: List<Effect>,
+    collectCollections: Map<String, String>
+): ForEachEffect = ForEachEffect(
+    IterationSpace.Players(players),
+    effects.asBody(),
+    collectCollections
+)
 
 /**
  * Run [effect] once per entity in a named pipeline collection, with

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -435,6 +435,16 @@ object CardLinter {
                     Kind.WRITE to (Space.COLLECTION to "toGraveyard"),
                     Kind.WRITE to (Space.COLLECTION to "toTop"),
                 )
+            type == "ForEach" -> {
+                val reducers = obj["collectCollections"] as? JsonObject
+                if (reducers == null) emptyList() else reducers.flatMap { (localName, aggregateValue) ->
+                    val aggregateName = (aggregateValue as? JsonPrimitive)?.contentOrNull
+                    if (aggregateName == null) emptyList() else listOf(
+                        Kind.READ to (Space.COLLECTION to localName),
+                        Kind.WRITE to (Space.COLLECTION to aggregateName),
+                    )
+                }
+            }
             else -> emptyList()
         }
 
@@ -980,7 +990,8 @@ object CardLinter {
                 if (engineSeeded(read)) continue
                 val inScope = scope.writes.filter { matches(read, it) }
                 when {
-                    inScope.any { it.pos <= read.pos } -> {}
+                    inScope.any { it.pos <= read.pos } ||
+                        (read.nodeType == "ForEach" && read.field == "(implicit)" && inScope.isNotEmpty()) -> {}
                     inScope.isNotEmpty() -> state.findings.add(
                         CardValidationError.PipelineReadBeforeWrite(
                             cardName = state.cardName,

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardSerializationRoundTripTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardSerializationRoundTripTest.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
 import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
 import com.wingedsheep.sdk.scripting.effects.ForEachEffect
 import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerCollectingEffect
 import com.wingedsheep.sdk.scripting.effects.IterationSpace
 import com.wingedsheep.sdk.scripting.effects.GainControlEffect
 import com.wingedsheep.sdk.scripting.effects.GrantHarmonizeEffect
@@ -34,6 +35,7 @@ import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
 import com.wingedsheep.sdk.scripting.predicates.StatePredicate
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.TriggerSpec
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
@@ -53,6 +55,25 @@ class CardSerializationRoundTripTest : DescribeSpec({
     val json = CardSerialization.json
 
     describe("Effect round-trip serialization") {
+
+        it("should round-trip player-iteration collection reducers") {
+            val card = card("Collect Player Outputs") {
+                manaCost = "{B}"
+                typeLine = "Sorcery"
+                spell {
+                    effect = ForEachPlayerCollectingEffect(
+                        players = Player.EachOpponent,
+                        effects = listOf(DrawCardsEffect(DynamicAmount.Fixed(1))),
+                        collectCollections = mapOf("local" to "all")
+                    )
+                }
+            }
+
+            val serialized = CardLoader.toJson(card)
+            val effect = CardLoader.fromJson(serialized).script.spellEffect as ForEachEffect
+
+            effect.collectCollections shouldBe mapOf("local" to "all")
+        }
 
         it("should round-trip a simple damage spell") {
             val card = card("Lightning Bolt") {

--- a/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/SyphonMind.kt
+++ b/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/SyphonMind.kt
@@ -25,6 +25,6 @@ val SyphonMind = card("Syphon Mind") {
         collectorNumber = "175"
         artist = "Jeff Easley"
         flavorText = "When tempers run high, it's easy to lose your head."
-        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b0d8543-78c9-4d7f-b45e-44ecf023d276.jpg?1562897508"
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b0d8543-78c9-4d7f-b45e-44ecf023d276.jpg?1783945062"
     }
 }

--- a/mtg-sets/2000-2002/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SyphonMindTest.kt
+++ b/mtg-sets/2000-2002/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SyphonMindTest.kt
@@ -122,4 +122,41 @@ class SyphonMindTest : FunSpec({
         // Controller gained 1 card net from the draw
         driver.getHandSize(activePlayer) shouldBe activeHandBefore + 1
     }
+
+    test("Syphon Mind makes every other player discard and draws for every card discarded") {
+        val driver = createDriver()
+        val players = driver.initMultiplayer(
+            decks = List(4) { Deck.of("Swamp" to 20, "Forest" to 20) },
+            startingLife = 20
+        )
+        val controller = players.first()
+        val opponents = players.drop(1)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val controllerHandBefore = driver.getHandSize(controller)
+        val opponentHandsBefore = opponents.associateWith(driver::getHandSize)
+        val syphonMind = driver.putCardInHand(controller, "Syphon Mind")
+        driver.giveMana(controller, Color.BLACK, 4)
+        driver.castSpell(controller, syphonMind).isSuccess shouldBe true
+
+        // A multiplayer priority round: every seat passes before the spell resolves.
+        repeat(players.size) {
+            driver.passPriority(driver.state.priorityPlayerId!!)
+        }
+
+        // Each opponent gets their own discard choice, in turn order.
+        opponents.forEach { opponent ->
+            driver.pendingDecision?.playerId shouldBe opponent
+            driver.submitCardSelection(opponent, listOf(driver.getHand(opponent).first()))
+        }
+
+        opponents.forEach { opponent ->
+            driver.getHandSize(opponent) shouldBe opponentHandsBefore.getValue(opponent) - 1
+        }
+        // The controller is not included and draws once for each of the three actual discards.
+        driver.getHandSize(controller) shouldBe controllerHandBefore + 3
+        driver.events.filterIsInstance<CardsDrawnEvent>()
+            .any { it.playerId == controller && it.count == 3 } shouldBe true
+    }
 })

--- a/mtg-sets/src/test/resources/snapshots/cards/ONS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONS.json
@@ -15455,43 +15455,58 @@
             "type": "Composite",
             "effects": [
                 {
-                    "type": "GatherCards",
-                    "source": {
-                        "type": "FromZone",
-                        "zone": "Hand",
-                        "player": "AnOpponent"
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
                     },
-                    "storeAs": "hand"
-                },
-                {
-                    "type": "SelectFromCollection",
-                    "from": "hand",
-                    "selection": {
-                        "type": "ChooseExactly",
-                        "count": {
-                            "type": "Fixed",
-                            "amount": 1
-                        }
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "discarded",
+                                "prompt": "Choose a card to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard",
+                                "storeMovedAs": "discarded_this_opponent"
+                            }
+                        ]
                     },
-                    "chooser": "Opponent",
-                    "storeSelected": "discarded",
-                    "prompt": "Choose a card to discard"
-                },
-                {
-                    "type": "MoveCollection",
-                    "from": "discarded",
-                    "destination": {
-                        "type": "ToZone",
-                        "zone": "Graveyard",
-                        "player": "AnOpponent"
-                    },
-                    "moveType": "Discard"
+                    "collectCollections": {
+                        "discarded_this_opponent": "discarded_by_opponents"
+                    }
                 },
                 {
                     "type": "DrawCards",
                     "count": {
-                        "type": "VariableReference",
-                        "variableName": "discarded_count"
+                        "type": "DistinctEntitiesInCollections",
+                        "collections": [
+                            "discarded_by_opponents"
+                        ]
                     }
                 }
             ]
@@ -15501,7 +15516,7 @@
         "collectorNumber": "175",
         "artist": "Jeff Easley",
         "flavorText": "When tempers run high, it's easy to lose your head.",
-        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b0d8543-78c9-4d7f-b45e-44ecf023d276.jpg?1562897508"
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b0d8543-78c9-4d7f-b45e-44ecf023d276.jpg?1783945062"
     },
     "colorIdentityOverride": [
         "BLACK"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CoreAutoResumerModule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CoreAutoResumerModule.kt
@@ -25,7 +25,9 @@ class CoreAutoResumerModule(
             mergeAndContinue(result, events)
         },
 
-        autoResumer(ForEachContinuation::class, canResume = { it.remainingItems.isNotEmpty() }) { state, continuation, events, checkForMore ->
+        autoResumer(ForEachContinuation::class, canResume = {
+            it.remainingItems.isNotEmpty() || it.effect.collectCollections.isNotEmpty()
+        }) { state, continuation, events, checkForMore ->
             val forEachExecutor = com.wingedsheep.engine.handlers.effects.composite.ForEachExecutor { s, e, c ->
                 services.effectExecutorRegistry.execute(s, e, c)
             }
@@ -34,8 +36,14 @@ class CoreAutoResumerModule(
                 continuation.effect,
                 continuation.remainingItems,
                 continuation.effectContext
-            ).toExecutionResult()
-            mergeAndContinue(result, events, checkForMore)
+            )
+            if (result.isPaused) {
+                return@autoResumer ExecutionResult.paused(
+                    result.state, result.pendingDecision!!, events + result.events
+                )
+            }
+            val published = exposeCollectionsToNextFrame(result.state, result.updatedCollections)
+            checkForMore(published, events + result.events)
         },
 
         autoResumer(DrawReplacementRemainingDrawsContinuation::class) { state, continuation, events, checkForMore ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/PipelineCollectionPropagation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/PipelineCollectionPropagation.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.handlers.continuations
 
 import com.wingedsheep.engine.core.EffectContinuation
 import com.wingedsheep.engine.core.GatedActionContinuation
+import com.wingedsheep.engine.core.ForEachContinuation
 import com.wingedsheep.engine.core.ReflexiveTriggerTargetContinuation
 import com.wingedsheep.engine.core.RepeatWhileContinuation
 import com.wingedsheep.engine.handlers.EffectContext
@@ -71,6 +72,25 @@ fun exposeCollectionsToNextFrame(
         )
 
     return when (val next = state.peekContinuation()) {
+        is ForEachContinuation -> {
+            var accumulated = next.effectContext.pipeline.storedCollections
+            for ((localName, aggregateName) in next.effect.collectCollections) {
+                val iterationOutput = collections[localName].orEmpty()
+                if (iterationOutput.isNotEmpty()) {
+                    accumulated = accumulated + (
+                        aggregateName to accumulated[aggregateName].orEmpty() + iterationOutput
+                    )
+                }
+            }
+            val (_, popped) = state.popContinuation()
+            popped.pushContinuation(
+                next.copy(
+                    effectContext = next.effectContext.copy(
+                        pipeline = next.effectContext.pipeline.copy(storedCollections = accumulated)
+                    )
+                )
+            )
+        }
         is EffectContinuation -> {
             val (_, popped) = state.popContinuation()
             popped.pushContinuation(next.copy(effectContext = next.effectContext.withMergedCollections()))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
@@ -86,21 +86,30 @@ class ForEachExecutor(
         items: List<ForEachItem>,
         outerContext: EffectContext
     ): EffectResult {
+        if (items.isEmpty()) {
+            val collected = effect.collectCollections.values.associateWith { aggregate ->
+                outerContext.pipeline.storedCollections[aggregate].orEmpty()
+            }
+            return EffectResult(state = state, updatedCollections = collected)
+        }
+
         var currentState = state
+        var currentOuterContext = outerContext
         val allEvents = mutableListOf<GameEvent>()
 
         for ((index, item) in items.withIndex()) {
             val remainingItems = items.drop(index + 1)
 
-            val iterationContext = bindIterationContext(currentState, outerContext, item)
+            val iterationContext = bindIterationContext(currentState, currentOuterContext, item)
 
-            val stateForExecution = if (remainingItems.isNotEmpty()) {
+            val needsContinuation = remainingItems.isNotEmpty() || effect.collectCollections.isNotEmpty()
+            val stateForExecution = if (needsContinuation) {
                 currentState.pushContinuation(
                     ForEachContinuation(
                         decisionId = "pending",
                         remainingItems = remainingItems,
                         effect = effect,
-                        effectContext = outerContext
+                        effectContext = currentOuterContext
                     )
                 )
             } else {
@@ -121,16 +130,45 @@ class ForEachExecutor(
 
             // Pop the pre-pushed continuation (it wasn't needed). A failed body
             // (per CR 608.2 partial resolution) still continues with the next item.
-            currentState = if (remainingItems.isNotEmpty()) {
+            currentState = if (needsContinuation) {
                 val (_, stateWithoutCont) = result.state.popContinuation()
                 stateWithoutCont
             } else {
                 result.state
             }
             allEvents.addAll(result.events)
+
+            if (effect.collectCollections.isNotEmpty()) {
+                currentOuterContext = appendCollectedCollections(
+                    currentOuterContext,
+                    effect,
+                    result.updatedCollections
+                )
+            }
         }
 
-        return EffectResult.success(currentState, allEvents)
+        val collected = effect.collectCollections.values.associateWith { aggregate ->
+            currentOuterContext.pipeline.storedCollections[aggregate].orEmpty()
+        }
+        return EffectResult(currentState, allEvents, updatedCollections = collected)
+    }
+
+    private fun appendCollectedCollections(
+        context: EffectContext,
+        effect: ForEachEffect,
+        outputs: Map<String, List<EntityId>>
+    ): EffectContext {
+        if (outputs.isEmpty()) return context
+        var collections = context.pipeline.storedCollections
+        for ((localName, aggregateName) in effect.collectCollections) {
+            val iterationOutput = outputs[localName].orEmpty()
+            if (iterationOutput.isNotEmpty()) {
+                collections = collections + (
+                    aggregateName to collections[aggregateName].orEmpty() + iterationOutput
+                )
+            }
+        }
+        return context.copy(pipeline = context.pipeline.copy(storedCollections = collections))
     }
 
     /** Snapshot the iteration space into concrete items. */


### PR DESCRIPTION
## Summary

- make Syphon Mind iterate over every opponent instead of resolving against only one
- add a reusable, pause-safe collection reducer for per-player pipelines so the final draw counts cards actually discarded across the pod
- add four-player regression coverage, SDK serialization coverage, lint support, docs, and the refreshed ONS snapshot/image URL

## Verification

- `just test`
- `just test-class SyphonMindTest`
- `just test-class CardSerializationRoundTripTest`
- `just rebless-cards`
- Syphon Mind image URL: HTTP 200

## Known unrelated repository drift

`just check-card-printing "Syphon Mind"` confirms ONS is the correct canonical set, but exits non-zero because scaffolded CLB and MSC are already missing Syphon Mind `Printing(...)` rows. Those unrelated reprint rows are outside this fix.