### PR TITLE
Add Voja, Jaws of the Conclave

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/VojaJawsOfTheConclave.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/VojaJawsOfTheConclave.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Voja, Jaws of the Conclave — Murders at Karlov Manor #432
+ * {2}{R}{G}{W} · Legendary Creature — Wolf · 5/5 · Mythic
+ *
+ * Both tribal counts are evaluated as the attack trigger resolves. Every creature receives the
+ * same number of +1/+1 counters, including Voja itself when it is still on the battlefield, and
+ * the subsequent draw uses the independently evaluated number of Wolves the player controls.
+ */
+val VojaJawsOfTheConclave = card("Voja, Jaws of the Conclave") {
+    manaCost = "{2}{R}{G}{W}"
+    colorIdentity = "RGW"
+    typeLine = "Legendary Creature — Wolf"
+    oracleText = "Vigilance, trample, ward {3}\n" +
+        "Whenever Voja attacks, put X +1/+1 counters on each creature you control, where X is " +
+        "the number of Elves you control. Draw a card for each Wolf you control."
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.VIGILANCE, Keyword.TRAMPLE)
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{3}")))
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.AddDynamicCounters(
+                counterType = Counters.PLUS_ONE_PLUS_ONE,
+                amount = DynamicAmounts
+                    .battlefield(Player.You, GameObjectFilter.Creature.withSubtype(Subtype.ELF))
+                    .count(),
+                target = EffectTarget.Self,
+            ),
+        ) then Effects.DrawCards(
+            DynamicAmounts
+                .battlefield(Player.You, GameObjectFilter.Creature.withSubtype(Subtype.WOLF))
+                .count()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "432"
+        artist = "Valera Lutfullina"
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bfa1bd2f-25bd-4fbd-877b-cef00ab7f92f.jpg?1783912763"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -14940,6 +14940,83 @@
     ]
 }
 
+// Voja, Jaws of the Conclave
+{
+    "name": "Voja, Jaws of the Conclave",
+    "manaCost": "{2}{R}{G}{W}",
+    "typeLine": "Legendary Creature — Wolf",
+    "oracleText": "Vigilance, trample, ward {3}\nWhenever Voja attacks, put X +1/+1 counters on each creature you control, where X is the number of Elves you control. Draw a card for each Wolf you control.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE",
+        "TRAMPLE",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{3}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "AddDynamicCounters",
+                                "counterType": "+1/+1",
+                                "amount": {
+                                    "type": "AggregateBattlefield",
+                                    "player": "You",
+                                    "filter": "creature Elf"
+                                },
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "creature Wolf"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "432",
+        "rarity": "MYTHIC",
+        "artist": "Valera Lutfullina",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bfa1bd2f-25bd-4fbd-877b-cef00ab7f92f.jpg?1783912763"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Warleader's Call
 {
     "name": "Warleader's Call",


### PR DESCRIPTION
## Summary

- Add Voja, Jaws of the Conclave to Murders at Karlov Manor.
- Compose its attack trigger from existing group iteration, dynamic battlefield counts, counter placement, and card draw primitives.
- Add the MKM golden snapshot entry with exact Scryfall printing metadata.

The remaining unimplemented MKM cards require unsupported mechanics or more complex engine behavior, so this PR intentionally contains one rules-faithful card.

## Verification

- `just check-card-printing "Voja, Jaws of the Conclave"`
- `just rebless-cards`
- `just build`