### PR TITLE
Add two Mirrodin artifacts

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ChaliceOfTheVoid.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ChaliceOfTheVoid.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Chalice of the Void
+ * {X}{X}
+ * Artifact
+ *
+ * This artifact enters with X charge counters on it.
+ * Whenever a player casts a spell with mana value equal to the number of charge counters on this
+ * artifact, counter that spell.
+ */
+val ChaliceOfTheVoid = card("Chalice of the Void") {
+    manaCost = "{X}{X}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "This artifact enters with X charge counters on it.\n" +
+        "Whenever a player casts a spell with mana value equal to the number of charge counters " +
+        "on this artifact, counter that spell."
+
+    replacementEffect(
+        EntersWithDynamicCounters(
+            counterType = CounterTypeFilter.Named(Counters.CHARGE),
+            count = DynamicAmount.CastX
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.AnyPlayerCastsSpell
+        triggerRestriction = Compare(
+            DynamicAmount.EntityProperty(EntityReference.Triggering, EntityNumericProperty.ManaValue),
+            ComparisonOperator.EQ,
+            DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.CHARGE))
+        )
+        effect = Effects.CounterTriggeringSpell()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "150"
+        artist = "Mark Zug"
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a02ca71-5e39-4a5f-aaba-a1e3e10a6a3e.jpg?1783944526"
+
+        ruling("2021-03-19", "A mana cost of {X}{X} means that you pay twice X. For example, if you want X to be 3, you pay {6} to cast Chalice of the Void.")
+        ruling("2021-03-19", "The number of charge counters on Chalice of the Void matters only at the time the spell is cast. Changing the number of charge counters on Chalice of the Void after a spell has been cast won't change whether the ability triggers or counters the spell.")
+        ruling("2021-03-19", "If there are zero charge counters on Chalice of the Void, it counters each spell with a mana value of 0. This includes face-down creature spells cast with morph's alternative cost.")
+        ruling("2021-03-19", "Chalice of the Void has to be on the battlefield at the end of casting a spell for the ability to trigger. If you sacrifice Chalice of the Void as a cost to cast a spell, its ability can't trigger. However, if it leaves the battlefield once its ability has triggered, that ability will still counter the spell.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Mindslaver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Mindslaver.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mindslaver
+ * {6}
+ * Legendary Artifact
+ *
+ * {4}, {T}, Sacrifice Mindslaver: You control target player during that player's next turn.
+ */
+val Mindslaver = card("Mindslaver") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact"
+    oracleText = "{4}, {T}, Sacrifice Mindslaver: You control target player during that player's " +
+        "next turn. (You see all cards that player could see and make all decisions for them.)"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap, Costs.SacrificeSelf)
+        val player = target("target player", Targets.Player)
+        effect = Effects.HijackNextTurn(player)
+        description = "{4}, {T}, Sacrifice Mindslaver: You control target player during that " +
+            "player's next turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "206"
+        artist = "Glen Angus"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98fb1eaa-2871-491a-a4f5-3e358778ba40.jpg?1783944513"
+
+        ruling("2024-04-12", "The player you're controlling is still the active player during that turn.")
+        ruling("2024-04-12", "You only control the player. You don't control any of that player's permanents, spells, or abilities.")
+        ruling("2024-04-12", "You can use only the affected player's resources (cards, mana, and so on) to pay costs for that player; you can't use your own. Similarly, you can use the affected player's resources only to pay that player's costs; you can't spend them on your costs.")
+        ruling("2024-04-12", "If the targeted player skips their next turn, you'll control the next turn the affected player actually takes.")
+        ruling("2024-04-12", "Multiple player-controlling effects that affect the same player overwrite each other. The last one to be created is the one that works.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/MindslaverReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/MindslaverReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mindslaver reprint in Scars of Mirrodin. The canonical card definition lives in Mirrodin; this
+ * file contributes only the later printing's presentation data.
+ */
+val MindslaverReprint = Printing(
+    oracleId = "a806f4ee-f48a-46c3-8772-5aaabebe4c7e",
+    name = "Mindslaver",
+    setCode = "SOM",
+    collectorNumber = "176",
+    scryfallId = "00d03b17-75ae-40d2-8570-b219ef0dfd4a",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/0/0/00d03b17-75ae-40d2-8570-b219ef0dfd4a.jpg?1783941703",
+    releaseDate = "2010-10-01",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -928,6 +928,85 @@
     ]
 }
 
+// Chalice of the Void
+{
+    "name": "Chalice of the Void",
+    "manaCost": "{X}{X}",
+    "typeLine": "Artifact",
+    "oracleText": "This artifact enters with X charge counters on it.\nWhenever a player casts a spell with mana value equal to the number of charge counters on this artifact, counter that spell.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Counter",
+                    "targetSource": "CounterTargetSource.TriggeringEntity"
+                },
+                "triggerRestriction": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Triggering",
+                        "numericProperty": "ManaValue"
+                    },
+                    "operator": "EQ",
+                    "right": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": {
+                                "type": "Named",
+                                "name": "charge"
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "charge"
+                },
+                "count": "CastX"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "rarity": "RARE",
+        "artist": "Mark Zug",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a02ca71-5e39-4a5f-aaba-a1e3e10a6a3e.jpg?1783944526",
+        "rulings": [
+            {
+                "date": "2021-03-19",
+                "text": "A mana cost of {X}{X} means that you pay twice X. For example, if you want X to be 3, you pay {6} to cast Chalice of the Void."
+            },
+            {
+                "date": "2021-03-19",
+                "text": "The number of charge counters on Chalice of the Void matters only at the time the spell is cast. Changing the number of charge counters on Chalice of the Void after a spell has been cast won't change whether the ability triggers or counters the spell."
+            },
+            {
+                "date": "2021-03-19",
+                "text": "If there are zero charge counters on Chalice of the Void, it counters each spell with a mana value of 0. This includes face-down creature spells cast with morph's alternative cost."
+            },
+            {
+                "date": "2021-03-19",
+                "text": "Chalice of the Void has to be on the battlefield at the end of casting a spell for the ability to trigger. If you sacrifice Chalice of the Void as a cost to cast a spell, its ability can't trigger. However, if it leaves the battlefield once its ability has triggered, that ability will still counter the spell."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Chimney Imp
 {
     "name": "Chimney Imp",

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -5489,6 +5489,78 @@
     }
 }
 
+// Mindslaver
+{
+    "name": "Mindslaver",
+    "manaCost": "{6}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "{4}, {T}, Sacrifice Mindslaver: You control target player during that player's next turn. (You see all cards that player could see and make all decisions for them.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "HijackNextTurn",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "descriptionOverride": "{4}, {T}, Sacrifice Mindslaver: You control target player during that player's next turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "206",
+        "rarity": "RARE",
+        "artist": "Glen Angus",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/98fb1eaa-2871-491a-a4f5-3e358778ba40.jpg?1783944513",
+        "rulings": [
+            {
+                "date": "2024-04-12",
+                "text": "The player you're controlling is still the active player during that turn."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You only control the player. You don't control any of that player's permanents, spells, or abilities."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "You can use only the affected player's resources (cards, mana, and so on) to pay costs for that player; you can't use your own. Similarly, you can use the affected player's resources only to pay that player's costs; you can't spend them on your costs."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "If the targeted player skips their next turn, you'll control the next turn the affected player actually takes."
+            },
+            {
+                "date": "2024-04-12",
+                "text": "Multiple player-controlling effects that affect the same player overwrite each other. The last one to be created is the one that works."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Molder Slug
 {
     "name": "Molder Slug",


### PR DESCRIPTION
## Summary

- **Chalice of the Void** — enters with the cast X in charge counters and counters spells whose mana value matches its charge-counter count, using existing replacement, trigger-condition, and counter primitives.
- **Mindslaver** — pays {4}, taps, and sacrifices itself to control the targeted player during their next turn, using the existing composite-cost and next-turn hijack primitives.
- Adds Mindslaver’s required Scars of Mirrodin `Printing` row.

The batch is intentionally limited to two because the remaining MRD gaps generally require unsupported or new engine vocabulary.

## Verification

- `just rebless-cards` — passed; MRD golden adds only Chalice of the Void and Mindslaver.
- `just check-card-printing "Chalice of the Void"` — passed.
- `just check-card-printing "Mindslaver"` — passed, including the SOM reprint row.
- Scryfall image URLs — HTTP 200.
- `git diff --check` — passed.
- `just build` — relevant card compilation, serialization, snapshot, lint, facade, and printing-discovery checks passed, but the final full run was not green due to unrelated existing-suite failures: AI `ArenaHarnessTest` timed out, `FrozenBaselineTest` reported a changed legacy hash, and old-set `AbuJafarTest` / `AccursedCentaurTest` timed out. No AI, rules-engine, or old-set test code is changed by this PR.