### PR TITLE
Add two Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GoblinMaskmaker.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GoblinMaskmaker.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Goblin Maskmaker — Murders at Karlov Manor #130
+ * {R} · Creature — Goblin Citizen · 1/2
+ *
+ * Whenever this creature attacks, face-down spells you cast this turn cost {1} less to cast.
+ *
+ * The discount is created when the attack trigger resolves and lives on the controller for the
+ * rest of the turn, so it survives the Maskmaker leaving the battlefield. A face-down spell is
+ * identified by the same projected face-down predicate used for disguise and cloak permanents;
+ * only generic mana can be reduced.
+ */
+val GoblinMaskmaker = card("Goblin Maskmaker") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Citizen"
+    oracleText = "Whenever this creature attacks, face-down spells you cast this turn cost {1} " +
+        "less to cast."
+    power = 1
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ReduceSpellCostsThisTurn(
+            spellFilter = GameObjectFilter.Any.faceDown(),
+            amount = DynamicAmount.Fixed(1),
+        )
+        description = "Whenever this creature attacks, face-down spells you cast this turn cost " +
+            "{1} less to cast."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Tomas Duchek"
+        flavorText = "\"When you can't show your own face, try one of mine!\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/" +
+            "6154a991-c602-4fca-91a3-3830060da60e.jpg?1783912880"
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/LivingConundrum.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/LivingConundrum.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CompositeStaticAbility
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ReplaceDrawWithEffect
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+private val emptyLibrary = Exists(
+    player = Player.You,
+    zone = Zone.LIBRARY,
+    negate = true,
+)
+
+/**
+ * Living Conundrum — Murders at Karlov Manor #63
+ * {4}{U} · Creature — Elemental · 2/5
+ *
+ * The empty-library draw replacement replaces each individual impossible draw with a no-op. The
+ * second ability is one conditional continuous effect spanning Layer 6 (flying and vigilance) and
+ * Layer 7b (base 10/10), so its components are bundled under one identity and one condition.
+ */
+val LivingConundrum = card("Living Conundrum") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental"
+    oracleText = "Hexproof\n" +
+        "If you would draw a card while your library has no cards in it, skip that draw instead.\n" +
+        "As long as there are no cards in your library, this creature has base power and " +
+        "toughness 10/10 and has flying and vigilance."
+    power = 2
+    toughness = 5
+
+    keywords(Keyword.HEXPROOF)
+
+    replacementEffect(
+        ReplaceDrawWithEffect(
+            replacementEffect = Effects.Composite(),
+            restrictions = listOf(emptyLibrary),
+        )
+    )
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = CompositeStaticAbility(
+                listOf(
+                    SetBasePowerToughnessStatic(10, 10, GroupFilter.source()),
+                    GrantKeyword(Keyword.FLYING, GroupFilter.source()),
+                    GrantKeyword(Keyword.VIGILANCE, GroupFilter.source()),
+                )
+            ),
+            condition = emptyLibrary,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "63"
+        artist = "Yeong-Hao Han"
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/" +
+            "97fb11c7-7b7f-4bdb-a022-53e28ebadecc.jpg?1783912908"
+
+        ruling(
+            "2024-02-02",
+            "If you're instructed to draw more than one card and you have fewer cards in your " +
+                "library, you draw each card in your library, then skip the remaining draws.",
+        )
+        ruling(
+            "2024-02-02",
+            "If two or more replacement effects would apply to a card-drawing event, the player " +
+                "drawing the card chooses the order in which to apply them.",
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -9165,6 +9165,100 @@
     ]
 }
 
+// Living Conundrum
+{
+    "name": "Living Conundrum",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Hexproof\nIf you would draw a card while your library has no cards in it, skip that draw instead.\nAs long as there are no cards in your library, this creature has base power and toughness 10/10 and has flying and vigilance.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "HEXPROOF"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "CompositeStaticAbility",
+                    "abilities": [
+                        {
+                            "type": "SetBasePowerToughnessStatic",
+                            "power": 10,
+                            "toughness": 10,
+                            "filter": {
+                                "baseFilter": "permanent",
+                                "scope": "Self"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FLYING",
+                            "filter": {
+                                "baseFilter": "permanent",
+                                "scope": "Self"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "filter": {
+                                "baseFilter": "permanent",
+                                "scope": "Self"
+                            }
+                        }
+                    ]
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Library",
+                    "negate": true
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "ReplaceDrawWith",
+                "replacementEffect": {
+                    "type": "Composite",
+                    "effects": []
+                },
+                "restrictions": [
+                    {
+                        "type": "Exists",
+                        "player": "You",
+                        "zone": "Library",
+                        "negate": true
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "rarity": "UNCOMMON",
+        "artist": "Yeong-Hao Han",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/97fb11c7-7b7f-4bdb-a022-53e28ebadecc.jpg?1783912908",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If you're instructed to draw more than one card and you have fewer cards in your library, you draw each card in your library, then skip the remaining draws."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If two or more replacement effects would apply to a card-drawing event, the player drawing the card chooses the order in which to apply them."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Long Goodbye
 {
     "name": "Long Goodbye",

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -6839,6 +6839,48 @@
     ]
 }
 
+// Goblin Maskmaker
+{
+    "name": "Goblin Maskmaker",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goblin Citizen",
+    "oracleText": "Whenever this creature attacks, face-down spells you cast this turn cost {1} less to cast.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ReduceSpellCostsThisTurn",
+                    "spellFilter": {
+                        "statePredicates": [
+                            "IsFaceDown"
+                        ]
+                    },
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever this creature attacks, face-down spells you cast this turn cost {1} less to cast."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "artist": "Tomas Duchek",
+        "flavorText": "\"When you can't show your own face, try one of mine!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/6154a991-c602-4fca-91a3-3830060da60e.jpg?1783912880"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Granite Witness
 {
     "name": "Granite Witness",


### PR DESCRIPTION
Adds two MKM cards that compose existing SDK primitives:

- Goblin Maskmaker — creates a turn-scoped generic cost reduction for face-down spells when it attacks.
- Living Conundrum — skips empty-library draws and conditionally bundles its 10/10 base stats, flying, and vigilance across the layer system.

The batch is intentionally limited to two cards because the other remaining candidates sampled require unsupported Case/suspect-prevention semantics or tricky composite optional costs that should not be approximated in a simple-card batch.

Verification:
- just build
- just check-card-printing "Goblin Maskmaker"
- just check-card-printing "Living Conundrum"
- git diff --check