### PR TITLE
Add two Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AureliaTheLawAbove.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AureliaTheLawAbove.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.AttackEvent
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.events.AttackPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Aurelia, the Law Above
+ * {3}{R}{W}
+ * Legendary Creature — Angel
+ * 4/4
+ * Flying, vigilance, haste
+ * Whenever a player attacks with three or more creatures, you draw a card.
+ * Whenever a player attacks with five or more creatures, Aurelia deals 3 damage to each of your
+ * opponents and you gain 3 life.
+ *
+ * Each ability observes the single declare-attackers event with an ANY binding. The attacker-count
+ * predicate is evaluated from that event's declared-attacker snapshot, so removing an attacker in
+ * response does not undo either trigger.
+ */
+val AureliaTheLawAbove = card("Aurelia, the Law Above") {
+    manaCost = "{3}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Angel"
+    oracleText = "Flying, vigilance, haste\n" +
+        "Whenever a player attacks with three or more creatures, you draw a card.\n" +
+        "Whenever a player attacks with five or more creatures, Aurelia deals 3 damage to each " +
+        "of your opponents and you gain 3 life."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE, Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = AttackEvent(
+                requires = setOf(AttackPredicate.AttackerCountAtLeast(3))
+            ),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.DrawCards(1)
+        description = "Whenever a player attacks with three or more creatures, you draw a card."
+    }
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = AttackEvent(
+                requires = setOf(AttackPredicate.AttackerCountAtLeast(5))
+            ),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.Composite(
+            Effects.DealDamage(
+                3,
+                EffectTarget.PlayerRef(Player.EachOpponent),
+                damageSource = EffectTarget.Self
+            ),
+            Effects.GainLife(3)
+        )
+        description = "Whenever a player attacks with five or more creatures, Aurelia deals 3 " +
+            "damage to each of your opponents and you gain 3 life."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "188"
+        artist = "Lie Setiawan"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8f80c6e7-e9f9-4ca6-87f7-a52c96079e4a.jpg?1783912856"
+
+        ruling(
+            "2024-02-02",
+            "For both triggered abilities, it doesn't matter what happens to the attacking " +
+                "creatures in response. As long as a player attacked with at least the " +
+                "appropriate number of creatures, the effects of Aurelia's triggered abilities " +
+                "will still occur."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/IntrudeOnTheMind.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/IntrudeOnTheMind.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Intrude on the Mind
+ * {3}{U}{U}
+ * Instant
+ * Reveal the top five cards of your library and separate them into two piles. An opponent chooses
+ * one of those piles. Put that pile into your hand and the other into your graveyard. Create a 0/0
+ * colorless Thopter artifact creature token with flying, then put a +1/+1 counter on it for each
+ * card put into your graveyard this way.
+ *
+ * The pipeline keeps the opponent's chosen pile and the graveyard pile in named collections. The
+ * latter remains available after its cards move, so its distinct-entity count sizes the counters
+ * placed on the freshly created token through the shared CREATED_TOKENS collection.
+ */
+val IntrudeOnTheMind = card("Intrude on the Mind") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Reveal the top five cards of your library and separate them into two piles. An " +
+        "opponent chooses one of those piles. Put that pile into your hand and the other into your " +
+        "graveyard. Create a 0/0 colorless Thopter artifact creature token with flying, then put " +
+        "a +1/+1 counter on it for each card put into your graveyard this way."
+
+    spell {
+        effect = Effects.Pipeline {
+            val revealed = gather(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(5)),
+                revealed = true,
+                name = "revealed"
+            )
+            val separated = chooseAnyNumberSplit(
+                from = revealed,
+                chooser = Chooser.Controller,
+                prompt = "Separate the revealed cards into two piles. The cards you select form " +
+                    "Pile 1; the rest form Pile 2.",
+                selectedLabel = "Pile 1",
+                remainderLabel = "Pile 2",
+                alwaysPrompt = true,
+                name = "pileOne",
+                remainderName = "pileTwo"
+            )
+            val chosen = choosePile(
+                pileA = separated.selected,
+                pileB = separated.remainder,
+                chooser = Chooser.Opponent,
+                prompt = "Choose a pile. That pile goes to your opponent's hand; the other goes " +
+                    "to their graveyard.",
+                chosenName = "handPile",
+                otherName = "graveyardPile"
+            )
+            toHand(chosen.chosen)
+            toGraveyard(chosen.other)
+            run(
+                Effects.CreateToken(
+                    power = 0,
+                    toughness = 0,
+                    colors = emptySet(),
+                    creatureTypes = setOf("Thopter"),
+                    keywords = setOf(Keyword.FLYING),
+                    artifactToken = true,
+                    name = "Thopter",
+                    imageUri = "https://cards.scryfall.io/normal/front/2/2/22ad97f4-cc41-493c-9848-c06f3cf778c7.jpg?1783912603"
+                )
+            )
+            run(
+                Effects.AddCountersToCollection(
+                    CREATED_TOKENS,
+                    Counters.PLUS_ONE_PLUS_ONE,
+                    DynamicAmount.DistinctEntitiesInCollections(listOf(chosen.other.key))
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "61"
+        artist = "Magali Villeneuve"
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fbe62f47-df17-4646-88ca-89a8ec4deee9.jpg?1783912908"
+
+        ruling(
+            "2024-02-02",
+            "You decide which opponent chooses the pile while resolving Intrude on the Mind."
+        )
+        ruling(
+            "2024-02-02",
+            "You may choose to put all of the cards into one pile and leave the other pile empty. " +
+                "If you do, the opponent will choose whether to put the revealed cards into your " +
+                "hand or your graveyard."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -1188,6 +1188,102 @@
     ]
 }
 
+// Aurelia, the Law Above
+{
+    "name": "Aurelia, the Law Above",
+    "manaCost": "{3}{R}{W}",
+    "typeLine": "Legendary Creature — Angel",
+    "oracleText": "Flying, vigilance, haste\nWhenever a player attacks with three or more creatures, you draw a card.\nWhenever a player attacks with five or more creatures, Aurelia deals 3 damage to each of your opponents and you gain 3 life.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE",
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "requires": [
+                        {
+                            "type": "AttackerCountAtLeast",
+                            "n": 3
+                        }
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever a player attacks with three or more creatures, you draw a card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "requires": [
+                        {
+                            "type": "AttackerCountAtLeast",
+                            "n": 5
+                        }
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            },
+                            "damageSource": "Self"
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever a player attacks with five or more creatures, Aurelia deals 3 damage to each of your opponents and you gain 3 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "188",
+        "rarity": "RARE",
+        "artist": "Lie Setiawan",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8f80c6e7-e9f9-4ca6-87f7-a52c96079e4a.jpg?1783912856",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "For both triggered abilities, it doesn't matter what happens to the attacking creatures in response. As long as a player attacked with at least the appropriate number of creatures, the effects of Aurelia's triggered abilities will still occur."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Auspicious Arrival
 {
     "name": "Auspicious Arrival",
@@ -8717,6 +8813,114 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Intrude on the Mind
+{
+    "name": "Intrude on the Mind",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put that pile into your hand and the other into your graveyard. Create a 0/0 colorless Thopter artifact creature token with flying, then put a +1/+1 counter on it for each card put into your graveyard this way.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 5
+                        }
+                    },
+                    "storeAs": "revealed",
+                    "revealed": true
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "revealed",
+                    "selection": "ChooseAnyNumber",
+                    "storeSelected": "pileOne",
+                    "storeRemainder": "pileTwo",
+                    "prompt": "Separate the revealed cards into two piles. The cards you select form Pile 1; the rest form Pile 2.",
+                    "selectedLabel": "Pile 1",
+                    "remainderLabel": "Pile 2",
+                    "alwaysPrompt": true
+                },
+                {
+                    "type": "ChoosePile",
+                    "pileA": "pileOne",
+                    "pileB": "pileTwo",
+                    "chooser": "Opponent",
+                    "storeChosenAs": "handPile",
+                    "storeOtherAs": "graveyardPile",
+                    "prompt": "Choose a pile. That pile goes to your opponent's hand; the other goes to their graveyard."
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "handPile",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "graveyardPile",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    }
+                },
+                {
+                    "type": "CreateToken",
+                    "power": 0,
+                    "toughness": 0,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Thopter"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "name": "Thopter",
+                    "imageUri": "https://cards.scryfall.io/normal/front/2/2/22ad97f4-cc41-493c-9848-c06f3cf778c7.jpg?1783912603",
+                    "artifactToken": true
+                },
+                {
+                    "type": "AddCountersToCollection",
+                    "collectionName": "createdTokens",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "DistinctEntitiesInCollections",
+                        "collections": [
+                            "graveyardPile"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "rarity": "MYTHIC",
+        "artist": "Magali Villeneuve",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fbe62f47-df17-4646-88ca-89a8ec4deee9.jpg?1783912908",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "You decide which opponent chooses the pile while resolving Intrude on the Mind."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "You may choose to put all of the cards into one pile and leave the other pile empty. If you do, the opponent will choose whether to put the revealed cards into your hand or your graveyard."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
## Summary

- **Aurelia, the Law Above** — observes declare-attackers batches with existing attack-count predicates, then draws or composes damage-to-each-opponent with life gain.
- **Intrude on the Mind** — composes the existing reveal/split/opponent-pile-choice pipeline, moves the piles, and sizes a flying Thopter through the created-token collection.

## Scope

Kept the batch to two cards after fidelity review. Lamplight Phoenix was dropped because the current collect-evidence affordability check can count the Phoenix before its required self-exile; Krenko’s Buzzcrusher and Tolsimir, Midnight’s Light need more exact multiplayer/forced-block linkage than the existing card primitives expose. No approximations were shipped.

## Verification

- `just build`
- `just check-card-printing "Aurelia, the Law Above"`
- `just check-card-printing "Intrude on the Mind"`
- `just check-backlog`
- Scryfall card and token image URLs return HTTP 200
- MKM snapshot diff contains only these two cards