### PR TITLE
Add two Mirrodin cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/JinxedChoker.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/JinxedChoker.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.EffectChoice
+import com.wingedsheep.sdk.scripting.effects.GiveControlToTargetPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.RemoveCountersEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Jinxed Choker — Mirrodin #189
+ * {3} · Artifact
+ *
+ * At the beginning of your end step, target opponent gains control of this artifact and puts a
+ * charge counter on it.
+ * At the beginning of your upkeep, this artifact deals damage to you equal to the number of charge
+ * counters on it.
+ * {3}: Put a charge counter on this artifact or remove one from it.
+ *
+ * The activated ability chooses its action on resolution, as the card's ruling requires. Removing
+ * is only offered while a charge counter exists; otherwise adding is the sole legal choice.
+ */
+val JinxedChoker = card("Jinxed Choker") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "At the beginning of your end step, target opponent gains control of this artifact " +
+        "and puts a charge counter on it.\n" +
+        "At the beginning of your upkeep, this artifact deals damage to you equal to the number of " +
+        "charge counters on it.\n" +
+        "{3}: Put a charge counter on this artifact or remove one from it."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        val opponent = target("opponent", TargetOpponent())
+        effect = Effects.Composite(
+            GiveControlToTargetPlayerEffect(
+                permanent = EffectTarget.Self,
+                newController = opponent,
+            ),
+            Effects.AddCounters(Counters.CHARGE, 1, EffectTarget.Self),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.DealDamage(
+            amount = DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.CHARGE)),
+            target = EffectTarget.Controller,
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}")
+        val addCounter = Effects.AddCounters(Counters.CHARGE, 1, EffectTarget.Self)
+        effect = ConditionalEffect(
+            condition = Conditions.SourceHasCounter(CounterTypeFilter.Named(Counters.CHARGE)),
+            effect = ChooseActionEffect(
+                choices = listOf(
+                    EffectChoice("Put a charge counter on Jinxed Choker", addCounter),
+                    EffectChoice(
+                        "Remove a charge counter from Jinxed Choker",
+                        RemoveCountersEffect(Counters.CHARGE, 1, EffectTarget.Self),
+                    ),
+                ),
+            ),
+            elseEffect = addCounter,
+        )
+        description = "Put a charge counter on this artifact or remove one from it"
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "189"
+        artist = "Mike Dringenberg"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/987910b0-0419-45ff-bda6-c6683fd00e49.jpg?1783944517"
+        ruling("2004-12-01", "“You” is always Jinxed Choker’s current controller.")
+        ruling("2004-12-01", "If you activate Jinxed Choker’s activated ability, you choose to either add or remove a counter when the ability resolves.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/WarElemental.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/WarElemental.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.TurnTracker
+
+/**
+ * War Elemental — Mirrodin #112
+ * {R}{R}{R} · Creature — Elemental · 1/1
+ *
+ * When this creature enters, sacrifice it unless an opponent was dealt damage this turn.
+ * Whenever an opponent is dealt damage, put that many +1/+1 counters on this creature.
+ *
+ * The entry trigger checks opponents' accumulated damage when it resolves; it is not an
+ * intervening-if trigger. The second ability observes every damage source and reads the amount
+ * actually dealt from the trigger context.
+ */
+val WarElemental = card("War Elemental") {
+    manaCost = "{R}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    oracleText = "When this creature enters, sacrifice it unless an opponent was dealt damage this turn.\n" +
+        "Whenever an opponent is dealt damage, put that many +1/+1 counters on this creature."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ConditionalEffect(
+            condition = Conditions.CompareAmounts(
+                DynamicAmount.TurnTracking(Player.EachOpponent, TurnTracker.DAMAGE_RECEIVED),
+                ComparisonOperator.LT,
+                DynamicAmount.Fixed(1),
+            ),
+            effect = Effects.Sacrifice(EffectTarget.Self),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Any,
+            recipient = RecipientFilter.Opponent,
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.AddDynamicCounters(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            amount = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT),
+            target = EffectTarget.Self,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "112"
+        artist = "Anthony S. Waters"
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9cc32bfc-7d87-46d9-a424-eac64eefd7ea.jpg?1783944535"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/WarElemental.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/WarElemental.kt
@@ -45,7 +45,7 @@ val WarElemental = card("War Elemental") {
                 ComparisonOperator.LT,
                 DynamicAmount.Fixed(1),
             ),
-            effect = Effects.Sacrifice(EffectTarget.Self),
+            effect = Effects.SacrificeTarget(EffectTarget.Self),
         )
     }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -4222,6 +4222,149 @@
     ]
 }
 
