### PR TITLE
Add Grab the Reins to Mirrodin

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GrabTheReins.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GrabTheReins.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Grab the Reins
+ * {3}{R}
+ * Instant
+ * Choose one —
+ * • Until end of turn, you gain control of target creature and it gains haste.
+ * • Sacrifice a creature. Grab the Reins deals damage equal to that creature's power to any target.
+ * Entwine {2}{R} (Choose both if you pay the entwine cost.)
+ */
+val GrabTheReins = card("Grab the Reins") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Until end of turn, you gain control of target creature and it gains haste.\n" +
+        "• Sacrifice a creature. Grab the Reins deals damage equal to that creature's power to any target.\n" +
+        "Entwine {2}{R} (Choose both if you pay the entwine cost.)"
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            additionalManaCostPerExtraMode = "{2}{R}",
+        ) {
+            mode("Gain control of target creature until end of turn; it gains haste") {
+                val creature = target("creature to gain control of", Targets.Creature)
+                effect = Effects.Composite(
+                    Effects.GainControl(creature, Duration.EndOfTurn),
+                    Effects.GrantKeyword(Keyword.HASTE, creature),
+                )
+            }
+            mode("Sacrifice a creature; deal damage equal to its power to any target") {
+                val damageTarget = target("damage target", Targets.Any)
+                effect = Effects.SacrificeOwn(GameObjectFilter.Creature)
+                    .then(Effects.DealDamage(DynamicAmounts.sacrificedPower(), damageTarget))
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "95"
+        artist = "Michael Sutfin"
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/570fa211-e937-4ad7-bc72-60f8adc3203d.jpg?1783944540"
+        ruling(
+            "2004-12-01",
+            "If you pay the entwine cost, you can sacrifice the creature you gain control of with Grab the Reins.",
+        )
+        ruling(
+            "2004-12-01",
+            "If you choose the sacrifice mode, choose the damage target as you cast the spell, but choose " +
+                "the creature to sacrifice as it resolves. You must sacrifice a creature if possible; if you " +
+                "control none, no damage is dealt.",
+        )
+        ruling(
+            "2004-12-01",
+            "An entwined Grab the Reins resolves as one spell; no player gets priority between gaining " +
+                "control of the creature and sacrificing a creature.",
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/GrabTheReinsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/GrabTheReinsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grab the Reins reprint in Commander 2016. The canonical card definition lives in Mirrodin;
+ * this file contributes only the Commander 2016 presentation data.
+ */
+val GrabTheReinsReprint = Printing(
+    oracleId = "3ceda405-8175-416a-beda-9a95f5acc60c",
+    name = "Grab the Reins",
+    setCode = "C16",
+    collectorNumber = "126",
+    scryfallId = "d74d181c-6783-4472-a3b9-2f6780e2b89b",
+    artist = "Michael Sutfin",
+    imageUri = "https://cards.scryfall.io/normal/front/d/7/d74d181c-6783-4472-a3b9-2f6780e2b89b.jpg?1783937066",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -3691,6 +3691,110 @@
     "colorIdentityOverride": []
 }
 
+// Grab the Reins
+{
+    "name": "Grab the Reins",
+    "manaCost": "{3}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Until end of turn, you gain control of target creature and it gains haste.\n• Sacrifice a creature. Grab the Reins deals damage equal to that creature's power to any target.\nEntwine {2}{R} (Choose both if you pay the entwine cost.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GainControl",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "creature to gain control of"
+                                },
+                                "duration": "EndOfTurn"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "creature to gain control of"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "creature to gain control of"
+                        }
+                    ],
+                    "description": "Gain control of target creature until end of turn; it gains haste"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Sacrifice",
+                                "filter": "creature"
+                            },
+                            {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "EntityProperty",
+                                    "entity": "Sacrificed",
+                                    "numericProperty": "Power"
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "damage target"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "AnyTarget",
+                            "id": "damage target"
+                        }
+                    ],
+                    "description": "Sacrifice a creature; deal damage equal to its power to any target"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "additionalManaCostPerExtraMode": "{2}{R}"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "rarity": "UNCOMMON",
+        "artist": "Michael Sutfin",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/570fa211-e937-4ad7-bc72-60f8adc3203d.jpg?1783944540",
+        "rulings": [
+            {
+                "date": "2004-12-01",
+                "text": "If you pay the entwine cost, you can sacrifice the creature you gain control of with Grab the Reins."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "If you choose the sacrifice mode, choose the damage target as you cast the spell, but choose the creature to sacrifice as it resolves. You must sacrifice a creature if possible; if you control none, no damage is dealt."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "An entwined Grab the Reins resolves as one spell; no player gets priority between gaining control of the creature and sacrificing a creature."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Granite Shard
 {
     "name": "Granite Shard",


### PR DESCRIPTION
## Summary

- Add Grab the Reins, composing the existing modal/entwine, temporary-control, haste, sacrifice, and sacrificed-power primitives.
- Add its required Commander 2016 printing metadata.
- Refresh the MRD card-definition snapshot.

The batch was intentionally reduced to one card: the other remaining unimplemented Mirrodin candidates require new engine/SDK vocabulary (including imprint/linking, dynamic cost taxes, unusual prevention, lowest-mana-value targeting, or turn-start state) and therefore cannot share an add-card batch under the repository workflow.

## Verification

- `just check-card-printing "Grab the Reins"`
- `just rebless-cards` (only Grab the Reins changed MRD.json)
- `just build`