### PR TITLE
Add two Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AgencyOutfitter.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AgencyOutfitter.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Agency Outfitter — Murders at Karlov Manor #38
+ * {4}{U}{U} · Creature — Sphinx Detective · 4/3 · Uncommon
+ *
+ * The two named-card clauses are independent: the controller may find neither, either, or both,
+ * but never two copies of the same named card. Two one-card multi-zone searches preserve that
+ * constraint while allowing each card to come from the graveyard, hand, or library.
+ */
+val AgencyOutfitter = card("Agency Outfitter") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sphinx Detective"
+    oracleText = "Flying\n" +
+        "When this creature enters, you may search your graveyard, hand and/or library for a card " +
+        "named Magnifying Glass and/or a card named Thinking Cap and put them onto the battlefield. " +
+        "If you search your library this way, shuffle."
+    power = 4
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.searchMultipleZones(
+            zones = listOf(Zone.GRAVEYARD, Zone.HAND, Zone.LIBRARY),
+            filter = GameObjectFilter.Any.named("Magnifying Glass"),
+            count = 1,
+            destination = SearchDestination.BATTLEFIELD,
+        ) then Patterns.Library.searchMultipleZones(
+            zones = listOf(Zone.GRAVEYARD, Zone.HAND, Zone.LIBRARY),
+            filter = GameObjectFilter.Any.named("Thinking Cap"),
+            count = 1,
+            destination = SearchDestination.BATTLEFIELD,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "38"
+        artist = "Andrew Mar"
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/8112f133-535e-4264-8357-9cbf97957710.jpg?1783912917"
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/HedgeWhisperer.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/HedgeWhisperer.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Hedge Whisperer — Murders at Karlov Manor #165
+ * {G} · Creature — Elf Druid Detective · 0/3 · Uncommon
+ *
+ * The animation keeps the target's existing Land type and lasts only while Hedge Whisperer remains
+ * tapped. If the Whisperer leaves before the ability resolves, the source-tapped duration is already
+ * false and the animation does not begin, matching the card's ruling.
+ */
+val HedgeWhisperer = card("Hedge Whisperer") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid Detective"
+    oracleText = "You may choose not to untap this creature during your untap step.\n" +
+        "{3}{G}, {T}, Collect evidence 4: Target land you control becomes a 5/5 green Plant Boar " +
+        "creature with haste for as long as this creature remains tapped. It's still a land. " +
+        "Activate only as a sorcery. (To collect evidence 4, exile cards with total mana value 4 " +
+        "or greater from your graveyard.)"
+    power = 0
+    toughness = 3
+
+    flags(AbilityFlag.MAY_NOT_UNTAP)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{G}"), Costs.Tap, Costs.CollectEvidence(4))
+        timing = TimingRule.SorcerySpeed
+        val land = target(
+            "target land you control",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Land.youControl())),
+        )
+        effect = Effects.BecomeCreature(
+            target = land,
+            power = 5,
+            toughness = 5,
+            keywords = setOf(Keyword.HASTE),
+            creatureTypes = setOf("Plant", "Boar"),
+            colors = setOf("G"),
+            duration = Duration.WhileSourceTapped("Hedge Whisperer"),
+        )
+        description = "Target land you control becomes a 5/5 green Plant Boar creature with haste " +
+            "for as long as Hedge Whisperer remains tapped. It's still a land. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "165"
+        artist = "Simon Dominic"
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/4627adcd-ace7-4777-a7e6-fc80ac6b9dfe.jpg?1783912865"
+        ruling("2024-02-02", "If Hedge Whisperer leaves the battlefield before its activated ability resolves, the target land won't become a creature at all.")
+        ruling("2024-02-02", "If you can't exile enough cards to meet or exceed the required mana value, you can't choose to collect evidence at all.")
+        ruling("2024-02-02", "Once you've announced that you're casting a spell, players can't take actions until you've finished doing so. Notably, opponents can't try to remove cards from your graveyard to stop you from collecting evidence.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -308,6 +308,121 @@
     ]
 }
 
