### PR TITLE
Run OnEnterRunEffect when an effect puts a permanent onto the battlefield

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -10178,8 +10178,12 @@ The priority groups are (CR 616.1a–f):
   executes via the normal effect-executor pipeline at entry time (so `EffectTarget.Self` resolves to
   the entering permanent) and may pause for player input. Compose with atomic pausable effects like
   `Effects.MayRevealCardFromHand` to build SOI shadow lands or other "as ~ enters" choices.
-  **Scope today:** only wired into the land-play path (`PlayLandHandler`). When the first non-land
-  permanent needs this, also wire it into `StackResolver.enterPermanentOnBattlefield`.
+  **Scope today:** the land-play path (`PlayLandHandler`) and every single-card "put onto the
+  battlefield" effect (`MoveToZoneEffectExecutor` → `PermanentEntryReplacements.runOnEnterRunEffect`),
+  which covers reanimation, blink, an earthbend/"return it to the battlefield" trigger, and fetches
+  that move one card. Not yet wired into the spell-resolution path
+  (`StackResolver.enterPermanentOnBattlefield` — needed when the first non-land permanent uses this)
+  or into the multi-card `MoveCollectionExecutor` batch move.
 - `EntersWithCounters(counterType?, count, selfOnly?, condition?, otherOnly?, appliesTo?)` /
   `EntersWithDynamicCounters(counterType?, count, otherOnly?, appliesTo?)` — "[permanent] enters with
   N counters." `EntersWithCounters` takes a fixed `count: Int` (Master Biomancer, Metallic Mimic);

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -10178,12 +10178,23 @@ The priority groups are (CR 616.1a–f):
   executes via the normal effect-executor pipeline at entry time (so `EffectTarget.Self` resolves to
   the entering permanent) and may pause for player input. Compose with atomic pausable effects like
   `Effects.MayRevealCardFromHand` to build SOI shadow lands or other "as ~ enters" choices.
-  **Scope today:** the land-play path (`PlayLandHandler`) and every single-card "put onto the
-  battlefield" effect (`MoveToZoneEffectExecutor` → `PermanentEntryReplacements.runOnEnterRunEffect`),
-  which covers reanimation, blink, an earthbend/"return it to the battlefield" trigger, and fetches
-  that move one card. Not yet wired into the spell-resolution path
-  (`StackResolver.enterPermanentOnBattlefield` — needed when the first non-land permanent uses this)
-  or into the multi-card `MoveCollectionExecutor` batch move.
+  **Scope today:** the land-play path (`PlayLandHandler`) and the single-card `MoveToZoneEffect`
+  path (`MoveToZoneEffectExecutor` → `PermanentEntryReplacements.runOnEnterRunEffect`), which covers
+  reanimation, blink, and an earthbend/"return it to the battlefield" trigger. Not yet wired into:
+  - `MoveCollectionExecutor` — the batch move. This is **not** only multi-card: a library search that
+    puts a *single* card onto the battlefield (`SearchDestination.BATTLEFIELD`, e.g. Wayfarer's
+    Bauble) routes here too, so tutoring up one of these lands still skips the clause. Closing it
+    needs a continuation, because the replacement can pause mid-loop.
+  - `StackResolver.enterPermanentOnBattlefield` — the spell-resolution path; needed when the first
+    non-land permanent uses this replacement.
+  - Auras, on any path — `MoveToZoneEffectExecutor` hands an entering Aura to its choose-a-host
+    continuation before reaching the replacement.
+
+  **Entry order caveat.** CR 614.12a says an as-enters choice is made *before* the permanent enters;
+  the engine places the permanent first and then runs the effect, so `EffectTarget.Self` resolves.
+  The observable difference is that the entry's triggers are matched against the pre-choice
+  characteristics — a "whenever a Mountain enters" trigger won't see the type a Multiversal Passage
+  just chose. Both entry paths behave the same way here, so it is consistent, not path-dependent.
 - `EntersWithCounters(counterType?, count, selfOnly?, condition?, otherOnly?, appliesTo?)` /
   `EntersWithDynamicCounters(counterType?, count, otherOnly?, appliesTo?)` — "[permanent] enters with
   N counters." `EntersWithCounters` takes a fixed `count: Int` (Master Biomancer, Metallic Mimic);

