### PR TITLE
Add three Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BranchOfVituGhazi.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BranchOfVituGhazi.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Branch of Vitu-Ghazi — Murders at Karlov Manor #258
+ * Land
+ *
+ * Although this is a land, disguise permits it to be cast face down as the standard colorless 2/2
+ * creature with ward {2}. Turning it face up is legal because the disguise procedure exposes the
+ * land's printed disguise cost; after the special action, the permanent is simply a land again.
+ *
+ * Its trigger adds two mana of one chosen color with the engine's end-of-turn expiry, so exactly
+ * that mana persists through intervening step and phase boundaries. The ordinary colorless mana
+ * ability remains a mana ability and therefore does not use the stack.
+ */
+val BranchOfVituGhazi = card("Branch of Vitu-Ghazi") {
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "Disguise {3} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. " +
+        "Turn it face up any time for its disguise cost.)\n" +
+        "When this land is turned face up, add two mana of any one color. Until end of turn, you " +
+        "don't lose this mana as steps and phases end."
+
+    disguise = "{3}"
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        effect = Effects.AddManaOfChoice(amount = 2)
+        description = "When this land is turned face up, add two mana of any one color. Until end " +
+            "of turn, you don't lose this mana as steps and phases end."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "258"
+        artist = "Alayna Danner"
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/" +
+            "73a8169f-b858-47a5-9c76-2e7c50ad4ecd.jpg?1783912825"
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to. Only a face-down permanent can " +
+                "be turned face up this way; a face-down spell cannot.",
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger.",
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/KrenkoBaronOfTinStreet.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/KrenkoBaronOfTinStreet.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Krenko, Baron of Tin Street — Murders at Karlov Manor #135
+ * {2}{R} · Legendary Creature — Goblin · 3/3
+ *
+ * The activated ability snapshots all Goblins its controller currently controls and puts one
+ * counter on each. Sacrificing an artifact is part of the cost, so that zone change can also
+ * trigger Krenko's second ability before the activated ability resolves.
+ *
+ * The graveyard trigger is ANY-bound and intentionally has no controller restriction: artifacts
+ * belonging to any player count. The optional payment is made on resolution. The created Goblin's
+ * haste is a temporary grant through the created-token pipeline rather than a printed token
+ * keyword, so a surviving token correctly loses haste at cleanup.
+ */
+val KrenkoBaronOfTinStreet = card("Krenko, Baron of Tin Street") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Goblin"
+    oracleText = "Haste\n" +
+        "{T}, Sacrifice an artifact: Put a +1/+1 counter on each Goblin you control.\n" +
+        "Whenever an artifact is put into a graveyard from the battlefield, you may pay {R}. " +
+        "If you do, create a 1/1 red Goblin creature token. It gains haste until end of turn."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.Sacrifice(GameObjectFilter.Artifact))
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.withSubtype("Goblin").youControl()),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+        )
+        description = "{T}, Sacrifice an artifact: Put a +1/+1 counter on each Goblin you control."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Artifact,
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY,
+        )
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{R}"),
+            effect = Effects.Composite(
+                Effects.CreateToken(
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.RED),
+                    creatureTypes = setOf("Goblin"),
+                    imageUri = "https://cards.scryfall.io/normal/front/c/d/" +
+                        "cd6cd0d3-7973-49e6-9c1c-6f516a5d5fe5.jpg?1783912608",
+                ),
+                Effects.GrantKeyword(
+                    Keyword.HASTE,
+                    EffectTarget.PipelineTarget(CREATED_TOKENS, 0),
+                ),
+            ),
+        )
+        description = "Whenever an artifact is put into a graveyard from the battlefield, you may " +
+            "pay {R}. If you do, create a 1/1 red Goblin creature token. It gains haste until end " +
+            "of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "135"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/" +
+            "5524b712-c67d-4d2e-9344-9e85a6ce3227.jpg?1783912878"
+        ruling(
+            "2024-02-02",
+            "If Krenko, Baron of Tin Street dies at the same time as one or more artifacts are put " +
+                "into a graveyard from the battlefield, its last ability will still trigger for " +
+                "each of those artifacts.",
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/MelekReforgedResearcher.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/MelekReforgedResearcher.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Melek, Reforged Researcher — Murders at Karlov Manor #430
+ * {3}{U}{R} · Legendary Creature — Weird Detective · * / *
+ *
+ * Both characteristic-defining values share one dynamic amount: twice the number of instant and
+ * sorcery cards in its controller's graveyard. As a characteristic-defining ability this is live
+ * in every zone, including while Melek itself is in the graveyard.
+ *
+ * The cost modifier uses the first-matching-spell gate. Instant and sorcery are one combined class,
+ * so casting either as the first matching spell consumes the reduction for both for that turn.
+ */
+val MelekReforgedResearcher = card("Melek, Reforged Researcher") {
+    manaCost = "{3}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Weird Detective"
+    oracleText = "Melek's power and toughness are each equal to twice the number of instant and " +
+        "sorcery cards in your graveyard.\n" +
+        "The first instant or sorcery spell you cast each turn costs {3} less to cast."
+
+    dynamicStats(
+        DynamicAmount.Multiply(
+            DynamicAmount.Count(Player.You, Zone.GRAVEYARD, Filters.Unified.instantOrSorcery),
+            2,
+        ),
+    )
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(Filters.Unified.instantOrSorcery),
+            modification = CostModification.ReduceGeneric(3),
+            gating = CostGating.NthOfTypePerTurn(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "430"
+        artist = "Andreas Zafiratos"
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/" +
+            "01c5ede0-a098-4f21-8b7e-795a83e75aae.jpg?1783912764"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -1736,6 +1736,74 @@
     ]
 }
 
+// Branch of Vitu-Ghazi
+{
+    "name": "Branch of Vitu-Ghazi",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\nDisguise {3} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this land is turned face up, add two mana of any one color. Until end of turn, you don't lose this mana as steps and phases end.",
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "When this land is turned face up, add two mana of any one color. Until end of turn, you don't lose this mana as steps and phases end."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "258",
+        "rarity": "UNCOMMON",
+        "artist": "Alayna Danner",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73a8169f-b858-47a5-9c76-2e7c50ad4ecd.jpg?1783912825",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Break Out
 {
     "name": "Break Out",
@@ -7973,6 +8041,120 @@
     ]
 }
 
+// Krenko, Baron of Tin Street
+{
+    "name": "Krenko, Baron of Tin Street",
+    "manaCost": "{2}{R}",
+    "typeLine": "Legendary Creature — Goblin",
+    "oracleText": "Haste\n{T}, Sacrifice an artifact: Put a +1/+1 counter on each Goblin you control.\nWhenever an artifact is put into a graveyard from the battlefield, you may pay {R}. If you do, create a 1/1 red Goblin creature token. It gains haste until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{R}"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "CreateToken",
+                                "power": 1,
+                                "toughness": 1,
+                                "colors": [
+                                    "RED"
+                                ],
+                                "creatureTypes": [
+                                    "Goblin"
+                                ],
+                                "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd6cd0d3-7973-49e6-9c1c-6f516a5d5fe5.jpg?1783912608"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "createdTokens"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Whenever an artifact is put into a graveyard from the battlefield, you may pay {R}. If you do, create a 1/1 red Goblin creature token. It gains haste until end of turn."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature Goblin ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "{T}, Sacrifice an artifact: Put a +1/+1 counter on each Goblin you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "rarity": "RARE",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/5524b712-c67d-4d2e-9344-9e85a6ce3227.jpg?1783912878",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If Krenko, Baron of Tin Street dies at the same time as one or more artifacts are put into a graveyard from the battlefield, its last ability will still trigger for each of those artifacts."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Krovod Haunch
 {
     "name": "Krovod Haunch",
@@ -9120,6 +9302,71 @@
     "colorIdentityOverride": [
         "RED",
         "WHITE"
+    ]
+}
+
+// Melek, Reforged Researcher
+{
+    "name": "Melek, Reforged Researcher",
+    "manaCost": "{3}{U}{R}",
+    "typeLine": "Legendary Creature — Weird Detective",
+    "oracleText": "Melek's power and toughness are each equal to twice the number of instant and sorcery cards in your graveyard.\nThe first instant or sorcery spell you cast each turn costs {3} less to cast.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Multiply",
+                "amount": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Graveyard",
+                    "filter": "instant|sorcery"
+                },
+                "multiplier": 2
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Multiply",
+                "amount": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Graveyard",
+                    "filter": "instant|sorcery"
+                },
+                "multiplier": 2
+            }
+        }
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "instant|sorcery"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 3
+                },
+                "gating": {
+                    "type": "NthOfTypePerTurn",
+                    "n": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "430",
+        "rarity": "MYTHIC",
+        "artist": "Andreas Zafiratos",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/01c5ede0-a098-4f21-8b7e-795a83e75aae.jpg?1783912764"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 


### PR DESCRIPTION
Adds three MKM cards using existing SDK primitives:

- **Krenko, Baron of Tin Street** — composes artifact sacrifice costs, group counter placement, an any-artifact graveyard trigger, optional mana payment, and a temporary haste grant to the created Goblin token.
- **Melek, Reforged Researcher** — composes graveyard-filtered dynamic stats with the existing first-spell-per-turn cost gate.
- **Branch of Vitu-Ghazi** — composes disguise, a colorless mana ability, a turned-face-up trigger, and any-one-color mana that persists until cleanup.

Goblin Maskmaker was considered but dropped because its temporary face-down-spell-only reduction is not faithfully expressible with the current turn cost-reduction primitive.

Verification:
- `just build`
- `just check-card-printing "Krenko, Baron of Tin Street"`
- `just check-card-printing "Melek, Reforged Researcher"`
- `just check-card-printing "Branch of Vitu-Ghazi"`
- `git diff --check`