### PR TITLE
Add three Mirrodin entwine cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SolarTide.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SolarTide.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+
+/**
+ * Solar Tide
+ * {4}{W}{W}
+ * Sorcery
+ * Choose one —
+ * • Destroy all creatures with power 2 or less.
+ * • Destroy all creatures with power 3 or greater.
+ * Entwine—Sacrifice two lands. (Choose both if you pay the entwine cost.)
+ */
+val SolarTide = card("Solar Tide") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n" +
+        "• Destroy all creatures with power 2 or less.\n" +
+        "• Destroy all creatures with power 3 or greater.\n" +
+        "Entwine—Sacrifice two lands. (Choose both if you pay the entwine cost.)"
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            additionalCostPerExtraMode = CostAtom.Sacrifice(GameObjectFilter.Land, count = 2),
+        ) {
+            mode(
+                "Destroy all creatures with power 2 or less",
+                Effects.DestroyAll(GameObjectFilter.Creature.powerAtMost(2)),
+            )
+            mode(
+                "Destroy all creatures with power 3 or greater",
+                Effects.DestroyAll(GameObjectFilter.Creature.powerAtLeast(3)),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "24"
+        artist = "Dave Dorman"
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/57ce33b6-267f-4ee8-a3f7-f41c619d0cfa.jpg?1783944559"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TemporalCascade.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TemporalCascade.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Temporal Cascade
+ * {5}{U}{U}
+ * Sorcery
+ * Choose one —
+ * • Each player shuffles their hand and graveyard into their library.
+ * • Each player draws seven cards.
+ * Entwine {2} (Choose both if you pay the entwine cost.)
+ */
+val TemporalCascade = card("Temporal Cascade") {
+    manaCost = "{5}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n" +
+        "• Each player shuffles their hand and graveyard into their library.\n" +
+        "• Each player draws seven cards.\n" +
+        "Entwine {2} (Choose both if you pay the entwine cost.)"
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            additionalManaCostPerExtraMode = "{2}",
+        ) {
+            mode("Each player shuffles their hand and graveyard into their library") {
+                effect = ForEachPlayerEffect(
+                    players = Player.Each,
+                    effects = listOf(
+                        GatherCardsEffect(
+                            source = CardSource.FromMultipleZones(
+                                zones = listOf(Zone.HAND, Zone.GRAVEYARD),
+                                player = Player.You,
+                            ),
+                            storeAs = "temporalCascadeCards",
+                        ),
+                        MoveCollectionEffect(
+                            from = "temporalCascadeCards",
+                            destination = CardDestination.ToZone(
+                                Zone.LIBRARY,
+                                Player.You,
+                                ZonePlacement.Shuffled,
+                            ),
+                        ),
+                    ),
+                )
+            }
+            mode(
+                "Each player draws seven cards",
+                ForEachPlayerEffect(Player.Each, listOf(Effects.DrawCards(7))),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "52"
+        artist = "Puddnhead"
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/daf180c6-7ab6-4922-9f5e-73b4f2c9488a.jpg?1783944551"
+        ruling(
+            "2013-07-01",
+            "This card won’t be put into your graveyard until after it’s finished resolving, which means " +
+                "it won’t be shuffled into your library as part of its own effect.",
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ToothAndNail.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ToothAndNail.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Tooth and Nail
+ * {5}{G}{G}
+ * Sorcery
+ * Choose one —
+ * • Search your library for up to two creature cards, reveal them, put them into your hand, then shuffle.
+ * • Put up to two creature cards from your hand onto the battlefield.
+ * Entwine {2} (Choose both if you pay the entwine cost.)
+ */
+val ToothAndNail = card("Tooth and Nail") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n" +
+        "• Search your library for up to two creature cards, reveal them, put them into your hand, then shuffle.\n" +
+        "• Put up to two creature cards from your hand onto the battlefield.\n" +
+        "Entwine {2} (Choose both if you pay the entwine cost.)"
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            additionalManaCostPerExtraMode = "{2}",
+        ) {
+            mode("Search your library for up to two creature cards") {
+                effect = Patterns.Library.searchLibrary(
+                    filter = GameObjectFilter.Creature,
+                    count = 2,
+                    destination = SearchDestination.HAND,
+                    shuffleAfter = true,
+                    reveal = true,
+                )
+            }
+            mode("Put up to two creature cards from your hand onto the battlefield") {
+                effect = GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.You, GameObjectFilter.Creature),
+                    storeAs = "toothAndNailCandidates",
+                ) then SelectFromCollectionEffect(
+                    from = "toothAndNailCandidates",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
+                    storeSelected = "toothAndNailChosen",
+                    prompt = "Choose up to two creature cards to put onto the battlefield",
+                ) then MoveCollectionEffect(
+                    from = "toothAndNailChosen",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You),
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "134"
+        artist = "Greg Hildebrandt"
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02f0067c-2d38-46bd-b52e-070c2ce424f0.jpg?1783944531"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -11486,6 +11486,111 @@
     ]
 }
 
+// Tooth and Nail
+{
+    "name": "Tooth and Nail",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Search your library for up to two creature cards, reveal them, put them into your hand, then shuffle.\n• Put up to two creature cards from your hand onto the battlefield.\nEntwine {2} (Choose both if you pay the entwine cost.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "creature"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    },
+                    "description": "Search your library for up to two creature cards"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "filter": "creature"
+                                },
+                                "storeAs": "toothAndNailCandidates"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "toothAndNailCandidates",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeSelected": "toothAndNailChosen",
+                                "prompt": "Choose up to two creature cards to put onto the battlefield"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "toothAndNailChosen",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                }
+                            }
+                        ]
+                    },
+                    "description": "Put up to two creature cards from your hand onto the battlefield"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "additionalManaCostPerExtraMode": "{2}"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "rarity": "RARE",
+        "artist": "Greg Hildebrandt",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02f0067c-2d38-46bd-b52e-070c2ce424f0.jpg?1783944531"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Tooth of Chiss-Goria
 {
     "name": "Tooth of Chiss-Goria",

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -11252,6 +11252,91 @@
     ]
 }
 
