### PR TITLE
Add Blinkmoth Urn to Mirrodin

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BlinkmothUrn.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BlinkmothUrn.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Blinkmoth Urn — Mirrodin #145 (canonical and earliest real-expansion printing)
+ * {5} · Artifact
+ *
+ * At the beginning of each player's first main phase, if this artifact is untapped, that player
+ * adds {C} for each artifact they control.
+ *
+ * The trigger watches every player's precombat main phase. [Effects.ForEachPlayer] rebinds the
+ * effect controller to the active player, so both [Player.You] in the artifact count and the mana
+ * recipient mean "that player," even on an opponent's turn. [Conditions.SourceIsUntapped] is the
+ * intervening-if gate, checked both when the ability would trigger and again when it resolves.
+ */
+val BlinkmothUrn = card("Blinkmoth Urn") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "At the beginning of each player's first main phase, if this artifact is untapped, " +
+        "that player adds {C} for each artifact they control."
+
+    triggeredAbility {
+        trigger = Triggers.phase(Step.PRECOMBAT_MAIN, Player.Each)
+        interveningIf = Conditions.SourceIsUntapped
+        effect = Effects.ForEachPlayer(
+            Player.TriggeringPlayer,
+            listOf(
+                Effects.AddColorlessMana(
+                    DynamicAmounts.battlefield(Player.You, GameObjectFilter.Artifact).count()
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "145"
+        artist = "David Martin"
+        flavorText = "The vedalken embed such urns in their living artifact creations."
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0ff34d0b-a278-4990-beaf-5a64885460db.jpg?1783944528"
+        ruling(
+            "2004-10-04",
+            "The precombat main phase is the first main phase of the turn. All others are postcombat " +
+                "main phases, even if they technically occur before combat."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/BlinkmothUrnReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/BlinkmothUrnReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blinkmoth Urn reprint in Commander 2016. The canonical card definition lives in Mirrodin;
+ * this file contributes only the Commander 2016 presentation data.
+ */
+val BlinkmothUrnReprint = Printing(
+    oracleId = "08497e8f-3521-48e4-a1e7-c192b485d891",
+    name = "Blinkmoth Urn",
+    setCode = "C16",
+    collectorNumber = "244",
+    scryfallId = "1016fb10-82b5-465a-8f33-ec54f9785544",
+    artist = "David Martin",
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/1016fb10-82b5-465a-8f33-ec54f9785544.jpg?1783937039",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -794,6 +794,61 @@
     ]
 }
 
+// Blinkmoth Urn
+{
+    "name": "Blinkmoth Urn",
+    "manaCost": "{5}",
+    "typeLine": "Artifact",
+    "oracleText": "At the beginning of each player's first main phase, if this artifact is untapped, that player adds {C} for each artifact they control.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "PRECOMBAT_MAIN",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "TriggeringPlayer"
+                    },
+                    "body": {
+                        "type": "AddColorlessMana",
+                        "amount": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "artifact"
+                        }
+                    }
+                },
+                "interveningIf": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "untapped"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "rarity": "RARE",
+        "artist": "David Martin",
+        "flavorText": "The vedalken embed such urns in their living artifact creations.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0ff34d0b-a278-4990-beaf-5a64885460db.jpg?1783944528",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "The precombat main phase is the first main phase of the turn. All others are postcombat main phases, even if they technically occur before combat."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Blinkmoth Well
 {
     "name": "Blinkmoth Well",


### PR DESCRIPTION
## Summary

- Blinkmoth Urn — triggers at each player’s first main phase, checks the Urn is untapped as an intervening-if condition, and gives that player colorless mana for their artifacts using existing primitives.
- Add the required Commander 2016 printing metadata while keeping Mirrodin as the canonical earliest printing.

## Scope

Current main already contains the straightforward Mirrodin candidates found during screening. The remaining gaps need unsupported or substantially more involved vocabulary (dynamic cost increases, exile-from-library activation costs, targeting-source controller bindings, or specialized prevention), so this PR intentionally contains one card rather than expanding into engine work.

## Verification

- just check-card-printing "Blinkmoth Urn"
- just rebless-cards
- just build
- git diff --check