### PR TITLE
Add two Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/IllicitMasquerade.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/IllicitMasquerade.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Illicit Masquerade — Murders at Karlov Manor #88
+ *
+ * The dies trigger's counter filter is evaluated from the zone-change event's last-known counters.
+ * Its optional graveyard target excludes that triggering creature, which is still in the graveyard
+ * when targets are chosen. On resolution the dead creature is exiled first, then the target is
+ * returned; if the target has become illegal, normal target legality makes the whole ability fizzle
+ * before the exile can happen.
+ */
+val IllicitMasquerade = card("Illicit Masquerade") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Flash\n" +
+        "When this enchantment enters, put an impostor counter on each creature you control.\n" +
+        "Whenever a creature you control with an impostor counter on it dies, exile it. Return " +
+        "up to one other target creature card from your graveyard to the battlefield."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreaturesYouControl,
+            Effects.AddCounters(IMPOSTOR_COUNTER, 1, EffectTarget.Self),
+        )
+        description = "When this enchantment enters, put an impostor counter on each creature " +
+            "you control."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl().withCounter(IMPOSTOR_COUNTER),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY,
+        )
+        val replacement = target(
+            "up to one other target creature card from your graveyard",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter.CreatureInYourGraveyard.otherThanTriggeringEntity(),
+            ),
+        )
+        effect = Effects.Move(EffectTarget.TriggeringEntity, Zone.EXILE, fromZone = Zone.GRAVEYARD)
+            .then(Effects.Move(replacement, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD))
+        description = "Whenever a creature you control with an impostor counter on it dies, " +
+            "exile it. Return up to one other target creature card from your graveyard to the " +
+            "battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "88"
+        artist = "Valera Lutfullina"
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2a7a3ec4-afaa-45e1-8cde-f15bf4bd7379.jpg?1783912896"
+
+        ruling(
+            "2024-02-02",
+            "Illicit Masquerade's last ability affects all creatures you control with impostor " +
+                "counters on them, not just ones that had impostor counters put on them with " +
+                "Illicit Masquerade's second ability.",
+        )
+    }
+}
+
+private const val IMPOSTOR_COUNTER = "IMPOSTOR"

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/KellanInquisitiveProdigy.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/KellanInquisitiveProdigy.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.PlayAdditionalLandsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Kellan, Inquisitive Prodigy // Tail the Suspect — Murders at Karlov Manor #212
+ *
+ * Kellan's attack trigger checks who controlled the chosen artifact before destroying it. That
+ * preserves the printed ruling that an indestructible artifact still draws a card for its
+ * controller: destruction succeeding is not the condition. Tail the Suspect composes the existing
+ * investigate and cumulative additional-land effects; the Adventure framework handles exile and
+ * the later creature cast.
+ */
+val KellanInquisitiveProdigy = card("Kellan, Inquisitive Prodigy") {
+    manaCost = "{2}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Human Faerie Detective"
+    oracleText = "Flying, vigilance\n" +
+        "Whenever Kellan attacks, destroy up to one target artifact. If you controlled that " +
+        "permanent, draw a card."
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val artifact = target(
+            "up to one target artifact",
+            TargetObject(filter = TargetFilter.Artifact, optional = true),
+        )
+        effect = ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(GameObjectFilter.Artifact.youControl()),
+            effect = Effects.Destroy(artifact).then(Effects.DrawCards(1)),
+            elseEffect = Effects.Destroy(artifact),
+        )
+        description = "Whenever Kellan attacks, destroy up to one target artifact. If you " +
+            "controlled that permanent, draw a card."
+    }
+
+    adventure("Tail the Suspect") {
+        manaCost = "{G}{U}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Investigate. You may play an additional land this turn. (Then exile this " +
+            "card. You may cast the creature later from exile.)"
+        spell {
+            effect = Effects.Investigate().then(PlayAdditionalLandsEffect(count = 1))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "212"
+        artist = "Joshua Raphael"
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c49690c7-c282-4eb4-8da3-5e0c46a80fc4.jpg?1783912845"
+
+        ruling(
+            "2024-02-02",
+            "If the artifact you target with Kellan, Inquisitive Prodigy's triggered ability " +
+                "isn't destroyed (perhaps because it's indestructible), you will still draw a " +
+                "card as long as you control the artifact.",
+        )
+        ruling(
+            "2024-02-02",
+            "The effect of Tail the Suspect that allows you to play an additional land is " +
+                "cumulative with similar effects.",
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -8037,6 +8037,111 @@
     ]
 }
 
+// Illicit Masquerade
+{
+    "name": "Illicit Masquerade",
+    "manaCost": "{3}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Flash\nWhen this enchantment enters, put an impostor counter on each creature you control.\nWhenever a creature you control with an impostor counter on it dies, exile it. Return up to one other target creature card from your graveyard to the battlefield.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "AddCounters",
+                        "counterType": "IMPOSTOR",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "When this enchantment enters, put an impostor counter on each creature you control."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "HasCounter",
+                                "counterType": "IMPOSTOR"
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "TriggeringEntity",
+                            "destination": "Exile",
+                            "fromZone": "Graveyard"
+                        },
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one other target creature card from your graveyard"
+                            },
+                            "destination": "Battlefield",
+                            "fromZone": "Graveyard"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard",
+                        "excludeTriggeringEntity": true
+                    },
+                    "id": "up to one other target creature card from your graveyard"
+                },
+                "descriptionOverride": "Whenever a creature you control with an impostor counter on it dies, exile it. Return up to one other target creature card from your graveyard to the battlefield."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "rarity": "RARE",
+        "artist": "Valera Lutfullina",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2a7a3ec4-afaa-45e1-8cde-f15bf4bd7379.jpg?1783912896",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Illicit Masquerade's last ability affects all creatures you control with impostor counters on them, not just ones that had impostor counters put on them with Illicit Masquerade's second ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Innocent Bystander
 {
     "name": "Innocent Bystander",
@@ -8486,6 +8591,127 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Kellan, Inquisitive Prodigy
+{
+    "name": "Kellan, Inquisitive Prodigy",
+    "manaCost": "{2}{G}{U}",
+    "typeLine": "Legendary Creature — Human Faerie Detective",
+    "oracleText": "Flying, vigilance\nWhenever Kellan attacks, destroy up to one target artifact. If you controlled that permanent, draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "filter": "artifact ctrl:you"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one target artifact"
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    },
+                    "otherwise": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "up to one target artifact"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "artifact"
+                    },
+                    "id": "up to one target artifact"
+                },
+                "descriptionOverride": "Whenever Kellan attacks, destroy up to one target artifact. If you controlled that permanent, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "212",
+        "rarity": "RARE",
+        "artist": "Joshua Raphael",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c49690c7-c282-4eb4-8da3-5e0c46a80fc4.jpg?1783912845",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If the artifact you target with Kellan, Inquisitive Prodigy's triggered ability isn't destroyed (perhaps because it's indestructible), you will still draw a card as long as you control the artifact."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "The effect of Tail the Suspect that allows you to play an additional land is cumulative with similar effects."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Tail the Suspect",
+            "manaCost": "{G}{U}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Investigate. You may play an additional land this turn. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Clue"
+                        },
+                        {
+                            "type": "PlayAdditionalLands",
+                            "count": 1
+                        }
+                    ]
+                }
+            }
+        }
     ]
 }
 


### PR DESCRIPTION
## Summary

- Kellan, Inquisitive Prodigy // Tail the Suspect — composes Adventure, investigate, an additional land play, optional artifact destruction, and the controller-sensitive draw rider.
- Illicit Masquerade — composes flash, named counters, last-known-information dies filtering, exile, and optional graveyard reanimation.

Kept the batch to two cards because the other missing MKM candidates probed require new SDK vocabulary or substantially more complex multi-target/choice machinery.

## Verification

- just build
- just check-card-printing "Kellan, Inquisitive Prodigy"
- just check-card-printing "Illicit Masquerade"
- Scryfall image URLs returned HTTP 200
- MKM snapshot reviewed: only these two cards were added