### PR TITLE
Make a Mount's saddle state readable, and its cost easier to pay

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7542,13 +7542,23 @@ composite abilities).
   Conditions.SourceIsSaddled` for "whenever this attacks while saddled"). The marker (engine
   `SaddledComponent`) is cleared at end of turn or when the permanent leaves the battlefield, and
   is not a copiable value (CR 702.171b). Mounts that gate on the saddled state use this.
+  Both halves reach the client on the card itself: `ClientCard.saddleRequirement` (the printed N,
+  present on every battlefield Mount) and `ClientCard.isSaddled` (the live designation). Both are
+  public — a saddled Mount and an unsaddled one are otherwise identical permanents, and the
+  designation expires at cleanup with no event of its own.
 - `CrewSaddleContribution(characteristic = POWER, modifier = 0)` — changes only the numeric value
   a creature contributes while paying a Crew or Saddle cost; it does not change that creature's
   power or toughness. The selected `characteristic` is read from projected state before `modifier`
   is applied, so counters and continuous effects are honored. Pilot text such as “saddles Mounts
   and crews Vehicles as though its power were 2 greater” uses `modifier = 2`; “using its toughness
   rather than its power” uses `characteristic = CrewSaddleCharacteristic.TOUGHNESS`. Printed and
-  token-granted instances use the same handler path.
+  token-granted instances use the same handler path. The Crew and Saddle **enumerators** report each
+  candidate's contribution through this same evaluator, so `LegalActionInfo.tapForPowerCreatures[].power`
+  is the number the handler charges against, not the creature's printed power — the client's progress
+  bar would otherwise refuse a crew or saddle the engine accepts. (Teamwork N deliberately keeps
+  counting plain projected power; the *measure* is what differs between the two costs.) Each candidate
+  also carries `canAttack`, the per-creature CR 508.1a attack check via `AttackAvailability`, since
+  paying the cost taps the creature out of combat.
 - `Modular(n)` — ETB with +1/+1 counters, transfer on death. Display-only; nothing in the engine
   reads `Keyword.MODULAR`. Lower it alongside the keyword ability as its two printed halves
   (Arcbound Condor): `replacementEffect(EntersWithCounters(CounterTypeFilter.PlusOnePlusOne, n,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
@@ -336,7 +336,22 @@ data class DelveCardData(
 data class TapForPowerCreatureData(
     val entityId: EntityId,
     val name: String,
-    val power: Int
+    /**
+     * What this creature contributes toward the cost. For Crew and Saddle that is its
+     * `CrewSaddleContributionEvaluator` value — the same measure the handlers charge against, which
+     * a "crews as though its power were 2 greater" static can raise above its printed power. For
+     * Teamwork N it is plain projected power, which is what that cost counts.
+     */
+    val power: Int,
+    /**
+     * Whether this creature could legally be declared as an attacker in the current state — the
+     * per-creature attack restrictions of CR 508.1a evaluated by
+     * [com.wingedsheep.engine.mechanics.combat.rules.AttackAvailability]. Tapping a creature to pay
+     * a Crew / Saddle / Teamwork cost takes it out of combat (CR 508.1a: an attacker must be
+     * untapped), so the client sorts its auto-pick to spend the creatures that weren't going to
+     * attack anyway, and marks the ones that were.
+     */
+    val canAttack: Boolean = true
 )
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CrewEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CrewEnumerator.kt
@@ -1,13 +1,16 @@
 package com.wingedsheep.engine.legalactions.enumerators
 
 import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.handlers.actions.ability.CrewSaddleContributionEvaluator
 import com.wingedsheep.engine.legalactions.ActionEnumerator
 import com.wingedsheep.engine.legalactions.TapForPowerCreatureData
 import com.wingedsheep.engine.legalactions.EnumerationContext
 import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.mechanics.combat.rules.AttackAvailability
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.KeywordAbility
 
 /**
@@ -24,6 +27,9 @@ class CrewEnumerator : ActionEnumerator {
         val state = context.state
         val playerId = context.playerId
         val projected = context.projected
+        // Every Vehicle sees the same candidate creatures, so answer "could it attack?" once per
+        // creature rather than once per (Vehicle, creature) pair.
+        val canAttackCache = HashMap<EntityId, Boolean>()
 
         for (entityId in context.battlefieldPermanents) {
             val container = state.getEntity(entityId) ?: continue
@@ -63,10 +69,21 @@ class CrewEnumerator : ActionEnumerator {
                 if (!projected.isCreature(creatureId)) continue
                 val creatureContainer = state.getEntity(creatureId) ?: continue
                 if (creatureContainer.has<TappedComponent>()) continue
-                // Summoning sickness does NOT prevent crewing
-                val power = projected.getPower(creatureId) ?: 0
+                // Summoning sickness does NOT prevent crewing.
+                // What it contributes, not its raw power — `CrewVehicleHandler` measures the cost
+                // through the same evaluator, so a creature that "crews Vehicles as though its
+                // power were 2 greater" must read that way here or the client's progress bar would
+                // refuse a crew the engine accepts.
+                val power = CrewSaddleContributionEvaluator.evaluate(
+                    state, projected, context.cardRegistry, creatureId
+                )
                 val creatureName = creatureContainer.get<CardComponent>()?.name ?: "Unknown"
-                validCrewCreatures.add(TapForPowerCreatureData(creatureId, creatureName, power))
+                val canAttack = canAttackCache.getOrPut(creatureId) {
+                    AttackAvailability.canAttack(state, projected, creatureId, playerId, context.cardRegistry)
+                }
+                validCrewCreatures.add(
+                    TapForPowerCreatureData(creatureId, creatureName, power, canAttack)
+                )
                 totalAvailablePower += power
             }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/SaddleEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/SaddleEnumerator.kt
@@ -4,10 +4,14 @@ import com.wingedsheep.engine.core.SaddleMount
 import com.wingedsheep.engine.legalactions.ActionEnumerator
 import com.wingedsheep.engine.legalactions.EnumerationContext
 import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.handlers.actions.ability.CrewSaddleContributionEvaluator
 import com.wingedsheep.engine.legalactions.TapForPowerCreatureData
+import com.wingedsheep.engine.mechanics.combat.rules.AttackAvailability
+import com.wingedsheep.engine.state.components.battlefield.SaddledComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.KeywordAbility
 
 /**
@@ -29,6 +33,9 @@ class SaddleEnumerator : ActionEnumerator {
         val state = context.state
         val playerId = context.playerId
         val projected = context.projected
+        // Every Mount sees the same candidate creatures, so answer "could it attack?" once per
+        // creature rather than once per (Mount, creature) pair.
+        val canAttackCache = HashMap<EntityId, Boolean>()
 
         for (entityId in context.battlefieldPermanents) {
             val container = state.getEntity(entityId) ?: continue
@@ -50,17 +57,37 @@ class SaddleEnumerator : ActionEnumerator {
                 if (!projected.isCreature(creatureId)) continue
                 val creatureContainer = state.getEntity(creatureId) ?: continue
                 if (creatureContainer.has<TappedComponent>()) continue
-                val power = projected.getPower(creatureId) ?: 0
+                // What it contributes, not its raw power — `SaddleMountHandler` measures the cost
+                // through the same evaluator, so a creature that "saddles as though its power were
+                // 2 greater" must read that way here or the client's progress bar would refuse a
+                // saddle the engine accepts.
+                val power = CrewSaddleContributionEvaluator.evaluate(
+                    state, projected, context.cardRegistry, creatureId
+                )
                 val creatureName = creatureContainer.get<CardComponent>()?.name ?: "Unknown"
-                validSaddleCreatures.add(TapForPowerCreatureData(creatureId, creatureName, power))
+                val canAttack = canAttackCache.getOrPut(creatureId) {
+                    AttackAvailability.canAttack(state, projected, creatureId, playerId, context.cardRegistry)
+                }
+                validSaddleCreatures.add(
+                    TapForPowerCreatureData(creatureId, creatureName, power, canAttack)
+                )
                 totalAvailablePower += power
             }
 
             val canAfford = totalAvailablePower >= saddleAbility.n
+            // Saddle has no once-each-turn clause (CR 702.171a), and re-activating it adds
+            // saddlers that "creatures that saddled it this turn" payoffs count — so keep offering
+            // it on an already-saddled Mount, but label it so the player doesn't spend creatures
+            // thinking they still need the designation.
+            val alreadySaddled = container.has<SaddledComponent>()
             result.add(
                 LegalAction(
                     actionType = "SaddleMount",
-                    description = "Saddle ${cardComponent.name}",
+                    description = if (alreadySaddled) {
+                        "Saddle ${cardComponent.name} again"
+                    } else {
+                        "Saddle ${cardComponent.name}"
+                    },
                     action = SaddleMount(playerId, entityId, emptyList()),
                     affordable = canAfford,
                     tapForPower = true,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackAvailability.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackAvailability.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.engine.mechanics.combat.rules
+
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * "Could this creature be declared as an attacker right now?" — the per-creature half of the
+ * declare-attackers legality check (CR 508.1a), asked outside the declare-attackers step.
+ *
+ * It runs the very same [defaultAttackRestrictionRules] list that [
+ * com.wingedsheep.engine.mechanics.combat.AttackPhaseManager] enforces when attackers are actually
+ * declared, so the two can never drift: if this says a creature can attack, declaring it would pass
+ * the per-creature gate. It deliberately does *not* consider the per-defender rules
+ * ([defaultAttackDefenderRules]) — those need a chosen defender, which doesn't exist yet.
+ *
+ * The caller is a cost enumerator: tapping a creature to pay Crew N / Saddle N / Teamwork N takes it
+ * out of combat, because an attacker must be untapped. Surfacing this on each candidate lets the
+ * client spend the creatures that weren't going to attack anyway.
+ */
+object AttackAvailability {
+
+    private val rules: List<AttackRestrictionRule> = defaultAttackRestrictionRules()
+
+    /**
+     * True iff [entityId] passes every per-creature attack restriction for [playerId] in [state].
+     * [projected] must be the projection the caller is already working with — attack legality reads
+     * projected types, keywords and controller, so base state would miss animated lands, granted
+     * haste, and control changes.
+     */
+    fun canAttack(
+        state: GameState,
+        projected: ProjectedState,
+        entityId: EntityId,
+        playerId: EntityId,
+        cardRegistry: CardRegistry
+    ): Boolean {
+        val ctx = AttackCheckContext(
+            state = state,
+            projected = projected,
+            attackerId = entityId,
+            attackingPlayer = playerId,
+            cardRegistry = cardRegistry
+        )
+        return rules.all { it.check(ctx) == null }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -337,6 +337,22 @@ data class ClientCard(
     /** Whether this permanent is suspected (CR 701.60 — has menace and can't block). Battlefield only. */
     val isSuspected: Boolean = false,
 
+    /**
+     * Saddle N (CR 702.171a) printed on this permanent, or null if it has no saddle ability.
+     * Battlefield only. Sent for every player's Mounts, not just the controller's: whether a Mount
+     * is saddled is public information that changes how the table blocks, and the number is the
+     * only way to read how much power the controller has to spend to turn it on.
+     */
+    val saddleRequirement: Int? = null,
+
+    /**
+     * Whether this permanent is currently saddled (CR 702.171b) — the designation a resolved Saddle
+     * ability grants until end of turn. Battlefield only. Mount payoffs are gated on it, and it
+     * silently expires at cleanup, so without a flag a saddled Mount and an unsaddled one are
+     * indistinguishable on the board.
+     */
+    val isSaddled: Boolean = false,
+
     /** Whether this card is plotted in exile (CR 718 — Plot keyword, castable for free on a later turn). Exile only. */
     val isPlotted: Boolean = false,
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1259,6 +1259,21 @@ class ClientStateTransformer(
         val isDashed = zoneKey.zoneType == Zone.BATTLEFIELD &&
             container.has<com.wingedsheep.engine.state.components.battlefield.DashedComponent>()
 
+        // Mounts (CR 702.171): surface the printed Saddle N and whether the permanent currently
+        // carries the saddled designation, so the client can badge both states. Read from the card
+        // definition for the same reason `SaddleEnumerator` does — the handler resolves the saddle
+        // keyword by definition id, so a renamed copy (CR 707.9) still saddles.
+        val saddleRequirement = if (zoneKey.zoneType == Zone.BATTLEFIELD) {
+            cardDef?.keywordAbilities
+                ?.filterIsInstance<com.wingedsheep.sdk.scripting.KeywordAbility.Numeric>()
+                ?.firstOrNull { it.keyword == com.wingedsheep.sdk.core.Keyword.SADDLE }
+                ?.n
+        } else {
+            null
+        }
+        val isSaddled = zoneKey.zoneType == Zone.BATTLEFIELD &&
+            container.has<com.wingedsheep.engine.state.components.battlefield.SaddledComponent>()
+
         // Threshold-style progress badge: detect static abilities gated on
         // "controller's graveyard has at least N cards".
         val thresholdInfo = cardDef?.let { def ->
@@ -1349,6 +1364,8 @@ class ClientStateTransformer(
             isFaceDown = isFaceDown,
             faceDownMode = if (isFaceDown) container.get<FaceDownModeComponent>()?.mode?.name else null,
             isSuspected = projectedValues?.isSuspected == true,
+            saddleRequirement = saddleRequirement,
+            isSaddled = isSaddled,
             isPlotted = isPlotted,
             isParadigm = isParadigm,
             isSuspended = isSuspended,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
@@ -321,7 +321,8 @@ class LegalActionEnricher(
     private fun TapForPowerCreatureData.toDto() = TapForPowerCreatureInfo(
         entityId = entityId,
         name = name,
-        power = power
+        power = power,
+        canAttack = canAttack
     )
 
     private fun CounterRemovalCreatureData.toDto() = CounterRemovalCreatureInfo(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
@@ -234,7 +234,16 @@ data class HarmonizeCreatureInfo(
 data class TapForPowerCreatureInfo(
     val entityId: EntityId,
     val name: String,
-    val power: Int
+    /** What this creature contributes toward the cost — for Crew and Saddle that can exceed its
+     * printed power (a "crews as though its power were 2 greater" static), and it is the number the
+     * handler charges against, so the client's progress bar must sum this and not power. */
+    val power: Int,
+    /**
+     * Whether this creature could legally attack right now (CR 508.1a per-creature restrictions).
+     * Paying with it taps it, which takes it out of combat — the client spends the creatures that
+     * couldn't attack anyway first, and flags the ones that could.
+     */
+    val canAttack: Boolean = true
 )
 
 @Serializable

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/SaddleEnumeratorTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/SaddleEnumeratorTest.kt
@@ -1,7 +1,9 @@
 package com.wingedsheep.engine.legalactions
 
 import com.wingedsheep.engine.legalactions.support.EnumerationTestDriver
+import com.wingedsheep.engine.state.components.battlefield.SaddledComponent
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
@@ -9,6 +11,7 @@ import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.CrewSaddleContribution
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -45,10 +48,30 @@ class SaddleEnumeratorTest : FunSpec({
         oracleText = ""
     }
 
+    // "Saddles Mounts and crews Vehicles as though its power were 2 greater" — the measure the
+    // handler charges against, which must be what the enumerator reports.
+    val testPilot = card("Test Pilot") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Pilot"
+        power = 1
+        toughness = 1
+        oracleText = "This creature saddles Mounts and crews Vehicles as though its power were 2 greater."
+        staticAbility { ability = CrewSaddleContribution(modifier = 2) }
+    }
+
+    val testWall = card("Test Wall") {
+        manaCost = "{1}"
+        typeLine = "Creature — Wall"
+        power = 3
+        toughness = 3
+        oracleText = "Defender"
+        keywords(Keyword.DEFENDER)
+    }
+
     fun driverInMainPhase(): EnumerationTestDriver {
         val driver = EnumerationTestDriver()
         driver.registerCards(TestCards.all)
-        driver.registerCards(listOf(testMount, testPony))
+        driver.registerCards(listOf(testMount, testPony, testPilot, testWall))
         driver.game.initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true)
         driver.game.passPriorityUntil(Step.PRECOMBAT_MAIN)
         return driver
@@ -111,6 +134,63 @@ class SaddleEnumeratorTest : FunSpec({
         val saddle = driver.saddleActionsFor(driver.player1).single()
         saddle.tapForPowerCreatures!!.map { it.entityId }.contains(bear) shouldBe false
         saddle.affordable shouldBe false // no untapped creature left to reach power 2
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // What the client needs to present the cost: the contribution actually charged, and whether
+    // spending a creature on it costs its controller an attacker.
+    // -----------------------------------------------------------------------------------------
+
+    test("a candidate's reported power is its crew/saddle contribution, not its printed power") {
+        val driver = driverInMainPhase()
+        driver.game.putCreatureOnBattlefield(driver.player1, "Test Mount")
+        driver.game.putCreatureOnBattlefield(driver.player1, "Test Pilot") // 1/1, contributes 3
+
+        val saddle = driver.saddleActionsFor(driver.player1).single()
+        saddle.tapForPowerCreatures!!.single().power shouldBe 3
+        // The handler measures the same way, so a lone Pilot must read as affording Saddle 2.
+        saddle.affordable shouldBe true
+    }
+
+    test("a summoning-sick creature reports canAttack = false; removing the sickness flips it") {
+        val driver = driverInMainPhase()
+        driver.game.putCreatureOnBattlefield(driver.player1, "Test Mount")
+        val bear = driver.game.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+
+        driver.saddleActionsFor(driver.player1).single()
+            .tapForPowerCreatures!!.single { it.entityId == bear }.canAttack shouldBe false
+
+        driver.game.removeSummoningSickness(bear)
+
+        driver.saddleActionsFor(driver.player1).single()
+            .tapForPowerCreatures!!.single { it.entityId == bear }.canAttack shouldBe true
+    }
+
+    test("a creature with defender reports canAttack = false even without summoning sickness") {
+        val driver = driverInMainPhase()
+        driver.game.putCreatureOnBattlefield(driver.player1, "Test Mount")
+        val wall = driver.game.putCreatureOnBattlefield(driver.player1, "Test Wall")
+        driver.game.removeSummoningSickness(wall)
+
+        val saddle = driver.saddleActionsFor(driver.player1).single()
+        saddle.tapForPowerCreatures!!.single { it.entityId == wall }.canAttack shouldBe false
+        // It still saddles — saddling is not attacking (CR 702.171a).
+        saddle.affordable shouldBe true
+    }
+
+    test("the action is labelled 'again' on a Mount that is already saddled") {
+        val driver = driverInMainPhase()
+        val mount = driver.game.putCreatureOnBattlefield(driver.player1, "Test Mount")
+        driver.game.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+
+        driver.saddleActionsFor(driver.player1).single().description shouldBe "Saddle Test Mount"
+
+        // Saddle has no once-each-turn clause (CR 702.171a), so it stays offered — the label is
+        // what stops a player spending creatures on a designation they already have.
+        driver.game.addComponent(mount, SaddledComponent)
+
+        driver.saddleActionsFor(driver.player1).single().description shouldBe
+            "Saddle Test Mount again"
     }
 
     test("Saddle is NOT available to a player who isn't the active player (sorcery-speed gate)") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/SaddledCardVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/SaddledCardVisibilityTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.core.SaddleMount
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * A Mount's saddle state as the clients see it (CR 702.171).
+ *
+ * Saddled is a designation with no rules meaning of its own — every Mount payoff is gated on it,
+ * it is granted only by a resolved saddle ability, and it disappears at cleanup without any event
+ * of its own. A saddled Mount and an unsaddled one are otherwise identical permanents, so
+ * [ClientStateTransformer] surfaces [ClientCard.isSaddled] alongside the printed
+ * [ClientCard.saddleRequirement]. Both are public: whether a Mount is switched on, and how much
+ * power its controller must spend to switch it on, are exactly what the other players block
+ * around. Mirrors [DashedCardVisibilityTest] and [WarpedCardVisibilityTest].
+ */
+class SaddledCardVisibilityTest : FunSpec({
+
+    val testMount = card("Test Mount") {
+        manaCost = "{2}"
+        typeLine = "Creature — Mount"
+        power = 1
+        toughness = 4
+        oracleText = "Saddle 2\nWhenever Test Mount attacks while saddled, draw a card."
+        keywordAbility(KeywordAbility.saddle(2))
+        triggeredAbility {
+            trigger = Triggers.Attacks
+            triggerRestriction = Conditions.SourceIsSaddled
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + testMount)
+        d.initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.viewOf(viewer: EntityId, id: EntityId) =
+        ClientStateTransformer(cardRegistry).transform(state, viewer).cards[id].shouldNotBeNull()
+
+    test("an unsaddled Mount exposes its Saddle N and reads as not saddled") {
+        val d = driver()
+        val mount = d.putCreatureOnBattlefield(d.player1, "Test Mount")
+
+        d.viewOf(d.player1, mount).saddleRequirement shouldBe 2
+        d.viewOf(d.player1, mount).isSaddled shouldBe false
+    }
+
+    test("a creature without saddle exposes no saddle requirement") {
+        val d = driver()
+        val bear = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+
+        d.viewOf(d.player1, bear).saddleRequirement shouldBe null
+        d.viewOf(d.player1, bear).isSaddled shouldBe false
+    }
+
+    test("a resolved saddle ability flags isSaddled for both players") {
+        val d = driver()
+        val mount = d.putCreatureOnBattlefield(d.player1, "Test Mount")
+        val bear = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears") // power 2
+
+        d.submitSuccess(SaddleMount(d.player1, mount, listOf(bear)))
+        d.bothPass()
+
+        d.viewOf(d.player1, mount).isSaddled shouldBe true
+        // Public — the opponent needs it to decide how to block.
+        d.viewOf(d.player2, mount).isSaddled shouldBe true
+        d.viewOf(d.player2, mount).saddleRequirement shouldBe 2
+    }
+
+    test("the flag clears with the designation at end of turn, but the requirement stays") {
+        val d = driver()
+        val mount = d.putCreatureOnBattlefield(d.player1, "Test Mount")
+        val bear = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+
+        d.submitSuccess(SaddleMount(d.player1, mount, listOf(bear)))
+        d.bothPass()
+        d.viewOf(d.player1, mount).isSaddled shouldBe true
+
+        d.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.viewOf(d.player1, mount).isSaddled shouldBe false
+        // Still a Mount — the requirement is printed, not conferred.
+        d.viewOf(d.player1, mount).saddleRequirement shouldBe 2
+    }
+})

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -2167,6 +2167,55 @@ export const styles: Record<string, React.CSSProperties> = {
     zIndex: 6,
   } as React.CSSProperties,
 
+  // Saddle (CR 702.171) — a Mount's designation cue, in two states sharing one slot so the eye
+  // reads them as the same fact switching on and off.
+  //
+  // `saddledBadge` is the live one: warm saddle-leather, lit, readable across the board, because
+  // every Mount payoff is gated on it and it silently expires at cleanup — a saddled Mount and an
+  // unsaddled one are otherwise identical permanents.
+  saddledBadge: {
+    position: 'absolute',
+    bottom: 4,
+    left: 4,
+    borderRadius: 4,
+    padding: '1px 5px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 3,
+    fontWeight: 700,
+    fontSize: 10,
+    color: '#2b1706',
+    background: 'linear-gradient(135deg, #d99a4e, #f2c98a)',
+    border: '1px solid #ffe1b8',
+    boxShadow: '0 0 6px rgba(217, 154, 78, 0.9)',
+    textShadow: 'none',
+    pointerEvents: 'none',
+    zIndex: 6,
+  } as React.CSSProperties,
+
+  // `saddleAvailableBadge` is the dormant one: the printed Saddle N on a Mount nobody has saddled
+  // yet. Deliberately muted — it is a standing fact about the permanent, not an event — but present
+  // for every player, since how much power the controller needs to switch the Mount on is exactly
+  // what the rest of the table plays around.
+  saddleAvailableBadge: {
+    position: 'absolute',
+    bottom: 4,
+    left: 4,
+    borderRadius: 4,
+    padding: '1px 5px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 3,
+    fontWeight: 600,
+    fontSize: 10,
+    color: '#d8c0a4',
+    background: 'rgba(60, 40, 22, 0.78)',
+    border: '1px solid rgba(217, 154, 78, 0.55)',
+    textShadow: 'none',
+    pointerEvents: 'none',
+    zIndex: 6,
+  } as React.CSSProperties,
+
   // Dash (CR 702.109, Khans of Tarkir) — a permanent cast for its dash cost: hasty and returned to
   // its owner's hand at the next end step. Unlike warp (multi-turn exile-then-recast, cosmic ring
   // treatment), dash resolves within the same turn, so a plain amber "hasty" badge is enough — no

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -1767,6 +1767,28 @@ function GameCardImpl({
         </>
       )}
 
+      {/* Saddle (CR 702.171): a Mount reads as saddled or not, and that is the whole difference
+          between its payoffs being on and off. The designation is granted by a resolved saddle
+          ability and lost at end of turn without any visible event, so the board itself has to
+          carry it. Two states, one slot: lit "Saddled" once it's on, muted "Saddle N" while it
+          isn't — the second doubles as "this permanent is a Mount, and here's the price".
+          Shown on every player's Mounts; saddled status is public and changes how you block.
+          Bottom-left, not the crowded top-left provenance lane: unlike a dashed or warped marker
+          this one is on every Mount for that permanent's whole life, so it must not sit on the
+          card name — and combat-relevant state is what the eye already goes to the bottom for. */}
+      {battlefield && !faceDown && card.saddleRequirement != null && (
+        <div
+          style={card.isSaddled ? styles.saddledBadge : styles.saddleAvailableBadge}
+          title={
+            card.isSaddled
+              ? `Saddled (CR 702.171b) until end of turn — its "while saddled" abilities are active`
+              : `Saddle ${card.saddleRequirement} (CR 702.171a) — tap other untapped creatures you control with total power ${card.saddleRequirement} or more, as a sorcery, to saddle it`
+          }
+        >
+          {card.isSaddled ? 'Saddled' : `Saddle ${card.saddleRequirement}`}
+        </div>
+      )}
+
       {/* Dash (CR 702.109, Khans of Tarkir): a permanent cast for its dash cost — hasty, returned to
           its owner's hand at the beginning of the next end step. */}
       {battlefield && card.isDashed && !faceDown && (

--- a/web-client/src/components/ui/TapForPowerSelector.tsx
+++ b/web-client/src/components/ui/TapForPowerSelector.tsx
@@ -1,49 +1,130 @@
-import { useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useGameStore } from '@/store/gameStore.ts'
+import { autoSelectForPower, totalPowerOf } from '@/utils/tapForPower'
 
 /**
- * Compact floating HUD bar for the "tap creatures with total power N" selection,
- * shared by Crew N (Vehicles) and Saddle N (Mounts). Shows power progress and
- * confirm/cancel buttons while creatures are selected directly on the battlefield.
+ * Compact floating HUD bar for the "tap creatures with total power N" cost, shared by Crew N
+ * (Vehicles, CR 702.122a) and Saddle N (Mounts, CR 702.171a).
+ *
+ * Creatures are picked on the battlefield, not in a list — the board is where their counters,
+ * auras and combat state are readable. The bar carries only what the board can't show: distance
+ * to N, which picks were going to attack (paying taps them out of combat, marked ⚔), and a
+ * one-click pick that spends the creatures that couldn't attack anyway first.
  */
 export function TapForPowerSelector() {
   const selection = useGameStore((state) => state.tapForPowerSelectionState)
   const cancelSelection = useGameStore((state) => state.cancelTapForPowerSelection)
   const confirmSelection = useGameStore((state) => state.confirmTapForPowerSelection)
+  const toggleCreature = useGameStore((state) => state.toggleTapForPowerCreature)
+  const setCreatures = useGameStore((state) => state.setTapForPowerCreatures)
 
-  const selectedPower = useMemo(() => {
-    if (!selection) return 0
-    const { selectedCreatures, validCreatures } = selection
-    let total = 0
-    for (const id of selectedCreatures) {
-      const creature = validCreatures.find((c) => c.entityId === id)
-      if (creature) total += creature.power
-    }
-    return total
+  const selectedPower = useMemo(
+    () => (selection ? totalPowerOf(selection.validCreatures, selection.selectedCreatures) : 0),
+    [selection]
+  )
+
+  const selectedCards = useMemo(() => {
+    if (!selection) return []
+    return selection.selectedCreatures
+      .map((id) => selection.validCreatures.find((c) => c.entityId === id))
+      .filter((c): c is NonNullable<typeof c> => c !== undefined)
   }, [selection])
+
+  const requiredPower = selection?.requiredPower ?? 0
+  const canConfirm = selection !== null && selectedPower >= requiredPower
+
+  const autoPick = useCallback(() => {
+    if (!selection) return
+    setCreatures(autoSelectForPower(selection.validCreatures, selection.requiredPower))
+  }, [selection, setCreatures])
+
+  // Enter confirms, Escape cancels — this bar owns the whole interaction while it is open.
+  useEffect(() => {
+    if (!selection) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        cancelSelection()
+      } else if (e.key === 'Enter' && canConfirm) {
+        e.preventDefault()
+        confirmSelection()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [selection, canConfirm, cancelSelection, confirmSelection])
 
   if (!selection) return null
 
-  const { verb, sourceName, requiredPower, selectedCreatures } = selection
-  const canConfirm = selectedPower >= requiredPower
+  const { verb, sourceName, alreadySaddled } = selection
+  const fillPercent = requiredPower > 0
+    ? Math.min(100, (selectedPower / requiredPower) * 100)
+    : 100
 
   return (
-    <div style={styles.bar}>
+    <div style={styles.bar} role="group" aria-label={`${verb} ${sourceName}`}>
       <span style={styles.label}>
-        {verb} <strong>{sourceName}</strong>
+        {verb} <strong style={styles.sourceName}>{sourceName}</strong>
+        {alreadySaddled && (
+          <span
+            style={styles.alreadyTag}
+            title='Already saddled until end of turn — this activation only adds saddlers for "creatures that saddled it this turn" payoffs.'
+          >
+            already saddled
+          </span>
+        )}
       </span>
-      <span style={styles.divider} />
+
+      <span style={styles.progressTrack} aria-hidden="true">
+        <span
+          style={{
+            ...styles.progressFill,
+            width: `${fillPercent}%`,
+            backgroundColor: canConfirm ? '#4caf50' : '#ff9800',
+          }}
+        />
+      </span>
       <span style={styles.powerInfo}>
-        Power:&nbsp;
-        <strong style={{ color: canConfirm ? '#4caf50' : '#ff9800' }}>
-          {selectedPower}
-        </strong>
-        &nbsp;/&nbsp;{requiredPower}
+        <strong style={{ color: canConfirm ? '#4caf50' : '#ff9800' }}>{selectedPower}</strong>
+        <span style={styles.slash}>/</span>
+        {requiredPower}
       </span>
-      <span style={styles.count}>
-        ({selectedCreatures.length} creature{selectedCreatures.length !== 1 ? 's' : ''})
-      </span>
+
       <span style={styles.divider} />
+
+      {selectedCards.length === 0 ? (
+        <span style={styles.emptyHint}>Click creatures to tap them</span>
+      ) : (
+        selectedCards.map((creature) => (
+          <button
+            key={creature.entityId}
+            onClick={() => toggleCreature(creature.entityId)}
+            style={{
+              ...styles.chip,
+              ...(creature.canAttack !== false ? styles.chipAttacker : styles.chipSpare),
+            }}
+            title={
+              creature.canAttack !== false
+                ? `${creature.name} can attack this turn — tapping it takes it out of combat. Click to unselect.`
+                : `${creature.name} can't attack this turn, so tapping it costs you nothing. Click to unselect.`
+            }
+          >
+            {creature.canAttack !== false && <span aria-hidden="true">⚔</span>}
+            {creature.name}
+            <span style={styles.chipPower}>{creature.power}</span>
+            <span style={styles.chipRemove} aria-hidden="true">×</span>
+          </button>
+        ))
+      )}
+
+      <span style={styles.divider} />
+      <button
+        onClick={autoPick}
+        style={styles.secondaryButton}
+        title="Pick creatures that reach the requirement, spending the ones that can't attack first"
+      >
+        Auto
+      </button>
       <button onClick={cancelSelection} style={styles.cancelButton}>
         Cancel
       </button>
@@ -56,7 +137,7 @@ export function TapForPowerSelector() {
           cursor: canConfirm ? 'pointer' : 'not-allowed',
         }}
       >
-        Confirm {verb}
+        {verb}
       </button>
     </div>
   )
@@ -70,31 +151,102 @@ const styles: Record<string, React.CSSProperties> = {
     transform: 'translateX(-50%)',
     display: 'flex',
     alignItems: 'center',
-    gap: 12,
+    gap: 10,
     padding: '10px 20px',
+    maxWidth: '92vw',
+    flexWrap: 'wrap',
     backgroundColor: 'rgba(20, 20, 40, 0.95)',
     border: '2px solid #4a4a6a',
     borderRadius: 10,
     boxShadow: '0 4px 20px rgba(0, 0, 0, 0.6)',
     zIndex: 1500,
-    whiteSpace: 'nowrap',
   },
   label: {
     color: '#ccc',
     fontSize: 14,
+    whiteSpace: 'nowrap',
+  },
+  sourceName: {
+    color: '#fff',
+  },
+  alreadyTag: {
+    marginLeft: 6,
+    color: '#d99a4e',
+    fontSize: 11,
+  },
+  progressTrack: {
+    display: 'inline-block',
+    width: 70,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
+    overflow: 'hidden',
+  },
+  progressFill: {
+    display: 'block',
+    height: '100%',
+    borderRadius: 3,
+    transition: 'width 120ms ease-out, background-color 120ms ease-out',
+  },
+  powerInfo: {
+    color: '#aaa',
+    fontSize: 14,
+    whiteSpace: 'nowrap',
+  },
+  slash: {
+    color: '#666',
+    margin: '0 2px',
   },
   divider: {
     width: 1,
     height: 20,
     backgroundColor: '#4a4a6a',
   },
-  powerInfo: {
-    color: '#aaa',
-    fontSize: 14,
-  },
-  count: {
-    color: '#666',
+  emptyHint: {
+    color: '#777',
     fontSize: 12,
+    fontStyle: 'italic',
+    whiteSpace: 'nowrap',
+  },
+  chip: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 5,
+    padding: '3px 8px',
+    fontSize: 12,
+    color: '#eee',
+    border: '1px solid',
+    borderRadius: 12,
+    cursor: 'pointer',
+    fontFamily: 'inherit',
+    whiteSpace: 'nowrap',
+  },
+  chipAttacker: {
+    backgroundColor: 'rgba(255, 152, 0, 0.14)',
+    borderColor: 'rgba(255, 152, 0, 0.55)',
+  },
+  chipSpare: {
+    backgroundColor: 'rgba(76, 175, 80, 0.12)',
+    borderColor: 'rgba(76, 175, 80, 0.45)',
+  },
+  chipPower: {
+    color: '#bbb',
+    fontVariantNumeric: 'tabular-nums',
+  },
+  chipRemove: {
+    color: '#888',
+    fontSize: 13,
+    lineHeight: 1,
+  },
+  secondaryButton: {
+    padding: '6px 12px',
+    fontSize: 13,
+    backgroundColor: '#333',
+    color: '#ddd',
+    border: '1px solid #4a4a6a',
+    borderRadius: 6,
+    cursor: 'pointer',
+    fontFamily: 'inherit',
   },
   cancelButton: {
     padding: '6px 14px',
@@ -104,6 +256,7 @@ const styles: Record<string, React.CSSProperties> = {
     border: 'none',
     borderRadius: 6,
     cursor: 'pointer',
+    fontFamily: 'inherit',
   },
   confirmButton: {
     padding: '6px 14px',
@@ -113,5 +266,6 @@ const styles: Record<string, React.CSSProperties> = {
     border: 'none',
     borderRadius: 6,
     cursor: 'pointer',
+    fontFamily: 'inherit',
   },
 }

--- a/web-client/src/hooks/interaction/actionResolvers.ts
+++ b/web-client/src/hooks/interaction/actionResolvers.ts
@@ -31,14 +31,24 @@ function isTapForPowerAction(info: LegalActionInfo): boolean {
 }
 
 function resolveTapForPower(info: LegalActionInfo, ctx: ActionContext): void {
-  const verb = info.action.type === 'SaddleMount' ? 'Saddle' : 'Crew'
+  const isSaddle = info.action.type === 'SaddleMount'
+  const verb = isSaddle ? 'Saddle' : 'Crew'
+  // Read the source off the action rather than the description: the server labels an
+  // already-saddled Mount "Saddle <name> again", so string-stripping the verb would leave the
+  // trailing "again" in the name. The card is also where the saddled designation lives.
+  const sourceId = isSaddle
+    ? (info.action as { mountId: EntityId }).mountId
+    : (info.action as { vehicleId: EntityId }).vehicleId
+  const source = useGameStore.getState().gameState?.cards?.[sourceId]
   ctx.startTapForPowerSelection({
     actionInfo: info,
+    sourceId,
     verb,
-    sourceName: info.description.replace(`${verb} `, ''),
+    sourceName: source?.name ?? info.description.replace(`${verb} `, ''),
     requiredPower: info.tapForPowerRequired ?? 0,
     selectedCreatures: [],
     validCreatures: info.tapForPowerCreatures!,
+    alreadySaddled: isSaddle && source?.isSaddled === true,
   })
   ctx.selectCard(null)
 }

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -474,6 +474,8 @@ export interface HarmonizeSelectionState {
  */
 export interface TapForPowerSelectionState {
   actionInfo: LegalActionInfo
+  /** The source permanent (Vehicle or Mount) being paid for. */
+  sourceId: EntityId
   /** The source permanent's name (Vehicle or Mount). */
   sourceName: string
   /** The verb shown to the player: "Crew" or "Saddle". */
@@ -484,6 +486,9 @@ export interface TapForPowerSelectionState {
   selectedCreatures: EntityId[]
   /** All valid creatures that can be tapped. */
   validCreatures: readonly TapForPowerCreatureInfo[]
+  /** Saddle only: the Mount already carries the saddled designation (CR 702.171b), so this
+   * activation only adds saddlers for "creatures that saddled it this turn" payoffs. */
+  alreadySaddled: boolean
 }
 
 /**
@@ -1185,6 +1190,7 @@ export type GameStore = {
   confirmHarmonizeSelection: () => void
   startTapForPowerSelection: (state: TapForPowerSelectionState) => void
   toggleTapForPowerCreature: (entityId: EntityId) => void
+  setTapForPowerCreatures: (entityIds: readonly EntityId[]) => void
   cancelTapForPowerSelection: () => void
   confirmTapForPowerSelection: () => void
   startDelveSelection: (state: DelveSelectionState) => void

--- a/web-client/src/store/slices/ui/selectionSlice.ts
+++ b/web-client/src/store/slices/ui/selectionSlice.ts
@@ -77,6 +77,7 @@ export interface SelectionSliceActions {
   confirmHarmonizeSelection: () => void
   startTapForPowerSelection: (state: TapForPowerSelectionState) => void
   toggleTapForPowerCreature: (entityId: EntityId) => void
+  setTapForPowerCreatures: (entityIds: readonly EntityId[]) => void
   cancelTapForPowerSelection: () => void
   confirmTapForPowerSelection: () => void
   startDelveSelection: (state: DelveSelectionState) => void
@@ -381,6 +382,19 @@ export const createSelectionSlice: SliceCreator<SelectionSlice> = (set, get) => 
         },
       }
     })
+  },
+
+  setTapForPowerCreatures: (entityIds) => {
+    set((state) =>
+      state.tapForPowerSelectionState
+        ? {
+            tapForPowerSelectionState: {
+              ...state.tapForPowerSelectionState,
+              selectedCreatures: [...entityIds],
+            },
+          }
+        : state
+    )
   },
 
   cancelTapForPowerSelection: () => {

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -328,6 +328,15 @@ export interface ClientCard {
    * Battlefield only. */
   readonly isDashed?: boolean
 
+  /** Saddle N printed on this permanent (CR 702.171a), or absent if it has no saddle ability.
+   * Public — the number is how much power its controller must spend to switch its Mount payoffs
+   * on, which is exactly what the other players need to play around. Battlefield only. */
+  readonly saddleRequirement?: number | null
+
+  /** Whether this permanent currently carries the saddled designation (CR 702.171b), granted by a
+   * resolved saddle ability and lost at end of turn. Battlefield only. */
+  readonly isSaddled?: boolean
+
   /** Morph cost for face-down creatures (only visible to controller) */
   readonly morphCost?: string | null
 

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1020,6 +1020,10 @@ export interface TapForPowerCreatureInfo {
   readonly name: string
   /** Projected power of this creature */
   readonly power: number
+  /** Whether the server says this creature could legally attack right now (CR 508.1a). Paying with
+   * it taps it, so it drops out of combat — the auto-pick spends creatures that couldn't attack
+   * anyway first, and the HUD flags the ones that could. */
+  readonly canAttack?: boolean
 }
 
 /**

--- a/web-client/src/utils/tapForPower.test.ts
+++ b/web-client/src/utils/tapForPower.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { autoSelectForPower, totalPowerOf, type PowerCandidate } from './tapForPower'
+import { entityId } from '@/types'
+
+function creature(id: string, power: number, canAttack?: boolean): PowerCandidate {
+  return { entityId: entityId(id), power, ...(canAttack === undefined ? {} : { canAttack }) }
+}
+
+/** Total contribution of a pick, so assertions read in the units the cost is paid in. */
+function powerOf(pool: readonly PowerCandidate[], picked: readonly ReturnType<typeof entityId>[]) {
+  return totalPowerOf(pool, picked)
+}
+
+describe('autoSelectForPower', () => {
+  it('takes the single creature that covers the cost with the least overshoot', () => {
+    const pool = [creature('a', 5), creature('b', 3), creature('c', 8)]
+    const picked = autoSelectForPower(pool, 3)
+    expect(picked).toEqual([entityId('b')])
+  })
+
+  it('combines creatures when none covers the cost alone, largest first', () => {
+    const pool = [creature('a', 2), creature('b', 1), creature('c', 2)]
+    const picked = autoSelectForPower(pool, 4)
+    expect(powerOf(pool, picked)).toBeGreaterThanOrEqual(4)
+    expect(picked).toHaveLength(2)
+  })
+
+  it('spends creatures that cannot attack before ones that can', () => {
+    const pool = [creature('attacker', 3, true), creature('sick', 3, false)]
+    expect(autoSelectForPower(pool, 3)).toEqual([entityId('sick')])
+  })
+
+  it('reaches into attackers only for the shortfall the spare creatures leave', () => {
+    const pool = [
+      creature('sick', 2, false),
+      creature('smallAttacker', 1, true),
+      creature('bigAttacker', 6, true),
+    ]
+    const picked = autoSelectForPower(pool, 3)
+    expect(picked).toEqual([entityId('sick'), entityId('smallAttacker')])
+  })
+
+  it('treats a missing canAttack as "could attack" so nothing is spent silently', () => {
+    const pool = [creature('unknown', 3), creature('sick', 3, false)]
+    expect(autoSelectForPower(pool, 3)).toEqual([entityId('sick')])
+  })
+
+  it('never picks a creature contributing nothing, and terminates on an all-zero board', () => {
+    const pool = [creature('a', 0), creature('b', 0)]
+    expect(autoSelectForPower(pool, 2)).toEqual([])
+  })
+
+  it('returns everything that helps when the board cannot cover the cost', () => {
+    const pool = [creature('a', 1, false), creature('b', 1, true)]
+    const picked = autoSelectForPower(pool, 5)
+    expect(picked).toHaveLength(2)
+    expect(powerOf(pool, picked)).toBe(2)
+  })
+
+  it('picks nothing for a zero requirement', () => {
+    expect(autoSelectForPower([creature('a', 3)], 0)).toEqual([])
+  })
+})
+
+describe('totalPowerOf', () => {
+  it('sums only the selected creatures and ignores ids that are no longer candidates', () => {
+    const pool = [creature('a', 2), creature('b', 3)]
+    expect(totalPowerOf(pool, [entityId('a'), entityId('b'), entityId('gone')])).toBe(5)
+  })
+})

--- a/web-client/src/utils/tapForPower.ts
+++ b/web-client/src/utils/tapForPower.ts
@@ -1,0 +1,91 @@
+/**
+ * Auto-pick for a "tap creatures with total power N" cost — Crew N (CR 702.122a), Saddle N
+ * (CR 702.171a) and Teamwork N (CR 702.194a).
+ *
+ * This is a *suggestion*, never a rules decision: the server enumerated the candidates, the server
+ * validates the submitted set, and the player can edit the pick freely afterwards. What it encodes
+ * is the one thing the numbers alone don't say — paying this cost taps the creatures, and a tapped
+ * creature can't be declared as an attacker, so the cheapest way to pay is with the creatures that
+ * weren't going to attack anyway.
+ */
+import type { EntityId } from '@/types'
+
+export interface PowerCandidate {
+  readonly entityId: EntityId
+  readonly power: number
+  /** Server's verdict on whether this creature could attack right now. Absent = assume it could. */
+  readonly canAttack?: boolean
+}
+
+/** Sum the contribution of the given selection. */
+export function totalPowerOf(
+  candidates: readonly PowerCandidate[],
+  selected: readonly EntityId[]
+): number {
+  let total = 0
+  for (const id of selected) {
+    const candidate = candidates.find((c) => c.entityId === id)
+    if (candidate) total += candidate.power
+  }
+  return total
+}
+
+/**
+ * Take from [pool] until [needed] is covered, preferring the single creature that finishes the job
+ * with the least overshoot and otherwise spending the largest first so the fewest creatures tap.
+ * Returns what was taken and what is still missing (0 when the pool covered it).
+ *
+ * Creatures contributing 0 or less are skipped outright — they can never close the gap, and
+ * including one would make the loop spin.
+ */
+function takeFrom(
+  pool: readonly PowerCandidate[],
+  needed: number
+): { chosen: PowerCandidate[]; missing: number } {
+  let remaining = pool.filter((c) => c.power > 0)
+  const chosen: PowerCandidate[] = []
+  let missing = needed
+
+  while (missing > 0 && remaining.length > 0) {
+    const finishers = remaining.filter((c) => c.power >= missing)
+    if (finishers.length > 0) {
+      // Smallest creature that covers the rest: one tap, least power wasted.
+      const best = finishers.reduce((a, b) => (b.power < a.power ? b : a))
+      chosen.push(best)
+      missing = 0
+      break
+    }
+    // Nothing covers it alone — spend the biggest so the gap closes in the fewest taps.
+    const biggest = remaining.reduce((a, b) => (b.power > a.power ? b : a))
+    chosen.push(biggest)
+    missing -= biggest.power
+    remaining = remaining.filter((c) => c !== biggest)
+  }
+
+  return { chosen, missing }
+}
+
+/**
+ * Choose creatures whose total contribution reaches [required], spending the least combat value.
+ *
+ * Creatures the server says can't attack are spent first (tapping them costs nothing this turn);
+ * only if they don't cover the cost does the pick reach into the creatures that could have
+ * attacked. Returns the ids in selection order. If the candidates can't cover [required] at all,
+ * returns everything that helps — the confirm button stays disabled and the player sees how short
+ * the board is.
+ */
+export function autoSelectForPower(
+  candidates: readonly PowerCandidate[],
+  required: number
+): EntityId[] {
+  if (required <= 0) return []
+
+  const spare = candidates.filter((c) => c.canAttack === false)
+  const attackers = candidates.filter((c) => c.canAttack !== false)
+
+  const fromSpare = takeFrom(spare, required)
+  if (fromSpare.missing <= 0) return fromSpare.chosen.map((c) => c.entityId)
+
+  const fromAttackers = takeFrom(attackers, fromSpare.missing)
+  return [...fromSpare.chosen, ...fromAttackers.chosen].map((c) => c.entityId)
+}


### PR DESCRIPTION
## Why

Saddled (CR 702.171b) is a designation with no rules meaning of its own: every Mount payoff is gated on it, only a resolved saddle ability grants it, and it disappears at cleanup with no event of its own. Nothing surfaced it — a saddled Mount and an unsaddled one were identical permanents on the board, for both players. And the shared "tap creatures with total power N" bar showed a running total and nothing else, in a cost whose whole hidden price is that the creatures you tap drop out of combat.

## Server

The client stays a dumb terminal — every judgement below is enumerated or transformed server-side.

- **`ClientCard.saddleRequirement` / `.isSaddled`**, both public. The first says "this is a Mount, and here is the price"; the second says whether it's switched on. Whether a Mount is saddled is what the rest of the table blocks around, so the opponent receives both too.
- **`TapForPowerCreatureData/Info.canAttack`** — the per-creature CR 508.1a check, run through the same `defaultAttackRestrictionRules` list `AttackPhaseManager` enforces at declare-attackers, extracted into `AttackAvailability` so the two can't drift. Memoised per creature across sources so N Mounts don't re-ask.
- **"Saddle \<name\> again"** on an already-saddled Mount. Re-saddling stays offered — CR 702.171a has no once-each-turn clause, and it adds saddlers that "creatures that saddled it this turn" payoffs count — but the label is what stops a player spending creatures on a designation they already have.

### Bug fixed along the way

The Crew and Saddle enumerators reported each candidate's **raw projected power**, while `CrewVehicleHandler` / `SaddleMountHandler` charge the `CrewSaddleContributionEvaluator` value. A Pilot that "crews Vehicles as though its power were 2 greater" therefore under-counted in `tapForPowerCreatures` and in `affordable`, so the client's progress bar would refuse a saddle the engine accepts. Both enumerators now report the contribution. Teamwork N deliberately keeps counting plain projected power — the *measure* is what differs between the two costs, and that split is load-bearing.

## Client

- **Two-state saddle badge**, bottom-left of the card: lit `Saddled` while the designation is live, muted `Saddle N` while it isn't. Bottom-left rather than the top-left provenance lane (plotted / prepared / warped / dashed) because unlike those markers this one is on every Mount for the permanent's whole life — it must not sit on the card name.
- **The tap-for-power bar** (shared with Crew) stays one compact row and gains a progress bar, chips for the picked creatures that are clickable to unselect and marked ⚔ when that creature could have attacked, an `Auto` pick, an "already saddled" tag, and Enter / Escape.
- **`Auto`** spends the creatures the server says can't attack first, then covers the shortfall with the smallest creature that finishes the job. It's a suggestion the player can edit, and it's unit-tested (`utils/tapForPower.test.ts`, 9 cases including the all-zero-power termination guard).

## Tests

- `SaddledCardVisibilityTest` (new, house `*CardVisibilityTest` shape) — the two flags, both players' views, and the flag clearing at end of turn while the requirement stays.
- `SaddleEnumeratorTest` — contribution-not-printed-power, `canAttack` false for summoning sickness and for defender (and true once the sickness is gone), and the `again` label.
- `:rules-engine:test` green on a `--rerun-tasks` pass; `tsc --noEmit` clean; 579 client tests green.
- Driven end to end in the running client: badge states, both players' views, the saddle flow, auto-pick on a board with a summoning-sick creature, and the re-saddle label.

## Docs

`docs/card-sdk-language-reference.md` — the `saddle(n)` entry now names the two client fields, and the `CrewSaddleContribution` entry records that the enumerators report the contribution (and that Teamwork deliberately doesn't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)