### PR TITLE
Add three Mirrodin entwine cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BetrayalOfFlesh.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BetrayalOfFlesh.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Betrayal of Flesh
+ * {5}{B}
+ * Instant
+ * Choose one —
+ * • Destroy target creature.
+ * • Return target creature card from your graveyard to the battlefield.
+ * Entwine—Sacrifice three lands. (Choose both if you pay the entwine cost.)
+ */
+val BetrayalOfFlesh = card("Betrayal of Flesh") {
+    manaCost = "{5}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Destroy target creature.\n" +
+        "• Return target creature card from your graveyard to the battlefield.\n" +
+        "Entwine—Sacrifice three lands. (Choose both if you pay the entwine cost.)"
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            additionalCostPerExtraMode = CostAtom.Sacrifice(GameObjectFilter.Land, count = 3),
+        ) {
+            mode("Destroy target creature") {
+                val creature = target("creature to destroy", TargetCreature())
+                effect = Effects.Destroy(creature)
+            }
+            mode("Return target creature card from your graveyard to the battlefield") {
+                val card = target(
+                    "creature card to return",
+                    TargetObject(filter = TargetFilter.CreatureInYourGraveyard),
+                )
+                effect = Effects.Move(card, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "58"
+        artist = "Wayne England"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9e2e107-0277-4e5c-81a7-258bb2998f3e.jpg?1783944549"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/InciteWar.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/InciteWar.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Incite War
+ * {2}{R}
+ * Instant
+ * Choose one —
+ * • Creatures target player controls attack this turn if able.
+ * • Creatures you control gain first strike until end of turn.
+ * Entwine {2} (Choose both if you pay the entwine cost.)
+ */
+val InciteWar = card("Incite War") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Creatures target player controls attack this turn if able.\n" +
+        "• Creatures you control gain first strike until end of turn.\n" +
+        "Entwine {2} (Choose both if you pay the entwine cost.)"
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            additionalManaCostPerExtraMode = "{2}",
+        ) {
+            mode("Creatures target player controls attack this turn if able") {
+                target("player whose creatures must attack", TargetPlayer())
+                effect = Effects.ForEachInGroup(
+                    GroupFilter(GameObjectFilter.Creature.targetPlayerControls()),
+                    Effects.MarkMustAttackThisTurn(EffectTarget.Self),
+                )
+            }
+            mode("Creatures you control gain first strike until end of turn") {
+                effect = Patterns.Group.grantKeywordToAll(
+                    Keyword.FIRST_STRIKE,
+                    GroupFilter.AllCreaturesYouControl,
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "96"
+        artist = "Alex Horley-Orlandelli"
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/ee30527c-0eb1-4b66-9028-1607a960019a.jpg?1783944540"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/PromiseOfPower.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/PromiseOfPower.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Promise of Power
+ * {2}{B}{B}{B}
+ * Sorcery
+ * Choose one —
+ * • You draw five cards and you lose 5 life.
+ * • Create an X/X black Demon creature token with flying, where X is the number of cards in your hand.
+ * Entwine {4} (Choose both if you pay the entwine cost.)
+ */
+val PromiseOfPower = card("Promise of Power") {
+    manaCost = "{2}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n" +
+        "• You draw five cards and you lose 5 life.\n" +
+        "• Create an X/X black Demon creature token with flying, where X is the number of cards in your hand.\n" +
+        "Entwine {4} (Choose both if you pay the entwine cost.)"
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            additionalManaCostPerExtraMode = "{4}",
+        ) {
+            mode("Draw five cards and lose 5 life") {
+                effect = Effects.DrawCards(5) then Effects.LoseLife(5)
+            }
+            mode("Create an X/X black Demon creature token with flying") {
+                effect = Effects.CreateDynamicToken(
+                    dynamicPower = DynamicAmounts.cardsInYourHand(),
+                    dynamicToughness = DynamicAmounts.cardsInYourHand(),
+                    colors = setOf(Color.BLACK),
+                    creatureTypes = setOf("Demon"),
+                    keywords = setOf(Keyword.FLYING),
+                    imageUri = "https://cards.scryfall.io/normal/front/c/6/c6df5992-9c1c-407d-9602-a6c659342a15.jpg?1783927202",
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "74"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d96c3947-0eec-48a1-ba69-59734b4ac9da.jpg?1783944545"
+        ruling(
+            "2004-12-01",
+            "The power and toughness of the Demon token are set when Promise of Power resolves. " +
+                "They’re unaffected if the number of cards in your hand changes later.",
+        )
+        ruling(
+            "2004-12-01",
+            "If you pay the entwine cost, you draw five cards, then lose five life, then put the " +
+                "Demon token onto the battlefield. The five cards you draw count toward the " +
+                "Demon’s power and toughness.",
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/PromiseOfPowerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/PromiseOfPowerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Promise of Power reprint in Commander 2014. Its canonical card definition lives in Mirrodin;
+ * this file contributes only the Commander 2014 presentation data.
+ */
+val PromiseOfPowerReprint = Printing(
+    oracleId = "fde459b2-f45f-40d2-b328-58f65440f494",
+    name = "Promise of Power",
+    setCode = "C14",
+    collectorNumber = "157",
+    scryfallId = "a5d6325e-f889-4aad-ba83-8d70774b7478",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a5d6325e-f889-4aad-ba83-8d70774b7478.jpg?1783938840",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -648,6 +648,80 @@
     ]
 }
 
+// Betrayal of Flesh
+{
+    "name": "Betrayal of Flesh",
+    "manaCost": "{5}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Destroy target creature.\n• Return target creature card from your graveyard to the battlefield.\nEntwine—Sacrifice three lands. (Choose both if you pay the entwine cost.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature to destroy"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "creature to destroy"
+                        }
+                    ],
+                    "description": "Destroy target creature"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature card to return"
+                        },
+                        "destination": "Battlefield",
+                        "fromZone": "Graveyard"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature own:you",
+                                "zone": "Graveyard"
+                            },
+                            "id": "creature card to return"
+                        }
+                    ],
+                    "description": "Return target creature card from your graveyard to the battlefield"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "additionalCostPerExtraMode": {
+                "type": "AtomSacrifice",
+                "filter": "land",
+                "count": 3
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "rarity": "UNCOMMON",
+        "artist": "Wayne England",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a9e2e107-0277-4e5c-81a7-258bb2998f3e.jpg?1783944549"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Blinding Beam
 {
     "name": "Blinding Beam",
@@ -3961,6 +4035,68 @@
         "artist": "Paolo Parente",
         "flavorText": "Centuries before the first peaks of the Oxidda Chain rewrote the laws of magnetism, the golems patrolled Mirrodin's featureless surface unhindered.",
         "imageUri": "https://cards.scryfall.io/normal/front/3/c/3cf8d47d-6ecb-424a-a908-a6501f308c8e.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Incite War
+{
+    "name": "Incite War",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Creatures target player controls attack this turn if able.\n• Creatures you control gain first strike until end of turn.\nEntwine {2} (Choose both if you pay the entwine cost.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:target-player"
+                            }
+                        },
+                        "body": "MarkMustAttackThisTurn"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "player whose creatures must attack"
+                        }
+                    ],
+                    "description": "Creatures target player controls attack this turn if able"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "GrantKeyword",
+                            "keyword": "FIRST_STRIKE",
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Creatures you control gain first strike until end of turn"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "additionalManaCostPerExtraMode": "{2}"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "96",
+        "artist": "Alex Horley-Orlandelli",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/ee30527c-0eb1-4b66-9028-1607a960019a.jpg?1783944540"
     },
     "colorIdentityOverride": [
         "RED"
@@ -7785,6 +7921,93 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Promise of Power
+{
+    "name": "Promise of Power",
+    "manaCost": "{2}{B}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• You draw five cards and you lose 5 life.\n• Create an X/X black Demon creature token with flying, where X is the number of cards in your hand.\nEntwine {4} (Choose both if you pay the entwine cost.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                }
+                            },
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                }
+                            }
+                        ]
+                    },
+                    "description": "Draw five cards and lose 5 life"
+                },
+                {
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 0,
+                        "toughness": 0,
+                        "colors": [
+                            "BLACK"
+                        ],
+                        "creatureTypes": [
+                            "Demon"
+                        ],
+                        "keywords": [
+                            "FLYING"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c6df5992-9c1c-407d-9602-a6c659342a15.jpg?1783927202",
+                        "dynamicPower": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Hand"
+                        },
+                        "dynamicToughness": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Hand"
+                        }
+                    },
+                    "description": "Create an X/X black Demon creature token with flying"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "additionalManaCostPerExtraMode": "{4}"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "rarity": "RARE",
+        "artist": "Kev Walker",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d96c3947-0eec-48a1-ba69-59734b4ac9da.jpg?1783944545",
+        "rulings": [
+            {
+                "date": "2004-12-01",
+                "text": "The power and toughness of the Demon token are set when Promise of Power resolves. They’re unaffected if the number of cards in your hand changes later."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "If you pay the entwine cost, you draw five cards, then lose five life, then put the Demon token onto the battlefield. The five cards you draw count toward the Demon’s power and toughness."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 


### PR DESCRIPTION
## Summary

- Betrayal of Flesh — composes the existing modal/entwine cost, destroy, and graveyard-to-battlefield primitives.
- Incite War — composes modal/entwine, targeted-player battlefield filtering, must-attack markers, and the group keyword grant.
- Promise of Power — composes modal/entwine, draw/life loss, and resolution-time dynamic token sizing; includes its mechanically relevant Scryfall rulings and Demon token art.
- Adds the required Commander 2014 `Printing` row for Promise of Power.

## Verification

- `just build`
- `just check-card-printing "Betrayal of Flesh"`
- `just check-card-printing "Incite War"`
- `just check-card-printing "Promise of Power"`
- Scryfall card and token image URLs return HTTP 200.
- Mirrodin snapshot re-blessed; only these three card trees were added.