### PR TITLE
Add Izoni, Center of the Web to Murders at Karlov Manor

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2789,11 +2789,12 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
   701.59a), for cards where collecting is not a cost. Use it as the `action` half of a
   `ReflexiveTriggerEffect` for "you may collect evidence 3. **When you do**, …" (Sample Collector —
   a real reflexive trigger per CR 603.12, so its target is chosen after the collection resolves and
-  opponents may respond), or under `MayEffect` / a gated effect for a bare "you may collect
-  evidence N" (Surveillance Monitor) and "if you do" (Izoni, Center of the Web).
-  `ReflexiveTriggerEffectExecutor.isActionFeasible` gates the prompt on reachability, so CR 701.59b
-  holds by construction — a player who can't reach N is never *asked*, rather than being asked and
-  forced to decline. Emits the same `EvidenceCollectedEvent` the cost contexts do.
+  opponents may respond), under `MayEffect` for a bare "you may collect evidence N" (Surveillance
+  Monitor), or as `OptionalCostEffect(cost = Effects.CollectEvidence(n), ifPaid = …)` for "you may
+  collect evidence N. If you do, …" (Izoni, Center of the Web). Both consent gates check the summed
+  graveyard mana value before prompting, so CR 701.59b holds by construction — a player who can't
+  reach N is never *asked*, rather than being asked and forced to decline. Emits the same
+  `EvidenceCollectedEvent` the cost contexts do.
 - `forage(afterEffect?)` — Forage as an *effect* ("you may forage"): a `ChooseActionEffect` letting
   the player choose to exile three cards from their graveyard or sacrifice a Food (each gated by a
   feasibility check), with `afterEffect` appended to whichever mode is taken (Bushy Bodyguard, Curious

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/IzoniCenterOfTheWeb.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/IzoniCenterOfTheWeb.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+
+/**
+ * Izoni, Center of the Web
+ * {4}{B}{G}
+ * Legendary Creature — Elf Detective
+ * 5/4
+ *
+ * Menace
+ * Whenever Izoni enters or attacks, you may collect evidence 4. If you do, create two 2/1 black
+ * and green Spider creature tokens with reach and menace.
+ * Sacrifice four tokens: Surveil 2, then draw two cards. You gain 2 life.
+ *
+ * "Enters or attacks" is represented by two triggered abilities sharing the same immutable payoff.
+ * The ordinary, non-reflexive "if you do" clause is an [OptionalCostEffect]: collecting evidence is
+ * the optional payment, and the tokens are created only after that payment completes. The activated
+ * ability pays its four-token sacrifice before resolving the surveil, draw, and life-gain sequence.
+ */
+val IzoniCenterOfTheWeb = card("Izoni, Center of the Web") {
+    manaCost = "{4}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Elf Detective"
+    oracleText = "Menace\n" +
+        "Whenever Izoni enters or attacks, you may collect evidence 4. If you do, create two 2/1 " +
+        "black and green Spider creature tokens with reach and menace.\n" +
+        "Sacrifice four tokens: Surveil 2, then draw two cards. You gain 2 life."
+    power = 5
+    toughness = 4
+
+    keywords(Keyword.MENACE)
+
+    val collectAndCreateSpiders = OptionalCostEffect(
+        cost = Effects.CollectEvidence(4),
+        ifPaid = Effects.CreateToken(
+            power = 2,
+            toughness = 1,
+            colors = setOf(Color.BLACK, Color.GREEN),
+            creatureTypes = setOf("Spider"),
+            keywords = setOf(Keyword.REACH, Keyword.MENACE),
+            count = 2,
+            imageUri = "https://cards.scryfall.io/normal/front/7/4/74cb3ba3-9a14-4d72-bf24-0b75ae747f96.jpg?1783912607"
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = collectAndCreateSpiders
+        description = "Whenever Izoni enters or attacks, you may collect evidence 4. If you do, " +
+            "create two 2/1 black and green Spider creature tokens with reach and menace."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = collectAndCreateSpiders
+        description = "Whenever Izoni enters or attacks, you may collect evidence 4. If you do, " +
+            "create two 2/1 black and green Spider creature tokens with reach and menace."
+    }
+
+    activatedAbility {
+        cost = Costs.SacrificeMultiple(4, GameObjectFilter.Token)
+        effect = Effects.Composite(
+            Patterns.Library.surveil(2),
+            Effects.DrawCards(2),
+            Effects.GainLife(2)
+        )
+        description = "Sacrifice four tokens: Surveil 2, then draw two cards. You gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "209"
+        artist = "Justine Cruz"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70ea66cd-587a-4ca6-87f7-a52c96079e4a.jpg?1783912846"
+
+        ruling(
+            "2024-02-02",
+            "If you can't exile enough cards to meet or exceed the required mana value, you " +
+                "can't choose to collect evidence at all."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -8808,6 +8808,153 @@
     ]
 }
 
+// Izoni, Center of the Web
+{
+    "name": "Izoni, Center of the Web",
+    "manaCost": "{4}{B}{G}",
+    "typeLine": "Legendary Creature — Elf Detective",
+    "oracleText": "Menace\nWhenever Izoni enters or attacks, you may collect evidence 4. If you do, create two 2/1 black and green Spider creature tokens with reach and menace.\nSacrifice four tokens: Surveil 2, then draw two cards. You gain 2 life.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "CollectEvidence",
+                            "amount": 4
+                        }
+                    },
+                    "then": {
+                        "type": "CreateToken",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "power": 2,
+                        "toughness": 1,
+                        "colors": [
+                            "BLACK",
+                            "GREEN"
+                        ],
+                        "creatureTypes": [
+                            "Spider"
+                        ],
+                        "keywords": [
+                            "REACH",
+                            "MENACE"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/7/4/74cb3ba3-9a14-4d72-bf24-0b75ae747f96.jpg?1783912607"
+                    }
+                },
+                "descriptionOverride": "Whenever Izoni enters or attacks, you may collect evidence 4. If you do, create two 2/1 black and green Spider creature tokens with reach and menace."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "CollectEvidence",
+                            "amount": 4
+                        }
+                    },
+                    "then": {
+                        "type": "CreateToken",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "power": 2,
+                        "toughness": 1,
+                        "colors": [
+                            "BLACK",
+                            "GREEN"
+                        ],
+                        "creatureTypes": [
+                            "Spider"
+                        ],
+                        "keywords": [
+                            "REACH",
+                            "MENACE"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/7/4/74cb3ba3-9a14-4d72-bf24-0b75ae747f96.jpg?1783912607"
+                    }
+                },
+                "descriptionOverride": "Whenever Izoni enters or attacks, you may collect evidence 4. If you do, create two 2/1 black and green Spider creature tokens with reach and menace."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "token",
+                        "count": 4
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Surveil",
+                            "count": 2
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Sacrifice four tokens: Surveil 2, then draw two cards. You gain 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "209",
+        "rarity": "RARE",
+        "artist": "Justine Cruz",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/70ea66cd-587a-4ca6-87f7-a52c96079e4a.jpg?1783912846",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If you can't exile enough cards to meet or exceed the required mana value, you can't choose to collect evidence at all."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Jaded Analyst
 {
     "name": "Jaded Analyst",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+import com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver
 import com.wingedsheep.engine.legalactions.utils.CostEnumerationUtils
 import com.wingedsheep.engine.mechanics.mana.CostCalculator
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
@@ -25,6 +26,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
+import com.wingedsheep.sdk.scripting.effects.CollectEvidenceEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.DynamicHint
@@ -628,6 +630,12 @@ class GatedEffectExecutor(
             is PayManaCostRepeatedlyEffect -> PayManaCostRepeatedlyExecutor.affordableRepetitions(
                 state, playerId, cost.cost, cost.maxTimes, cardRegistry
             ) >= 1
+            // Resolution-time collect evidence is also a payable action (Izoni): the player may
+            // choose it only when their graveyard can meet the full mana-value threshold.
+            is CollectEvidenceEffect -> {
+                val collector = TargetResolutionUtils.resolvePlayerRef(cost.player, context, state)
+                collector != null && CollectEvidenceResolver.canCollect(state, collector, cost.amount)
+            }
             is CompositeEffect -> cost.effects.all { canAfford(state, playerId, it, context) }
             // "You may sacrifice [filter]" — payable only if the player controls enough matching
             // permanents (`any = true`, "sacrifice any number", is always payable: zero is legal).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CollectEvidenceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CollectEvidenceScenarioTest.kt
@@ -30,6 +30,7 @@ import com.wingedsheep.sdk.scripting.SpellCostTarget
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
 import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
@@ -194,6 +195,21 @@ class CollectEvidenceScenarioTest : ScenarioTestBase() {
         }
     }
 
+    // Izoni, Center of the Web's shape: collect evidence is the cost of an optional effect.
+    private val optionalCostCollector = card("Optional-Cost Evidence Collector") {
+        manaCost = "{G}"
+        typeLine = "Creature — Elf Detective"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = OptionalCostEffect(
+                cost = Effects.CollectEvidence(4),
+                ifPaid = Effects.GainLife(7),
+            )
+        }
+    }
+
     // Controls for the "separate fact" tests — same rail, different slots.
     private val kickerBear = card("Evidence Kicker Bear") {
         manaCost = "{1}{G}"
@@ -260,6 +276,7 @@ class CollectEvidenceScenarioTest : ScenarioTestBase() {
         cardRegistry.register(collector)
         cardRegistry.register(examiner)
         cardRegistry.register(monitor)
+        cardRegistry.register(optionalCostCollector)
         cardRegistry.register(kickerBear)
         cardRegistry.register(evidenceBearReadsKicked)
 
@@ -485,6 +502,25 @@ class CollectEvidenceScenarioTest : ScenarioTestBase() {
             // and the attacker gained no counter.
             game.state.pendingDecision shouldBe null
             game.containerOf("Evidence Collector").plusOneCounters() shouldBe 0
+        }
+
+        test("collect evidence used as an optional effect cost is not offered when it can't be paid") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardInHand(1, "Optional-Cost Evidence Collector")
+                .withCardInGraveyard(1, "Test Pebble")
+                .withLandsOnBattlefield(1, "Forest", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val life = game.getLifeTotal(1)
+            game.castSpell(1, "Optional-Cost Evidence Collector").error shouldBe null
+            game.resolveStack()
+
+            game.state.pendingDecision shouldBe null
+            game.getLifeTotal(1) shouldBe life
+            game.isInGraveyard(1, "Test Pebble") shouldBe true
         }
 
         // ---------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- implement Izoni, Center of the Web with its enter/attack evidence payment and exact Spider tokens
- implement its four-token sacrifice ability using existing surveil, draw, and life-gain primitives
- teach optional-cost gates to suppress collect-evidence choices that cannot be paid, with focused engine coverage and SDK documentation

Only one card is included because the remaining unimplemented MKM candidates require substantially larger mechanics or bespoke engine vocabulary.

## Verification
- `just test`
- `just test-class CollectEvidenceScenarioTest`
- `just rebless-cards`
- `just check-card-printing "Izoni, Center of the Web"`
- Scryfall card and token image URLs return HTTP 200