### PR TITLE
Add Repulsive Mutation to Murders at Karlov Manor

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RepulsiveMutation.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RepulsiveMutation.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetSpell
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Repulsive Mutation
+ * {X}{G}{U}
+ * Instant
+ *
+ * Put X +1/+1 counters on target creature you control. Then counter up to one target spell unless
+ * its controller pays mana equal to the greatest power among creatures you control.
+ */
+val RepulsiveMutation = card("Repulsive Mutation") {
+    manaCost = "{X}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Instant"
+    oracleText = "Put X +1/+1 counters on target creature you control. Then counter up to one target " +
+        "spell unless its controller pays mana equal to the greatest power among creatures you control."
+
+    spell {
+        val creature = target("creature you control", Targets.CreatureYouControl)
+        target("up to one target spell", TargetSpell(optional = true))
+        effect = Effects.Composite(
+            Effects.AddDynamicCounters(Counters.PLUS_ONE_PLUS_ONE, DynamicAmount.XValue, creature),
+            Effects.CounterUnlessDynamicPays(
+                DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature).maxPower()
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "227"
+        artist = "Filip Burburan"
+        flavorText = "\"Remind me to send the biomancer team a gift basket.\"\n" +
+            "—Olana, Simic field researcher"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/7/1/71701c28-f113-4d38-8fd3-a19cd9749661.jpg?1783912838"
+
+        ruling(
+            "2024-02-02",
+            "If you control no creatures as Repulsive Mutation is resolving, the amount of mana the " +
+                "target spell's controller must pay to stop their spell from being countered is 0. " +
+                "That player can choose not to pay 0 mana; if they do, the spell will be countered."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -11933,6 +11933,78 @@
     ]
 }
 
+// Repulsive Mutation
+{
+    "name": "Repulsive Mutation",
+    "manaCost": "{X}{G}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Put X +1/+1 counters on target creature you control. Then counter up to one target spell unless its controller pays mana equal to the greatest power among creatures you control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": "XValue",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                {
+                    "type": "Counter",
+                    "condition": {
+                        "type": "CounterCondition.UnlessPaysDynamic",
+                        "amount": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "creature",
+                            "aggregation": "MAX",
+                            "property": "POWER"
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "creature you control"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                },
+                "id": "up to one target spell"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "rarity": "UNCOMMON",
+        "artist": "Filip Burburan",
+        "flavorText": "\"Remind me to send the biomancer team a gift basket.\"\n—Olana, Simic field researcher",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/71701c28-f113-4d38-8fd3-a19cd9749661.jpg?1783912838",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If you control no creatures as Repulsive Mutation is resolving, the amount of mana the target spell's controller must pay to stop their spell from being countered is 0. That player can choose not to pay 0 mana; if they do, the spell will be countered."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Riftburst Hellion
 {
     "name": "Riftburst Hellion",


### PR DESCRIPTION
## Summary

- Add Repulsive Mutation, composing X-scaled +1/+1 counters with the existing greatest-power dynamic amount and counter-unless-paid effect.
- Refresh the MKM card-definition snapshot.

## Scope

I initially selected Agency Outfitter as a second card, but dropped it during snapshot review: expressing its single combined named-card search as two existing searches would shuffle twice and was not rules-faithful. The remaining unimplemented MKM pool is similarly mechanic-heavy, so this PR intentionally contains one card per the request to pick fewer cards when complex.

## Verification

- `just build`
- `just check-card-printing "Repulsive Mutation"`
- `git diff --check`
- Scryfall metadata, rulings, printing history, and image URL rechecked