### PR TITLE
Add Glissa Sunseeker to Mirrodin

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GlissaSunseeker.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GlissaSunseeker.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Glissa Sunseeker — Mirrodin #120
+ * {2}{G}{G} · Legendary Creature — Elf Warrior · 3/2
+ *
+ * The activated ability can target any artifact. Its mana value is compared with the controller's
+ * unspent mana only as the ability resolves, so changing the mana pool in response can make the
+ * conditional destruction succeed or fail.
+ */
+val GlissaSunseeker = card("Glissa Sunseeker") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Elf Warrior"
+    oracleText = "First strike\n" +
+        "{T}: Destroy target artifact if its mana value is equal to the amount of unspent mana you have."
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        target = Targets.Artifact
+        effect = ConditionalEffect(
+            condition = Compare(
+                left = DynamicAmount.EntityProperty(
+                    EntityReference.Target(0),
+                    EntityNumericProperty.ManaValue,
+                ),
+                operator = ComparisonOperator.EQ,
+                right = DynamicAmount.UnspentMana(Player.You),
+            ),
+            effect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "120"
+        artist = "Brom"
+        flavorText = "\"There's a secret at the heart of this world, and I will unlock it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/670c3106-71fc-464e-8c94-81bf7fafc3e6.jpg?1783944533"
+        ruling(
+            "2004-12-01",
+            "The artifact's mana value must be exactly equal to the amount of unspent mana you " +
+                "have when the ability resolves. If there's less mana or more mana, the artifact " +
+                "won't be destroyed.",
+        )
+        ruling(
+            "2004-12-01",
+            "You need to have the unspent mana before the ability resolves. The ability doesn't " +
+                "allow you to activate mana abilities while it's resolving.",
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -3105,6 +3105,85 @@
     "colorIdentityOverride": []
 }
 
+// Glissa Sunseeker
+{
+    "name": "Glissa Sunseeker",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Legendary Creature — Elf Warrior",
+    "oracleText": "First strike\n{T}: Destroy target artifact if its mana value is equal to the amount of unspent mana you have.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Target",
+                                "numericProperty": "ManaValue"
+                            },
+                            "operator": "EQ",
+                            "right": {
+                                "type": "UnspentMana",
+                                "player": "You"
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact"
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "rarity": "RARE",
+        "artist": "Brom",
+        "flavorText": "\"There's a secret at the heart of this world, and I will unlock it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/670c3106-71fc-464e-8c94-81bf7fafc3e6.jpg?1783944533",
+        "rulings": [
+            {
+                "date": "2004-12-01",
+                "text": "The artifact's mana value must be exactly equal to the amount of unspent mana you have when the ability resolves. If there's less mana or more mana, the artifact won't be destroyed."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "You need to have the unspent mana before the ability resolves. The ability doesn't allow you to activate mana abilities while it's resolving."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Goblin Dirigible
 {
     "name": "Goblin Dirigible",


### PR DESCRIPTION
## Summary

- Glissa Sunseeker — targets any artifact, then compares its mana value with the controller’s unspent mana at resolution before destroying it. Composes existing tap cost, artifact targeting, dynamic amount comparison, and destroy primitives.
- Updates the Mirrodin card-definition snapshot.

## Scope

The remaining Mirrodin backlog is mechanically complex, so this batch was intentionally reduced to one faithful card. Mesmeric Orb was investigated and dropped because the current mill pattern cannot route to the controller of the triggering permanent without SDK work. Modal entwine cards and other candidates likewise require new engine vocabulary and belong in dedicated feature/card PRs.

## Verification

- just check-card-printing "Glissa Sunseeker"
- just rebless-cards
- just build