### PR TITLE
Add two Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/IllTimedExplosion.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/IllTimedExplosion.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ill-Timed Explosion — Murders at Karlov Manor #207
+ * {2}{U}{R} · Sorcery · Rare
+ *
+ * The optional discard is the action of a reflexive trigger, so the damage ability is created only
+ * after two cards were actually discarded. The discarded pipeline collection crosses onto that
+ * reflexive ability; filtering it to the greatest mana value (keeping ties) lets the ordinary
+ * stored-card mana-value amount drive the damage to every creature.
+ */
+val IllTimedExplosion = card("Ill-Timed Explosion") {
+    manaCost = "{2}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Sorcery"
+    oracleText = "Draw two cards. Then you may discard two cards. When you do, Ill-Timed " +
+        "Explosion deals X damage to each creature, where X is the greatest mana value among " +
+        "cards discarded this way."
+
+    spell {
+        effect = Effects.Composite(
+            Effects.DrawCards(2),
+            ReflexiveTriggerEffect(
+                action = Patterns.Hand.discardCards(2),
+                optional = true,
+                reflexiveEffect = Effects.Composite(
+                    FilterCollectionEffect(
+                        from = "discarded",
+                        filter = CollectionFilter.GreatestManaValue,
+                        storeMatching = "greatestDiscarded",
+                    ),
+                    Patterns.Group.dealDamageToAll(
+                        amount = DynamicAmount.StoredCardManaValue("greatestDiscarded"),
+                        filter = GroupFilter.AllCreatures,
+                    ),
+                ),
+                descriptionOverride = "You may discard two cards. When you do, Ill-Timed " +
+                    "Explosion deals damage to each creature equal to the greatest mana value " +
+                    "among cards discarded this way.",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "207"
+        artist = "Aaron J. Riley"
+        flavorText = "Only too late did the Agency custodians realize the device had not been " +
+            "inactive—it was just waiting for the right trigger."
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b5cdb01-eaa4-4a0a-b42a-332bcf4d6fff.jpg?1783912847"
+
+        ruling("2024-02-02", "If a card discarded this way has {X} in its mana cost, X is 0.")
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/OutrageousRobbery.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/OutrageousRobbery.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Outrageous Robbery — Murders at Karlov Manor #97
+ * {X}{B}{B} · Instant · Rare
+ *
+ * This is the same hidden-exile permission pipeline used by Expensive Taste: gathering from the
+ * targeted opponent's library privately reveals the cards to the caster, HIDDEN keeps them opaque
+ * to everyone else in exile, and a permanent may-play permission lets the caster play lands or
+ * cast spells while spending mana as though it were mana of any type.
+ */
+val OutrageousRobbery = card("Outrageous Robbery") {
+    manaCost = "{X}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target opponent exiles the top X cards of their library face down. You may " +
+        "look at and play those cards for as long as they remain exiled. If you cast a spell " +
+        "this way, you may spend mana as though it were mana of any type to cast it."
+
+    spell {
+        target("target opponent", Targets.Opponent)
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.XValue, Player.TargetOpponent),
+                storeAs = "robbedCards",
+            ),
+            MoveCollectionEffect(
+                from = "robbedCards",
+                destination = CardDestination.ToZone(Zone.EXILE, Player.TargetOpponent),
+                faceDown = FaceDownMode.HIDDEN,
+            ),
+            Effects.GrantMayPlayFromExile(
+                from = "robbedCards",
+                expiry = MayPlayExpiry.Permanent,
+                withAnyManaType = true,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "97"
+        artist = "Kai Carpenter"
+        flavorText = "\"When you can't erase your own trail, leave as many false ones as " +
+            "possible.\"\n—Etrata"
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b87813fa-ad12-4062-bb9e-436d8418fba5.jpg?1783912894"
+
+        ruling(
+            "2024-02-02",
+            "You pay all costs and follow all normal timing rules for cards played this way. For " +
+                "example, if one of the exiled cards is a land card, you may play it only during " +
+                "your main phase while the stack is empty.",
+        )
+        ruling(
+            "2024-02-02",
+            "If you leave the game, the exiled cards remain exiled face down indefinitely. No " +
+                "player may look at them.",
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -7889,6 +7889,112 @@
     "hasNoManaCost": true
 }
 
+// Ill-Timed Explosion
+{
+    "name": "Ill-Timed Explosion",
+    "manaCost": "{2}{U}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Draw two cards. Then you may discard two cards. When you do, Ill-Timed Explosion deals X damage to each creature, where X is the greatest mana value among cards discarded this way.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeSelected": "discarded",
+                                "prompt": "Choose 2 cards to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    },
+                    "reflexiveEffect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "FilterCollection",
+                                "from": "discarded",
+                                "filter": "GreatestManaValue",
+                                "storeMatching": "greatestDiscarded"
+                            },
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature"
+                                    }
+                                },
+                                "body": {
+                                    "type": "DealDamage",
+                                    "amount": {
+                                        "type": "StoredCardManaValue",
+                                        "collectionName": "greatestDiscarded"
+                                    },
+                                    "target": "Self"
+                                }
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "You may discard two cards. When you do, Ill-Timed Explosion deals damage to each creature equal to the greatest mana value among cards discarded this way."
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "207",
+        "rarity": "RARE",
+        "artist": "Aaron J. Riley",
+        "flavorText": "Only too late did the Agency custodians realize the device had not been inactive—it was just waiting for the right trigger.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b5cdb01-eaa4-4a0a-b42a-332bcf4d6fff.jpg?1783912847",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If a card discarded this way has {X} in its mana cost, X is 0."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // Innocent Bystander
 {
     "name": "Innocent Bystander",

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -10717,6 +10717,72 @@
     ]
 }
 
+// Outrageous Robbery
+{
+    "name": "Outrageous Robbery",
+    "manaCost": "{X}{B}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target opponent exiles the top X cards of their library face down. You may look at and play those cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any type to cast it.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": "XValue",
+                        "player": "TargetOpponent"
+                    },
+                    "storeAs": "robbedCards"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "robbedCards",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Exile",
+                        "player": "TargetOpponent"
+                    },
+                    "faceDown": "HIDDEN"
+                },
+                {
+                    "type": "GrantMayPlayFromExile",
+                    "from": "robbedCards",
+                    "expiry": "Permanent",
+                    "withAnyManaType": true
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponent",
+                "id": "target opponent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "rarity": "RARE",
+        "artist": "Kai Carpenter",
+        "flavorText": "\"When you can't erase your own trail, leave as many false ones as possible.\"\n—Etrata",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b87813fa-ad12-4062-bb9e-436d8418fba5.jpg?1783912894",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "You pay all costs and follow all normal timing rules for cards played this way. For example, if one of the exiled cards is a land card, you may play it only during your main phase while the stack is empty."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If you leave the game, the exiled cards remain exiled face down indefinitely. No player may look at them."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Perimeter Enforcer
 {
     "name": "Perimeter Enforcer",


### PR DESCRIPTION
## Summary

- Ill-Timed Explosion — composes draw, optional discard, a reflexive trigger, greatest-mana-value filtering, and group damage.
- Outrageous Robbery — composes target-opponent library gathering, hidden exile, and a permanent play permission with mana-type relaxation.

## Verification

- `just build`
- `just check-card-printing "Ill-Timed Explosion"`
- `just check-card-printing "Outrageous Robbery"`
- MKM snapshot reviewed: only these two cards were added.

Both cards use existing engine/SDK primitives; no new visual or decision mechanic was introduced.