### PR TITLE
Add Culling Scales to Mirrodin

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4065,6 +4065,9 @@ work for abilities-on-stack (which carry no `CardComponent`).
   `hasLeastPower()`) — has the greatest / least projected power among creatures *its controller*
   controls (ties all qualify). Used for "creature with the greatest/least power" target and edict
   filters, e.g. Witch-king, Bringer of Ruin: `Effects.Sacrifice(Creature.hasLeastPower(), 1, EachOpponent)`.
+- `HasLeastManaValueAmong(candidates)` (filter builder `hasLeastManaValueAmong(candidates)`) — has the
+  least mana value among battlefield permanents matching the supplied composable filter. Ties all
+  qualify, and target legality is rechecked at resolution (Culling Scales).
 - `IsRingBearer` (filter builder `ringBearer()`) — the creature is its controller's Ring-bearer
   (CR 701.54: has `RingBearerComponent` and is controlled by its designating owner). Used for
   player-level Ring-bearer conditions via `Conditions.YouControl(Creature.ringBearer(), negate = …)`

--- a/manual-scenarios/cards/c/culling-scales-lowest-mana-value.json
+++ b/manual-scenarios/cards/c/culling-scales-lowest-mana-value.json
@@ -1,0 +1,32 @@
+{
+  "player1Name": "Scales Controller",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Culling Scales"},
+      {"name": "Chromatic Sphere"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Myr Moonvessel"},
+      {"name": "Hill Giant"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "ENDING",
+  "step": "END",
+  "activePlayer": 2,
+  "priorityPlayer": 2,
+  "player1StopAtSteps": ["UPKEEP"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -1099,6 +1099,11 @@ data class GameObjectFilter(
         statePredicates = statePredicates + StatePredicate.HasLeastPowerAmongAllCreatures
     )
 
+    /** Must have the least mana value among battlefield permanents matching [candidates]. */
+    fun hasLeastManaValueAmong(candidates: GameObjectFilter) = copy(
+        statePredicates = statePredicates + StatePredicate.HasLeastManaValueAmong(candidates)
+    )
+
     /** Must have the least power among creatures its controller controls */
     fun hasLeastPower() = copy(
         statePredicates = statePredicates + StatePredicate.HasLeastPower

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.sdk.scripting.predicates
 
 import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -535,6 +536,18 @@ sealed interface StatePredicate {
     @Serializable
     data object HasLeastPowerAmongAllCreatures : Entity {
         override val description: String = "with the least power"
+    }
+
+    /**
+     * Has the least mana value among battlefield permanents matching [candidates]. Ties match every
+     * permanent sharing the minimum, allowing ordinary target selection to choose among them.
+     */
+    @SerialName("HasLeastManaValueAmong")
+    @Serializable
+    data class HasLeastManaValueAmong(
+        val candidates: GameObjectFilter
+    ) : Entity {
+        override val description: String = "with the least mana value among ${candidates.description}"
     }
 
     /** Has the least power among creatures its controller controls */

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/CullingScales.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/CullingScales.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Culling Scales
+ * {3}
+ * Artifact
+ *
+ * At the beginning of your upkeep, destroy target nonland permanent with the lowest mana value.
+ * (If two or more permanents are tied for lowest, target any one of them.)
+ */
+val CullingScales = card("Culling Scales") {
+    manaCost = "{3}"
+    typeLine = "Artifact"
+    oracleText = "At the beginning of your upkeep, destroy target nonland permanent with the " +
+        "lowest mana value. (If two or more permanents are tied for lowest, target any one of them.)"
+
+    val abilityText = oracleText
+    val nonlandPermanents = GameObjectFilter.NonlandPermanent
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        target = TargetObject(
+            filter = TargetFilter(nonlandPermanents.hasLeastManaValueAmong(nonlandPermanents))
+        )
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+        description = abilityText
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "160"
+        artist = "Daren Bader"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db9a57d6-bba6-463d-ad12-6f93c035d16b.jpg?1783944524"
+        ruling("2004-12-01", "You choose the target. If there's more than one nonland permanent tied for lowest mana value, you choose which one to target.")
+        ruling("2004-12-01", "If the targeted permanent doesn't have the lowest mana value when the ability resolves, the ability doesn't resolve and the permanent isn't destroyed.")
+        ruling("2004-12-01", "Most tokens have a mana value of 0. A token that's a copy of another permanent or card has a mana value equal to that permanent or card's mana value.")
+        ruling("2004-12-01", "If the lowest mana value is 3, Culling Scales can destroy itself.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CullingScalesScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CullingScalesScenarioTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/** Scenario coverage for Culling Scales (MRD #160). */
+class CullingScalesScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(testCreature("One-Mana Test Creature", "{1}"))
+        cardRegistry.register(testCreature("Another One-Mana Test Creature", "{1}"))
+        cardRegistry.register(testCreature("Four-Mana Test Creature", "{4}"))
+        cardRegistry.register(testCreature("Zero-Mana Test Token", null))
+
+        context("Culling Scales upkeep trigger") {
+            test("only permanents tied for the lowest mana value are legal targets") {
+                val game = upkeepScenario(
+                    "One-Mana Test Creature",
+                    "Another One-Mana Test Creature",
+                    "Four-Mana Test Creature"
+                )
+
+                advanceToScalesTargetChoice(game)
+                val expensive = game.findPermanent("Four-Mana Test Creature").shouldNotBeNull()
+                withClue("A higher-mana-value permanent is not a legal target") {
+                    game.selectTargets(listOf(expensive)).error.shouldNotBeNull()
+                }
+
+                val tiedMinimum = game.findPermanent("Another One-Mana Test Creature").shouldNotBeNull()
+                game.selectTargets(listOf(tiedMinimum)).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Another One-Mana Test Creature") shouldBe false
+                game.isOnBattlefield("One-Mana Test Creature") shouldBe true
+            }
+
+            test("a target that is no longer a minimum at resolution is not destroyed") {
+                val game = upkeepScenario("One-Mana Test Creature", "Four-Mana Test Creature")
+                advanceToScalesTargetChoice(game)
+
+                val target = game.findPermanent("One-Mana Test Creature").shouldNotBeNull()
+                val bystander = game.findPermanent("Four-Mana Test Creature").shouldNotBeNull()
+                game.selectTargets(listOf(target)).error shouldBe null
+
+                // A face-down permanent has mana value 0. Making the bystander face down after
+                // targets are chosen causes the original target to fail its resolution-time check.
+                val bystanderContainer = game.state.getEntity(bystander).shouldNotBeNull()
+                game.state = game.state.withEntity(bystander, bystanderContainer.with(FaceDownComponent))
+                game.resolveStack()
+
+                withClue("The former minimum remains because the ability has no legal target") {
+                    game.isOnBattlefield("One-Mana Test Creature") shouldBe true
+                }
+            }
+
+            test("a mana-value-zero token is the minimum") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Culling Scales")
+                    .withCardOnBattlefield(2, "Zero-Mana Test Token", isToken = true)
+                    .withCardOnBattlefield(2, "One-Mana Test Creature")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                advanceToScalesTargetChoice(game)
+                val token = game.findPermanent("Zero-Mana Test Token").shouldNotBeNull()
+                game.selectTargets(listOf(token)).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Zero-Mana Test Token") shouldBe false
+                game.isOnBattlefield("One-Mana Test Creature") shouldBe true
+            }
+
+            test("can destroy itself when it is the lowest-mana-value nonland permanent") {
+                val game = upkeepScenario("Four-Mana Test Creature")
+                advanceToScalesTargetChoice(game)
+
+                val scales = game.findPermanent("Culling Scales").shouldNotBeNull()
+                game.selectTargets(listOf(scales)).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Culling Scales") shouldBe false
+                game.isInGraveyard(1, "Culling Scales") shouldBe true
+            }
+        }
+    }
+
+    private fun upkeepScenario(vararg permanents: String): TestGame {
+        var builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Culling Scales")
+            .withCardInLibrary(1, "Forest")
+            .withCardInLibrary(2, "Forest")
+            .withActivePlayer(2)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        permanents.forEach { builder = builder.withCardOnBattlefield(2, it) }
+        return builder.build()
+    }
+
+    private fun advanceToScalesTargetChoice(game: TestGame) {
+        game.passUntilPhase(Phase.ENDING, Step.END)
+        game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+        game.resolveStack()
+        game.getPendingDecision().shouldNotBeNull()
+    }
+
+    private fun testCreature(name: String, cost: String?): CardDefinition = CardDefinition.creature(
+        name = name,
+        manaCost = cost?.let(ManaCost::parse) ?: ManaCost.ZERO,
+        subtypes = setOf(Subtype("Construct")),
+        power = 1,
+        toughness = 1
+    )
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -2146,6 +2146,82 @@
     ]
 }
 
+// Culling Scales
+{
+    "name": "Culling Scales",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "At the beginning of your upkeep, destroy target nonland permanent with the lowest mana value. (If two or more permanents are tied for lowest, target any one of them.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsNonland",
+                                "IsPermanent"
+                            ],
+                            "statePredicates": [
+                                {
+                                    "type": "HasLeastManaValueAmong",
+                                    "candidates": {
+                                        "cardPredicates": [
+                                            "IsNonland",
+                                            "IsPermanent"
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "descriptionOverride": "At the beginning of your upkeep, destroy target nonland permanent with the lowest mana value. (If two or more permanents are tied for lowest, target any one of them.)"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "rarity": "RARE",
+        "artist": "Daren Bader",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db9a57d6-bba6-463d-ad12-6f93c035d16b.jpg?1783944524",
+        "rulings": [
+            {
+                "date": "2004-12-01",
+                "text": "You choose the target. If there's more than one nonland permanent tied for lowest mana value, you choose which one to target."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "If the targeted permanent doesn't have the lowest mana value when the ability resolves, the ability doesn't resolve and the permanent isn't destroyed."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "Most tokens have a mana value of 0. A token that's a copy of another permanent or card has a mana value equal to that permanent or card's mana value."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "If the lowest mana value is 3, Culling Scales can destroy itself."
+            }
+        ]
+    }
+}
+
 // Damping Matrix
 {
     "name": "Damping Matrix",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -508,6 +508,10 @@ class BeginningPhaseManager(
         is StatePredicate.Or -> predicate.predicates.any { matchesStatePredicateForUntap(it, container) }
         is StatePredicate.And -> predicate.predicates.all { matchesStatePredicateForUntap(it, container) }
         is StatePredicate.Not -> !matchesStatePredicateForUntap(predicate.predicate, container)
+        // Relational battlefield predicates need the whole projected battlefield, which this
+        // narrow untap helper deliberately does not receive. Fail closed rather than untapping an
+        // unrelated permanent.
+        is StatePredicate.HasLeastManaValueAmong -> false
         // Untap-during-other-untap-step filters only meaningfully restrict by counter type
         // and structural combinators. Tap / combat / face-down / damage-history / equipment
         // predicates would either be redundant at this point in the turn (e.g. IsTapped is

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -2124,6 +2124,9 @@ class TriggerMatcher(
             predicate.predicates.all { matchesStatePredicateForTrigger(it, state, entityId) }
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.Not ->
             !matchesStatePredicateForTrigger(predicate.predicate, state, entityId)
+        // This relational predicate is a targeting/gathering constraint. Trigger matching has no
+        // ability-controller context with which to evaluate an arbitrary candidate filter.
+        is com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasLeastManaValueAmong -> false
         // Trigger-matching predicates beyond IsFaceDown are not currently used as
         // *trigger-gating* filters (those evaluate the triggering entity, not the source
         // state). Returning true preserves the prior "don't gate" behavior, but listing

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1646,6 +1646,26 @@ class PredicateEvaluator {
                 entityPower <= minPower
             }
 
+            is StatePredicate.HasLeastManaValueAmong -> {
+                val predicateContext = context ?: return false
+                val entityManaValue = if (projected.getProjectedValues(entityId)?.isFaceDown == true) {
+                    0
+                } else {
+                    container.get<CardComponent>()?.manaValue ?: return false
+                }
+                val minManaValue = state.getBattlefield()
+                    .asSequence()
+                    .filter { matches(state, projected, it, predicate.candidates, predicateContext) }
+                    .mapNotNull { candidateId ->
+                        val candidate = state.getEntity(candidateId) ?: return@mapNotNull null
+                        if (projected.getProjectedValues(candidateId)?.isFaceDown == true) 0
+                        else candidate.get<CardComponent>()?.manaValue
+                    }
+                    .minOrNull()
+                    ?: return false
+                entityManaValue == minManaValue
+            }
+
             StatePredicate.HasLeastPower -> {
                 val entityController = projected.getController(entityId)
                     ?: container.get<ControllerComponent>()?.playerId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -588,6 +588,10 @@ internal class AffectsFilterResolver {
         is StatePredicate.WasCastFromZone -> false
         StatePredicate.HasGreatestPower -> hasGreatestPowerInProjection(state, entityId, container, projectedValues)
         StatePredicate.HasLeastPowerAmongAllCreatures -> hasLeastPowerAmongAllCreaturesInProjection(state, entityId, container, projectedValues)
+        // Relational minimum-mana-value matching is intended for point-of-use filters (targeting
+        // and gathering), where PredicateEvaluator has the full ability context. It is not a
+        // continuous-effect applicability predicate.
+        is StatePredicate.HasLeastManaValueAmong -> false
         StatePredicate.HasLeastPower -> hasLeastPowerInProjection(state, entityId, container, projectedValues)
         StatePredicate.HasAnyCounter -> {
             val counters = container.get<CountersComponent>()


### PR DESCRIPTION
## Summary

- implement Culling Scales with authoritative Mirrodin metadata
- add a reusable lowest-mana-value state predicate for relational targeting
- document the SDK addition and add a manual scenario

Only one card is included because Mirrodin’s remaining backlog is the complex tail, and this card required new engine/SDK vocabulary. Per the add-card workflow, cards needing new vocabulary are kept in their own PR.

## Verification

- `just test-class CullingScalesScenarioTest` (4 scenarios)
- `just rebless-cards`
- `just check-card-printing "Culling Scales"`
- `just test` (115 actionable tasks; BUILD SUCCESSFUL)
- `git diff --check`