### PR TITLE
Add two Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BehindTheMask.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BehindTheMask.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.collectEvidence
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Behind the Mask — Murders at Karlov Manor #39
+ *
+ * The optional collect-evidence cast cost stamps the shared evidence choice, which selects the
+ * alternate 1/1 base stats at resolution. [Effects.BecomeCreature] adds both CREATURE and ARTIFACT
+ * while retaining the target's other types, and its Layer-7b base-stat change composes correctly
+ * with counters and later power/toughness modifiers.
+ */
+val BehindTheMask = card("Behind the Mask") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, you may collect evidence 6. " +
+        "(Exile cards with total mana value 6 or greater from your graveyard.)\n" +
+        "Until end of turn, target artifact or creature becomes an artifact creature with base " +
+        "power and toughness 4/3. If evidence was collected, it has base power and toughness 1/1 " +
+        "until end of turn instead."
+
+    collectEvidence(6)
+
+    spell {
+        val permanent = target(
+            "target artifact or creature",
+            TargetPermanent(filter = TargetFilter.CreatureOrArtifact),
+        )
+        effect = ConditionalEffect(
+            condition = Conditions.WasEvidenceCollected,
+            effect = Effects.BecomeCreature(
+                target = permanent,
+                power = 1,
+                toughness = 1,
+                addTypes = setOf("ARTIFACT"),
+            ),
+            elseEffect = Effects.BecomeCreature(
+                target = permanent,
+                power = 4,
+                toughness = 3,
+                addTypes = setOf("ARTIFACT"),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Caio Monteiro"
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e522b043-fbd8-48a4-9f20-39e2a66a35ec.jpg?1783912917"
+
+        ruling(
+            "2024-02-02",
+            "Behind the Mask overwrites earlier effects that set specific power and toughness " +
+                "values, while modifiers and counters continue to apply.",
+        )
+        ruling(
+            "2024-02-02",
+            "Making a Vehicle an artifact creature this way does not count as crewing it.",
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/HustleBustle.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/HustleBustle.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.TurnFaceUpEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Hustle // Bustle — Murders at Karlov Manor #249
+ *
+ * Hustle creates both combat requirements on its one target; legality still excuses a creature
+ * that cannot attack or block. Bustle pumps the current creature group, then uses a non-targeting
+ * battlefield selection for its optional face-up action, so ward, hexproof, and shroud do not
+ * interfere with that choice.
+ */
+val HustleBustle = card("Hustle // Bustle") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "URG"
+
+    face("Hustle") {
+        manaCost = "{U/R}"
+        typeLine = "Instant"
+        oracleText = "Target creature attacks or blocks this turn if able."
+
+        spell {
+            val creature = target("target creature", com.wingedsheep.sdk.dsl.Targets.Creature)
+            effect = Effects.Composite(
+                Effects.MarkMustAttackThisTurn(creature),
+                Effects.MarkMustBlockThisTurn(creature),
+            )
+        }
+    }
+
+    face("Bustle") {
+        manaCost = "{4}{R/G}{R/G}"
+        typeLine = "Sorcery"
+        oracleText = "Creatures you control get +2/+2 and gain trample until end of turn. You may " +
+            "turn a creature you control face up."
+
+        spell {
+            effect = Effects.Composite(
+                Effects.ForEachInGroup(
+                    GroupFilter(GameObjectFilter.Creature.youControl()),
+                    Effects.Composite(
+                        Effects.ModifyStats(2, 2, EffectTarget.Self),
+                        Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self),
+                    ),
+                ),
+                GatherCardsEffect(
+                    source = CardSource.BattlefieldMatching(
+                        filter = GameObjectFilter.Creature.faceDown(),
+                        player = Player.You,
+                    ),
+                    storeAs = "faceDownCreatures",
+                ),
+                SelectFromCollectionEffect(
+                    from = "faceDownCreatures",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "turnFaceUp",
+                    prompt = "You may turn a creature you control face up",
+                    useTargetingUI = true,
+                ),
+                TurnFaceUpEffect(EffectTarget.PipelineTarget("turnFaceUp", 0)),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "249"
+        artist = "Valera Lutfullina"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f664827-e22e-43af-82f1-861b3c7607f1.jpg?1783912830"
+
+        ruling(
+            "2024-02-02",
+            "A creature that is tapped, cannot attack or block, or would require an unpaid cost " +
+                "is not forced to attack or block.",
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -7530,6 +7530,145 @@
     ]
 }
 
+// Hustle // Bustle
+{
+    "name": "Hustle // Bustle",
+    "manaCost": "",
+    "typeLine": "Instant",
+    "oracleText": "Target creature attacks or blocks this turn if able.\n//\nCreatures you control get +2/+2 and gain trample until end of turn. You may turn a creature you control face up.",
+    "metadata": {
+        "collectorNumber": "249",
+        "rarity": "UNCOMMON",
+        "artist": "Valera Lutfullina",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f664827-e22e-43af-82f1-861b3c7607f1.jpg?1783912830",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "A creature that is tapped, cannot attack or block, or would require an unpaid cost is not forced to attack or block."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED",
+        "GREEN"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Hustle",
+            "manaCost": "{U/R}",
+            "typeLine": "Instant",
+            "oracleText": "Target creature attacks or blocks this turn if able.",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MarkMustAttackThisTurn",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        },
+                        {
+                            "type": "MarkMustBlockThisTurn",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Bustle",
+            "manaCost": "{4}{R/G}{R/G}",
+            "typeLine": "Sorcery",
+            "oracleText": "Creatures you control get +2/+2 and gain trample until end of turn. You may turn a creature you control face up.",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "ModifyStats",
+                                        "powerModifier": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "toughnessModifier": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "target": "Self"
+                                    },
+                                    {
+                                        "type": "GrantKeyword",
+                                        "keyword": "TRAMPLE",
+                                        "target": "Self"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": "creature facedown",
+                                "player": "You"
+                            },
+                            "storeAs": "faceDownCreatures"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "faceDownCreatures",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "turnFaceUp",
+                            "prompt": "You may turn a creature you control face up",
+                            "useTargetingUI": true
+                        },
+                        {
+                            "type": "TurnFaceUp",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "turnFaceUp"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "hasNoManaCost": true
+}
+
 // Innocent Bystander
 {
     "name": "Innocent Bystander",

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -1364,6 +1364,102 @@
     ]
 }
 
+// Behind the Mask
+{
+    "name": "Behind the Mask",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, you may collect evidence 6. (Exile cards with total mana value 6 or greater from your graveyard.)\nUntil end of turn, target artifact or creature becomes an artifact creature with base power and toughness 4/3. If evidence was collected, it has base power and toughness 1/1 until end of turn instead.",
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomCollectEvidence",
+                    "amount": 6
+                }
+            },
+            "declaredSlot": "EVIDENCE_COLLECTED"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": {
+                    "type": "CastChoiceMade",
+                    "slot": "EVIDENCE_COLLECTED"
+                }
+            },
+            "then": {
+                "type": "BecomeCreature",
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target artifact or creature"
+                },
+                "power": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "toughness": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "addTypes": [
+                    "ARTIFACT"
+                ]
+            },
+            "otherwise": {
+                "type": "BecomeCreature",
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target artifact or creature"
+                },
+                "power": {
+                    "type": "Fixed",
+                    "amount": 4
+                },
+                "toughness": {
+                    "type": "Fixed",
+                    "amount": 3
+                },
+                "addTypes": [
+                    "ARTIFACT"
+                ]
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|artifact"
+                },
+                "id": "target artifact or creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "Caio Monteiro",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e522b043-fbd8-48a4-9f20-39e2a66a35ec.jpg?1783912917",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Behind the Mask overwrites earlier effects that set specific power and toughness values, while modifiers and counters continue to apply."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Making a Vehicle an artifact creature this way does not count as crewing it."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Benthic Criminologists
 {
     "name": "Benthic Criminologists",


### PR DESCRIPTION
## Summary

- **Behind the Mask** — composes optional collect evidence with a conditional temporary artifact-creature base-stat effect.
- **Hustle // Bustle** — composes combat requirements, a group pump/trample effect, and an optional non-targeting face-up selection.

The batch is intentionally limited to two cards because the remaining sampled MKM candidates require broader engine vocabulary or substantially more complex linked behavior.

## Verification

- `just build`
- `just check-card-printing "Behind the Mask"`
- `just check-card-printing "Hustle // Bustle"`
- Scryfall image URLs return HTTP 200
- MKM snapshot diff contains only these two cards