+// Jinxed Choker
+{
+    "name": "Jinxed Choker",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "At the beginning of your end step, target opponent gains control of this artifact and puts a charge counter on it.\nAt the beginning of your upkeep, this artifact deals damage to you equal to the number of charge counters on it.\n{3}: Put a charge counter on this artifact or remove one from it.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GiveControlToTargetPlayer",
+                            "permanent": "Self",
+                            "newController": {
+                                "type": "BoundVariable",
+                                "name": "opponent"
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "charge",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "opponent"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": {
+                                "type": "Named",
+                                "name": "charge"
+                            }
+                        }
+                    },
+                    "target": "Controller"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": "Self",
+                            "filter": {
+                                "statePredicates": [
+                                    {
+                                        "type": "HasCounter",
+                                        "counterType": "CHARGE"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "ChooseAction",
+                        "choices": [
+                            {
+                                "label": "Put a charge counter on Jinxed Choker",
+                                "effect": {
+                                    "type": "AddCounters",
+                                    "counterType": "charge",
+                                    "count": 1,
+                                    "target": "Self"
+                                }
+                            },
+                            {
+                                "label": "Remove a charge counter from Jinxed Choker",
+                                "effect": {
+                                    "type": "RemoveCounters",
+                                    "counterType": "charge",
+                                    "count": 1,
+                                    "target": "Self"
+                                }
+                            }
+                        ]
+                    },
+                    "otherwise": {
+                        "type": "AddCounters",
+                        "counterType": "charge",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Put a charge counter on this artifact or remove one from it"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "189",
+        "rarity": "RARE",
+        "artist": "Mike Dringenberg",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/987910b0-0419-45ff-bda6-c6683fd00e49.jpg?1783944517",
+        "rulings": [
+            {
+                "date": "2004-12-01",
+                "text": "“You” is always Jinxed Choker’s current controller."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "If you activate Jinxed Choker’s activated ability, you choose to either add or remove a counter when the ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Journey of Discovery
 {
     "name": "Journey of Discovery",
@@ -12966,6 +13109,78 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// War Elemental
+{
+    "name": "War Elemental",
+    "manaCost": "{R}{R}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "When this creature enters, sacrifice it unless an opponent was dealt damage this turn.\nWhenever an opponent is dealt damage, put that many +1/+1 counters on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "TurnTracking",
+                                "player": "EachOpponent",
+                                "tracker": "DAMAGE_RECEIVED"
+                            },
+                            "operator": "LT",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "SacrificeTarget",
+                        "target": "Self"
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "recipient": "RecipientOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "RARE",
+        "artist": "Anthony S. Waters",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9cc32bfc-7d87-46d9-a424-eac64eefd7ea.jpg?1783944535"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 


### PR DESCRIPTION
## Summary

- Jinxed Choker — composes existing upkeep/end-step triggers, opponent targeting, permanent control transfer, dynamic charge-counter damage, and resolution-time action choice.
- War Elemental — composes existing opponent-damage observation, turn tracking, conditional self-sacrifice, and dynamic +1/+1 counter placement.

The remaining unimplemented Mirrodin candidates sampled require new engine/SDK vocabulary, so this batch stays at two cards.

## Verification

- `just build`
- `just check-card-printing "Jinxed Choker"`
- `just check-card-printing "War Elemental"`
- MRD snapshot reviewed: only Jinxed Choker and War Elemental added