### PR TITLE
Add three Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CeaseDesist.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CeaseDesist.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Cease // Desist — Murders at Karlov Manor #246
+ *
+ * Cease gathers only object targets (the target player is not a card entity), so its pipeline moves
+ * exactly the zero-to-two graveyard cards before applying the life gain and draw to the separately
+ * captured player target. [TargetObject.sameOwner] enforces "from a single graveyard" at targeting.
+ */
+val CeaseDesist = card("Cease // Desist") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "WBG"
+
+    face("Cease") {
+        manaCost = "{1}{B/G}"
+        typeLine = "Instant"
+        oracleText = "Exile up to two target cards from a single graveyard. Target player gains 2 life and draws a card."
+
+        spell {
+            target(
+                "up to two target cards from a single graveyard",
+                TargetObject(
+                    count = 2,
+                    optional = true,
+                    filter = TargetFilter.CardInGraveyard,
+                    sameOwner = true,
+                ),
+            )
+            val player = target("target player", Targets.Player)
+            effect = Effects.Composite(
+                GatherCardsEffect(CardSource.ChosenTargets, "ceaseTargets"),
+                MoveCollectionEffect(
+                    from = "ceaseTargets",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                ),
+                Effects.GainLife(2, player),
+                Effects.DrawCards(1, player),
+            )
+        }
+    }
+
+    face("Desist") {
+        manaCost = "{4}{G/W}{G/W}"
+        typeLine = "Sorcery"
+        oracleText = "Destroy all artifacts and enchantments."
+
+        spell {
+            effect = Effects.DestroyAll(
+                filter = com.wingedsheep.sdk.scripting.GameObjectFilter.Artifact.or(
+                    com.wingedsheep.sdk.scripting.GameObjectFilter.Enchantment,
+                ),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "246"
+        artist = "Dominik Mayer"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb59130a-a134-4383-b983-e4b526d11fb4.jpg?1783912830"
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/LeylineOfTheGuildpact.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/LeylineOfTheGuildpact.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.mayBeginGameOnBattlefield
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantColor
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Leyline of the Guildpact — Murders at Karlov Manor #217
+ * {G/W}{G/U}{B/G}{R/G} · Enchantment
+ *
+ * The five [GrantColor] abilities share the nonland-permanents-you-control filter and combine in
+ * layer 5 to make every affected permanent all colors. The five [GrantSubtype] abilities similarly
+ * add every basic land type in layer 4 without replacing a land's printed types or abilities; the
+ * engine derives the corresponding intrinsic mana abilities from those projected basic land types.
+ */
+val LeylineOfTheGuildpact = card("Leyline of the Guildpact") {
+    manaCost = "{G/W}{G/U}{B/G}{R/G}"
+    colorIdentity = "WUBRG"
+    typeLine = "Enchantment"
+    oracleText = "If this card is in your opening hand, you may begin the game with it on the battlefield.\n" +
+        "Each nonland permanent you control is all colors.\n" +
+        "Lands you control are every basic land type in addition to their other types."
+
+    mayBeginGameOnBattlefield()
+
+    val nonlandPermanentsYouControl = GroupFilter(GameObjectFilter.NonlandPermanent.youControl())
+    Color.entries.forEach { color ->
+        staticAbility {
+            ability = GrantColor(color, nonlandPermanentsYouControl)
+        }
+    }
+
+    val landsYouControl = GroupFilter(GameObjectFilter.Land.youControl())
+    listOf("Plains", "Island", "Swamp", "Mountain", "Forest").forEach { subtype ->
+        staticAbility {
+            ability = GrantSubtype(subtype, landsYouControl)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "217"
+        artist = "Daarken"
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bf6e59be-f959-4f4a-8c2d-b7c441e88135.jpg?1783912844"
+        ruling("2024-02-02", "Each land you control will have the land types Plains, Island, Swamp, Mountain, and Forest. They'll also have the mana ability of each basic land type. They'll still have their other subtypes and abilities.")
+        ruling("2024-02-02", "Giving a land additional basic land types doesn't change its name or whether it's legendary or basic.")
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PushPull.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PushPull.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Push // Pull — Murders at Karlov Manor #250
+ *
+ * Pull gathers its surviving targets, moves them together under the caster's control, and records
+ * only the cards that actually entered. Haste and the delayed sacrifice are then attached to each
+ * moved permanent independently, so a target that becomes illegal does not affect the other one.
+ */
+val PushPull = card("Push // Pull") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "WBR"
+
+    face("Push") {
+        manaCost = "{1}{W/B}"
+        typeLine = "Sorcery"
+        oracleText = "Destroy target tapped creature."
+
+        spell {
+            val creature = target("target tapped creature", Targets.TappedCreature)
+            effect = Effects.Destroy(creature)
+        }
+    }
+
+    face("Pull") {
+        manaCost = "{4}{B/R}{B/R}"
+        typeLine = "Sorcery"
+        oracleText = "Put up to two target creature cards from a single graveyard onto the battlefield under your control. " +
+            "They gain haste until end of turn. Sacrifice them at the beginning of the next end step."
+
+        spell {
+            target = TargetObject(
+                count = 2,
+                optional = true,
+                filter = TargetFilter.CreatureInGraveyard,
+                sameOwner = true,
+            )
+            effect = Effects.Pipeline {
+                val targets = gather(CardSource.ChosenTargets, name = "pullTargets")
+                val entered = moveTracked(
+                    from = targets,
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                    name = "pullEntered",
+                )
+                run(
+                    ForEachInCollectionEffect(
+                        collection = entered.key,
+                        effect = Effects.Composite(
+                            Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self, Duration.EndOfTurn),
+                            CreateDelayedTriggerEffect(
+                                step = Step.END,
+                                effect = Effects.SacrificeTarget(EffectTarget.Self),
+                            ),
+                        ),
+                    ),
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "250"
+        artist = "Eli Minaya"
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85835473-b9b6-4f4a-bb93-fef93d5ec57b.jpg?1783912830"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -2369,6 +2369,124 @@
     ]
 }
 
+// Cease // Desist
+{
+    "name": "Cease // Desist",
+    "manaCost": "",
+    "typeLine": "Instant",
+    "oracleText": "Exile up to two target cards from a single graveyard. Target player gains 2 life and draws a card.\n//\nDestroy all artifacts and enchantments.",
+    "metadata": {
+        "collectorNumber": "246",
+        "rarity": "UNCOMMON",
+        "artist": "Dominik Mayer",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cb59130a-a134-4383-b983-e4b526d11fb4.jpg?1783912830"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK",
+        "GREEN"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Cease",
+            "manaCost": "{1}{B/G}",
+            "typeLine": "Instant",
+            "oracleText": "Exile up to two target cards from a single graveyard. Target player gains 2 life and draws a card.",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "ceaseTargets"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "ceaseTargets",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "count": 2,
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "up to two target cards from a single graveyard",
+                        "sameOwner": true
+                    },
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Desist",
+            "manaCost": "{4}{G/W}{G/W}",
+            "typeLine": "Sorcery",
+            "oracleText": "Destroy all artifacts and enchantments.",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": "artifact|enchantment"
+                            },
+                            "storeAs": "destroyAll_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "destroyAll_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "hasNoManaCost": true
+}
+
 // Cerebral Confiscation
 {
     "name": "Cerebral Confiscation",
@@ -8156,6 +8274,112 @@
     ]
 }
 
+// Leyline of the Guildpact
+{
+    "name": "Leyline of the Guildpact",
+    "manaCost": "{G/W}{G/U}{B/G}{R/G}",
+    "typeLine": "Enchantment",
+    "oracleText": "If this card is in your opening hand, you may begin the game with it on the battlefield.\nEach nonland permanent you control is all colors.\nLands you control are every basic land type in addition to their other types.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantColor",
+                "color": "WHITE",
+                "filter": {
+                    "baseFilter": "nonland permanent ctrl:you"
+                }
+            },
+            {
+                "type": "GrantColor",
+                "color": "BLUE",
+                "filter": {
+                    "baseFilter": "nonland permanent ctrl:you"
+                }
+            },
+            {
+                "type": "GrantColor",
+                "color": "BLACK",
+                "filter": {
+                    "baseFilter": "nonland permanent ctrl:you"
+                }
+            },
+            {
+                "type": "GrantColor",
+                "color": "RED",
+                "filter": {
+                    "baseFilter": "nonland permanent ctrl:you"
+                }
+            },
+            {
+                "type": "GrantColor",
+                "color": "GREEN",
+                "filter": {
+                    "baseFilter": "nonland permanent ctrl:you"
+                }
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Plains",
+                "filter": {
+                    "baseFilter": "land ctrl:you"
+                }
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Island",
+                "filter": {
+                    "baseFilter": "land ctrl:you"
+                }
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Swamp",
+                "filter": {
+                    "baseFilter": "land ctrl:you"
+                }
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Mountain",
+                "filter": {
+                    "baseFilter": "land ctrl:you"
+                }
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Forest",
+                "filter": {
+                    "baseFilter": "land ctrl:you"
+                }
+            }
+        ],
+        "mayStartOnBattlefield": true
+    },
+    "metadata": {
+        "collectorNumber": "217",
+        "rarity": "RARE",
+        "artist": "Daarken",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bf6e59be-f959-4f4a-8c2d-b7c441e88135.jpg?1783912844",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Each land you control will have the land types Plains, Island, Swamp, Mountain, and Forest. They'll also have the mana ability of each basic land type. They'll still have their other subtypes and abilities."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Giving a land additional basic land types doesn't change its name or whether it's legendary or basic."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK",
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Long Goodbye
 {
     "name": "Long Goodbye",
@@ -10703,6 +10927,119 @@
         ]
     },
     "colorIdentityOverride": []
+}
+
+// Push // Pull
+{
+    "name": "Push // Pull",
+    "manaCost": "",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target tapped creature.\n//\nPut up to two target creature cards from a single graveyard onto the battlefield under your control. They gain haste until end of turn. Sacrifice them at the beginning of the next end step.",
+    "metadata": {
+        "collectorNumber": "250",
+        "rarity": "UNCOMMON",
+        "artist": "Eli Minaya",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/85835473-b9b6-4f4a-bb93-fef93d5ec57b.jpg?1783912830"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK",
+        "RED"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Push",
+            "manaCost": "{1}{W/B}",
+            "typeLine": "Sorcery",
+            "oracleText": "Destroy target tapped creature.",
+            "script": {
+                "spellEffect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target tapped creature"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature tapped"
+                        },
+                        "id": "target tapped creature"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Pull",
+            "manaCost": "{4}{B/R}{B/R}",
+            "typeLine": "Sorcery",
+            "oracleText": "Put up to two target creature cards from a single graveyard onto the battlefield under your control. They gain haste until end of turn. Sacrifice them at the beginning of the next end step.",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "pullTargets"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "pullTargets",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "storeMovedAs": "pullEntered"
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Collection",
+                                "collection": "pullEntered"
+                            },
+                            "body": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GrantKeyword",
+                                        "keyword": "HASTE",
+                                        "target": "Self"
+                                    },
+                                    {
+                                        "type": "CreateDelayedTrigger",
+                                        "step": "END",
+                                        "effect": {
+                                            "type": "SacrificeTarget",
+                                            "target": "Self"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "count": 2,
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature",
+                            "zone": "Graveyard"
+                        },
+                        "sameOwner": true
+                    }
+                ]
+            }
+        }
+    ],
+    "hasNoManaCost": true
 }
 
 // Pyrotechnic Performer


### PR DESCRIPTION
## Summary

- **Leyline of the Guildpact** — composes the existing opening-hand Leyline marker with additive color and basic-land-subtype static abilities.
- **Cease // Desist** — composes split-card faces, constrained multi-card graveyard targeting, exile, targeted life gain/draw, and an artifact/enchantment sweep.
- **Push // Pull** — composes tapped-creature removal with constrained graveyard reanimation, temporary haste, and delayed sacrifice.

All three use existing SDK vocabulary; no engine, SDK, or client changes were needed. The standard targeting and mulligan decision UIs already cover their player experience.

## Verification

- `just build`
- `just check-card-printing "Leyline of the Guildpact"`
- `just check-card-printing "Cease // Desist"`
- `just check-card-printing "Push // Pull"`
- MKM snapshot re-blessed and inspected: only these three card trees were added
- Scryfall metadata, Oracle text, rulings, canonical placement, and image URLs re-verified