### PR TITLE
Add Delney, Streetwise Lookout

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DelneyStreetwiseLookout.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DelneyStreetwiseLookout.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalSourceTriggers
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Delney, Streetwise Lookout
+ * {2}{W}
+ * Legendary Creature — Human Scout
+ * 2/2
+ *
+ * Creatures you control with power 2 or less can't be blocked by creatures with power 3 or greater.
+ * If a triggered ability of a creature you control with power 2 or less triggers, that ability
+ * triggers an additional time.
+ */
+val DelneyStreetwiseLookout = card("Delney, Streetwise Lookout") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Scout"
+    power = 2
+    toughness = 2
+    oracleText = "Creatures you control with power 2 or less can't be blocked by creatures with " +
+        "power 3 or greater.\n" +
+        "If a triggered ability of a creature you control with power 2 or less triggers, that " +
+        "ability triggers an additional time."
+
+    staticAbility {
+        ability = CantBeBlockedBy(
+            blockerFilter = GameObjectFilter.Creature.powerAtLeast(3),
+            filter = GroupFilter.AllCreaturesYouControl.powerAtMost(2),
+        )
+    }
+
+    staticAbility {
+        ability = AdditionalSourceTriggers(
+            sourceFilter = GameObjectFilter.Creature.powerAtMost(2),
+            excludeSelf = false,
+            description = "If a triggered ability of a creature you control with power 2 or less " +
+                "triggers, that ability triggers an additional time",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "12"
+        artist = "Darren Tan"
+        flavorText = "\"It's not a matter of what I know. It's a matter of making it worth my " +
+            "while to tell you.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/" +
+            "be219928-3d0e-4d00-b124-152ce8a8c13b.jpg?1783912925"
+
+        ruling("2024-02-02", "Once a creature you control has become blocked, reducing its power " +
+            "to 2 or less and/or increasing the power of the creature blocking it to 3 or greater " +
+            "won't cause it to become unblocked.")
+        ruling("2024-02-02", "Replacement effects and abilities that apply as a creature enters " +
+            "the battlefield or is turned face up are unaffected by Delney's last ability.")
+        ruling("2024-02-02", "Each additional instance of a triggered ability has its choices, " +
+            "including modes and targets, made separately.")
+        ruling("2024-02-02", "Multiple Delneys are additive: two cause qualifying abilities to " +
+            "trigger three times, three cause them to trigger four times, and so on.")
+        ruling("2024-02-02", "A face-up trigger is doubled only if that creature's power is 2 or " +
+            "less after it has been turned face up.")
+        ruling("2024-02-02", "Whether Delney adds a trigger is determined when the ability " +
+            "triggers; later power changes don't add or remove the additional instance.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -4255,6 +4255,79 @@
     ]
 }
 
+// Delney, Streetwise Lookout
+{
+    "name": "Delney, Streetwise Lookout",
+    "manaCost": "{2}{W}",
+    "typeLine": "Legendary Creature — Human Scout",
+    "oracleText": "Creatures you control with power 2 or less can't be blocked by creatures with power 3 or greater.\nIf a triggered ability of a creature you control with power 2 or less triggers, that ability triggers an additional time.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "PowerAtLeast",
+                            "min": 3
+                        }
+                    ]
+                },
+                "filter": {
+                    "baseFilter": "creature pow<=2 ctrl:you"
+                }
+            },
+            {
+                "type": "AdditionalSourceTriggers",
+                "sourceFilter": "creature pow<=2",
+                "excludeSelf": false,
+                "description": "If a triggered ability of a creature you control with power 2 or less triggers, that ability triggers an additional time"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "rarity": "MYTHIC",
+        "artist": "Darren Tan",
+        "flavorText": "\"It's not a matter of what I know. It's a matter of making it worth my while to tell you.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/be219928-3d0e-4d00-b124-152ce8a8c13b.jpg?1783912925",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Once a creature you control has become blocked, reducing its power to 2 or less and/or increasing the power of the creature blocking it to 3 or greater won't cause it to become unblocked."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Replacement effects and abilities that apply as a creature enters the battlefield or is turned face up are unaffected by Delney's last ability."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Each additional instance of a triggered ability has its choices, including modes and targets, made separately."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Multiple Delneys are additive: two cause qualifying abilities to trigger three times, three cause them to trigger four times, and so on."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "A face-up trigger is doubled only if that creature's power is 2 or less after it has been turned face up."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Whether Delney adds a trigger is determined when the ability triggers; later power changes don't add or remove the additional instance."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Demand Answers
 {
     "name": "Demand Answers",


### PR DESCRIPTION
## Summary

- Delney, Streetwise Lookout — composes projected power filters, CantBeBlockedBy, and AdditionalSourceTriggers to implement both static abilities.
- Adds the MKM card-definition snapshot and mechanically significant Scryfall rulings.

## Scope

The remaining MKM cards were probed as a potential handful. The other candidates require Case support, cast-cost replacement, staged transformation, or X-linked disguise/exile behavior, so they were left out rather than expanding a card PR into new engine vocabulary.

## Verification

- just build
- just check-card-printing "Delney, Streetwise Lookout"
- Exact Scryfall image URL returns HTTP 200
- MKM snapshot diff contains only Delney