### PR TITLE
Add two Mirrodin cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GateToTheAether.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GateToTheAether.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Gate to the Aether
+ * {6}
+ * Artifact
+ * At the beginning of each player's upkeep, that player reveals the top card of their library. If
+ * it's an artifact, creature, enchantment, or land card, the player may put it onto the battlefield.
+ */
+val GateToTheAether = card("Gate to the Aether") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "At the beginning of each player's upkeep, that player reveals the top card of " +
+        "their library. If it's an artifact, creature, enchantment, or land card, the player may " +
+        "put it onto the battlefield."
+
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        effect = Effects.Pipeline {
+            val top = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(1), Player.TriggeringPlayer))
+            reveal(top)
+            val permanent = filter(top, GameObjectFilter.Permanent)
+            ifNotEmpty(permanent) {
+                run(
+                    MayEffect(
+                        effect = Effects.Move(
+                            EffectTarget.PipelineTarget(permanent.key),
+                            Zone.BATTLEFIELD,
+                            controllerOverride = EffectTarget.PlayerRef(Player.TriggeringPlayer)
+                        ),
+                        descriptionOverride = "Put the revealed permanent card onto the battlefield?",
+                        decisionMaker = EffectTarget.PlayerRef(Player.TriggeringPlayer)
+                    )
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "174"
+        artist = "Pete Venters"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c28fd840-e633-46d3-991a-b9fea95a2f28.jpg?1783944521"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/LumengridAugur.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/LumengridAugur.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lumengrid Augur
+ * {3}{U}
+ * Creature — Vedalken Wizard
+ * 2/2
+ * {1}, {T}: Target player draws a card, then discards a card. If that player discards an
+ * artifact card this way, untap this creature.
+ */
+val LumengridAugur = card("Lumengrid Augur") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Vedalken Wizard"
+    oracleText = "{1}, {T}: Target player draws a card, then discards a card. If that player " +
+        "discards an artifact card this way, untap this creature."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        val player = target("player", Targets.Player)
+        effect = Effects.Pipeline {
+            run(Effects.DrawCards(1, player))
+            val hand = gather(CardSource.FromZone(Zone.HAND, Player.TargetPlayer))
+            val discarded = chooseExactly(
+                1,
+                from = hand,
+                chooser = Chooser.TargetPlayer,
+                prompt = "Choose a card to discard",
+                selectedLabel = "Discard"
+            )
+            move(
+                discarded,
+                CardDestination.ToZone(Zone.GRAVEYARD, Player.TargetPlayer),
+                moveType = MoveType.Discard
+            )
+            ifNotEmpty(discarded, GameObjectFilter.Artifact) {
+                run(Effects.Untap(EffectTarget.Self))
+            }
+        }
+        description = "Target player draws a card, then discards a card. If that player discards " +
+            "an artifact card this way, untap this creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "39"
+        artist = "rk post"
+        flavorText = "Information pumps like blood through vedalken society."
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/65704c0f-cc97-490e-a0f7-fab9a18e1e88.jpg?1783944554"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -2862,6 +2862,89 @@
     "colorIdentityOverride": []
 }
 
+// Gate to the Aether
+{
+    "name": "Gate to the Aether",
+    "manaCost": "{6}",
+    "typeLine": "Artifact",
+    "oracleText": "At the beginning of each player's upkeep, that player reveals the top card of their library. If it's an artifact, creature, enchantment, or land card, the player may put it onto the battlefield.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "player": "TriggeringPlayer"
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "gathered0"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "gathered0",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "permanent"
+                            },
+                            "storeMatching": "matching2"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "matching2",
+                            "ifNotEmpty": {
+                                "type": "Gated",
+                                "gate": "Gate.MayDecide",
+                                "then": {
+                                    "type": "MoveToZone",
+                                    "target": {
+                                        "type": "PipelineTarget",
+                                        "collectionName": "matching2"
+                                    },
+                                    "destination": "Battlefield",
+                                    "controllerOverride": {
+                                        "type": "PlayerRef",
+                                        "player": "TriggeringPlayer"
+                                    }
+                                },
+                                "decisionMaker": {
+                                    "type": "PlayerRef",
+                                    "player": "TriggeringPlayer"
+                                },
+                                "descriptionOverride": "Put the revealed permanent card onto the battlefield?"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "RARE",
+        "artist": "Pete Venters",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c28fd840-e633-46d3-991a-b9fea95a2f28.jpg?1783944521"
+    },
+    "colorIdentityOverride": []
+}
+
 // Gilded Lotus
 {
     "name": "Gilded Lotus",
@@ -4731,6 +4814,115 @@
         "imageUri": "https://cards.scryfall.io/normal/front/a/1/a1a6e375-5c47-4447-9453-adf0038693e3.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Lumengrid Augur
+{
+    "name": "Lumengrid Augur",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Vedalken Wizard",
+    "oracleText": "{1}, {T}: Target player draws a card, then discards a card. If that player discards an artifact card this way, untap this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "player"
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": "TargetPlayer"
+                            },
+                            "storeAs": "gathered1"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered1",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "selected2",
+                            "prompt": "Choose a card to discard",
+                            "selectedLabel": "Discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected2",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": "TargetPlayer"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "selected2",
+                            "ifNotEmpty": {
+                                "type": "TapUntap",
+                                "target": "Self",
+                                "tap": false
+                            },
+                            "filter": "artifact"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "player"
+                    }
+                ],
+                "descriptionOverride": "Target player draws a card, then discards a card. If that player discards an artifact card this way, untap this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "RARE",
+        "artist": "rk post",
+        "flavorText": "Information pumps like blood through vedalken society.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/65704c0f-cc97-490e-a0f7-fab9a18e1e88.jpg?1783944554"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // Lumengrid Sentinel


### PR DESCRIPTION
## Summary

- Lumengrid Augur composes draw, targeted-player discard, artifact filtering, and self-untap through the existing pipeline primitives.
- Gate to the Aether composes each-upkeep triggering, top-library reveal/filtering, a delegated yes/no decision, and battlefield movement.

## Scope

- Blinkmoth Urn was evaluated and dropped because faithful cross-player dynamic colorless mana production needs SDK support; that mechanic belongs in a separate feature PR.
- Other missing Mirrodin cards were similarly avoided where they require Entwine or other new vocabulary.

## Verification

- just build
- just check-card-printing Lumengrid Augur
- just check-card-printing Gate to the Aether
- Exact Scryfall image URLs return HTTP 200
- MRD snapshot diff contains only the two new card trees