### PR TITLE
Add two Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DeadlyCoverUp.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DeadlyCoverUp.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.collectEvidence
+import com.wingedsheep.sdk.dsl.namedFromVariable
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Deadly Cover-Up — Murders at Karlov Manor #83
+ * {3}{B}{B} · Sorcery · Rare
+ *
+ * The optional collect-evidence cost records the standard cast choice. On resolution the wipe
+ * always happens first. Only the paid branch gathers one card from all opponents' graveyards; its
+ * owner is snapshotted before exile, then becomes the per-player context for the graveyard, hand,
+ * and library search. Counting the hand subset before moving the chosen cards preserves the exact
+ * number of replacement draws.
+ */
+val DeadlyCoverUp = card("Deadly Cover-Up") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, you may collect evidence 6.\n" +
+        "Destroy all creatures. If evidence was collected, exile a card from an opponent's " +
+        "graveyard. Then search its owner's graveyard, hand, and library for any number of cards " +
+        "with that name and exile them. That player shuffles, then draws a card for each card " +
+        "exiled from their hand this way."
+
+    collectEvidence(6)
+
+    spell {
+        val extraction = Effects.Pipeline {
+            val graveyardCards = gather(
+                CardSource.FromZone(
+                    zone = Zone.GRAVEYARD,
+                    player = Player.EachOpponent,
+                    filter = GameObjectFilter.Any,
+                ),
+                name = "opponentGraveyardCards",
+            )
+            val seed = chooseExactly(
+                1,
+                from = graveyardCards,
+                chooser = Chooser.SourceController,
+                prompt = "Choose a card from an opponent's graveyard to exile",
+                name = "seed",
+            )
+            val owners = captureControllers(seed, name = "owners")
+            val cardName = storeCardName(seed, name = "cardName")
+            exile(seed)
+
+            forEachCaptured(seed, seed, owners) {
+                val matches = gather(
+                    CardSource.FromMultipleZones(
+                        zones = listOf(Zone.GRAVEYARD, Zone.HAND, Zone.LIBRARY),
+                        player = Player.You,
+                        filter = GameObjectFilter.Any.namedFromVariable(cardName.key),
+                    ),
+                    name = "matches",
+                )
+                val selected = chooseAnyNumber(
+                    from = matches,
+                    chooser = Chooser.SourceController,
+                    prompt = "Choose any number of cards with that name to exile",
+                    showAllCards = true,
+                    alwaysPrompt = true,
+                    name = "selected",
+                )
+                val selectedFromHand = filter(
+                    selected,
+                    CollectionFilter.InZone(Zone.HAND),
+                    name = "selectedFromHand",
+                )
+                exile(selected)
+                run(ShuffleLibraryEffect(target = EffectTarget.Controller))
+                run(
+                    Effects.DrawCards(
+                        DynamicAmount.VariableReference("${selectedFromHand.key}_count"),
+                        EffectTarget.Controller,
+                    ),
+                )
+            }
+        }
+
+        effect = Effects.Composite(
+            Effects.DestroyAll(GameObjectFilter.Creature),
+            ConditionalEffect(Conditions.WasEvidenceCollected, extraction),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "83"
+        artist = "Sam Guay"
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/3876aa0f-b199-43f5-8a91-c2d620b8ef84.jpg?1783912899"
+        ruling(
+            "2024-02-02",
+            "Unlike many other effects of this kind, Deadly Cover-Up allows its controller to exile " +
+                "a basic land.",
+        )
+        ruling(
+            "2024-02-02",
+            "If you can't exile enough cards to meet or exceed the required mana value, you can't " +
+                "choose to collect evidence at all.",
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SlimeAgainstHumanity.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SlimeAgainstHumanity.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Slime Against Humanity — Murders at Karlov Manor #177
+ * {2}{G} · Sorcery · Common
+ *
+ * The Ooze-or-name test is one union filter reused for both relevant zones. The resolving spell is
+ * still on the stack, so it does not count itself; face-down exiled cards have no matching name or
+ * subtype. The token creator publishes the new Ooze through [CREATED_TOKENS], allowing the counter
+ * effect to address exactly that token after it enters.
+ *
+ * The final sentence is a deck-construction allowance and requires no in-game script.
+ */
+val SlimeAgainstHumanity = card("Slime Against Humanity") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Create a 0/0 green Ooze creature token with trample. Put X +1/+1 counters on it, " +
+        "where X is two plus the total number of cards you own in exile and in your graveyard that " +
+        "are Oozes or are named Slime Against Humanity.\n" +
+        "A deck can have any number of cards named Slime Against Humanity."
+
+    spell {
+        val matchingSlimes = (
+            GameObjectFilter.Any.withSubtype("Ooze") or
+                GameObjectFilter.Any.named("Slime Against Humanity")
+            ).faceUp()
+        val counterCount = DynamicAmount.Add(
+            DynamicAmount.Fixed(2),
+            DynamicAmount.Add(
+                DynamicAmounts.zone(Player.You, Zone.EXILE, matchingSlimes).count(),
+                DynamicAmounts.zone(Player.You, Zone.GRAVEYARD, matchingSlimes).count(),
+            ),
+        )
+
+        effect = Effects.CreateToken(
+            power = 0,
+            toughness = 0,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Ooze"),
+            keywords = setOf(Keyword.TRAMPLE),
+            imageUri = "https://cards.scryfall.io/normal/front/5/4/54b37032-9660-4dfb-9629-c4e8eddc43b0.jpg?1783912608",
+        ).then(
+            Effects.AddDynamicCounters(
+                Counters.PLUS_ONE_PLUS_ONE,
+                counterCount,
+                EffectTarget.PipelineTarget(CREATED_TOKENS, 0),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "177"
+        artist = "Brent Hollowell"
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1eb21318-d32e-4724-8908-c0d7613de2f4.jpg?1783912861"
+        ruling(
+            "2024-02-02",
+            "Slime Against Humanity isn't put into your graveyard until after it finishes resolving, " +
+                "so it doesn't count itself for its own effect.",
+        )
+        ruling(
+            "2024-02-02",
+            "If you own face-down cards in exile, they won't count toward the value of X, even if " +
+                "you're allowed to look at them and you know they are Ooze cards or cards named " +
+                "Slime Against Humanity.",
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -4174,6 +4174,195 @@
     ]
 }
 
+// Deadly Cover-Up
+{
+    "name": "Deadly Cover-Up",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, you may collect evidence 6.\nDestroy all creatures. If evidence was collected, exile a card from an opponent's graveyard. Then search its owner's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.",
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomCollectEvidence",
+                    "amount": 6
+                }
+            },
+            "declaredSlot": "EVIDENCE_COLLECTED"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": "creature"
+                            },
+                            "storeAs": "destroyAll_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "destroyAll_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy"
+                        }
+                    ]
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "CastChoiceMade",
+                            "slot": "EVIDENCE_COLLECTED"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Graveyard",
+                                    "player": "EachOpponent"
+                                },
+                                "storeAs": "opponentGraveyardCards"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "opponentGraveyardCards",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "chooser": "SourceController",
+                                "storeSelected": "seed",
+                                "prompt": "Choose a card from an opponent's graveyard to exile"
+                            },
+                            {
+                                "type": "CaptureControllers",
+                                "from": "seed",
+                                "storeAs": "owners"
+                            },
+                            {
+                                "type": "StoreCardName",
+                                "from": "seed",
+                                "storeAs": "cardName"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "seed",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                }
+                            },
+                            {
+                                "type": "ForEachCapturedController",
+                                "collection": "seed",
+                                "originalCollection": "seed",
+                                "controllerSnapshot": "owners",
+                                "countVariable": "count5",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromMultipleZones",
+                                            "zones": [
+                                                "Graveyard",
+                                                "Hand",
+                                                "Library"
+                                            ],
+                                            "filter": {
+                                                "cardPredicates": [
+                                                    {
+                                                        "type": "NameEqualsChosen",
+                                                        "variableName": "cardName"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "storeAs": "matches"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "matches",
+                                        "selection": "ChooseAnyNumber",
+                                        "chooser": "SourceController",
+                                        "storeSelected": "selected",
+                                        "prompt": "Choose any number of cards with that name to exile",
+                                        "showAllCards": true,
+                                        "alwaysPrompt": true
+                                    },
+                                    {
+                                        "type": "FilterCollection",
+                                        "from": "selected",
+                                        "filter": {
+                                            "type": "InZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeMatching": "selectedFromHand"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "selected",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Exile"
+                                        }
+                                    },
+                                    "ShuffleLibrary",
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "VariableReference",
+                                            "variableName": "selectedFromHand_count"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "RARE",
+        "artist": "Sam Guay",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/3876aa0f-b199-43f5-8a91-c2d620b8ef84.jpg?1783912899",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Unlike many other effects of this kind, Deadly Cover-Up allows its controller to exile a basic land."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If you can't exile enough cards to meet or exceed the required mana value, you can't choose to collect evidence at all."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Deduce
 {
     "name": "Deduce",

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -14620,6 +14620,122 @@
     ]
 }
 
+// Slime Against Humanity
+{
+    "name": "Slime Against Humanity",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a 0/0 green Ooze creature token with trample. Put X +1/+1 counters on it, where X is two plus the total number of cards you own in exile and in your graveyard that are Oozes or are named Slime Against Humanity.\nA deck can have any number of cards named Slime Against Humanity.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreateToken",
+                    "power": 0,
+                    "toughness": 0,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Ooze"
+                    ],
+                    "keywords": [
+                        "TRAMPLE"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/4/54b37032-9660-4dfb-9629-c4e8eddc43b0.jpg?1783912608"
+                },
+                {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "Add",
+                        "left": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "right": {
+                            "type": "Add",
+                            "left": {
+                                "type": "AggregateZone",
+                                "player": "You",
+                                "zone": "Exile",
+                                "filter": {
+                                    "cardPredicates": [
+                                        {
+                                            "type": "Or",
+                                            "predicates": [
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Ooze"
+                                                },
+                                                {
+                                                    "type": "NameEquals",
+                                                    "name": "Slime Against Humanity"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "statePredicates": [
+                                        "IsFaceUp"
+                                    ]
+                                }
+                            },
+                            "right": {
+                                "type": "AggregateZone",
+                                "player": "You",
+                                "zone": "Graveyard",
+                                "filter": {
+                                    "cardPredicates": [
+                                        {
+                                            "type": "Or",
+                                            "predicates": [
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Ooze"
+                                                },
+                                                {
+                                                    "type": "NameEquals",
+                                                    "name": "Slime Against Humanity"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "statePredicates": [
+                                        "IsFaceUp"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "target": {
+                        "type": "PipelineTarget",
+                        "collectionName": "createdTokens"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "artist": "Brent Hollowell",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1eb21318-d32e-4724-8908-c0d7613de2f4.jpg?1783912861",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Slime Against Humanity isn't put into your graveyard until after it finishes resolving, so it doesn't count itself for its own effect."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If you own face-down cards in exile, they won't count toward the value of X, even if you're allowed to look at them and you know they are Ooze cards or cards named Slime Against Humanity."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Slimy Dualleech
 {
     "name": "Slimy Dualleech",


### PR DESCRIPTION
## Cards

- Deadly Cover-Up — composes the optional collect-evidence cast cost, creature wipe, and multi-zone extraction pipeline.
- Slime Against Humanity — composes cross-zone filtered counts, Ooze token creation, and dynamic +1/+1 counters; face-down exiled cards are excluded per its ruling.

## Verification

- just build
- just check-card-printing "Deadly Cover-Up"
- just check-card-printing "Slime Against Humanity"
- Scryfall card and token image URLs return HTTP 200