### PR TITLE
Add four Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AnzragTheQuakeMole.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AnzragTheQuakeMole.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MustBeBlockedEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Anzrag, the Quake-Mole — Murders at Karlov Manor #186
+ * {2}{R}{G} · Legendary Creature — Mole God · 8/4
+ *
+ * Whenever Anzrag becomes blocked, untap each creature you control. After this phase, there is an
+ * additional combat phase.
+ * {3}{R}{R}{G}{G}: Anzrag must be blocked each combat this turn if able.
+ *
+ * The two halves are a loop by design: pay the activation, Anzrag is forced through a block, the
+ * becomes-blocked trigger untaps the team and queues another combat, and the block requirement is
+ * still there for that combat too. That last part is why the activated ability uses
+ * [MustBeBlockedEffect] rather than a one-combat requirement — `MustBeBlockedExecutor` installs a
+ * `Duration.EndOfTurn` floating effect, so the requirement outlives the combat phase it was
+ * activated in and applies again in each additional one, exactly as "each combat this turn" prints.
+ *
+ * `allCreatures = false` is the Gaea's-Protector reading, not the Lure reading: the printed text is
+ * "must be blocked … if able" (at least one blocker), not "all creatures able to block it do so".
+ *
+ * The untap is `ForEachInGroup` over creatures you control rather than a targeted untap — the
+ * trigger targets nothing, so it can't be fizzled and doesn't care about hexproof.
+ * [Effects.AddCombatPhase] is the atomic extra-combat piece with no trailing main phase, which is
+ * what "After this phase, there is an additional combat phase" prints (CR 500.8).
+ */
+val AnzragTheQuakeMole = card("Anzrag, the Quake-Mole") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Creature — Mole God"
+    oracleText = "Whenever Anzrag becomes blocked, untap each creature you control. After this " +
+        "phase, there is an additional combat phase.\n" +
+        "{3}{R}{R}{G}{G}: Anzrag must be blocked each combat this turn if able."
+    power = 8
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature.youControl()),
+                Effects.Untap(EffectTarget.Self),
+            ),
+            Effects.AddCombatPhase,
+        )
+        description = "Whenever Anzrag becomes blocked, untap each creature you control. After " +
+            "this phase, there is an additional combat phase."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{R}{R}{G}{G}")
+        effect = MustBeBlockedEffect(EffectTarget.Self, allCreatures = false)
+        description = "Anzrag must be blocked each combat this turn if able."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "186"
+        artist = "Helge C. Balzer"
+        flavorText = "His claws tear at the foundations of civilization."
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70e9d8b8-4b32-4414-b32f-1f47523239c5.jpg?1783912855"
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CrypticCoat.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CrypticCoat.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlocked
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Cryptic Coat — Murders at Karlov Manor #50
+ * {2}{U} · Artifact — Equipment
+ *
+ * When this Equipment enters, cloak the top card of your library, then attach this Equipment to it.
+ * Equipped creature gets +1/+0 and can't be blocked.
+ * {1}{U}: Return this Equipment to its owner's hand.
+ *
+ * The enters trigger is one pipeline, not two effects: [GatherCardsEffect] lifts the top card,
+ * [MoveCollectionEffect] puts it onto the battlefield face down as a cloak ([FaceDownMode.CLOAK] —
+ * a 2/2 with ward {2}, CR 701.58a), and `storeMovedAs` hands the *battlefield* entity id to the
+ * attach step through [EffectTarget.PipelineTarget]. Attaching by id is what makes the "then" in
+ * the oracle text real: the Coat lands on the very permanent this ability just created, with no
+ * targeting and therefore no ward tax on itself.
+ *
+ * Cryptic Coat deliberately has **no equip ability** (Scryfall ruling 2024-02-02: "Without
+ * assistance from other cards, there's no way to attach it to a creature other than with its first
+ * triggered ability"), so nothing here calls `equipAbility`. The {1}{U} bounce is the card's whole
+ * engine: return it, recast it, cloak another card.
+ *
+ * "Can't be blocked" is the unconditional [CantBeBlocked], not a `CantBeBlockedBy` restriction —
+ * both halves of the static are scoped to [Filters.EquippedCreature] so they follow the Coat when
+ * it moves.
+ */
+val CrypticCoat = card("Cryptic Coat") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, cloak the top card of your library, then attach this " +
+        "Equipment to it. (To cloak a card, put it onto the battlefield face down as a 2/2 creature " +
+        "with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)\n" +
+        "Equipped creature gets +1/+0 and can't be blocked.\n" +
+        "{1}{U}: Return this Equipment to its owner's hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                storeAs = "crypticCoatCloak",
+            ),
+            MoveCollectionEffect(
+                from = "crypticCoatCloak",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                faceDown = FaceDownMode.CLOAK,
+                storeMovedAs = "crypticCoatCloaked",
+            ),
+            Effects.AttachEquipment(EffectTarget.PipelineTarget("crypticCoatCloaked")),
+        )
+        description = "When this Equipment enters, cloak the top card of your library, then attach " +
+            "this Equipment to it."
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 0, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = CantBeBlocked(Filters.EquippedCreature)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{U}")
+        effect = Effects.ReturnToHand(EffectTarget.Self)
+        description = "Return this Equipment to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "50"
+        artist = "Julia Metzger"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c3d7e2c-a104-4757-9984-fb31088f92c4.jpg?1783912915"
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ThePrideOfHullClade.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ThePrideOfHullClade.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+
+/**
+ * The Pride of Hull Clade — Murders at Karlov Manor #172
+ * {10}{G} · Legendary Creature — Crocodile Elk Turtle · 2/15
+ *
+ * This spell costs {X} less to cast, where X is the total toughness of creatures you control.
+ * Defender
+ * {2}{U}{U}: Until end of turn, target creature you control gets +1/+0, gains "Whenever this
+ * creature deals combat damage to a player, draw cards equal to its toughness," and can attack as
+ * though it didn't have defender.
+ *
+ * The cost reduction is the toughness reading of Ghalta's power reduction —
+ * [CostReductionSource.TotalPropertyAmongPermanentsYouControl] is the `(property, filter)`
+ * generalization of `TotalPowerYouControl`, so this is `Toughness` over creatures you control
+ * rather than a bespoke source. Both read *projected* toughness, so counters and anthems count,
+ * and only generic mana is reduced (CR 601.2f) — which is what the ruling "can't reduce the total
+ * cost below {G}" means in practice.
+ *
+ * The activated ability is three separate grants onto one target, not one bundled effect: a pump,
+ * a granted quoted trigger, and a defender bypass. Inside the granted ability "this creature" is
+ * the *host*, not The Pride — [Triggers.DealsCombatDamageToPlayer] is SELF-bound and
+ * [DynamicAmounts.sourceToughness] reads the ability's source, so both re-point at whatever
+ * creature received the grant. That is what makes the card's own 15 toughness a payload you can
+ * hand to something with evasion.
+ *
+ * The bypass is [Effects.CanAttackDespiteDefenderThisTurn] on the *target*, not on The Pride
+ * itself — a 2/15 with defender is meant to hand the attack off, though targeting itself is legal
+ * and is the obvious line when nothing better is on board.
+ */
+val ThePrideOfHullClade = card("The Pride of Hull Clade") {
+    manaCost = "{10}{G}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Crocodile Elk Turtle"
+    oracleText = "This spell costs {X} less to cast, where X is the total toughness of creatures " +
+        "you control.\n" +
+        "Defender\n" +
+        "{2}{U}{U}: Until end of turn, target creature you control gets +1/+0, gains \"Whenever " +
+        "this creature deals combat damage to a player, draw cards equal to its toughness,\" and " +
+        "can attack as though it didn't have defender."
+    power = 2
+    toughness = 15
+
+    keywords(Keyword.DEFENDER)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.TotalPropertyAmongPermanentsYouControl(
+                    property = EntityNumericProperty.Toughness,
+                    filter = GameObjectFilter.Creature,
+                ),
+            ),
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{U}{U}")
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 0, creature),
+            GrantTriggeredAbilityEffect(
+                ability = TriggeredAbility.create(
+                    trigger = Triggers.DealsCombatDamageToPlayer.event,
+                    binding = Triggers.DealsCombatDamageToPlayer.binding,
+                    effect = Effects.DrawCards(DynamicAmounts.sourceToughness()),
+                ),
+                target = creature,
+            ),
+            Effects.CanAttackDespiteDefenderThisTurn(creature),
+        )
+        description = "Until end of turn, target creature you control gets +1/+0, gains " +
+            "\"Whenever this creature deals combat damage to a player, draw cards equal to its " +
+            "toughness,\" and can attack as though it didn't have defender."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "172"
+        artist = "Brent Hollowell"
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/edb40ab9-e552-4eb5-9c35-09094136dd4f.jpg?1783912862"
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/VannifarEvolvedEnigma.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/VannifarEvolvedEnigma.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Vannifar, Evolved Enigma — Murders at Karlov Manor #241
+ * {2}{G}{U} · Legendary Creature — Elf Ooze Wizard · 3/4
+ *
+ * At the beginning of combat on your turn, choose one —
+ * • Cloak a card from your hand.
+ * • Put a +1/+1 counter on each colorless creature you control.
+ *
+ * The two modes are one engine: cloaking makes colorless 2/2s, and the counter mode grows exactly
+ * those. Nothing links them in the SDK — the link is that a face-down permanent is colorless
+ * (CR 708.2), and [CardPredicate.IsColorless] reads *projected* colors, so a cloaked card counts
+ * regardless of what it is on the front.
+ *
+ * The cloak mode is the hand-side twin of Hide in Plain Sight's library pipeline: gather the hand,
+ * select one, and move it to the battlefield with [FaceDownMode.CLOAK]. There is no
+ * cloak-from-hand facade because this is the first card that needs one — `Patterns.Hand.putFromHand`
+ * has no face-down mode, and widening it for a single caller would be speculative. An empty hand
+ * simply selects nothing and the mode does nothing; the mode is still legal to choose (CR 601.2b
+ * — modes aren't checked for effect).
+ *
+ * The counter mode is `ForEachInGroup` rather than a targeted effect: "each colorless creature you
+ * control" targets nothing, so it reaches hexproof creatures and can't be fizzled.
+ */
+val VannifarEvolvedEnigma = card("Vannifar, Evolved Enigma") {
+    manaCost = "{2}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Elf Ooze Wizard"
+    oracleText = "At the beginning of combat on your turn, choose one —\n" +
+        "• Cloak a card from your hand. (Put it onto the battlefield face down as a 2/2 creature " +
+        "with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)\n" +
+        "• Put a +1/+1 counter on each colorless creature you control."
+    power = 3
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        effect = ModalEffect(
+            modes = listOf(
+                Mode.noTarget(
+                    Effects.Composite(
+                        GatherCardsEffect(
+                            source = CardSource.FromZone(Zone.HAND),
+                            storeAs = "vannifarHand",
+                        ),
+                        SelectFromCollectionEffect(
+                            from = "vannifarHand",
+                            selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                            storeSelected = "vannifarCloaking",
+                            prompt = "Choose a card to cloak",
+                        ),
+                        MoveCollectionEffect(
+                            from = "vannifarCloaking",
+                            destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                            faceDown = FaceDownMode.CLOAK,
+                        ),
+                    ),
+                    "Cloak a card from your hand",
+                ),
+                Mode.noTarget(
+                    Effects.ForEachInGroup(
+                        GroupFilter(
+                            GameObjectFilter.Creature
+                                .withCardPredicate(CardPredicate.IsColorless)
+                                .youControl(),
+                        ),
+                        Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+                    ),
+                    "Put a +1/+1 counter on each colorless creature you control",
+                ),
+            ),
+            chooseCount = 1,
+            countsAsModalSpell = false,
+        )
+        description = "At the beginning of combat on your turn, choose one — Cloak a card from " +
+            "your hand; or put a +1/+1 counter on each colorless creature you control."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "241"
+        artist = "Uriah Voth"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6d381eb-6cb6-4505-aebe-995c1ddc8527.jpg?1783912833"
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AnzragTheQuakeMoleScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AnzragTheQuakeMoleScenarioTest.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.AdditionalPhasesComponent
+import com.wingedsheep.engine.state.components.player.ExtraPhaseKind
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.AnzragTheQuakeMole
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Anzrag, the Quake-Mole (MKM #186) — {2}{R}{G} 8/4 Legendary Creature — Mole God.
+ *
+ * "Whenever Anzrag becomes blocked, untap each creature you control. After this phase, there is an
+ *  additional combat phase.
+ *  {3}{R}{R}{G}{G}: Anzrag must be blocked each combat this turn if able."
+ *
+ * The card is a loop: the activated ability forces a block, the block fires the trigger, the
+ * trigger untaps the team and queues another combat — and the block requirement is still standing
+ * for that combat. The load-bearing detail is the *duration*: `MustBeBlockedExecutor` installs a
+ * [Duration.EndOfTurn] floating effect, not a this-combat one, which is the only reason "each
+ * combat this turn" is faithful. A this-combat duration would look identical in a single-combat
+ * test and silently break the card's whole engine, so the duration is asserted directly.
+ *
+ * The extra combat phase is asserted on the active player's [AdditionalPhasesComponent] queue
+ * (CR 500.8) rather than by driving a second combat, so the test stays inside one turn.
+ */
+class AnzragTheQuakeMoleScenarioTest : FunSpec({
+
+    val blocker = card("Anzrag Test Wall") {
+        manaCost = "{2}"
+        typeLine = "Creature — Wall"
+        power = 0
+        toughness = 6
+    }
+
+    val bystander = card("Anzrag Test Ox") {
+        manaCost = "{2}{G}"
+        typeLine = "Creature — Ox"
+        power = 3
+        toughness = 3
+    }
+
+    val mustBeBlockedAbilityId = AnzragTheQuakeMole.activatedAbilities.single().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AnzragTheQuakeMole, blocker, bystander))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        return driver
+    }
+
+    // Player 1 may not be active at game start (random turn order) — advance until it is.
+    fun GameTestDriver.advanceToPlayer1DeclareAttackers() {
+        passPriorityUntil(Step.DECLARE_ATTACKERS)
+        var safety = 0
+        while (activePlayer != player1 && safety < 50) {
+            bothPass()
+            passPriorityUntil(Step.DECLARE_ATTACKERS)
+            safety++
+        }
+    }
+
+    fun GameTestDriver.isTapped(id: EntityId) =
+        state.getEntity(id)?.has<TappedComponent>() == true
+
+    fun GameTestDriver.queuedExtraPhases(playerId: EntityId) =
+        state.getEntity(playerId)?.get<AdditionalPhasesComponent>()?.phases.orEmpty()
+
+    test("becoming blocked untaps the team and queues an additional combat phase") {
+        val driver = createDriver()
+        val anzrag = driver.putCreatureOnBattlefield(driver.player1, "Anzrag, the Quake-Mole")
+        val ox = driver.putCreatureOnBattlefield(driver.player1, "Anzrag Test Ox")
+        val wall = driver.putCreatureOnBattlefield(driver.player2, "Anzrag Test Wall")
+        driver.removeSummoningSickness(anzrag)
+        driver.removeSummoningSickness(ox)
+
+        driver.advanceToPlayer1DeclareAttackers()
+        driver.tapPermanent(ox) // a creature that stayed home, tapped for mana
+        driver.declareAttackers(driver.player1, listOf(anzrag), driver.player2)
+        driver.isTapped(anzrag) shouldBe true
+
+        driver.bothPass() // end declare attackers → declare blockers
+        driver.declareBlockers(driver.player2, mapOf(wall to listOf(anzrag)))
+        driver.bothPass() // the becomes-blocked trigger resolves
+
+        // "untap each creature you control" — including the attacker itself, which stays in combat.
+        driver.isTapped(anzrag) shouldBe false
+        driver.isTapped(ox) shouldBe false
+        // …and the defending player's creature is untouched by "you control".
+        driver.state.getEntity(wall)?.has<TappedComponent>() shouldBe false
+
+        val queued = driver.queuedExtraPhases(driver.player1)
+        queued.size shouldBe 1
+        queued.single().kind shouldBe ExtraPhaseKind.COMBAT
+    }
+
+    test("attacking unblocked does not fire the trigger") {
+        val driver = createDriver()
+        val anzrag = driver.putCreatureOnBattlefield(driver.player1, "Anzrag, the Quake-Mole")
+        driver.removeSummoningSickness(anzrag)
+
+        driver.advanceToPlayer1DeclareAttackers()
+        driver.declareAttackers(driver.player1, listOf(anzrag), driver.player2)
+        driver.bothPass()
+        driver.declareNoBlockers(driver.player2)
+        driver.bothPass()
+
+        driver.isTapped(anzrag) shouldBe true
+        driver.queuedExtraPhases(driver.player1) shouldBe emptyList()
+    }
+
+    test("the activated ability installs a must-be-blocked requirement that lasts the whole turn") {
+        val driver = createDriver()
+        val anzrag = driver.putCreatureOnBattlefield(driver.player1, "Anzrag, the Quake-Mole")
+        driver.removeSummoningSickness(anzrag)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(driver.player1, Color.RED, 4)
+        driver.giveMana(driver.player1, Color.GREEN, 3)
+
+        driver.submit(
+            ActivateAbility(playerId = driver.player1, sourceId = anzrag, abilityId = mustBeBlockedAbilityId)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        val requirement = driver.state.floatingEffects.single {
+            it.effect.modification is SerializableModification.MustBeBlockedIfAble
+        }
+        requirement.effect.affectedEntities shouldBe setOf(anzrag)
+        // "each combat this turn" — not "this combat". An end-of-turn duration is what makes the
+        // requirement survive into the additional combat phase the trigger queues.
+        requirement.duration shouldBe Duration.EndOfTurn
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CrypticCoatScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CrypticCoatScenarioTest.kt
@@ -1,0 +1,152 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.CrypticCoat
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cryptic Coat (MKM #50) — {2}{U} Artifact — Equipment.
+ *
+ * "When this Equipment enters, cloak the top card of your library, then attach this Equipment to
+ * it. Equipped creature gets +1/+0 and can't be blocked. {1}{U}: Return this Equipment to its
+ * owner's hand."
+ *
+ * The whole card hangs on the "then": the Equipment must land on the very permanent its own
+ * trigger just created, with no targeting. That is a two-step pipeline handoff —
+ * `MoveCollectionEffect.storeMovedAs` republishes the *battlefield* entity id after the face-down
+ * move, and `EffectTarget.PipelineTarget` feeds it to the attach. If that handoff silently
+ * resolved to nothing, the card would still cloak and would still look correct on the board, so
+ * the attachment assertion is the point of this file, not decoration.
+ *
+ * Cryptic Coat has no equip ability by design (Scryfall ruling 2024-02-02), so the bounce test
+ * doubles as the "re-cloak" loop check: return it, recast it, and a second card is cloaked.
+ */
+class CrypticCoatScenarioTest : FunSpec({
+
+    val bear = card("Coat Test Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    val bounceAbilityId = CrypticCoat.activatedAbilities.single().id
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CrypticCoat, bear))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.faceDownPermanents(playerId: EntityId) =
+        getPermanents(playerId).filter { state.getEntity(it)?.has<FaceDownComponent>() == true }
+
+    /** Cast the Coat from hand and let its enters trigger resolve. */
+    fun GameTestDriver.playCoat(playerId: EntityId): EntityId {
+        val inHand = putCardInHand(playerId, "Cryptic Coat")
+        giveMana(playerId, Color.BLUE, 3)
+        castSpell(playerId, inHand).error shouldBe null
+        bothPass() // the Coat resolves; its enters trigger goes on the stack
+        bothPass() // the trigger resolves
+        return inHand
+    }
+
+    test("the enters trigger cloaks the top card and attaches the Coat to it") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val topCard = driver.putCardOnTopOfLibrary(player, "Coat Test Bear")
+        val librarySizeBefore = driver.state.getLibrary(player).size
+
+        val coat = driver.playCoat(player)
+
+        // The top card — that exact card — is now a face-down cloaked permanent.
+        val cloaked = driver.faceDownPermanents(player)
+        cloaked shouldBe listOf(topCard)
+        driver.state.getEntity(topCard)?.get<FaceDownModeComponent>()?.mode shouldBe FaceDownMode.CLOAK
+        driver.state.getLibrary(player).size shouldBe librarySizeBefore - 1
+
+        // …and the Coat is attached to it. This is the pipeline handoff under test.
+        val attachment = driver.state.getEntity(coat)?.get<AttachedToComponent>()
+        attachment.shouldNotBeNull()
+        attachment.targetId shouldBe topCard
+    }
+
+    test("the equipped cloaked creature is a 3/2 that can't be blocked") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val topCard = driver.putCardOnTopOfLibrary(player, "Coat Test Bear")
+        driver.playCoat(player)
+
+        val projected = driver.state.projectedState
+        // 2/2 face-down body (CR 701.58a) plus the Equipment's +1/+0.
+        projected.getPower(topCard) shouldBe 3
+        projected.getToughness(topCard) shouldBe 2
+        // Ward {2} is a face-down characteristic of cloak, kept alongside the Coat's grants.
+        projected.hasKeyword(topCard, Keyword.WARD) shouldBe true
+        projected.hasKeyword(topCard, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+    }
+
+    test("{1}{U} returns the Coat to hand, unattaching it") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val topCard = driver.putCardOnTopOfLibrary(player, "Coat Test Bear")
+        val coat = driver.playCoat(player)
+
+        driver.giveMana(player, Color.BLUE, 2)
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = coat, abilityId = bounceAbilityId)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(player, Zone.HAND)).contains(coat) shouldBe true
+        driver.state.getEntity(coat)?.get<AttachedToComponent>() shouldBe null
+        // The cloaked creature stays behind as a plain 2/2 — the buff left with the Coat.
+        driver.state.projectedState.getPower(topCard) shouldBe 2
+        driver.state.projectedState.hasKeyword(topCard, AbilityFlag.CANT_BE_BLOCKED) shouldBe false
+    }
+
+    test("recasting the returned Coat cloaks a second card") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        driver.putCardOnTopOfLibrary(player, "Coat Test Bear")
+        val coat = driver.playCoat(player)
+
+        driver.giveMana(player, Color.BLUE, 2)
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = coat, abilityId = bounceAbilityId)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.putCardOnTopOfLibrary(player, "Coat Test Bear")
+        driver.giveMana(player, Color.BLUE, 3)
+        driver.castSpell(player, coat).error shouldBe null
+        driver.bothPass()
+        driver.bothPass()
+
+        driver.faceDownPermanents(player).size shouldBe 2
+        driver.state.getEntity(coat)?.get<AttachedToComponent>().shouldNotBeNull()
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ThePrideOfHullCladeScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ThePrideOfHullCladeScenarioTest.kt
@@ -1,0 +1,157 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.state.components.combat.CanAttackDespiteDefenderThisTurnComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Pride of Hull Clade (MKM #172) — {10}{G} 2/15 Legendary Creature — Crocodile Elk Turtle.
+ *
+ * "This spell costs {X} less to cast, where X is the total toughness of creatures you control.
+ *  Defender
+ *  {2}{U}{U}: Until end of turn, target creature you control gets +1/+0, gains 'Whenever this
+ *  creature deals combat damage to a player, draw cards equal to its toughness,' and can attack as
+ *  though it didn't have defender."
+ *
+ * Two things are worth pinning down. The cost reduction is the *toughness* reading of Ghalta's
+ * power reduction, so it is asserted against creatures whose power and toughness differ — a
+ * power-vs-toughness mix-up would pass any test built on vanilla bears. And the ruling that the
+ * reduction "can't reduce the total cost below {G}" falls out of CR 601.2f (only generic mana is
+ * reduced), which is checked with a board big enough to overshoot the {10}.
+ *
+ * The activated ability's three grants land on the *target*, not on the Pride: inside the granted
+ * trigger "this creature" re-points at whatever received it, which is the whole reason the card
+ * hands its ability to something with evasion rather than attacking with a defender-bearing 2/15.
+ */
+class ThePrideOfHullCladeScenarioTest : ScenarioTestBase() {
+
+    init {
+        val abilityId by lazy {
+            cardRegistry.getCard("The Pride of Hull Clade")!!.script.activatedAbilities.single().id
+        }
+
+        context("cost reduction — total toughness, not total power") {
+
+            test("with no creatures the spell costs its printed {10}{G}") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .build()
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("The Pride of Hull Clade"),
+                    game.player1Id,
+                    fromZone = Zone.HAND,
+                )
+                cost.genericAmount shouldBe 10
+            }
+
+            test("a 1/5 reduces the cost by 5, its toughness — not by 1, its power") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wall of Air")
+                    .build()
+
+                val wall = cardRegistry.requireCard("Wall of Air")
+                withClue("the fixture creature must have differing power and toughness") {
+                    (wall.creatureStats!!.power == wall.creatureStats!!.toughness) shouldBe false
+                }
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("The Pride of Hull Clade"),
+                    game.player1Id,
+                    fromZone = Zone.HAND,
+                )
+                withClue("Wall of Air is 1/5, so the {10} drops to {5} — by toughness, not power") {
+                    cost.genericAmount shouldBe 5
+                }
+            }
+
+            test("only creatures you control count toward the reduction") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(2, "Wall of Air")
+                    .build()
+
+                val calc = CostCalculator(cardRegistry)
+                val pride = cardRegistry.requireCard("The Pride of Hull Clade")
+
+                withClue("an opponent's creature contributes nothing") {
+                    calc.calculateEffectiveCost(game.state, pride, game.player1Id, fromZone = Zone.HAND)
+                        .genericAmount shouldBe 10
+                }
+                withClue("the opponent casting it does get their own board's reduction") {
+                    calc.calculateEffectiveCost(game.state, pride, game.player2Id, fromZone = Zone.HAND)
+                        .genericAmount shouldBe 5
+                }
+            }
+
+            test("the reduction bottoms out at {G} — only generic mana is reduced (CR 601.2f)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wall of Air")
+                    .withCardOnBattlefield(1, "Wall of Swords")
+                    .withCardOnBattlefield(1, "Force of Nature")
+                    .build()
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("The Pride of Hull Clade"),
+                    game.player1Id,
+                    fromZone = Zone.HAND,
+                )
+                withClue("total toughness here overshoots the {10}; generic can only reach 0") {
+                    cost.genericAmount shouldBe 0
+                }
+            }
+        }
+
+        context("the activated ability") {
+
+            test("grants +1/+0 and a defender bypass to the targeted creature, not to itself") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Pride of Hull Clade")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pride = game.findPermanent("The Pride of Hull Clade")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = pride,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                )
+                withClue("activating should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                withClue("Grizzly Bears is 2/2 base, +1/+0 from the ability") {
+                    projected.getPower(bears) shouldBe 3
+                    projected.getToughness(bears) shouldBe 2
+                }
+                game.state.getEntity(bears)?.has<CanAttackDespiteDefenderThisTurnComponent>() shouldBe true
+                withClue("the Pride keeps its own printed body and its own defender") {
+                    projected.getPower(pride) shouldBe 2
+                    projected.getToughness(pride) shouldBe 15
+                    game.state.getEntity(pride)?.has<CanAttackDespiteDefenderThisTurnComponent>() shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/VannifarEvolvedEnigmaScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/VannifarEvolvedEnigmaScenarioTest.kt
@@ -1,0 +1,161 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.VannifarEvolvedEnigma
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Vannifar, Evolved Enigma (MKM #241) — {2}{G}{U} 3/4.
+ *
+ * "At the beginning of combat on your turn, choose one —
+ *  • Cloak a card from your hand.
+ *  • Put a +1/+1 counter on each colorless creature you control."
+ *
+ * The two modes are one engine and the test proves the link the card never states: a cloaked
+ * permanent is *colorless* (CR 708.2), so the second mode grows exactly what the first mode makes.
+ * That is why the counter mode is asserted against a cloaked green bear rather than an obviously
+ * colorless artifact — if the filter read the card's printed colors instead of projected ones, a
+ * green card cloaked face down would be skipped and the card's whole loop would quietly not work.
+ *
+ * The cloak mode is a hand-side pipeline (gather hand → select one → move face down with
+ * [FaceDownMode.CLOAK]); this is the first card in the corpus to cloak from hand rather than from
+ * the library, so the selection decision and the face-down mode are both asserted here.
+ */
+class VannifarEvolvedEnigmaScenarioTest : FunSpec({
+
+    val greenBear = card("Vannifar Test Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(VannifarEvolvedEnigma, greenBear))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        return driver
+    }
+
+    // Player 1 may not be active at game start (random turn order) — advance until it is.
+    fun GameTestDriver.advanceToPlayer1BeginCombat() {
+        passPriorityUntil(Step.BEGIN_COMBAT)
+        var safety = 0
+        while (activePlayer != player1 && safety < 50) {
+            bothPass()
+            passPriorityUntil(Step.BEGIN_COMBAT)
+            safety++
+        }
+    }
+
+    fun GameTestDriver.faceDownPermanents(playerId: EntityId) =
+        getPermanents(playerId).filter { state.getEntity(it)?.has<FaceDownComponent>() == true }
+
+    /** Put [cardName] onto the battlefield already cloaked, the way a real cloak entry leaves it. */
+    fun GameTestDriver.cloak(playerId: EntityId, cardName: String): EntityId {
+        val id = putPermanentOnBattlefield(playerId, cardName)
+        val cardDef = cardRegistry.requireCard(cardName)
+        replaceState(
+            state.updateEntity(id) { container ->
+                var c = container.with(FaceDownComponent)
+                    .with(FaceDownModeComponent(FaceDownMode.CLOAK))
+                FaceDownTurnUp.dataFor(cardDef, cardName, FaceDownMode.CLOAK)?.let { c = c.with(it) }
+                c
+            }
+        )
+        return id
+    }
+
+    fun GameTestDriver.plusOneCounters(entityId: EntityId): Int =
+        state.getEntity(entityId)?.get<CountersComponent>()
+            ?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("the trigger offers exactly the two printed modes") {
+        val driver = createDriver()
+        driver.putCreatureOnBattlefield(driver.player1, "Vannifar, Evolved Enigma")
+        driver.advanceToPlayer1BeginCombat()
+        driver.bothPass()
+
+        val modeDecision = driver.pendingDecision as ChooseOptionDecision
+        modeDecision.options shouldBe listOf(
+            "Cloak a card from your hand",
+            "Put a +1/+1 counter on each colorless creature you control",
+        )
+    }
+
+    test("mode 1 cloaks the chosen card from hand as a 2/2 with ward") {
+        val driver = createDriver()
+        driver.putCreatureOnBattlefield(driver.player1, "Vannifar, Evolved Enigma")
+        val inHand = driver.putCardInHand(driver.player1, "Vannifar Test Bear")
+        driver.advanceToPlayer1BeginCombat()
+        driver.bothPass()
+
+        val modeDecision = driver.pendingDecision as ChooseOptionDecision
+        driver.submitDecision(driver.player1, OptionChosenResponse(modeDecision.id, 0))
+        driver.bothPass() // the mode is picked as the trigger goes on the stack; now resolve it
+        driver.submitCardSelection(driver.player1, listOf(inHand))
+
+        driver.faceDownPermanents(driver.player1) shouldBe listOf(inHand)
+        driver.state.getEntity(inHand)?.get<FaceDownModeComponent>()?.mode shouldBe FaceDownMode.CLOAK
+        driver.state.projectedState.getPower(inHand) shouldBe 2
+        driver.state.projectedState.getToughness(inHand) shouldBe 2
+        driver.state.projectedState.hasKeyword(inHand, Keyword.WARD) shouldBe true
+        driver.state.getHand(driver.player1).contains(inHand) shouldBe false
+    }
+
+    test("mode 2 counters a cloaked green card — face-down means colorless, not printed-colorless") {
+        val driver = createDriver()
+        val vannifar = driver.putCreatureOnBattlefield(driver.player1, "Vannifar, Evolved Enigma")
+        // Cloak the green bear directly: this test is about the counter mode's filter, and the
+        // cloak-from-hand path has its own test above.
+        val bear = driver.cloak(driver.player1, "Vannifar Test Bear")
+
+        driver.advanceToPlayer1BeginCombat()
+        driver.bothPass()
+        val counterMode = driver.pendingDecision as ChooseOptionDecision
+        driver.submitDecision(driver.player1, OptionChosenResponse(counterMode.id, 1))
+        driver.bothPass()
+
+        // The face-down bear is colorless (CR 708.2) and gets the counter…
+        driver.plusOneCounters(bear) shouldBe 1
+        driver.state.projectedState.getPower(bear) shouldBe 3
+        driver.state.projectedState.getToughness(bear) shouldBe 3
+        // …while Vannifar herself, green-blue and face up, does not.
+        driver.plusOneCounters(vannifar) shouldBe 0
+    }
+
+    test("mode 1 with an empty hand is a legal choice that simply does nothing") {
+        val driver = createDriver()
+        driver.putCreatureOnBattlefield(driver.player1, "Vannifar, Evolved Enigma")
+        driver.replaceState(
+            driver.state.copy(
+                zones = driver.state.zones + (ZoneKey(driver.player1, Zone.HAND) to emptyList()),
+            )
+        )
+        driver.advanceToPlayer1BeginCombat()
+        driver.bothPass()
+
+        val modeDecision = driver.pendingDecision as ChooseOptionDecision
+        driver.submitDecision(driver.player1, OptionChosenResponse(modeDecision.id, 0))
+        driver.bothPass()
+
+        driver.faceDownPermanents(driver.player1) shouldBe emptyList()
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -928,6 +928,76 @@
     ]
 }
 
+// Anzrag, the Quake-Mole
+{
+    "name": "Anzrag, the Quake-Mole",
+    "manaCost": "{2}{R}{G}",
+    "typeLine": "Legendary Creature — Mole God",
+    "oracleText": "Whenever Anzrag becomes blocked, untap each creature you control. After this phase, there is an additional combat phase.\n{3}{R}{R}{G}{G}: Anzrag must be blocked each combat this turn if able.",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "TapUntap",
+                                "target": "Self",
+                                "tap": false
+                            }
+                        },
+                        "AddCombatPhase"
+                    ]
+                },
+                "descriptionOverride": "Whenever Anzrag becomes blocked, untap each creature you control. After this phase, there is an additional combat phase."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{R}{R}{G}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "MustBeBlocked",
+                    "target": "Self",
+                    "allCreatures": false
+                },
+                "descriptionOverride": "Anzrag must be blocked each combat this turn if able."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "rarity": "MYTHIC",
+        "artist": "Helge C. Balzer",
+        "flavorText": "His claws tear at the foundations of civilization.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/70e9d8b8-4b32-4414-b32f-1f47523239c5.jpg?1783912855"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Archdruid's Charm
 {
     "name": "Archdruid's Charm",
@@ -3983,6 +4053,100 @@
         ]
     },
     "colorIdentityOverride": []
