### PR TITLE
Add Mirrodin basic lands

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MirrodinBasicLands.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MirrodinBasicLands.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/** Mirrodin's four art variants for each basic land type (collector numbers 287–306). */
+val Plains287 = basicLand("Plains") {
+    collectorNumber = "287"
+    artist = "Mark Tedin"
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5bac2d0d-43db-41f7-99dd-9ff55a4f2b3b.jpg?1783944493"
+}
+
+val Plains288 = basicLand("Plains") {
+    collectorNumber = "288"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c160b1e7-8fad-4592-899c-995d09bc8b52.jpg?1783944493"
+}
+
+val Plains289 = basicLand("Plains") {
+    collectorNumber = "289"
+    artist = "Martina Pilcerova"
+    imageUri = "https://cards.scryfall.io/normal/front/e/a/eac11282-82d6-40db-8c28-5ed02268d2c6.jpg?1783944493"
+}
+
+val Plains290 = basicLand("Plains") {
+    collectorNumber = "290"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/546507c7-8fa8-44e3-aeb7-56fabf419d82.jpg?1783944492"
+}
+
+val Island291 = basicLand("Island") {
+    collectorNumber = "291"
+    artist = "Mark Tedin"
+    imageUri = "https://cards.scryfall.io/normal/front/9/a/9a5235cd-5d25-498d-8e36-7a7c0791f212.jpg?1783944492"
+}
+
+val Island292 = basicLand("Island") {
+    collectorNumber = "292"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/1/2/12dd90bb-b5d1-47a3-b566-3407db04dd55.jpg?1783944491"
+}
+
+val Island293 = basicLand("Island") {
+    collectorNumber = "293"
+    artist = "Martina Pilcerova"
+    imageUri = "https://cards.scryfall.io/normal/front/9/d/9db3309e-2893-4a39-876f-fd68ea057e22.jpg?1783944491"
+}
+
+val Island294 = basicLand("Island") {
+    collectorNumber = "294"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/d/e/de46f610-fab8-4819-b86a-d1defed319a1.jpg?1783944491"
+}
+
+val Swamp295 = basicLand("Swamp") {
+    collectorNumber = "295"
+    artist = "Mark Tedin"
+    imageUri = "https://cards.scryfall.io/normal/front/6/b/6bae27d4-9de5-4f95-8c56-79afc6cbeb0c.jpg?1783944490"
+}
+
+val Swamp296 = basicLand("Swamp") {
+    collectorNumber = "296"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/4/5/45927890-52ef-448c-b302-4192afa27a04.jpg?1783944489"
+}
+
+val Swamp297 = basicLand("Swamp") {
+    collectorNumber = "297"
+    artist = "Martina Pilcerova"
+    imageUri = "https://cards.scryfall.io/normal/front/c/4/c4b5147e-99b0-47fd-bec2-3baaf7e8ac4a.jpg?1783944489"
+}
+
+val Swamp298 = basicLand("Swamp") {
+    collectorNumber = "298"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/9/3/93d48cef-cfaf-4223-9efb-d76762a896d6.jpg?1783944489"
+}
+
+val Mountain299 = basicLand("Mountain") {
+    collectorNumber = "299"
+    artist = "Mark Tedin"
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b082f22f-6c01-4e8c-80ad-6fdae5c3f22f.jpg?1783944489"
+}
+
+val Mountain300 = basicLand("Mountain") {
+    collectorNumber = "300"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/4/3/4399a832-4406-4a12-a5e5-81744d02ceec.jpg?1783944489"
+}
+
+val Mountain301 = basicLand("Mountain") {
+    collectorNumber = "301"
+    artist = "Martina Pilcerova"
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/ba50901e-a030-4f52-8369-f4c9ca6b9c7a.jpg?1783944487"
+}
+
+val Mountain302 = basicLand("Mountain") {
+    collectorNumber = "302"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/2/2/22965406-d8d7-46ad-992e-7fc0e994698d.jpg?1783944486"
+}
+
+val Forest303 = basicLand("Forest") {
+    collectorNumber = "303"
+    artist = "Mark Tedin"
+    imageUri = "https://cards.scryfall.io/normal/front/7/7/77aec0b2-30f2-4f35-a9a3-24d87795d177.jpg?1783944487"
+}
+
+val Forest304 = basicLand("Forest") {
+    collectorNumber = "304"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/1/7/174cb9a0-afa3-4f45-b317-238fa9d4f55f.jpg?1783944485"
+}
+
+val Forest305 = basicLand("Forest") {
+    collectorNumber = "305"
+    artist = "Martina Pilcerova"
+    imageUri = "https://cards.scryfall.io/normal/front/3/7/37f8d695-a3e4-4707-9db9-886849ce4c42.jpg?1783944485"
+}
+
+val Forest306 = basicLand("Forest") {
+    collectorNumber = "306"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7c4bfc1c-20d5-40f4-8863-c69a89872159.jpg?1783944485"
+}


### PR DESCRIPTION
## Summary

- Plains — adds all four MRD art variants via the existing `basicLand` DSL.
- Island — adds all four MRD art variants via the existing `basicLand` DSL.
- Swamp — adds all four MRD art variants via the existing `basicLand` DSL.
- Mountain — adds all four MRD art variants via the existing `basicLand` DSL.
- Forest — adds all four MRD art variants via the existing `basicLand` DSL.

All collector numbers, artists, and exact image URIs were rechecked against Scryfall; all 20 image URLs return HTTP 200. This moves MRD from 235/291 to 240/291 implemented card identities.

## Verification

- `just build` — passed (137 actionable tasks; full scenario suite)
- `scripts/card-status --set MRD --list` — 240/291 implemented
- `git diff --check` — passed

`just check-card-printing` is not applicable cleanly to basic-land art variants: it reports repository-wide pre-existing Alpha/Beta canonical and missing-printing drift for the five basic land names, while set implementations intentionally use per-art `basicLand` definitions.