### PR TITLE
Add two Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/KrenkosBuzzcrusher.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/KrenkosBuzzcrusher.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Krenko's Buzzcrusher — Murders at Karlov Manor #136
+ * {2}{R}{R} · Artifact Creature — Insect Thopter · Rare
+ * 4/4
+ *
+ * The lands are deliberately selected during resolution rather than declared as targets. One
+ * [Effects.ForEachPlayer] iteration rebinds `Player.You` to that player while preserving
+ * [Chooser.SourceController] for the Buzzcrusher controller's choice. [moveTracked] distinguishes
+ * a land actually destroyed from an indestructible one, so only a successful destruction offers
+ * that land's controller the compensating basic-land search.
+ */
+val KrenkosBuzzcrusher = card("Krenko's Buzzcrusher") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact Creature — Insect Thopter"
+    oracleText = "Flying, trample\n" +
+        "When this creature enters, for each player, destroy up to one nonbasic land that player " +
+        "controls. For each land destroyed this way, its controller may search their library for " +
+        "a basic land card, put it onto the battlefield tapped, then shuffle."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachPlayer(
+            Player.Each,
+            listOf(
+                Effects.Pipeline {
+                    val lands = gather(
+                        CardSource.FromZone(
+                            Zone.BATTLEFIELD,
+                            Player.You,
+                            GameObjectFilter(
+                                cardPredicates = listOf(
+                                    CardPredicate.IsLand,
+                                    CardPredicate.Not(CardPredicate.IsBasicLand),
+                                ),
+                            ),
+                        ),
+                    )
+                    val chosen = chooseUpTo(
+                        1,
+                        from = lands,
+                        chooser = Chooser.SourceController,
+                        prompt = "Choose up to one nonbasic land this player controls to destroy",
+                        useTargetingUI = true,
+                        alwaysPrompt = true,
+                    )
+                    val destroyed = moveTracked(
+                        chosen,
+                        CardDestination.ToZone(Zone.GRAVEYARD),
+                        moveType = MoveType.Destroy,
+                    )
+                    ifNotEmpty(destroyed) {
+                        run(
+                            MayEffect(
+                                Patterns.Library.searchLibrary(
+                                    filter = GameObjectFilter.BasicLand,
+                                    count = 1,
+                                    destination = SearchDestination.BATTLEFIELD,
+                                    entersTapped = true,
+                                ),
+                            ),
+                        )
+                    }
+                },
+            ),
+        )
+        description = "For each player, destroy up to one nonbasic land that player controls. For " +
+            "each land destroyed this way, its controller may search their library for a basic " +
+            "land card, put it onto the battlefield tapped, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "136"
+        artist = "Joshua Raphael"
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0edcda2a-071b-40c5-9fb3-8a4ff87ca00e.jpg?1783912878"
+
+        ruling(
+            "2024-02-02",
+            "None of the nonbasic lands are targets of Krenko's Buzzcrusher's triggered ability.",
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/LamplightPhoenix.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/LamplightPhoenix.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lamplight Phoenix — Murders at Karlov Manor #137
+ * {1}{R}{R} · Creature — Phoenix · Rare
+ * 3/3
+ *
+ * The dies trigger functions from the graveyard so its composite optional payment can exile the
+ * Phoenix itself before collecting evidence. That ordering matters: the Phoenix is no longer in
+ * the graveyard when the evidence selection is made, so it cannot help pay its own evidence cost.
+ * The payment composite stops on failure, and the return happens only after both parts succeed.
+ */
+val LamplightPhoenix = card("Lamplight Phoenix") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Phoenix"
+    oracleText = "Flying\n" +
+        "When this creature dies, you may exile it and collect evidence 4. If you do, return this " +
+        "card to the battlefield tapped. (To collect evidence 4, exile cards with total mana " +
+        "value 4 or greater from your graveyard.)"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        triggerZone = Zone.GRAVEYARD
+        effect = OptionalCostEffect(
+            cost = Effects.Composite(
+                Effects.Exile(EffectTarget.Self, fromZone = Zone.GRAVEYARD),
+                Effects.CollectEvidence(4),
+            ),
+            ifPaid = Effects.PutOntoBattlefield(EffectTarget.Self, tapped = true),
+        )
+        description = "When this creature dies, you may exile it and collect evidence 4. If you " +
+            "do, return this card to the battlefield tapped."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "137"
+        artist = "Ryan Pancoast"
+        flavorText = "The only warning was the faint smell of burning plasma."
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2faa0e56-527c-4be5-b8c9-b10ccde275f5.jpg?1783912876"
+
+        ruling(
+            "2024-02-02",
+            "You can't exile Lamplight Phoenix from your graveyard to pay the collect evidence " +
+                "cost of its triggered ability.",
+        )
+        ruling(
+            "2024-02-02",
+            "If you can't exile enough cards to meet or exceed the required mana value, you " +
+                "can't choose to collect evidence at all.",
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -9558,6 +9558,149 @@
     ]
 }
 