+}
+
+// Cryptic Coat
+{
+    "name": "Cryptic Coat",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, cloak the top card of your library, then attach this Equipment to it. (To cloak a card, put it onto the battlefield face down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)\nEquipped creature gets +1/+0 and can't be blocked.\n{1}{U}: Return this Equipment to its owner's hand.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "crypticCoatCloak"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "crypticCoatCloak",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "faceDown": "CLOAK",
+                            "storeMovedAs": "crypticCoatCloaked"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "crypticCoatCloaked"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this Equipment enters, cloak the top card of your library, then attach this Equipment to it."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand"
+                },
+                "descriptionOverride": "Return this Equipment to its owner's hand."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "CantBeBlocked",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "rarity": "RARE",
+        "artist": "Julia Metzger",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c3d7e2c-a104-4757-9984-fb31088f92c4.jpg?1783912915"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // Culvert Ambusher
@@ -16217,6 +16381,119 @@
     ]
 }
 
+// The Pride of Hull Clade
+{
+    "name": "The Pride of Hull Clade",
+    "manaCost": "{10}{G}",
+    "typeLine": "Legendary Creature — Crocodile Elk Turtle",
+    "oracleText": "This spell costs {X} less to cast, where X is the total toughness of creatures you control.\nDefender\n{2}{U}{U}: Until end of turn, target creature you control gets +1/+0, gains \"Whenever this creature deals combat damage to a player, draw cards equal to its toughness,\" and can attack as though it didn't have defender.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 15
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        },
+                        {
+                            "type": "GrantTriggeredAbility",
+                            "ability": {
+                                "id": "ability_2",
+                                "trigger": {
+                                    "type": "DealsDamageEvent",
+                                    "damageType": "DamageCombat",
+                                    "recipient": "AnyPlayer"
+                                },
+                                "effect": {
+                                    "type": "DrawCards",
+                                    "count": {
+                                        "type": "EntityProperty",
+                                        "entity": "Source",
+                                        "numericProperty": "Toughness"
+                                    }
+                                }
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        },
+                        {
+                            "type": "CanAttackDespiteDefenderThisTurn",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    }
+                ],
+                "descriptionOverride": "Until end of turn, target creature you control gets +1/+0, gains \"Whenever this creature deals combat damage to a player, draw cards equal to its toughness,\" and can attack as though it didn't have defender."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "TotalPropertyAmongPermanentsYouControl",
+                        "property": "Toughness",
+                        "filter": "creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "172",
+        "rarity": "MYTHIC",
+        "artist": "Brent Hollowell",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/edb40ab9-e552-4eb5-9c35-09094136dd4f.jpg?1783912862"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // They Went This Way
 {
     "name": "They Went This Way",
@@ -17374,6 +17651,109 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Vannifar, Evolved Enigma
+{
+    "name": "Vannifar, Evolved Enigma",
+    "manaCost": "{2}{G}{U}",
+    "typeLine": "Legendary Creature — Elf Ooze Wizard",
+    "oracleText": "At the beginning of combat on your turn, choose one —\n• Cloak a card from your hand. (Put it onto the battlefield face down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)\n• Put a +1/+1 counter on each colorless creature you control.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "vannifarHand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "vannifarHand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "vannifarCloaking",
+                                        "prompt": "Choose a card to cloak"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "vannifarCloaking",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Battlefield"
+                                        },
+                                        "faceDown": "CLOAK"
+                                    }
+                                ]
+                            },
+                            "description": "Cloak a card from your hand"
+                        },
+                        {
+                            "effect": {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": {
+                                            "cardPredicates": [
+                                                "IsCreature",
+                                                "IsColorless"
+                                            ],
+                                            "controllerPredicate": "ControlledByYou"
+                                        }
+                                    }
+                                },
+                                "body": {
+                                    "type": "AddCounters",
+                                    "counterType": "+1/+1",
+                                    "count": 1,
+                                    "target": "Self"
+                                }
+                            },
+                            "description": "Put a +1/+1 counter on each colorless creature you control"
+                        }
+                    ],
+                    "countsAsModalSpell": false
+                },
+                "descriptionOverride": "At the beginning of combat on your turn, choose one — Cloak a card from your hand; or put a +1/+1 counter on each colorless creature you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "rarity": "MYTHIC",
+        "artist": "Uriah Voth",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6d381eb-6cb6-4505-aebe-995c1ddc8527.jpg?1783912833"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
Four MKM cards, each built entirely from existing SDK primitives — no new engine vocabulary.