--- a/mtg-sets/2025/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MultiversalPassageScenarioTest.kt
+++ b/mtg-sets/2025/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MultiversalPassageScenarioTest.kt
@@ -6,10 +6,14 @@ import com.wingedsheep.engine.core.OptionChosenResponse
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.spm.cards.MultiversalPassage
+import com.wingedsheep.mtg.sets.definitions.spm.cards.SandmanShiftingScoundrel
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityId
@@ -35,7 +39,7 @@ class MultiversalPassageScenarioTest : FunSpec({
 
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
-        driver.registerCards(TestCards.all + MultiversalPassage)
+        driver.registerCards(TestCards.all + MultiversalPassage + SandmanShiftingScoundrel)
         return driver
     }
 
@@ -91,6 +95,50 @@ class MultiversalPassageScenarioTest : FunSpec({
         driver.state.getEntity(passage)?.has<TappedComponent>() shouldBe true
         driver.getLifeTotal(p1) shouldBe 20
         driver.state.projectedState.hasSubtype(passage, "Island").shouldBeTrue()
+    }
+
+    test("returning it to the battlefield with an effect asks for the basic land type again") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Sandman's graveyard ability ("return this card and target land card from your graveyard
+        // to the battlefield tapped") is a plain MoveToZone onto the battlefield — the same shape
+        // every other non-cast entry uses (reanimation, blink, the earthbend return trigger).
+        val sandman = driver.putCardInGraveyard(p1, "Sandman, Shifting Scoundrel")
+        val passage = driver.putCardInGraveyard(p1, "Multiversal Passage")
+        driver.giveMana(p1, Color.GREEN, 5) // {3}{G}{G}
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = sandman,
+                abilityId = SandmanShiftingScoundrel.activatedAbilities.first().id,
+                targets = listOf(ChosenTarget.Card(passage, ownerId = p1, zone = Zone.GRAVEYARD)),
+            )
+        )
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && driver.pendingDecision == null && guard++ < 20) {
+            driver.bothPass()
+        }
+
+        // The as-enters clause applies to this entry too (it is not limited to playing the land):
+        // choose a basic land type, then the pay-2-life gate.
+        val choice = driver.pendingDecision
+        choice.shouldBeInstanceOf<ChooseOptionDecision>()
+        choice.options shouldContain "Mountain"
+        driver.submitDecision(p1, OptionChosenResponse(choice.id, choice.options.indexOf("Mountain")))
+
+        val payDecision = driver.pendingDecision
+        payDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(p1, false)
+
+        // It came back as a Mountain rather than a typeless land that can't do anything.
+        driver.state.projectedState.hasSubtype(passage, "Mountain").shouldBeTrue()
+        driver.untapPermanent(passage) // it returned tapped, per Sandman's ability
+        driver.submitSuccess(ActivateAbility(p1, passage, AbilityId.intrinsicMana('R')))
+        driver.pool(p1).red shouldBe 1
     }
 
     test("choosing Mountain makes it a Mountain that taps for R") {

--- a/mtg-sets/2025/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MultiversalPassageScenarioTest.kt
+++ b/mtg-sets/2025/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MultiversalPassageScenarioTest.kt
@@ -14,6 +14,9 @@ import com.wingedsheep.mtg.sets.definitions.spm.cards.SandmanShiftingScoundrel
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityId
@@ -32,6 +35,25 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  * gate whose decline branch taps the land. These tests prove the chosen type sticks (subtype +
  * intrinsic mana), and that the pay/decline branch controls tapped-ness.
  */
+/**
+ * Landfall witness for the deferred-trigger case below. The entry's `ZoneChangeEvent` is emitted
+ * before the as-enters clause pauses for its choice, so this trigger only fires if the paused
+ * result carries that event up to the resume path.
+ */
+private val LandfallWatcher = card("Landfall Watcher") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Creature — Spirit"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever a land you control enters, you gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.GainLife(1)
+    }
+}
+
 class MultiversalPassageScenarioTest : FunSpec({
 
     fun GameTestDriver.pool(playerId: EntityId): ManaPoolComponent =
@@ -39,7 +61,9 @@ class MultiversalPassageScenarioTest : FunSpec({
 
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
-        driver.registerCards(TestCards.all + MultiversalPassage + SandmanShiftingScoundrel)
+        driver.registerCards(
+            TestCards.all + MultiversalPassage + SandmanShiftingScoundrel + LandfallWatcher
+        )
         return driver
     }
 
@@ -139,6 +163,50 @@ class MultiversalPassageScenarioTest : FunSpec({
         driver.untapPermanent(passage) // it returned tapped, per Sandman's ability
         driver.submitSuccess(ActivateAbility(p1, passage, AbilityId.intrinsicMana('R')))
         driver.pool(p1).red shouldBe 1
+    }
+
+    test("the entry's landfall trigger survives the as-enters pause and fires after the choice") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(p1, "Landfall Watcher")
+        val sandman = driver.putCardInGraveyard(p1, "Sandman, Shifting Scoundrel")
+        val passage = driver.putCardInGraveyard(p1, "Multiversal Passage")
+        driver.giveMana(p1, Color.GREEN, 5)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = sandman,
+                abilityId = SandmanShiftingScoundrel.activatedAbilities.first().id,
+                targets = listOf(ChosenTarget.Card(passage, ownerId = p1, zone = Zone.GRAVEYARD)),
+            )
+        )
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && driver.pendingDecision == null && guard++ < 20) {
+            driver.bothPass()
+        }
+
+        // Paused mid-entry for the basic land type. The land is physically on the battlefield and
+        // its ZoneChangeEvent has been emitted, but nothing has resolved off it yet.
+        val choice = driver.pendingDecision
+        choice.shouldBeInstanceOf<ChooseOptionDecision>()
+        driver.getLifeTotal(p1) shouldBe 20
+
+        driver.submitDecision(p1, OptionChosenResponse(choice.id, choice.options.indexOf("Mountain")))
+        val payDecision = driver.pendingDecision
+        payDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(p1, false)
+
+        // The entry event was carried through the pause, so the landfall trigger was deferred onto
+        // the stack rather than dropped. Drain it.
+        guard = 0
+        while (driver.state.stack.isNotEmpty() && driver.pendingDecision == null && guard++ < 20) {
+            driver.bothPass()
+        }
+        driver.getLifeTotal(p1) shouldBe 21
     }
 
     test("choosing Mountain makes it a Mountain that taps for R") {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -31,7 +31,6 @@ import com.wingedsheep.sdk.scripting.EntersAsCopy
 import com.wingedsheep.sdk.scripting.EntersTapped
 import com.wingedsheep.sdk.scripting.ChoiceType
 import com.wingedsheep.sdk.scripting.EntersWithChoice
-import com.wingedsheep.sdk.scripting.OnEnterRunEffect
 import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
 import com.wingedsheep.sdk.scripting.MayPlayLandsFromGraveyard
 import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
@@ -291,9 +290,8 @@ class PlayLandHandler(
         // Effects.Tap(EffectTarget.Self) (Game Trail's "otherwise" rider) apply
         // synchronously with entry. May pause for player input via continuations.
         if (cardDef != null) {
-            val onEnter = cardDef.script.replacementEffects
-                .filterIsInstance<OnEnterRunEffect>()
-                .firstOrNull()
+            val onEnter = com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
+                .onEnterRunEffectFor(cardDef)
             if (onEnter != null) {
                 // Use up the land drop and emit the entry event before running the
                 // effect — by this point the land is fully on the battlefield and

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EffectExecutorRegistry.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EffectExecutorRegistry.kt
@@ -58,6 +58,9 @@ class EffectExecutorRegistry(
     // Held as a field so its recursion (for ModifyKeywordAction's Composite delegation) can be wired
     // before the module is registered, mirroring libraryExecutors.
     private val permanentExecutors = PermanentExecutors(decisionHandler, amountEvaluator, cardRegistry)
+    // Held as a field so its recursion (for an entering permanent's OnEnterRunEffect) can be wired
+    // before the module is registered, mirroring permanentExecutors.
+    private val zonesExecutors = ZonesExecutors(cardRegistry)
 
     /**
      * Exposed so [com.wingedsheep.engine.core.EngineServices] can call
@@ -82,7 +85,11 @@ class EffectExecutorRegistry(
         registerModule(StackExecutors(amountEvaluator, cardRegistry))
         registerModule(InformationExecutors())
         registerModule(CombatExecutors(amountEvaluator))
-        registerModule(ZonesExecutors(cardRegistry))
+        // Wire the recursion (so a card put onto the battlefield by an effect can run its
+        // OnEnterRunEffect replacement) before registering; the ref is read lazily at execution
+        // time, so order is not load-bearing.
+        zonesExecutors.initializeRecursion(::recurse)
+        registerModule(zonesExecutors)
         registerModule(LinkedExileExecutors())
         registerModule(RegenerationExecutors())
         registerModule(BendExecutors())

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.core.ContinuationFrame
 import com.wingedsheep.engine.core.DecisionContext
 import com.wingedsheep.engine.core.DecisionPhase
 import com.wingedsheep.engine.core.CloneEntersOnBattlefieldContinuation
+import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.EntersWithChoiceOnBattlefieldContinuation
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEvent
@@ -14,8 +15,10 @@ import com.wingedsheep.engine.core.HandLookedAtEvent
 import com.wingedsheep.engine.core.OptionMetadata
 import com.wingedsheep.engine.core.PendingDecision
 import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
@@ -27,17 +30,22 @@ import com.wingedsheep.sdk.scripting.CardNamePool
 import com.wingedsheep.sdk.scripting.ChoiceType
 import com.wingedsheep.sdk.scripting.EntersAsCopy
 import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.OnEnterRunEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.references.Player
 
 /**
- * Applies a permanent's own "as-enters" [EntersWithChoice] replacement (CR 614.12 — choose a
- * color / creature type / mode / … as the permanent enters) to an entity that has *already* been
- * placed on the battlefield **directly** — i.e. not cast as a spell that resolves off the stack.
+ * Applies a permanent's own "as-enters" replacements — [EntersWithChoice] (CR 614.12 — choose a
+ * color / creature type / mode / … as the permanent enters), [EntersAsCopy], and the generic
+ * [OnEnterRunEffect] — to an entity that has *already* been placed on the battlefield
+ * **directly**, i.e. not cast as a spell that resolves off the stack.
  *
- * Two callers share this seam:
- *  - [com.wingedsheep.engine.handlers.actions.land.PlayLandHandler] — a land played directly, and
+ * Callers share this seam:
+ *  - [com.wingedsheep.engine.handlers.actions.land.PlayLandHandler] — a land played directly,
  *  - [com.wingedsheep.engine.handlers.effects.token.TokenFromDefinition] — a token minted from a
- *    card definition (e.g. the Momir Basic avatar's random-creature token).
+ *    card definition (e.g. the Momir Basic avatar's random-creature token), and
+ *  - [com.wingedsheep.engine.handlers.effects.zones.MoveToZoneEffectExecutor] — a card put onto
+ *    the battlefield by an effect (reanimation, a blink or earthbend return from exile, a fetch).
  *
  * The spell-resolution path keeps its own pre-battlefield variant
  * ([com.wingedsheep.engine.mechanics.stack.StackResolver.pauseForEntersWithChoice]) because there
@@ -84,6 +92,52 @@ object PermanentEntryReplacements {
             }
         }
         return newState to listOf(HandLookedAtEvent(viewerId, opponentId, handCards))
+    }
+
+    /**
+     * Run a permanent's own [OnEnterRunEffect] — the generic "as ~ enters, run [effect]"
+     * self-replacement — on an entity that has *already* been placed on the battlefield.
+     *
+     * [com.wingedsheep.engine.handlers.actions.land.PlayLandHandler] runs this inline for a land
+     * being played; this is the counterpart for every *other* direct battlefield entry (a return
+     * from exile or the graveyard, a reanimation, a "put onto the battlefield" fetch). Without it,
+     * a permanent whose entry choice lives in this replacement — Multiversal Passage's "as this
+     * land enters, choose a basic land type" — comes back with the choice never made and no way to
+     * make it later.
+     *
+     * The effect runs with a fresh [EffectContext] rooted at the entering permanent, so
+     * `EffectTarget.Self` resolves to it rather than to whatever moved it. It may pause for player
+     * input like any other effect; the caller forwards the pause (with the entry events it has
+     * already collected) and the normal continuation machinery finishes the rest.
+     *
+     * @param resolutionDepth the calling effect's depth, carried into the fresh context so the
+     *   registry's runaway-recursion backstop still counts a self-perpetuating entry loop.
+     * @return the [EffectResult] of running the replacement, or `null` if the card has no
+     *   [OnEnterRunEffect] — the caller then completes entry normally.
+     */
+    fun runOnEnterRunEffect(
+        state: GameState,
+        entityId: EntityId,
+        controllerId: EntityId,
+        cardRegistry: CardRegistry,
+        effectExecutor: (GameState, Effect, EffectContext) -> EffectResult,
+        resolutionDepth: Int = 0,
+    ): EffectResult? {
+        val cardDefinitionId = state.getEntity(entityId)?.get<CardComponent>()?.cardDefinitionId ?: return null
+        val cardDef = cardRegistry.getCard(cardDefinitionId) ?: return null
+        val onEnter = cardDef.script.replacementEffects
+            .filterIsInstance<OnEnterRunEffect>()
+            .firstOrNull()
+            ?: return null
+        return effectExecutor(
+            state,
+            onEnter.effect,
+            EffectContext(
+                sourceId = entityId,
+                controllerId = controllerId,
+                resolutionDepth = resolutionDepth,
+            ),
+        )
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
@@ -25,6 +25,7 @@ import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.CardNamePool
 import com.wingedsheep.sdk.scripting.ChoiceType
@@ -40,12 +41,23 @@ import com.wingedsheep.sdk.scripting.references.Player
  * [OnEnterRunEffect] — to an entity that has *already* been placed on the battlefield
  * **directly**, i.e. not cast as a spell that resolves off the stack.
  *
- * Callers share this seam:
- *  - [com.wingedsheep.engine.handlers.actions.land.PlayLandHandler] — a land played directly,
+ * **Each caller uses a different subset — this is a toolbox, not one entry point.** Which of the
+ * two helper families is wired where today:
+ *
+ *  - [com.wingedsheep.engine.handlers.actions.land.PlayLandHandler] — a land played directly.
+ *    Both: [pauseForEntersWithChoice] / [entersAsCopyCandidates], and [OnEnterRunEffect] inline
+ *    (sharing this object's [onEnterRunEffectFor] lookup).
  *  - [com.wingedsheep.engine.handlers.effects.token.TokenFromDefinition] — a token minted from a
- *    card definition (e.g. the Momir Basic avatar's random-creature token), and
+ *    card definition (e.g. the Momir Basic avatar's random-creature token).
+ *    [pauseForEntersWithChoice] only.
  *  - [com.wingedsheep.engine.handlers.effects.zones.MoveToZoneEffectExecutor] — a card put onto
- *    the battlefield by an effect (reanimation, a blink or earthbend return from exile, a fetch).
+ *    the battlefield by an effect (reanimation, a blink or earthbend return from exile).
+ *    [runOnEnterRunEffect] only.
+ *
+ * Those omissions are real gaps, not deliberate exclusions. The next one worth closing is
+ * [EntersWithChoice] on the move path: a reanimated Shapeshifter or Sorcerous Spyglass currently
+ * enters with its as-enters choice never made — the same shape of bug [runOnEnterRunEffect] was
+ * added to fix, one replacement over.
  *
  * The spell-resolution path keeps its own pre-battlefield variant
  * ([com.wingedsheep.engine.mechanics.stack.StackResolver.pauseForEntersWithChoice]) because there
@@ -95,15 +107,33 @@ object PermanentEntryReplacements {
     }
 
     /**
+     * The single [OnEnterRunEffect] a card definition contributes, or `null` if it has none.
+     *
+     * **First one wins.** Both entry paths consult only the first, so a card that needs two
+     * "as ~ enters" clauses must fold them into one composite inside a single replacement — see
+     * `MultiversalPassage`, whose choose-a-type and pay-2-life clauses share one wrapper for
+     * exactly this reason. That rule is single-sourced here so
+     * [com.wingedsheep.engine.handlers.actions.land.PlayLandHandler] and [runOnEnterRunEffect]
+     * cannot drift apart on it.
+     */
+    fun onEnterRunEffectFor(cardDef: CardDefinition?): OnEnterRunEffect? =
+        cardDef?.script?.replacementEffects
+            ?.filterIsInstance<OnEnterRunEffect>()
+            ?.firstOrNull()
+
+    /**
      * Run a permanent's own [OnEnterRunEffect] — the generic "as ~ enters, run [effect]"
      * self-replacement — on an entity that has *already* been placed on the battlefield.
      *
      * [com.wingedsheep.engine.handlers.actions.land.PlayLandHandler] runs this inline for a land
      * being played; this is the counterpart for every *other* direct battlefield entry (a return
-     * from exile or the graveyard, a reanimation, a "put onto the battlefield" fetch). Without it,
-     * a permanent whose entry choice lives in this replacement — Multiversal Passage's "as this
-     * land enters, choose a basic land type" — comes back with the choice never made and no way to
-     * make it later.
+     * from exile or the graveyard, a reanimation). Without it, a permanent whose entry choice
+     * lives in this replacement — Multiversal Passage's "as this land enters, choose a basic land
+     * type" — comes back with the choice never made and no way to make it later.
+     *
+     * Not a library search that puts a card onto the battlefield: `SearchDestination.BATTLEFIELD`
+     * routes through `MoveCollectionExecutor` even for a single card, and that executor does not
+     * run this replacement yet.
      *
      * The effect runs with a fresh [EffectContext] rooted at the entering permanent, so
      * `EffectTarget.Self` resolves to it rather than to whatever moved it. It may pause for player
@@ -124,11 +154,7 @@ object PermanentEntryReplacements {
         resolutionDepth: Int = 0,
     ): EffectResult? {
         val cardDefinitionId = state.getEntity(entityId)?.get<CardComponent>()?.cardDefinitionId ?: return null
-        val cardDef = cardRegistry.getCard(cardDefinitionId) ?: return null
-        val onEnter = cardDef.script.replacementEffects
-            .filterIsInstance<OnEnterRunEffect>()
-            .firstOrNull()
-            ?: return null
+        val onEnter = onEnterRunEffectFor(cardRegistry.getCard(cardDefinitionId)) ?: return null
         return effectExecutor(
             state,
             onEnter.effect,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
@@ -822,6 +822,14 @@ class MoveCollectionExecutor(
             // battlefield from a non-stack zone (e.g., Celestial Reunion tutoring directly to
             // play, Hideaway's free-cast pile). Face-down entries skip this — morphed creatures
             // enter as 2/2 nameless with no replacement effects from their face-up identity.
+            //
+            // KNOWN GAP: the single-card sibling of this path (MoveToZoneEffectExecutor) also runs
+            // PermanentEntryReplacements.runOnEnterRunEffect here; this one does not, so a card
+            // with an "as ~ enters, run [effect]" replacement (Multiversal Passage, Game Trail)
+            // tutored onto the battlefield still enters with its clause never run. Closing it
+            // needs more than the two-line call: this is a loop, the replacement can pause for a
+            // decision, and pausing mid-loop requires a continuation that resumes the remaining
+            // cards. See docs/card-sdk-language-reference.md, OnEnterRunEffect "Scope today".
             if (destZone == Zone.BATTLEFIELD && faceDown == null) {
                 val (counterState, counterEvents) = EntersWithReplacements.applyOnEntry(
                     newState, cardId, actualDestPlayerId, cardRegistry

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ReturnSpellOrPermanentToOwnersHandExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/ReturnSpellOrPermanentToOwnersHandExecutor.kt
@@ -37,7 +37,16 @@ class ReturnSpellOrPermanentToOwnersHandExecutor(
     override val effectType: KClass<ReturnSpellOrPermanentToOwnersHandEffect> =
         ReturnSpellOrPermanentToOwnersHandEffect::class
 
-    private val permanentBounce = MoveToZoneEffectExecutor(cardRegistry)
+    // Bounce is always to hand, so the entering-permanent recursion can never fire. A throwing
+    // stub rather than a real executor keeps that assumption honest: if this delegation ever
+    // grows a battlefield destination, it fails here instead of silently skipping the entering
+    // permanent's OnEnterRunEffect replacement.
+    private val permanentBounce = MoveToZoneEffectExecutor(
+        cardRegistry,
+        effectExecutor = { _, _, _ ->
+            error("ReturnSpellOrPermanentToOwnersHandExecutor bounces to hand; nothing enters the battlefield")
+        }
+    )
 
     override fun execute(
         state: GameState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
@@ -40,14 +40,15 @@ import kotlin.reflect.KClass
  * Delegates all zone movement to [ZoneTransitionService] for consistent cleanup.
  *
  * @param effectExecutor the registry's recursive executor, used to run an entering permanent's
- *   [com.wingedsheep.sdk.scripting.OnEnterRunEffect] replacement. Null only for the internal
- *   bounce-to-hand reuse in `ReturnSpellOrPermanentToOwnersHandExecutor`, which never puts a
- *   permanent onto the battlefield.
+ *   [com.wingedsheep.sdk.scripting.OnEnterRunEffect] replacement. Required rather than nullable:
+ *   a caller that provably never reaches the battlefield passes a throwing stub (the
+ *   bounce-to-hand reuse in `ReturnSpellOrPermanentToOwnersHandExecutor`), so if that destination
+ *   ever changes it fails loudly instead of silently skipping a rules-required replacement.
  */
 class MoveToZoneEffectExecutor(
     private val cardRegistry: CardRegistry,
     private val targetFinder: TargetFinder = TargetFinder(),
-    private val effectExecutor: ((GameState, Effect, EffectContext) -> EffectResult)? = null
+    private val effectExecutor: (GameState, Effect, EffectContext) -> EffectResult
 ) : EffectExecutor<MoveToZoneEffect> {
 
     override val effectType: KClass<MoveToZoneEffect> = MoveToZoneEffect::class
@@ -175,20 +176,23 @@ class MoveToZoneEffectExecutor(
 
         // "As this permanent enters, run [effect]" (OnEnterRunEffect) — the self-replacement
         // PlayLandHandler runs inline for a played land, applied here for every *other* way a card
-        // reaches the battlefield: reanimation, a blink or earthbend return from exile, a fetch
-        // that puts the card onto the battlefield. Without it a permanent whose entry choice lives
-        // in this replacement — Multiversal Passage's "as this land enters, choose a basic land
-        // type" — comes back with the choice never made and no way to make it afterwards.
+        // reaches the battlefield: reanimation, a blink or earthbend return from exile. Without it
+        // a permanent whose entry choice lives in this replacement — Multiversal Passage's "as
+        // this land enters, choose a basic land type" — comes back with the choice never made and
+        // no way to make it afterwards. (A library search that puts a card onto the battlefield
+        // does NOT land here even for a single card: it routes through MoveCollectionExecutor,
+        // which doesn't run this replacement yet.)
         //
         // Runs last so the entry's own events are already collected: the effect may pause for the
         // choice, and the paused result carries them (including the entry ZoneChangeEvent) so the
         // entry's ETB triggers are deferred by the resume path rather than lost. Skipped for
         // face-down entries (CR 708.2 — no abilities) and for a battlefield→battlefield redirect,
-        // which is not a new entry.
+        // which is not a new entry. An Aura never reaches here either — attachAuraOnEnter above
+        // returns first — so an Aura carrying this replacement would still skip it; no card does
+        // today, and wiring it belongs with the choose-a-host continuation, not here.
         if (actualDestZone == Zone.BATTLEFIELD &&
             effect.faceDown == null &&
-            currentZone.zoneType != Zone.BATTLEFIELD &&
-            effectExecutor != null
+            currentZone.zoneType != Zone.BATTLEFIELD
         ) {
             val onEnterResult = PermanentEntryReplacements.runOnEnterRunEffect(
                 resultState, targetId, controllerId, cardRegistry, effectExecutor,
@@ -197,11 +201,24 @@ class MoveToZoneEffectExecutor(
             if (onEnterResult != null) {
                 resultState = onEnterResult.state
                 extraEvents.addAll(onEnterResult.events)
-                onEnterResult.pendingDecision?.let { decision ->
-                    return EffectResult.paused(
-                        resultState, decision, transitionResult.events + extraEvents
-                    )
-                }
+                // pendingDecision is null when the replacement finished without asking anything,
+                // so this one return covers both the paused and the completed case.
+                //
+                // triggersAlreadyProcessed must ride along: the replacement can nest a cast
+                // (CastFromCollectionWithoutPayingCost routes through CastSpellHandler, which
+                // stacks its own cast-triggers), and dropping the flag makes the resume path
+                // re-scan those events and fire the trigger twice.
+                //
+                // onEnterResult.error is deliberately NOT propagated. The permanent did enter —
+                // only the as-enters clause failed — and surfacing an error here would make the
+                // enclosing composite treat the whole move as the failed step (CR 609.3: an
+                // effect that attempts something impossible does only as much as possible).
+                return EffectResult(
+                    state = resultState,
+                    events = transitionResult.events + extraEvents,
+                    pendingDecision = onEnterResult.pendingDecision,
+                    triggersAlreadyProcessed = onEnterResult.triggersAlreadyProcessed,
+                )
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
 import com.wingedsheep.engine.handlers.effects.LibraryPlacement
+import com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
 import com.wingedsheep.engine.handlers.effects.ZoneEntryOptions
 import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
 import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.destroyPermanent
@@ -24,6 +25,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
 import com.wingedsheep.sdk.scripting.effects.ZonePlacement
@@ -36,10 +38,16 @@ import kotlin.reflect.KClass
  * shuffle-into-library, put-on-top, etc.
  *
  * Delegates all zone movement to [ZoneTransitionService] for consistent cleanup.
+ *
+ * @param effectExecutor the registry's recursive executor, used to run an entering permanent's
+ *   [com.wingedsheep.sdk.scripting.OnEnterRunEffect] replacement. Null only for the internal
+ *   bounce-to-hand reuse in `ReturnSpellOrPermanentToOwnersHandExecutor`, which never puts a
+ *   permanent onto the battlefield.
  */
 class MoveToZoneEffectExecutor(
     private val cardRegistry: CardRegistry,
-    private val targetFinder: TargetFinder = TargetFinder()
+    private val targetFinder: TargetFinder = TargetFinder(),
+    private val effectExecutor: ((GameState, Effect, EffectContext) -> EffectResult)? = null
 ) : EffectExecutor<MoveToZoneEffect> {
 
     override val effectType: KClass<MoveToZoneEffect> = MoveToZoneEffect::class
@@ -152,18 +160,52 @@ class MoveToZoneEffectExecutor(
         // as the opponent. controllerId only diverges from ownerId for a controller-override
         // move onto the battlefield (see above); returns to hand/library never carry an
         // override, so controllerId == ownerId there and behaviour is unchanged.
-        val revealEvents = autoRevealForReturn(
-            fromZone = currentZone.zoneType,
-            toZone = effect.destination,
-            targetId = targetId,
-            cardName = cardComponent.name,
-            imageUri = cardComponent.imageUri,
-            controllerId = controllerId,
-            sourceId = context.sourceId,
-            state = resultState
+        extraEvents.addAll(
+            autoRevealForReturn(
+                fromZone = currentZone.zoneType,
+                toZone = effect.destination,
+                targetId = targetId,
+                cardName = cardComponent.name,
+                imageUri = cardComponent.imageUri,
+                controllerId = controllerId,
+                sourceId = context.sourceId,
+                state = resultState
+            )
         )
 
-        return EffectResult.success(resultState, transitionResult.events + extraEvents + revealEvents)
+        // "As this permanent enters, run [effect]" (OnEnterRunEffect) — the self-replacement
+        // PlayLandHandler runs inline for a played land, applied here for every *other* way a card
+        // reaches the battlefield: reanimation, a blink or earthbend return from exile, a fetch
+        // that puts the card onto the battlefield. Without it a permanent whose entry choice lives
+        // in this replacement — Multiversal Passage's "as this land enters, choose a basic land
+        // type" — comes back with the choice never made and no way to make it afterwards.
+        //
+        // Runs last so the entry's own events are already collected: the effect may pause for the
+        // choice, and the paused result carries them (including the entry ZoneChangeEvent) so the
+        // entry's ETB triggers are deferred by the resume path rather than lost. Skipped for
+        // face-down entries (CR 708.2 — no abilities) and for a battlefield→battlefield redirect,
+        // which is not a new entry.
+        if (actualDestZone == Zone.BATTLEFIELD &&
+            effect.faceDown == null &&
+            currentZone.zoneType != Zone.BATTLEFIELD &&
+            effectExecutor != null
+        ) {
+            val onEnterResult = PermanentEntryReplacements.runOnEnterRunEffect(
+                resultState, targetId, controllerId, cardRegistry, effectExecutor,
+                resolutionDepth = context.resolutionDepth
+            )
+            if (onEnterResult != null) {
+                resultState = onEnterResult.state
+                extraEvents.addAll(onEnterResult.events)
+                onEnterResult.pendingDecision?.let { decision ->
+                    return EffectResult.paused(
+                        resultState, decision, transitionResult.events + extraEvents
+                    )
+                }
+            }
+        }
+
+        return EffectResult.success(resultState, transitionResult.events + extraEvents)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ZonesExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/ZonesExecutors.kt
@@ -1,9 +1,14 @@
 package com.wingedsheep.engine.handlers.effects.zones
 
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.ExecutorModule
 import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.scripting.effects.Effect
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Module providing zone-transition effect executors — effects that physically move
@@ -14,8 +19,28 @@ class ZonesExecutors(
     private val cardRegistry: CardRegistry,
     private val targetFinder: TargetFinder = TargetFinder()
 ) : ExecutorModule {
+
+    // Late-bound registry recursion so [MoveToZoneEffectExecutor] can run an entering permanent's
+    // OnEnterRunEffect replacement ("as this enters, …") when an effect puts a card onto the
+    // battlefield. Mirrors PermanentExecutors' wiring: read through the ref at execution time, so
+    // constructing this module before initialization (as some unit tests do) never trips over an
+    // unset property.
+    private val recursionRef =
+        AtomicReference<((GameState, Effect, EffectContext) -> EffectResult)?>(null)
+
+    private val recursion: (GameState, Effect, EffectContext) -> EffectResult = { state, effect, context ->
+        val executor = recursionRef.get()
+            ?: error("ZonesExecutors.initializeRecursion(...) was not called before a zone executor ran")
+        executor(state, effect, context)
+    }
+
+    /** Late-bind the registry's recursive executor so the zone executors can delegate. */
+    fun initializeRecursion(executor: (GameState, Effect, EffectContext) -> EffectResult) {
+        recursionRef.set(executor)
+    }
+
     override fun executors(): List<EffectExecutor<*>> = listOf(
-        MoveToZoneEffectExecutor(cardRegistry, targetFinder),
+        MoveToZoneEffectExecutor(cardRegistry, targetFinder, recursion),
         ExileAndGrantOwnerPlayPermissionExecutor(),
         WarpExileExecutor(),
         MoveTrackedBattlefieldObjectExecutor(),

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutorTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutorTest.kt
@@ -28,7 +28,12 @@ import io.kotest.matchers.shouldBe
 class MoveToZoneEffectExecutorTest : FunSpec({
 
     val cardRegistry = com.wingedsheep.engine.registry.CardRegistry()
-    val executor = MoveToZoneEffectExecutor(cardRegistry)
+    // None of the cases below use a card definition carrying an OnEnterRunEffect, so the
+    // entering-permanent recursion must never fire; throwing makes that explicit.
+    val executor = MoveToZoneEffectExecutor(
+        cardRegistry,
+        effectExecutor = { _, _, _ -> error("no OnEnterRunEffect expected in this test") }
+    )
 
     val playerId = EntityId.generate()
     val cardId = EntityId.generate()


### PR DESCRIPTION
# Run `OnEnterRunEffect` when an effect puts a permanent onto the battlefield

## The bug

An earthbent Multiversal Passage that was exiled and returned by its granted "when this dies or is
exiled, return it to the battlefield tapped" trigger came back inert: its "as this land enters,
choose a basic land type" clause never ran, so the land had no subtype, no intrinsic mana ability,
and nothing its controller could do with it.

That clause is an `OnEnterRunEffect` replacement, and the engine only consulted it in
`PlayLandHandler` — i.e. only when the land was *played*. Every other route onto the battlefield
(a return from exile or the graveyard, reanimation, blink) skipped it.

## The fix

Wire it into `MoveToZoneEffectExecutor` through a new helper on the existing as-enters seam,
`PermanentEntryReplacements.runOnEnterRunEffect`. No new SDK type: this reuses the
`OnEnterRunEffect` replacement and the executor pipeline that already exist.

- The effect runs with a fresh `EffectContext` rooted at the entering permanent, so
  `EffectTarget.Self` resolves to it rather than to whatever moved it.
- It carries the caller's `resolutionDepth`, so the registry's runaway-recursion backstop still
  counts a self-perpetuating entry loop.
- A pause forwards the entry events already collected (including the entry `ZoneChangeEvent`), so
  the entry's ETB triggers are deferred by the normal resume path instead of being lost.
- Skipped for face-down entries (CR 708.2) and for a battlefield-to-battlefield redirect, which is
  not a new entry.
- `ZonesExecutors` gains late-bound registry recursion for this, mirroring `PermanentExecutors`.

## Review round

A review of the first commit produced eight findings; all are addressed in the follow-up commit.

**Correctness**

- `MoveToZoneEffectExecutor` now propagates `triggersAlreadyProcessed` from the replacement's
  result. Dropping it would double-fire cast triggers if a future `OnEnterRunEffect` nested a cast
  (`CastFromCollectionWithoutPayingCost` routes through `CastSpellHandler`, which stacks its own).
  `error` is still deliberately not propagated, with the reasoning recorded inline: the permanent
  did enter, only the as-enters clause failed, and surfacing an error would make the enclosing
  composite treat the whole move as the failed step (CR 609.3).
- The `effectExecutor` constructor parameter is now required rather than nullable. The one caller
  that cannot reach the battlefield — the bounce-to-hand reuse in
  `ReturnSpellOrPermanentToOwnersHandExecutor` — passes a throwing stub, so if that destination
  ever changes it fails loudly instead of silently skipping a rules-required replacement.

**A doc claim that was wrong**

The original scope note claimed "fetches that move one card" were covered. They are not: a library
search that puts a *single* card onto the battlefield (`SearchDestination.BATTLEFIELD`, e.g.
Wayfarer's Bauble) routes through `MoveCollectionExecutor`, which the same note correctly lists as
unwired. Corrected in `docs/card-sdk-language-reference.md` and in both KDoc copies.

**Accuracy of the shared-seam docs**

`PermanentEntryReplacements`' object KDoc read as though all three as-enters replacements applied
on all three listed paths. They don't — each caller uses a different subset. It now says which,
and names the next gap explicitly: `EntersWithChoice` on the move path, where a reanimated
Shapeshifter or Sorcerous Spyglass still enters with its choice never made. Same shape of bug, one
replacement over.

**Deduplication**

The `OnEnterRunEffect` lookup was duplicated in `PlayLandHandler` and `PermanentEntryReplacements`.
`MultiversalPassage`'s KDoc explicitly depends on the "first one wins" rule, so the two copies
could have drifted on it. Single-sourced as `PermanentEntryReplacements.onEnterRunEffectFor`.

**Gaps now recorded where the code is, not only in the docs**

- `MoveCollectionExecutor` carries a `KNOWN GAP` comment next to its `EntersWithReplacements`
  call, explaining both what is missing and why closing it needs a continuation (the replacement
  can pause, and this is a loop over cards).
- An Aura carrying this replacement would still skip it, because `attachAuraOnEnter` returns
  first. No card does today; noted in the code and the scope list.
- CR 614.12a says an as-enters choice is made *before* the permanent enters, whereas the engine
  places it first so `EffectTarget.Self` resolves. The observable consequence — entry triggers are
  matched against pre-choice characteristics, so "whenever a Mountain enters" won't see the type a
  Multiversal Passage just chose — is now written down. Both entry paths behave identically here,
  so it is consistent rather than path-dependent.

## Still out of scope

Recorded in the SDK reference's "Scope today" list rather than fixed here:

- `MoveCollectionExecutor` — the batch move, which also covers single-card library searches onto
  the battlefield. Needs a continuation to pause mid-loop.
- `StackResolver.enterPermanentOnBattlefield` — the spell-resolution path. Nothing needs it until
  the first non-land permanent uses this replacement; the only two cards using it today
  (Multiversal Passage, Game Trail) are lands.
- Auras, on any path.

## Tests

`MultiversalPassageScenarioTest` gains two cases:

1. **Returned by an effect asks for the basic land type again.** Uses Sandman, Shifting Scoundrel's
   graveyard ability, which is `CompositeEffect(MoveToZoneEffect, MoveToZoneEffect)` — structurally
   identical to the earthbend return trigger that produced the original bug
   (`Effects.kt`, `earthbendReturnTapped`). Asserts the land comes back as the chosen Mountain and
   taps for `{R}`, rather than as a typeless land that can't do anything.
2. **The entry's landfall trigger survives the as-enters pause.** This one exists because the
   riskiest line in the change is the claim that the paused result carries the entry
   `ZoneChangeEvent` up to the resume path. Without it, a refactor returning the pause with no
   events stayed green. Verified by mutation: dropping the entry events from the paused return
   fails this test and only this test.

## Verification

| Gate | Result |
|---|---|
| `:rules-engine:test` | 2923 tests, 0 failures, 0 errors |
| `:mtg-sets:2025:tests:test` | 1594 tests, 0 failures, 0 errors |

Both suites re-run after the review fixes, with fresh test-result XML confirmed (the first attempt
at the targeted run came back all-`UP-TO-DATE`, i.e. a cached false green, and was forced).

**Not covered by these gates:** `mtg-sets` scenario suites outside the 2025 era, `game-server`, and
the web client — none of which this diff touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