+// Agency Outfitter
+{
+    "name": "Agency Outfitter",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Sphinx Detective",
+    "oracleText": "Flying\nWhen this creature enters, you may search your graveyard, hand and/or library for a card named Magnifying Glass and/or a card named Thinking Cap and put them onto the battlefield. If you search your library this way, shuffle.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromMultipleZones",
+                                "zones": [
+                                    "Graveyard",
+                                    "Hand",
+                                    "Library"
+                                ],
+                                "filter": "name:Magnifying Glass"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent",
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromMultipleZones",
+                                        "zones": [
+                                            "Graveyard",
+                                            "Hand",
+                                            "Library"
+                                        ],
+                                        "filter": "name:Thinking Cap"
+                                    },
+                                    "storeAs": "searchable"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "searchable",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "found"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "found",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield"
+                                    }
+                                },
+                                "ShuffleLibrary",
+                                "EmitLibrarySearchedEvent"
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "rarity": "UNCOMMON",
+        "artist": "Andrew Mar",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/1/8112f133-535e-4264-8357-9cbf97957710.jpg?1783912917"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Agrus Kos, Spirit of Justice
 {
     "name": "Agrus Kos, Spirit of Justice",

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -7354,6 +7354,111 @@
     ]
 }
 
+// Hedge Whisperer
+{
+    "name": "Hedge Whisperer",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Elf Druid Detective",
+    "oracleText": "You may choose not to untap this creature during your untap step.\n{3}{G}, {T}, Collect evidence 4: Target land you control becomes a 5/5 green Plant Boar creature with haste for as long as this creature remains tapped. It's still a land. Activate only as a sorcery. (To collect evidence 4, exile cards with total mana value 4 or greater from your graveyard.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "flags": [
+        "MAY_NOT_UNTAP"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{G}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomCollectEvidence",
+                                "amount": 4
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "BecomeCreature",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target land you control"
+                    },
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "keywords": [
+                        "HASTE"
+                    ],
+                    "creatureTypes": [
+                        "Plant",
+                        "Boar"
+                    ],
+                    "colors": [
+                        "G"
+                    ],
+                    "duration": {
+                        "type": "WhileSourceTapped",
+                        "sourceDescription": "Hedge Whisperer"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land ctrl:you"
+                        },
+                        "id": "target land you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Target land you control becomes a 5/5 green Plant Boar creature with haste for as long as Hedge Whisperer remains tapped. It's still a land. Activate only as a sorcery."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "UNCOMMON",
+        "artist": "Simon Dominic",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/4627adcd-ace7-4777-a7e6-fc80ac6b9dfe.jpg?1783912865",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If Hedge Whisperer leaves the battlefield before its activated ability resolves, the target land won't become a creature at all."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If you can't exile enough cards to meet or exceed the required mana value, you can't choose to collect evidence at all."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Once you've announced that you're casting a spell, players can't take actions until you've finished doing so. Notably, opponents can't try to remove cards from your graveyard to stop you from collecting evidence."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Hide in Plain Sight
 {
     "name": "Hide in Plain Sight",


### PR DESCRIPTION
## Summary

- Agency Outfitter searches graveyard, hand, and/or library independently for Magnifying Glass and Thinking Cap using the existing multi-zone search pattern.
- Hedge Whisperer composes the existing collect-evidence cost, optional untap flag, battlefield targeting, and source-tapped land animation.

The batch is intentionally limited to two cards because the remaining candidates examined require additional engine vocabulary or more complex card-specific support.

## Verification

- `just build`
- `just check-card-printing "Agency Outfitter"`
- `just check-card-printing "Hedge Whisperer"`
- Scryfall image URLs returned HTTP 200
- MKM snapshot diff contains only these two cards