### PR TITLE
Add Oblivion Stone to Mirrodin

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3746,7 +3746,9 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   projection / trigger matching / cost calculation report `false` (no X context). Underlying
   predicate: `CardPredicate.PowerAtLeastX`.
 - `.tapped()` / `.untapped()` — tap state.
-- `.withCounter(type)` / `.withAnyCounter()` / `.withoutCounters()` — counter presence: a specific kind,
+- `.withCounter(type)` / `.withoutCounter(type)` / `.withAnyCounter()` / `.withoutCounters()` — counter presence: a specific kind,
+  absence of one specific kind while permitting others, any kind, or no counters at all. The named
+  negative form models clauses such as Oblivion Stone's “without a fate counter on it.”
   any kind, or none at all. `.withoutCounters()` is `StatePredicate.Not(HasAnyCounter)` for "with no
   counters on it" (Heartless Act). All three are also on `TargetFilter`
   (`TargetFilter.Creature.withoutCounters()`).

--- a/manual-scenarios/cards/o/oblivion-stone.json
+++ b/manual-scenarios/cards/o/oblivion-stone.json
@@ -1,0 +1,42 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Oblivion Stone"},
+      {"name": "Grizzly Bears"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Grizzly Bears", "Hill Giant"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Bonesplitter"},
+      {"name": "Centaur Courser"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Wind Drake", "Hill Giant"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -29,6 +29,7 @@ enum class CounterType {
     GOLD,
     PLAGUE,
     TRAP,
+    FATE,
     DEPLETION,
     EGG,
     LORE,
@@ -165,6 +166,7 @@ object Counters {
     const val GOLD = "gold"
     const val PLAGUE = "plague"
     const val TRAP = "trap"
+    const val FATE = "fate"
     const val DEPLETION = "depletion"
     const val EGG = "egg"
     const val LORE = "lore"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1920,6 +1920,12 @@ object Effects {
     fun RemoveAllCounters(target: EffectTarget = EffectTarget.ContextTarget(0)): Effect =
         com.wingedsheep.sdk.scripting.effects.RemoveAllCountersEffect(target)
 
+    /** Remove every counter of [type] from [target], preserving counters of other kinds. */
+    fun RemoveAllCountersOfType(
+        type: String,
+        target: EffectTarget = EffectTarget.ContextTarget(0)
+    ): Effect = com.wingedsheep.sdk.scripting.effects.RemoveAllCountersOfTypeEffect(type, target)
+
     /**
      * Add counters to all entities in a named collection.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
@@ -301,6 +301,20 @@ data class RemoveAllCountersEffect(
 }
 
 /**
+ * Remove every counter of one specified kind from a target permanent.
+ * Other counter kinds on that permanent are left unchanged.
+ */
+@SerialName("RemoveAllCountersOfType")
+@Serializable
+data class RemoveAllCountersOfTypeEffect(
+    val counterType: String,
+    val target: EffectTarget = EffectTarget.ContextTarget(0)
+) : Effect {
+    override val description: String =
+        "Remove all $counterType counters from ${target.description}"
+}
+
+/**
  * Add counters to all entities in a named collection.
  * Used for non-targeting "choose" effects that place counters on multiple permanents.
  * "Put an aim counter on each of them"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/GroupFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/GroupFilter.kt
@@ -238,6 +238,9 @@ data class GroupFilter(
     /** Must have a counter of the given type (e.g. `Counters.PLUS_ONE_PLUS_ONE`) */
     fun withCounter(counterType: String) = copy(baseFilter = baseFilter.withCounter(counterType))
 
+    /** Must not have a counter of the given type; delegates to [GameObjectFilter.withoutCounter]. */
+    fun withoutCounter(counterType: String) = copy(baseFilter = baseFilter.withoutCounter(counterType))
+
     /** Add keyword requirement */
     fun withKeyword(keyword: Keyword) = copy(baseFilter = baseFilter.withKeyword(keyword))
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -1070,6 +1070,11 @@ data class GameObjectFilter(
         statePredicates = statePredicates + StatePredicate.HasCounter(counterType)
     )
 
+    /** Must not have a counter of the specified type. Other counter types are allowed. */
+    fun withoutCounter(counterType: String) = copy(
+        statePredicates = statePredicates + StatePredicate.Not(StatePredicate.HasCounter(counterType))
+    )
+
     /** Must have any counter of any type */
     fun withAnyCounter() = copy(
         statePredicates = statePredicates + StatePredicate.HasAnyCounter

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -412,6 +412,9 @@ data class TargetFilter(
     /** Must have no counters of any type ("with no counters on it" — Heartless Act). */
     fun withoutCounters() = copy(baseFilter = baseFilter.withoutCounters())
 
+    /** Must not have a counter of the given type; other counter types are allowed. */
+    fun withoutCounter(counterType: String) = copy(baseFilter = baseFilter.withoutCounter(counterType))
+
     /** Must be tapped */
     fun tapped() = copy(baseFilter = baseFilter.tapped())
 

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/OblivionStone.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/OblivionStone.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Oblivion Stone — Mirrodin #222
+ * {3} · Artifact
+ *
+ * The board wipe gathers every nonland permanent lacking a fate counter before any of them are
+ * destroyed, so destruction is simultaneous. Its second step iterates only the surviving
+ * fate-marked permanents and removes fate counters while preserving counters of every other kind.
+ */
+val OblivionStone = card("Oblivion Stone") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{4}, {T}: Put a fate counter on target permanent.\n" +
+        "{5}, {T}, Sacrifice this artifact: Destroy each nonland permanent without a fate counter " +
+        "on it, then remove all fate counters from all permanents."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap)
+        target = Targets.Permanent
+        effect = Effects.AddCounters(Counters.FATE, 1, EffectTarget.ContextTarget(0))
+        description = "{4}, {T}: Put a fate counter on target permanent."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.Composite(
+            Effects.DestroyAll(GameObjectFilter.NonlandPermanent.withoutCounter(Counters.FATE)),
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Permanent.withCounter(Counters.FATE)),
+                Effects.RemoveAllCountersOfType(Counters.FATE, EffectTarget.Self)
+            )
+        )
+        description = "{5}, {T}, Sacrifice this artifact: Destroy each nonland permanent without " +
+            "a fate counter on it, then remove all fate counters from all permanents."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "222"
+        artist = "Sam Wood"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/ddba1566-2778-4636-b4d3-9095fb2d83c8.jpg?1783944509"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/OblivionStoneScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/OblivionStoneScenarioTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.OblivionStone
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/** Scenario coverage for both activated abilities of Oblivion Stone (MRD #222). */
+class OblivionStoneScenarioTest : ScenarioTestBase() {
+    private val fate = CounterType.FATE
+
+    private fun setCounters(game: TestGame, id: EntityId, counters: Map<CounterType, Int>) {
+        game.state = game.state.updateEntity(id) { it.with(CountersComponent(counters)) }
+    }
+
+    private fun count(game: TestGame, id: EntityId, type: CounterType): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(type) ?: 0
+
+    init {
+        context("Oblivion Stone") {
+            test("first ability puts a fate counter on target permanent") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Oblivion Stone")
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val stone = game.findPermanent("Oblivion Stone")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = stone,
+                        abilityId = OblivionStone.activatedAbilities[0].id,
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                )
+                withClue("the targeted ability should activate: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                count(game, bears, fate) shouldBe 1
+            }
+
+            test("wipe spares fate-marked permanents, preserves lands, and removes only fate counters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Oblivion Stone")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Bonesplitter")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val stone = game.findPermanent("Oblivion Stone")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                setCounters(
+                    game,
+                    bears,
+                    mapOf(fate to 1, CounterType.PLUS_ONE_PLUS_ONE to 2)
+                )
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = stone,
+                        abilityId = OblivionStone.activatedAbilities[1].id
+                    )
+                )
+                withClue("the sacrifice ability should activate: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the Stone is sacrificed as a cost and unmarked nonland permanents die") {
+                    game.isInGraveyard(1, "Oblivion Stone") shouldBe true
+                    game.isInGraveyard(2, "Bonesplitter") shouldBe true
+                }
+                withClue("a fate counter protects the permanent, then is removed") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                    count(game, bears, fate) shouldBe 0
+                }
+                withClue("counter cleanup is type-specific") {
+                    count(game, bears, CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+                }
+                withClue("lands are outside the destruction filter") {
+                    game.isOnBattlefield("Plains") shouldBe true
+                    game.isOnBattlefield("Forest") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/OblivionStoneReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/OblivionStoneReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Oblivion Stone reprint in Commander 2011; the canonical definition lives in Mirrodin. */
+val OblivionStoneReprint = Printing(
+    oracleId = "2fd61c9f-44d2-48d7-a271-8e4208407cca",
+    name = "Oblivion Stone",
+    setCode = "CMD",
+    collectorNumber = "254",
+    scryfallId = "d5894997-030f-4c8a-b294-f08f0819f754",
+    artist = "Sam Wood",
+    imageUri = "https://cards.scryfall.io/normal/front/d/5/d5894997-030f-4c8a-b294-f08f0819f754.jpg?1783941155",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/OblivionStoneReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/OblivionStoneReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Oblivion Stone reprint in New Capenna Commander; the canonical definition lives in Mirrodin. */
+val OblivionStoneReprint = Printing(
+    oracleId = "2fd61c9f-44d2-48d7-a271-8e4208407cca",
+    name = "Oblivion Stone",
+    setCode = "NCC",
+    collectorNumber = "373",
+    scryfallId = "f0cd5548-ce7b-493a-8119-62f000839e4d",
+    artist = "Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/f/0/f0cd5548-ce7b-493a-8119-62f000839e4d.jpg?1783923213",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -6605,6 +6605,142 @@
     "colorIdentityOverride": []
 }
 
+// Oblivion Stone
+{
+    "name": "Oblivion Stone",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{4}, {T}: Put a fate counter on target permanent.\n{5}, {T}, Sacrifice this artifact: Destroy each nonland permanent without a fate counter on it, then remove all fate counters from all permanents.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "fate",
+                    "count": 1,
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent"
+                        }
+                    }
+                ],
+                "descriptionOverride": "{4}, {T}: Put a fate counter on target permanent."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "BattlefieldMatching",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                "IsNonland",
+                                                "IsPermanent"
+                                            ],
+                                            "statePredicates": [
+                                                {
+                                                    "type": "StateNot",
+                                                    "predicate": {
+                                                        "type": "HasCounter",
+                                                        "counterType": "fate"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "storeAs": "destroyAll_gathered"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "destroyAll_gathered",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Destroy"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": {
+                                        "cardPredicates": [
+                                            "IsPermanent"
+                                        ],
+                                        "statePredicates": [
+                                            {
+                                                "type": "HasCounter",
+                                                "counterType": "fate"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "body": {
+                                "type": "RemoveAllCountersOfType",
+                                "counterType": "fate",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "{5}, {T}, Sacrifice this artifact: Destroy each nonland permanent without a fate counter on it, then remove all fate counters from all permanents."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "rarity": "RARE",
+        "artist": "Sam Wood",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/ddba1566-2778-4636-b4d3-9095fb2d83c8.jpg?1783944509"
+    },
+    "colorIdentityOverride": []
+}
+
 // Ogre Leadfoot
 {
     "name": "Ogre Leadfoot",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
@@ -42,6 +42,7 @@ import com.wingedsheep.engine.handlers.effects.permanent.counters.GrantCounterPl
 import com.wingedsheep.engine.handlers.effects.permanent.counters.DistributeCountersFromSelfExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.ProliferateExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.RemoveAllCountersExecutor
+import com.wingedsheep.engine.handlers.effects.permanent.counters.RemoveAllCountersOfTypeExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.RemoveAnyNumberOfCountersExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.RemoveCountersExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.protection.ChooseColorThenExecutor
@@ -151,6 +152,7 @@ class PermanentExecutors(
         MoveCountersExecutor(),
         MoveChosenCountersToTargetExecutor(),
         RemoveAllCountersExecutor(),
+        RemoveAllCountersOfTypeExecutor(),
         DistributeCountersFromSelfExecutor(),
         DistributeCountersAmongTargetsExecutor(),
         DistributeCountersAmongFilteredExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/RemoveAllCountersOfTypeExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/RemoveAllCountersOfTypeExecutor.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.engine.handlers.effects.permanent.counters
+
+import com.wingedsheep.engine.core.CountersRemovedEvent
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.scripting.effects.RemoveAllCountersOfTypeEffect
+import kotlin.reflect.KClass
+
+/** Executor for mandatory, non-interactive removal of every counter of one named kind. */
+class RemoveAllCountersOfTypeExecutor : EffectExecutor<RemoveAllCountersOfTypeEffect> {
+    override val effectType: KClass<RemoveAllCountersOfTypeEffect> = RemoveAllCountersOfTypeEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: RemoveAllCountersOfTypeEffect,
+        context: EffectContext
+    ): EffectResult {
+        val targetId = context.resolveTarget(effect.target, state)
+            ?: return EffectResult.success(state, emptyList())
+        val targetEntity = state.getEntity(targetId)
+            ?: return EffectResult.success(state, emptyList())
+        val counters = targetEntity.get<CountersComponent>()
+            ?: return EffectResult.success(state, emptyList())
+        val type = CounterType.fromName(effect.counterType)
+            ?: return EffectResult.success(state, emptyList())
+        val amount = counters.counters[type] ?: 0
+        if (amount <= 0) return EffectResult.success(state, emptyList())
+
+        val remaining = counters.counters - type
+        val newState = state.updateEntity(targetId) { container ->
+            if (remaining.isEmpty()) container.without<CountersComponent>()
+            else container.with(CountersComponent(remaining))
+        }
+        val entityName = targetEntity.get<CardComponent>()?.name ?: ""
+        return EffectResult.success(
+            newState,
+            listOf(CountersRemovedEvent(targetId, effect.counterType, amount, entityName))
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- **Oblivion Stone** — composes targeted fate-counter placement, simultaneous filtered destruction, and type-specific counter cleanup.
- Adds reusable `withoutCounter(type)` filters and `RemoveAllCountersOfType(type, target)` SDK/engine support.
- Adds Commander 2011 and New Capenna Commander printing rows plus a manual play scenario.

The batch was intentionally reduced to one card: the remaining unimplemented Mirrodin cards each require unsupported mechanics or broader engine vocabulary (including Entwine), so they were not approximated or bundled.

## Verification

- `just test-class OblivionStoneScenarioTest`
- `just test`
- `just check-card-printing "Oblivion Stone"`
- `git diff --check`