+// Krenko's Buzzcrusher
+{
+    "name": "Krenko's Buzzcrusher",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Artifact Creature — Insect Thopter",
+    "oracleText": "Flying, trample\nWhen this creature enters, for each player, destroy up to one nonbasic land that player controls. For each land destroyed this way, its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "Each"
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Battlefield",
+                                    "filter": {
+                                        "cardPredicates": [
+                                            "IsLand",
+                                            {
+                                                "type": "Not",
+                                                "predicate": "IsBasicLand"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "storeAs": "gathered0"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "gathered0",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "chooser": "SourceController",
+                                "storeSelected": "selected1",
+                                "prompt": "Choose up to one nonbasic land this player controls to destroy",
+                                "useTargetingUI": true,
+                                "alwaysPrompt": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "selected1",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Destroy",
+                                "storeMovedAs": "moved2"
+                            },
+                            {
+                                "type": "ConditionalOnCollection",
+                                "collection": "moved2",
+                                "ifNotEmpty": {
+                                    "type": "Gated",
+                                    "gate": "Gate.MayDecide",
+                                    "then": {
+                                        "type": "Composite",
+                                        "effects": [
+                                            {
+                                                "type": "GatherCards",
+                                                "source": {
+                                                    "type": "FromZone",
+                                                    "zone": "Library",
+                                                    "filter": "basicland"
+                                                },
+                                                "storeAs": "searchable"
+                                            },
+                                            {
+                                                "type": "SelectFromCollection",
+                                                "from": "searchable",
+                                                "selection": {
+                                                    "type": "ChooseUpTo",
+                                                    "count": {
+                                                        "type": "Fixed",
+                                                        "amount": 1
+                                                    }
+                                                },
+                                                "storeSelected": "found"
+                                            },
+                                            {
+                                                "type": "MoveCollection",
+                                                "from": "found",
+                                                "destination": {
+                                                    "type": "ToZone",
+                                                    "zone": "Battlefield",
+                                                    "placement": "Tapped"
+                                                }
+                                            },
+                                            "ShuffleLibrary",
+                                            "EmitLibrarySearchedEvent"
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "For each player, destroy up to one nonbasic land that player controls. For each land destroyed this way, its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "RARE",
+        "artist": "Joshua Raphael",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0edcda2a-071b-40c5-9fb3-8a4ff87ca00e.jpg?1783912878",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "None of the nonbasic lands are targets of Krenko's Buzzcrusher's triggered ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Krenko, Baron of Tin Street
 {
     "name": "Krenko, Baron of Tin Street",
@@ -9792,6 +9935,84 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Lamplight Phoenix
+{
+    "name": "Lamplight Phoenix",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Creature — Phoenix",
+    "oracleText": "Flying\nWhen this creature dies, you may exile it and collect evidence 4. If you do, return this card to the battlefield tapped. (To collect evidence 4, exile cards with total mana value 4 or greater from your graveyard.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "MoveToZone",
+                                    "target": "Self",
+                                    "destination": "Exile",
+                                    "fromZone": "Graveyard"
+                                },
+                                {
+                                    "type": "CollectEvidence",
+                                    "amount": 4
+                                }
+                            ]
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Battlefield",
+                        "placement": "Tapped"
+                    }
+                },
+                "activeZones": [
+                    "Graveyard"
+                ],
+                "descriptionOverride": "When this creature dies, you may exile it and collect evidence 4. If you do, return this card to the battlefield tapped."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "rarity": "RARE",
+        "artist": "Ryan Pancoast",
+        "flavorText": "The only warning was the faint smell of burning plasma.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2faa0e56-527c-4be5-b8c9-b10ccde275f5.jpg?1783912876",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "You can't exile Lamplight Phoenix from your graveyard to pay the collect evidence cost of its triggered ability."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If you can't exile enough cards to meet or exceed the required mana value, you can't choose to collect evidence at all."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 


### PR DESCRIPTION
## Summary

- **Lamplight Phoenix** — composes the existing dies trigger, graveyard self-exile, collect-evidence gate, and tapped self-return primitives; the payment order prevents the Phoenix from paying for its own evidence cost.
- **Krenko's Buzzcrusher** — composes per-player iteration, non-targeting battlefield selection, tracked destruction, and the existing optional basic-land search pipeline.

Scope is intentionally limited to two cards because the remaining MKM backlog is dominated by cards requiring unsupported or substantially more complex mechanics.

## Verification

- `just build`
- `just check-card-printing "Lamplight Phoenix"`
- `just check-card-printing "Krenko's Buzzcrusher"`
- `just check-backlog`
- Scryfall field-by-field re-verification and image HTTP 200 checks
- MKM snapshot inspected: only these two card trees were added