### PR TITLE
Add two Mirrodin cards

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/BrownOuphe.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/BrownOuphe.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Brown Ouphe
+ * {G}
+ * Creature — Ouphe
+ * 1/1
+ *
+ * {1}{G}, {T}: Counter target activated ability from an artifact source.
+ * (Mana abilities can't be targeted.)
+ */
+val BrownOuphe = card("Brown Ouphe") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ouphe"
+    power = 1
+    toughness = 1
+    oracleText = "{1}{G}, {T}: Counter target activated ability from an artifact source. " +
+        "(Mana abilities can't be targeted.)"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{G}"), Costs.Tap)
+        target = TargetObject(
+            filter = TargetFilter.ActivatedAbilityOnStack
+                .abilitySourceMatches(GameObjectFilter.Artifact)
+        )
+        effect = Effects.CounterAbility()
+        description = "{1}{G}, {T}: Counter target activated ability from an artifact source."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "228"
+        artist = "Daniel Gelon"
+        flavorText = "\"Ouphes love trinkets and love to take them apart. I only wish they wouldn't do so with the magical ones.\"\n—Taaveti of Kelsinko, Elvish Hunter"
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e26ce35b-ba65-451d-a5ed-e1db6f1d0c6f.jpg?1783947480"
+        ruling("6/8/2016", "Activated abilities contain a colon and are generally written as '[Cost]: [Effect].' Some keywords are activated abilities and have colons in their reminder text.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BrownOupheReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BrownOupheReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Brown Ouphe reprint in Mirrodin; the canonical definition lives in Ice Age. */
+val BrownOupheReprint = Printing(
+    oracleId = "5b42e91a-e3bd-4f69-9abf-ed6273715fff",
+    name = "Brown Ouphe",
+    setCode = "MRD",
+    collectorNumber = "115",
+    scryfallId = "1d8779ec-0ebd-45a1-96c9-4b1146871ab7",
+    artist = "Greg Hildebrandt",
+    imageUri = "https://cards.scryfall.io/normal/front/1/d/1d8779ec-0ebd-45a1-96c9-4b1146871ab7.jpg?1783944535",
+    releaseDate = "2003-10-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MesmericOrb.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MesmericOrb.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mesmeric Orb
+ * {2}
+ * Artifact
+ *
+ * Whenever a permanent becomes untapped, that permanent's controller mills a card.
+ */
+val MesmericOrb = card("Mesmeric Orb") {
+    manaCost = "{2}"
+    typeLine = "Artifact"
+    oracleText = "Whenever a permanent becomes untapped, that permanent's controller mills a card."
+
+    triggeredAbility {
+        trigger = Triggers.becomesUntapped(binding = TriggerBinding.ANY)
+        effect = Patterns.Library.mill(1, EffectTarget.ControllerOfTriggeringEntity)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "204"
+        artist = "David Martin"
+        flavorText = "A step in one direction is two steps away from another."
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/29d11b14-43a9-4d1c-ba2c-3025d51d841e.jpg?1783944514"
+        ruling("8/7/2020", "If permanents become untapped during the untap step, Mesmeric Orb's ability triggers once for each of them. The triggers wait to be put on the stack until the upkeep begins.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ICE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ICE.json
@@ -191,6 +191,79 @@
     ]
 }
 
+// Brown Ouphe
+{
+    "name": "Brown Ouphe",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Ouphe",
+    "oracleText": "{1}{G}, {T}: Counter target activated ability from an artifact source. (Mana abilities can't be targeted.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Counter",
+                    "target": "CounterTarget.Ability"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsActivatedAbility",
+                                    {
+                                        "type": "AbilitySourceMatches",
+                                        "subfilter": {
+                                            "cardPredicates": [
+                                                "IsArtifact"
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "zone": "Stack"
+                        }
+                    }
+                ],
+                "descriptionOverride": "{1}{G}, {T}: Counter target activated ability from an artifact source."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "artist": "Daniel Gelon",
+        "flavorText": "\"Ouphes love trinkets and love to take them apart. I only wish they wouldn't do so with the magical ones.\"\n—Taaveti of Kelsinko, Elvish Hunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e26ce35b-ba65-451d-a5ed-e1db6f1d0c6f.jpg?1783947480",
+        "rulings": [
+            {
+                "date": "6/8/2016",
+                "text": "Activated abilities contain a colon and are generally written as '[Cost]: [Effect].' Some keywords are activated abilities and have colons in their reminder text."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Brushland
 {
     "name": "Brushland",

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -5983,6 +5983,61 @@
     ]
 }
 
+// Mesmeric Orb
+{
+    "name": "Mesmeric Orb",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever a permanent becomes untapped, that permanent's controller mills a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "UntapEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "rarity": "RARE",
+        "artist": "David Martin",
+        "flavorText": "A step in one direction is two steps away from another.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/29d11b14-43a9-4d1c-ba2c-3025d51d841e.jpg?1783944514",
+        "rulings": [
+            {
+                "date": "8/7/2020",
+                "text": "If permanents become untapped during the untap step, Mesmeric Orb's ability triggers once for each of them. The triggers wait to be put on the stack until the upkeep begins."
+            }
+        ]
+    }
+}
+
 // Mind's Eye
 {
     "name": "Mind's Eye",


### PR DESCRIPTION
## Summary

- **Brown Ouphe** — counters an activated ability from an artifact source using the existing stack-object source filter and counter effect; canonical Ice Age definition plus Mirrodin printing metadata.
- **Mesmeric Orb** — mills each permanent’s controller through the existing any-permanent untap trigger and library mill pattern.

The batch is intentionally limited to two because the remaining unimplemented Mirrodin cards require broader engine/SDK vocabulary or substantially more complex rules handling.

## Verification

- `just build`
- `just check-card-printing "Brown Ouphe"`
- `just check-card-printing "Mesmeric Orb"`
- Scryfall image URLs return HTTP 200