- **Cryptic Coat** ({2}{U} Equipment) — enters trigger cloaks the top card of your library and attaches the Coat to it; equipped creature gets +1/+0 and can't be blocked; {1}{U} returns it to hand. The "then" is a pipeline handoff: `MoveCollectionEffect.storeMovedAs` republishes the *battlefield* entity id after the face-down move and `Effects.AttachEquipment` reads it via `EffectTarget.PipelineTarget`, so the Coat lands on the permanent it just made — no targeting, no ward tax on itself. No equip ability, per the card's own ruling.
- **Anzrag, the Quake-Mole** ({2}{R}{G} 8/4) — `Triggers.BecomesBlocked` + `ForEachInGroup` untap + `Effects.AddCombatPhase`; the activation is `MustBeBlockedEffect(allCreatures = false)`. `MustBeBlockedExecutor` installs a `Duration.EndOfTurn` floating effect, which is what makes "each combat this turn" faithful across the extra combat the trigger queues.
- **Vannifar, Evolved Enigma** ({2}{G}{U} 3/4) — modal `Triggers.BeginCombat`: cloak a card from hand, or +1/+1 counter on each colorless creature you control. The link between the modes is CR 708.2 — a face-down permanent is colorless, and `CardPredicate.IsColorless` reads *projected* colors. Cloak-from-hand is the first of its kind in the corpus and is spelled inline; `Patterns.Hand.putFromHand` has no face-down mode and widening it for one caller would be speculative.
- **The Pride of Hull Clade** ({10}{G} 2/15) — cost reduction is `CostReductionSource.TotalPropertyAmongPermanentsYouControl(Toughness, Creature)`, the toughness reading of Ghalta's power source. The {2}{U}{U} ability is three grants onto one target (`ModifyStats`, `GrantTriggeredAbilityEffect`, `CanAttackDespiteDefenderThisTurn`); inside the granted ability "this creature" re-points at the host, which is what makes the card hand its ability off.

