### PR TITLE
Add Reenact the Crime

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ReenactTheCrime.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ReenactTheCrime.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Reenact the Crime — Murders at Karlov Manor #70
+ * {1}{U}{U}{U} · Instant
+ *
+ * Exile target nonland card in a graveyard that was put there from anywhere this turn. Copy it.
+ * You may cast the copy without paying its mana cost.
+ *
+ * The graveyard-history predicate deliberately accepts a card put there from any zone, not merely
+ * one that died. The resolution then uses the shared exile → copy → optional free-cast pipeline.
+ * The cast happens during this spell's resolution; declining leaves a phantom copy that the
+ * state-based-action check removes.
+ */
+val ReenactTheCrime = card("Reenact the Crime") {
+    manaCost = "{1}{U}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Exile target nonland card in a graveyard that was put there from anywhere this " +
+        "turn. Copy it. You may cast the copy without paying its mana cost."
+
+    spell {
+        val reenacted = target(
+            "target nonland card in a graveyard that was put there from anywhere this turn",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Nonland.putIntoGraveyardThisTurn(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.Composite(
+            Effects.Move(reenacted, Zone.EXILE, fromZone = Zone.GRAVEYARD),
+            Effects.CopyCardIntoCollection(reenacted, storeAs = "copy"),
+            MayEffect(
+                Effects.CastFromCollectionWithoutPayingCost("copy"),
+                descriptionOverride = "You may cast the copy without paying its mana cost."
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "70"
+        artist = "Daarken"
+        flavorText = "At Proft's command, an ethereal model of the ransacked workshop sprang " +
+            "into being, every detail perfectly recreated. He'd missed something—he knew it—but what?"
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/" +
+            "d942e4ce-f582-4264-89aa-9b4a743e6b29.jpg?1783912905"
+
+        ruling(
+            "2024-02-02",
+            "You cast the copy while Reenact the Crime is resolving and still on the stack. You " +
+                "can't wait to cast it later in the turn."
+        )
+        ruling(
+            "2024-02-02",
+            "If a spell has {X} in its mana cost, you must choose 0 as the value of X when casting " +
+                "it without paying its mana cost."
+        )
+        ruling(
+            "2024-02-02",
+            "If you cast a spell without paying its mana cost, you can't choose an alternative " +
+                "cost, but you may pay optional additional costs and must pay mandatory additional costs."
+        )
+        ruling(
+            "2024-02-02",
+            "If you don't cast the copy, it ceases to exist the next time state-based actions are checked."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -13739,6 +13739,92 @@
     ]
 }
 
+// Reenact the Crime
+{
+    "name": "Reenact the Crime",
+    "manaCost": "{1}{U}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target nonland card in a graveyard that was put there from anywhere this turn. Copy it. You may cast the copy without paying its mana cost.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target nonland card in a graveyard that was put there from anywhere this turn"
+                    },
+                    "destination": "Exile",
+                    "fromZone": "Graveyard"
+                },
+                {
+                    "type": "CopyCardIntoCollection",
+                    "source": {
+                        "type": "BoundVariable",
+                        "name": "target nonland card in a graveyard that was put there from anywhere this turn"
+                    },
+                    "storeAs": "copy"
+                },
+                {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "CastFromCollectionWithoutPayingCost",
+                        "from": "copy"
+                    },
+                    "descriptionOverride": "You may cast the copy without paying its mana cost."
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsNonland"
+                        ],
+                        "statePredicates": [
+                            "PutIntoGraveyardThisTurn"
+                        ]
+                    },
+                    "zone": "Graveyard"
+                },
+                "id": "target nonland card in a graveyard that was put there from anywhere this turn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "rarity": "RARE",
+        "artist": "Daarken",
+        "flavorText": "At Proft's command, an ethereal model of the ransacked workshop sprang into being, every detail perfectly recreated. He'd missed something—he knew it—but what?",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d942e4ce-f582-4264-89aa-9b4a743e6b29.jpg?1783912905",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "You cast the copy while Reenact the Crime is resolving and still on the stack. You can't wait to cast it later in the turn."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a spell has {X} in its mana cost, you must choose 0 as the value of X when casting it without paying its mana cost."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If you cast a spell without paying its mana cost, you can't choose an alternative cost, but you may pay optional additional costs and must pay mandatory additional costs."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If you don't cast the copy, it ceases to exist the next time state-based actions are checked."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Relive the Past
 {
     "name": "Relive the Past",


### PR DESCRIPTION
## Summary

- **Reenact the Crime** — composes the existing graveyard-history target predicate with exile, card-copy, and optional free-cast primitives.

## Scope

The remaining MKM backlog is mechanic-heavy, so this batch was intentionally reduced to one card. Airtight Alibi needs a missing “can’t become suspected” rule, while Anzrag’s Rampage needs turn-history accounting that includes artifact tokens after they cease to exist; both were dropped rather than approximated.

## Verification

- `just check-card-printing "Reenact the Crime"`
- `just build`
- `just rebless-cards` (MKM snapshot changed only for Reenact the Crime)
- final field-by-field Scryfall recheck