+// Temporal Cascade
+{
+    "name": "Temporal Cascade",
+    "manaCost": "{5}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Each player shuffles their hand and graveyard into their library.\n• Each player draws seven cards.\nEntwine {2} (Choose both if you pay the entwine cost.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Players",
+                            "players": "Each"
+                        },
+                        "body": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromMultipleZones",
+                                        "zones": [
+                                            "Hand",
+                                            "Graveyard"
+                                        ]
+                                    },
+                                    "storeAs": "temporalCascadeCards"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "temporalCascadeCards",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Library",
+                                        "placement": "Shuffled"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "description": "Each player shuffles their hand and graveyard into their library"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Players",
+                            "players": "Each"
+                        },
+                        "body": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 7
+                            }
+                        }
+                    },
+                    "description": "Each player draws seven cards"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "additionalManaCostPerExtraMode": "{2}"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "rarity": "RARE",
+        "artist": "Puddnhead",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/daf180c6-7ab6-4922-9f5e-73b4f2c9488a.jpg?1783944551",
+        "rulings": [
+            {
+                "date": "2013-07-01",
+                "text": "This card won’t be put into your graveyard until after it’s finished resolving, which means it won’t be shuffled into your library as part of its own effect."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Thirst for Knowledge
 {
     "name": "Thirst for Knowledge",

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -9625,6 +9625,87 @@
     ]
 }
 
+// Solar Tide
+{
+    "name": "Solar Tide",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Destroy all creatures with power 2 or less.\n• Destroy all creatures with power 3 or greater.\nEntwine—Sacrifice two lands. (Choose both if you pay the entwine cost.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "BattlefieldMatching",
+                                    "filter": "creature pow<=2"
+                                },
+                                "storeAs": "destroyAll_gathered"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "destroyAll_gathered",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Destroy"
+                            }
+                        ]
+                    },
+                    "description": "Destroy all creatures with power 2 or less"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "BattlefieldMatching",
+                                    "filter": "creature pow>=3"
+                                },
+                                "storeAs": "destroyAll_gathered"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "destroyAll_gathered",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Destroy"
+                            }
+                        ]
+                    },
+                    "description": "Destroy all creatures with power 3 or greater"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "additionalCostPerExtraMode": {
+                "type": "AtomSacrifice",
+                "filter": "land",
+                "count": 2
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "RARE",
+        "artist": "Dave Dorman",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/57ce33b6-267f-4ee8-a3f7-f41c619d0cfa.jpg?1783944559"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Soldier Replica
 {
     "name": "Soldier Replica",


### PR DESCRIPTION
## Summary

- Solar Tide — composes the existing modal-spell, projected-power filter, mass-destroy, and sacrifice-cost primitives.
- Temporal Cascade — composes modal resolution, per-player iteration, multi-zone gather/shuffle, and draw primitives.
- Tooth and Nail — composes modal resolution, library search/reveal/shuffle, hand selection, and battlefield move primitives.

## Verification

- `just build`
- `just check-card-printing "Solar Tide"`
- `just check-card-printing "Temporal Cascade"`
- `just check-card-printing "Tooth and Nail"`
- `git diff --check`

The MRD card snapshot was re-blessed and contains only these three additions.