### PR TITLE
Add Lightning Coils to Mirrodin

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1518,7 +1518,9 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 ### Tokens & emblems
 
-- `CreateToken(p, t, colors?, creatureTypes, keywords?, count?, controller?, imageUri?, name?, legendary?, tapped?, artifactToken?, enchantmentToken?, staticAbilities?, sacrificeAtStep?)` — make N creature tokens.
+- `CreateToken(p, t, colors?, creatureTypes, keywords?, count?, controller?, imageUri?, name?, legendary?, tapped?, artifactToken?, enchantmentToken?, staticAbilities?, exileAtStep?, sacrificeAtStep?)` — make N creature tokens.
+  `exileAtStep: Step?` arms the exile counterpart of the delayed trigger described below. Both the fixed
+  and dynamic-count overloads expose both delayed zone-change options.
   `sacrificeAtStep: Step?` arms a delayed trigger that sacrifices each created token at the beginning of the next
   step of that kind — the "create …, sacrifice it at the beginning of the next end step" rider (Harried Dronesmith
   passes `Step.END`; because its ability triggers at the beginning of combat on the controller's own turn, "your

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2416,6 +2416,8 @@ object Effects {
      *   Ayala). Null (the default) names the token after its creature types, which is what an
      *   ordinary "create a 1/1 white Soldier creature token" wants. Pair it with
      *   `legendary = true` when the printed token is legendary, so the legend rule applies.
+     * @param exileAtStep Arms a delayed trigger that exiles each created token at the beginning
+     *   of the next step of this kind.
      * @param sacrificeAtStep Arms a delayed trigger that sacrifices each created token at the
      *   beginning of the next step of this kind — the "create …, sacrifice it at the beginning of
      *   the next end step" rider (Harried Dronesmith). The plain-token sibling of the parameter of
@@ -2436,6 +2438,7 @@ object Effects {
         artifactToken: Boolean = false,
         enchantmentToken: Boolean = false,
         staticAbilities: List<com.wingedsheep.sdk.scripting.StaticAbility> = emptyList(),
+        exileAtStep: com.wingedsheep.sdk.core.Step? = null,
         sacrificeAtStep: com.wingedsheep.sdk.core.Step? = null
     ): Effect = CreateTokenEffect(
         count = DynamicAmount.Fixed(count), power = power, toughness = toughness,
@@ -2443,7 +2446,8 @@ object Effects {
         controller = controller, imageUri = imageUri, name = name,
         legendary = legendary, tapped = tapped,
         artifactToken = artifactToken, enchantmentToken = enchantmentToken,
-        staticAbilities = staticAbilities, sacrificeAtStep = sacrificeAtStep
+        staticAbilities = staticAbilities, exileAtStep = exileAtStep,
+        sacrificeAtStep = sacrificeAtStep
     )
 
     /**
@@ -2451,6 +2455,7 @@ object Effects {
      * time (e.g. "create X 1/1 green Saproling creature tokens" for Verdeloth the Ancient,
      * where X is the kicker amount read via [DynamicAmount.XValue]). Distinct from the
      * `Int`-count overload above; callers pass `count = DynamicAmount.XValue` etc.
+     * Both delayed zone-change parameters are also available for dynamic token counts.
      */
     fun CreateToken(
         count: DynamicAmount,
@@ -2463,12 +2468,15 @@ object Effects {
         imageUri: String? = null,
         legendary: Boolean = false,
         tapped: Boolean = false,
-        staticAbilities: List<com.wingedsheep.sdk.scripting.StaticAbility> = emptyList()
+        staticAbilities: List<com.wingedsheep.sdk.scripting.StaticAbility> = emptyList(),
+        exileAtStep: com.wingedsheep.sdk.core.Step? = null,
+        sacrificeAtStep: com.wingedsheep.sdk.core.Step? = null
     ): Effect = CreateTokenEffect(
         count = count, power = power, toughness = toughness, colors = colors,
         creatureTypes = creatureTypes, keywords = keywords,
         controller = controller, imageUri = imageUri, legendary = legendary, tapped = tapped,
-        staticAbilities = staticAbilities
+        staticAbilities = staticAbilities, exileAtStep = exileAtStep,
+        sacrificeAtStep = sacrificeAtStep
     )
 
     /**

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/LightningCoils.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/LightningCoils.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/** Lightning Coils — Mirrodin #198. */
+val LightningCoils = card("Lightning Coils") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever a nontoken creature you control dies, put a charge counter on this " +
+        "artifact.\nAt the beginning of your upkeep, if this artifact has five or more charge " +
+        "counters on it, remove all of them from it and create that many 3/1 red Elemental creature " +
+        "tokens with haste. Exile them at the beginning of the next end step."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl().nontoken(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.AddCounters(Counters.CHARGE, 1, EffectTarget.Self)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        interveningIf = Conditions.SourceCounterCountAtLeast(Counters.CHARGE, 5)
+        effect = Effects.Composite(
+            Effects.StoreNumber(
+                "removedChargeCounters",
+                DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.CHARGE)),
+            ),
+            Effects.RemoveAllCountersOfType(Counters.CHARGE, EffectTarget.Self),
+            Effects.CreateToken(
+                count = DynamicAmount.VariableReference("removedChargeCounters"),
+                power = 3,
+                toughness = 1,
+                colors = setOf(Color.RED),
+                creatureTypes = setOf("Elemental"),
+                keywords = setOf(Keyword.HASTE),
+                exileAtStep = Step.END,
+                imageUri = "https://cards.scryfall.io/normal/front/e/4/e4a9051b-f964-43f9-877b-ea4f17620ecb.jpg?1783915251",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "198"
+        artist = "Brian Snõddy"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a800f326-3416-4917-a1cf-0f90255777d3.jpg?1783944514"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LightningCoilsScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LightningCoilsScenarioTest.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.LightningCoils
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class LightningCoilsScenarioTest : FunSpec({
+
+    fun addChargeCounters(driver: GameTestDriver, entityId: EntityId, count: Int) {
+        driver.replaceState(
+            driver.state.updateEntity(entityId) { container ->
+                val existing = container.get<CountersComponent>() ?: CountersComponent()
+                container.with(existing.withAdded(CounterType.CHARGE, count))
+            }
+        )
+    }
+
+    fun tokenCount(driver: GameTestDriver, playerId: EntityId): Int =
+        driver.state.getBattlefield(playerId).count { id ->
+            driver.state.getEntity(id)?.has<TokenComponent>() == true
+        }
+
+    test("upkeep removes every charge counter, creates that many hasty tokens, then exiles them") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + LightningCoils)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+
+        val controller = driver.activePlayer!!
+        val coils = driver.putPermanentOnBattlefield(controller, "Lightning Coils")
+        addChargeCounters(driver, coils, 6)
+
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.bothPass()
+
+        (driver.state.getEntity(coils)!!.get<CountersComponent>()
+            ?.getCount(CounterType.CHARGE) ?: 0) shouldBe 0
+        tokenCount(driver, controller) shouldBe 6
+
+        driver.passPriorityUntil(Step.END)
+        while (driver.stackSize > 0) driver.bothPass()
+
+        tokenCount(driver, controller) shouldBe 0
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -4934,6 +4934,113 @@
     ]
 }
 
+// Lightning Coils
+{
+    "name": "Lightning Coils",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever a nontoken creature you control dies, put a charge counter on this artifact.\nAt the beginning of your upkeep, if this artifact has five or more charge counters on it, remove all of them from it and create that many 3/1 red Elemental creature tokens with haste. Exile them at the beginning of the next end step.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature nontoken ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "charge",
+                    "count": 1,
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "StoreNumber",
+                            "name": "removedChargeCounters",
+                            "amount": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": {
+                                    "type": "CounterCount",
+                                    "counterType": {
+                                        "type": "Named",
+                                        "name": "charge"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "RemoveAllCountersOfType",
+                            "counterType": "charge",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "CreateToken",
+                            "count": {
+                                "type": "VariableReference",
+                                "variableName": "removedChargeCounters"
+                            },
+                            "power": 3,
+                            "toughness": 1,
+                            "colors": [
+                                "RED"
+                            ],
+                            "creatureTypes": [
+                                "Elemental"
+                            ],
+                            "keywords": [
+                                "HASTE"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/e/4/e4a9051b-f964-43f9-877b-ea4f17620ecb.jpg?1783915251",
+                            "exileAtStep": "END"
+                        }
+                    ]
+                },
+                "interveningIf": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": {
+                                "type": "Named",
+                                "name": "charge"
+                            }
+                        }
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "rarity": "RARE",
+        "artist": "Brian Snõddy",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a800f326-3416-4917-a1cf-0f90255777d3.jpg?1783944514"
+    },
+    "colorIdentityOverride": []
+}
+
 // Lightning Greaves
 {
     "name": "Lightning Greaves",


### PR DESCRIPTION
## Summary

- Add Lightning Coils with its nontoken-creature death trigger, intervening-if upkeep trigger, dynamic token count, haste, and delayed exile.
- Expose the existing delayed-exile and delayed-sacrifice token options through both `Effects.CreateToken` overloads and document the SDK surface.
- Add a dedicated scenario test and refresh the Mirrodin card snapshot.

## Scope

I selected one card because the remaining unimplemented Mirrodin pool is dominated by cards that need larger engine vocabulary. I excluded those rather than approximate their Oracle behavior.

## Verification

- `just test`
- `just test-class LightningCoilsScenarioTest`
- `just rebless-cards`
- `just check-card-printing "Lightning Coils"`
- Card and token image URLs returned HTTP 200
- `git diff --check`