### PR TITLE
Add Roar of the Kha to Mirrodin

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/RoarOfTheKha.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/RoarOfTheKha.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Roar of the Kha
+ * {1}{W}
+ * Instant
+ * Choose one —
+ * • Creatures you control get +1/+1 until end of turn.
+ * • Untap all creatures you control.
+ * Entwine {1}{W} (Choose both if you pay the entwine cost.)
+ */
+val RoarOfTheKha = card("Roar of the Kha") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Creatures you control get +1/+1 until end of turn.\n" +
+        "• Untap all creatures you control.\n" +
+        "Entwine {1}{W} (Choose both if you pay the entwine cost.)"
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            additionalManaCostPerExtraMode = "{1}{W}"
+        ) {
+            mode("Creatures you control get +1/+1 until end of turn") {
+                effect = Effects.ForEachInGroup(
+                    GroupFilter(GameObjectFilter.Creature.youControl()),
+                    Effects.ModifyStats(1, 1, EffectTarget.Self)
+                )
+            }
+            mode("Untap all creatures you control") {
+                effect = Effects.ForEachInGroup(
+                    GroupFilter(GameObjectFilter.Creature.youControl()),
+                    Effects.Untap(EffectTarget.Self)
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "18"
+        artist = "Matt Cavotta"
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dc697a4c-f219-46fd-90f2-63c638cd5ef7.jpg?1783944560"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -7885,6 +7885,74 @@
     ]
 }
 
+// Roar of the Kha
+{
+    "name": "Roar of the Kha",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Creatures you control get +1/+1 until end of turn.\n• Untap all creatures you control.\nEntwine {1}{W} (Choose both if you pay the entwine cost.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Creatures you control get +1/+1 until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "TapUntap",
+                            "target": "Self",
+                            "tap": false
+                        }
+                    },
+                    "description": "Untap all creatures you control"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "additionalManaCostPerExtraMode": "{1}{W}"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Cavotta",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dc697a4c-f219-46fd-90f2-63c638cd5ef7.jpg?1783944560"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Rule of Law
 {
     "name": "Rule of Law",


### PR DESCRIPTION
## Summary

- Roar of the Kha — models both printed modes with the existing group stat-modification and untap primitives; choosing both charges the printed {1}{W} Entwine cost through the modal extra-mode cost path.

## Scope

Mirrodin had only four unimplemented cards on current main, all nontrivial. Blinding Beam was dropped because its Scryfall ruling requires suppressing creatures controlled by other players during the targeted player’s untap step, which the current controller-scoped skip-untap primitive cannot model. Awe Strike and Loxodon Peacekeeper also require new engine vocabulary, so they were excluded rather than approximated.

## Verification

- just check-card-printing "Roar of the Kha"
- just rebless-cards (MRD snapshot changed only for Roar of the Kha)
- just build