### Tests

16 scenario tests across four files (one per card), all passing, plus `just build` green and the MKM golden re-blessed with only these four cards moving. Each test file targets the wiring that would fail *silently*: the attach-to-pipeline-target handoff, the end-of-turn (not this-combat) block requirement, the projected-colorless filter proved with a cloaked green card, and toughness-vs-power in the cost reduction proved with a 1/5.

### Considered and dropped

Four other MKM cards were surveyed and left out because they need engine work rather than composition, each of which belongs in its own `add-feature` PR:

- **Airtight Alibi** — "can't become suspected" has no static; needs a `CantBecomeSuspected` modification, a projection flag, and a guard in `SetSuspectedExecutor` (model on `CantBeTurnedFaceUp`).
- **Judith, Carnage Connoisseur** — "that spell gains deathtouch" is inert. `DamageUtils` consults `SpellGrantedKeywordsComponent` for lifelink and wither but reads deathtouch only off projected keywords, which never cover stack objects.
- **Tolsimir, Midnight's Light** — `ForceBlockExecutor` hardcodes the forced attacker to `context.sourceId`; Tolsimir's attacker is the triggering Wolf. The underlying `MustBlockSpecificAttacker` modification already takes an arbitrary attacker id, so the fix is an `attacker: EffectTarget` parameter.
- **Flotsam // Jetsam** — Jetsam's "if a spell cast this way would be put into a graveyard, exile it instead" has no rider on the collection-cast rail; `CastFromCollectionWithoutPayingCostEffect` has no `exileAfterResolve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)