### PR TITLE
Add two Murders at Karlov Manor cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6697,15 +6697,20 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
     grant. (Cascade-style granted keywords are instead modelled as a `youCastSpell(...)`-triggered `Effects.Cascade`
     on the granter — see **Quandrix, the Proof** / Wildsear, Scouring Maw — since cascade is a cast trigger, not a
     cost keyword.)
-  - **Damage keywords on the spell object** (LIFELINK) — the noncombat-damage path (`DamageUtils.dealDamageToTarget`)
-    now also consults `GrantedKeywordResolver` for the spell *source's* current controller, so
-    "`<type>` spells you control have lifelink" is honored when a matching spell deals damage → its controller
-    gains that much life (**Lo and Li, Twin Tutors** → `GrantKeywordToOwnSpells(LIFELINK, Any.withSubtype("Lesson"))`,
-    validated with a burn Lesson like Ozai's Cruelty). Static keyword projection only reaches battlefield permanents,
-    so a *spell* granted lifelink is invisible to `projected.hasKeyword`; the damage site reads the grant directly
-    (the same shape as the existing wither-on-spell check, which reads `SpellGrantedKeywordsComponent`). One-shot
-    per-spell grants (`GrantKeywordToSpellEffect` → `SpellGrantedKeywordsComponent`, e.g. a copy that gains lifelink)
-    feed the same check.
+  - **Damage keywords on the spell object** (LIFELINK, DEATHTOUCH) — the noncombat-damage path
+    (`DamageUtils.dealDamageToTarget`) also consults `GrantedKeywordResolver` for the spell *source's* current
+    controller, so "`<type>` spells you control have lifelink" is honored when a matching spell deals damage → its
+    controller gains that much life (**Lo and Li, Twin Tutors** →
+    `GrantKeywordToOwnSpells(LIFELINK, Any.withSubtype("Lesson"))`, validated with a burn Lesson like Ozai's
+    Cruelty). Static keyword projection only reaches battlefield permanents, so a *spell* granted lifelink or
+    deathtouch is invisible to `projected.hasKeyword`; the damage site reads the grant directly (the same shape as
+    the existing wither-on-spell check, which reads `SpellGrantedKeywordsComponent`). One-shot per-spell grants
+    (`GrantKeywordToSpellEffect` → `SpellGrantedKeywordsComponent`) feed the same check — a copy that gains
+    lifelink, or **Judith, Carnage Connoisseur**'s "that spell gains deathtouch and lifelink". Both read sites go
+    through one helper each (`DamageUtils.sourceHasDeathtouch` / `sourceHasGrantedDamageKeyword`), so a third
+    source-read damage keyword is a one-line addition rather than a new hunt for read sites. Combat damage is
+    deliberately *not* wired this way: a combat-damage source is always a permanent, which projection already
+    covers.
   **Gating this with a condition is silently inert today.** `staticAbility { condition = … }`
   wraps the ability in a `ConditionalStaticAbility`, and `GrantedKeywordResolver` matches the bare type
   without unwrapping it — so the grant never applies rather than applying conditionally. Teach

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/Doppelgang.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/Doppelgang.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfTargetEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Doppelgang — Murders at Karlov Manor #198
+ * {X}{X}{X}{G}{U} · Sorcery
+ *
+ * For each of X target permanents, create X tokens that are copies of that permanent.
+ *
+ * X squared, for three mana each. The single X is spent three times over: it prices the spell, it
+ * caps how many permanents you may target, and it sets how many copies each of them gets — so the
+ * card's whole shape is one number read in three places.
+ *
+ * Both quantity reads are the same [DynamicAmount.XValue], resolved from the X locked in at cast
+ * time:
+ *  - `TargetPermanent.dynamicMaxCount` clamps the *target count* to X. This surfaces as
+ *    `xConstrainsTargetCount` on the legal action, so the client's targeting overlay stops the
+ *    player at X and `TargetValidator` rejects a cast that exceeded it. `optional = true` follows
+ *    the [com.wingedsheep.mtg.sets.definitions.mir.cards.BuildersBane] precedent for the "X target"
+ *    shape: X=0 is legal but does nothing, and a board with fewer than X legal permanents doesn't
+ *    make the spell uncastable.
+ *  - `CreateTokenCopyOfTargetEffect.count` is the *copies per target*.
+ *
+ * [ForEachTargetEffect] is what turns one into the other: it re-runs its body once per surviving
+ * target with that target bound to `ContextTarget(0)`, so a target that became illegal in response
+ * is skipped without costing the others their copies.
+ *
+ * Copying is the standard copiable-values path, which is exactly what the rulings ask for: tokens
+ * take printed characteristics (plus whatever the original was itself copying), not counters,
+ * Auras, damage, or tap state, and their enters-the-battlefield abilities trigger normally. Nothing
+ * strips legendary — copying your own legend is a real, deliberate way to lose it to the legend
+ * rule, and copying an opponent's is a real way to make them lose theirs.
+ */
+val Doppelgang = card("Doppelgang") {
+    manaCost = "{X}{X}{X}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Sorcery"
+    oracleText = "For each of X target permanents, create X tokens that are copies of that permanent."
+
+    spell {
+        target = TargetPermanent(
+            optional = true,
+            filter = TargetFilter.Permanent,
+            dynamicMaxCount = DynamicAmount.XValue
+        )
+        effect = ForEachTargetEffect(
+            listOf(
+                CreateTokenCopyOfTargetEffect(
+                    target = EffectTarget.ContextTarget(0),
+                    count = DynamicAmount.XValue
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "198"
+        artist = "Chris Rallis"
+        flavorText = "\"Suspect spotted at the Tin Street Market, Yescu Street entrance. And the " +
+            "Oak Street entrance. And somehow also in Lobar Alley!\"\n" +
+            "—Avult of the Foundway Associates"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2daec58-78ed-4da5-b3b0-b04f12b0acbd.jpg?1783912852"
+
+        ruling(
+            "2024-02-02",
+            "The tokens copy exactly what was printed on the original permanent and nothing else " +
+                "(unless that permanent is itself copying something else; see below). They don't " +
+                "copy whether that permanent is tapped or untapped, whether it has any counters " +
+                "on it or Auras attached to it, or any non-copy effects that have changed its " +
+                "power, toughness, types, color, and so on."
+        )
+        ruling(
+            "2024-02-02",
+            "If the copied permanent is copying something else, then the tokens enter the " +
+                "battlefield as whatever that permanent copied."
+        )
+        ruling("2024-02-02", "If the copied permanent has {X} in its mana cost, X is 0.")
+        ruling(
+            "2024-02-02",
+            "Any enters-the-battlefield abilities of the copied permanent will trigger when the " +
+                "tokens enter the battlefield. Any \"as [this permanent] enters the battlefield\" " +
+                "or \"[this permanent] enters the battlefield with\" abilities of the permanent " +
+                "will also work."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/JudithCarnageConnoisseur.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/JudithCarnageConnoisseur.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Judith, Carnage Connoisseur — Murders at Karlov Manor #210
+ * {3}{B}{R} · Legendary Creature — Human Shaman · 3/4
+ *
+ * Whenever you cast an instant or sorcery spell, choose one —
+ * • That spell gains deathtouch and lifelink.
+ * • Create a 2/2 red Imp creature token with "When this token dies, it deals 2 damage to each
+ *   opponent."
+ *
+ * A cast trigger with two payoffs that want opposite kinds of spell: mode one turns a burn spell
+ * into removal-plus-drain, mode two banks value off a spell that was never going to deal damage
+ * (a counterspell, a tutor) — so the choice is made per cast, not per Judith.
+ *
+ * Modelled as a [ModalEffect] hanging off [Triggers.YouCastInstantOrSorcery]. The engine picks the
+ * mode when the *ability resolves* rather than when it's put on the stack (CR 601.2b via 603.3d);
+ * that is the existing convention for every modal triggered ability in the corpus (Faces of the
+ * Past), and it is unobservable here because the ability resolves before the spell that triggered
+ * it either way.
+ *
+ * Mode one is two [Effects.GrantKeywordToSpell] grants onto [EffectTarget.TriggeringEntity] — the
+ * spell object still on the stack, not a permanent. Static keyword projection only reaches
+ * battlefield permanents, so both keywords have to be read back off the spell-grant channel when
+ * the spell deals its damage; the lifelink half of that read already existed, the deathtouch half
+ * is added in this change (`DamageUtils.sourceHasDeathtouch`). Per the rulings, the spell must
+ * *itself* deal the damage: a spell that tells another object to deal damage keeps neither keyword's
+ * benefit, which falls out for free because the damage source is then that other object.
+ *
+ * Mode two's Imp carries its death trigger as a token-level [TriggeredAbility] rather than a
+ * granted static, so the token is self-contained and a copy of it keeps the trigger.
+ */
+val JudithCarnageConnoisseur = card("Judith, Carnage Connoisseur") {
+    manaCost = "{3}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Human Shaman"
+    power = 3
+    toughness = 4
+    oracleText = "Whenever you cast an instant or sorcery spell, choose one —\n" +
+        "• That spell gains deathtouch and lifelink.\n" +
+        "• Create a 2/2 red Imp creature token with \"When this token dies, it deals 2 damage to " +
+        "each opponent.\""
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(
+                Effects.Composite(
+                    Effects.GrantKeywordToSpell(Keyword.DEATHTOUCH, EffectTarget.TriggeringEntity),
+                    Effects.GrantKeywordToSpell(Keyword.LIFELINK, EffectTarget.TriggeringEntity)
+                ),
+                "That spell gains deathtouch and lifelink"
+            ),
+            Mode.noTarget(
+                CreateTokenEffect(
+                    power = 2,
+                    toughness = 2,
+                    colors = setOf(Color.RED),
+                    creatureTypes = setOf("Imp"),
+                    imageUri = "https://cards.scryfall.io/normal/front/4/7/47a1385b-2be2-49a8-8400-186cd5525dad.jpg?1783912609",
+                    triggeredAbilities = listOf(
+                        TriggeredAbility.create(
+                            trigger = Triggers.Dies.event,
+                            binding = Triggers.Dies.binding,
+                            effect = DealDamageEffect(2, EffectTarget.PlayerRef(Player.EachOpponent))
+                        )
+                    )
+                ),
+                "Create a 2/2 red Imp creature token with \"When this token dies, it deals 2 " +
+                    "damage to each opponent.\""
+            )
+        )
+        description = "Whenever you cast an instant or sorcery spell, choose one — " +
+            "that spell gains deathtouch and lifelink; or create a 2/2 red Imp creature token " +
+            "with \"When this token dies, it deals 2 damage to each opponent.\""
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "210"
+        artist = "Jodie Muir"
+        flavorText = "\"I don't make my living hiding the truth, detective. I shout it from the stage.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3eaa19ce-cace-499e-8b23-ef9e56b23700.jpg?1783912849"
+
+        ruling(
+            "2024-02-02",
+            "Judith, Carnage Connoisseur's triggered ability resolves before the spell that " +
+                "caused it to trigger. The ability will resolve even if that spell is countered."
+        )
+        ruling(
+            "2024-02-02",
+            "An instant or sorcery spell with deathtouch must actually deal damage to a creature " +
+                "for it to be destroyed. If the spell instructs another object to deal damage " +
+                "(for example, Hard-Hitting Question), the spell doesn't deal any damage itself " +
+                "and its instance of deathtouch doesn't apply. Dealing 0 damage isn't dealing damage."
+        )
+        ruling(
+            "2024-02-02",
+            "Similarly, an instant or sorcery spell with lifelink must actually deal damage in " +
+                "order to cause its controller to gain life. If the spell instructs another " +
+                "object to deal damage, its controller won't gain life when that damage is dealt."
+        )
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DoppelgangScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DoppelgangScenarioTest.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Doppelgang (MKM #198) — {X}{X}{X}{G}{U} Sorcery.
+ *
+ * "For each of X target permanents, create X tokens that are copies of that permanent."
+ *
+ * One announced X is read in two different places — the number of permanents you may target and
+ * the number of copies each of them gets — so the card produces X² tokens. A wiring that resolved
+ * the copy count from anything other than the same announced X (a fixed 1, the target count, the
+ * mana actually spent) would still look plausible at X=1, where every reading agrees. X=2 is the
+ * smallest value that separates them: four tokens, two per target.
+ */
+class DoppelgangScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Doppelgang") {
+
+            test("X = 2 makes two copies of each of two targets") {
+                val game = scenario()
+                    .withPlayers("Copier", "Opponent")
+                    .withCardInHand(1, "Doppelgang")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+                val doppelgang = game.findCardsInHand(1, "Doppelgang").single()
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = doppelgang,
+                        targets = listOf(
+                            ChosenTarget.Permanent(bears),
+                            ChosenTarget.Permanent(courser)
+                        ),
+                        xValue = 2
+                    )
+                )
+                withClue("casting with X = 2 and two targets should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("two copies of your own creature, plus the original") {
+                    game.findAllPermanents("Grizzly Bears").size shouldBe 3
+                }
+                withClue("two copies of the opponent's creature, plus the original") {
+                    game.findAllPermanents("Centaur Courser").size shouldBe 3
+                }
+            }
+
+            test("X = 1 makes a single copy of a single target") {
+                val game = scenario()
+                    .withPlayers("Copier", "Opponent")
+                    .withCardInHand(1, "Doppelgang")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val doppelgang = game.findCardsInHand(1, "Doppelgang").single()
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = doppelgang,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                        xValue = 1
+                    )
+                )
+                withClue("casting with X = 1 should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("one copy joins the original") {
+                    game.findAllPermanents("Grizzly Bears").size shouldBe 2
+                }
+            }
+
+            test("X = 0 is castable and copies nothing") {
+                val game = scenario()
+                    .withPlayers("Copier", "Opponent")
+                    .withCardInHand(1, "Doppelgang")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val doppelgang = game.findCardsInHand(1, "Doppelgang").single()
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = doppelgang,
+                        targets = emptyList(),
+                        xValue = 0
+                    )
+                )
+                withClue("X = 0 with no targets is a legal (if pointless) cast: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("no tokens were created") {
+                    game.findAllPermanents("Grizzly Bears").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/JudithCarnageConnoisseurScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/JudithCarnageConnoisseurScenarioTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Judith, Carnage Connoisseur (MKM #210) — {3}{B}{R} 3/4 Legendary Human Shaman.
+ *
+ * "Whenever you cast an instant or sorcery spell, choose one —
+ *  • That spell gains deathtouch and lifelink.
+ *  • Create a 2/2 red Imp creature token with "When this token dies, it deals 2 damage to each
+ *    opponent.""
+ *
+ * Mode one is the reason this file exists. Keywords granted to a *spell* live on the stack object,
+ * which static keyword projection never reaches — so a damage path that reads deathtouch or
+ * lifelink only through `projected.hasKeyword` sees nothing, and the mode silently does nothing.
+ * Lifelink already consulted the spell-grant channel; deathtouch did not, and now does
+ * (`DamageUtils.sourceHasDeathtouch`). The Shock-into-a-3/3 test is the shape that catches it: a
+ * 3/3 survives 2 damage unless deathtouch applied, so the kill *is* the assertion.
+ *
+ * The same test run without Judith is the control — it proves the 3/3 dying is the grant's doing
+ * and not something about Shock or the harness.
+ *
+ * Mode two's Imp carries its own death trigger, so the drain has to survive the token leaving the
+ * battlefield: it is last-known information about a token that no longer exists when the ability
+ * resolves.
+ */
+class JudithCarnageConnoisseurScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Judith, Carnage Connoisseur") {
+
+            test("mode one: the spell gains deathtouch, so 2 damage kills a 3/3") {
+                val game = scenario()
+                    .withPlayers("Judith", "Opponent")
+                    .withCardOnBattlefield(1, "Judith, Carnage Connoisseur", summoningSickness = false)
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                val lifeBefore = game.getLifeTotal(1)
+
+                val cast = game.castSpell(1, "Shock", courser)
+                withClue("casting Shock should succeed: ${cast.error}") { cast.error shouldBe null }
+
+                // Judith's trigger goes on the stack above Shock and resolves first.
+                game.resolveStack()
+                val modeDecision = game.getPendingDecision() as? ChooseOptionDecision
+                    ?: error("expected a mode choice for Judith's trigger; got ${game.getPendingDecision()}")
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 0))
+
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("a 3/3 dealt 2 deathtouch damage is destroyed as a state-based action") {
+                    game.isInGraveyard(2, "Centaur Courser") shouldBe true
+                }
+                withClue("and lifelink on the same spell gains its controller 2") {
+                    game.getLifeTotal(1) shouldBe lifeBefore + 2
+                }
+            }
+
+            test("control: without Judith, Shock leaves the 3/3 alive and gains nothing") {
+                val game = scenario()
+                    .withPlayers("Burner", "Opponent")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                val lifeBefore = game.getLifeTotal(1)
+
+                game.castSpell(1, "Shock", courser).error shouldBe null
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("2 damage does not kill a 3/3 on its own") {
+                    game.isInGraveyard(2, "Centaur Courser") shouldBe false
+                }
+                withClue("and no life is gained") { game.getLifeTotal(1) shouldBe lifeBefore }
+            }
+
+            test("mode two: creates a 2/2 red Imp whose death drains each opponent for 2") {
+                val game = scenario()
+                    .withPlayers("Judith", "Opponent")
+                    .withCardOnBattlefield(1, "Judith, Carnage Connoisseur", summoningSickness = false)
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(2, "Shock")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Point Judith's own Shock at the opponent so the only creature that can die is the Imp.
+                val cast = game.castSpellTargetingPlayer(1, "Shock", 2)
+                withClue("casting Shock should succeed: ${cast.error}") { cast.error shouldBe null }
+
+                game.resolveStack()
+                val modeDecision = game.getPendingDecision() as? ChooseOptionDecision
+                    ?: error("expected a mode choice for Judith's trigger; got ${game.getPendingDecision()}")
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 1))
+                game.resolveStack()
+
+                val imp = game.findPermanent("Imp Token")
+                withClue("mode two put an Imp token on the battlefield") { (imp != null) shouldBe true }
+
+                val opponentLifeBefore = game.getLifeTotal(2)
+
+                // The opponent kills the token; their own Shock never triggers Judith ("you cast").
+                game.passPriority()
+                val kill = game.castSpell(2, "Shock", imp!!)
+                withClue("the opponent can Shock the Imp: ${kill.error}") { kill.error shouldBe null }
+                game.resolveStack()
+                game.checkStateBasedActions()
+                game.resolveStack()
+
+                withClue("the 2/2 Imp died to 2 damage") { game.findPermanent("Imp Token") shouldBe null }
+                withClue("its death trigger drained each opponent of its controller for 2") {
+                    game.getLifeTotal(2) shouldBe opponentLifeBefore - 2
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/KellanInquisitiveProdigyScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/KellanInquisitiveProdigyScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.player.LandDropsComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Kellan, Inquisitive Prodigy // Tail the Suspect (MKM #212).
+ *
+ * Creature face: {2}{G}{U} 3/4 Legendary Human Faerie Detective with flying and vigilance,
+ * "Whenever Kellan attacks, destroy up to one target artifact. If you controlled that permanent,
+ * draw a card."
+ * Adventure face: Tail the Suspect {G}{U}, "Investigate. You may play an additional land this turn."
+ *
+ * The attack trigger's ordering is the thing worth pinning. The draw is conditioned on *your*
+ * control of the artifact, and the artifact is destroyed in the same resolution — so a control test
+ * that ran after the destruction would look at a graveyard card and always answer no, silently
+ * turning the card into plain artifact removal. These tests separate the two halves: your own
+ * artifact draws, an opponent's does not, and "up to one" means the trigger can resolve having
+ * chosen nothing at all.
+ */
+class KellanInquisitiveProdigyScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Kellan, Inquisitive Prodigy") {
+
+            test("attacking and destroying your own artifact draws a card") {
+                val game = scenario()
+                    .withPlayers("Kellan", "Opponent")
+                    .withCardOnBattlefield(1, "Kellan, Inquisitive Prodigy", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Magnifying Glass")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                    .build()
+
+                val glass = game.findPermanent("Magnifying Glass")!!
+                val handBefore = game.handSize(1)
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Kellan, Inquisitive Prodigy" to 2)).error shouldBe null
+
+                game.selectTargets(listOf(glass)).error shouldBe null
+                game.resolveStack()
+
+                withClue("your own artifact is destroyed all the same") {
+                    game.isInGraveyard(1, "Magnifying Glass") shouldBe true
+                }
+                withClue("and because you controlled it, you draw") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+
+            test("destroying an opponent's artifact draws nothing") {
+                val game = scenario()
+                    .withPlayers("Kellan", "Opponent")
+                    .withCardOnBattlefield(1, "Kellan, Inquisitive Prodigy", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Magnifying Glass")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                    .build()
+
+                val glass = game.findPermanent("Magnifying Glass")!!
+                val handBefore = game.handSize(1)
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Kellan, Inquisitive Prodigy" to 2)).error shouldBe null
+
+                game.selectTargets(listOf(glass)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the opponent's artifact is destroyed") {
+                    game.isInGraveyard(2, "Magnifying Glass") shouldBe true
+                }
+                withClue("but you never controlled it, so no card") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+
+            test("'up to one target' resolves cleanly with nothing chosen") {
+                val game = scenario()
+                    .withPlayers("Kellan", "Opponent")
+                    .withCardOnBattlefield(1, "Kellan, Inquisitive Prodigy", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Magnifying Glass")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Kellan, Inquisitive Prodigy" to 2)).error shouldBe null
+
+                game.skipTargets().error shouldBe null
+                game.resolveStack()
+
+                withClue("nothing was destroyed") {
+                    game.isOnBattlefield("Magnifying Glass") shouldBe true
+                }
+                withClue("and nothing was drawn") { game.handSize(1) shouldBe handBefore }
+            }
+
+            test("Tail the Suspect investigates and grants a second land drop") {
+                val game = scenario()
+                    .withPlayers("Kellan", "Opponent")
+                    .withCardInHand(1, "Kellan, Inquisitive Prodigy")
+                    .withCardsInHand(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val kellan = game.findCardsInHand(1, "Kellan, Inquisitive Prodigy").single()
+
+                // faceIndex 0 is the Adventure face (CR 715.3).
+                val cast = game.execute(
+                    CastSpell(playerId = game.player1Id, cardId = kellan, faceIndex = 0)
+                )
+                withClue("casting the Adventure face should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("investigate made a Clue") { game.findPermanents("Clue").size shouldBe 1 }
+                withClue("the adventurer card went on an adventure rather than to the graveyard") {
+                    game.isInExile(1, "Kellan, Inquisitive Prodigy") shouldBe true
+                }
+
+                val forests = game.findCardsInHand(1, "Forest")
+                game.execute(PlayLand(game.player1Id, forests[0])).error shouldBe null
+                withClue("the extra land drop makes a second land legal this turn") {
+                    game.execute(PlayLand(game.player1Id, forests[1])).error shouldBe null
+                }
+                withClue("both land drops were spent") {
+                    game.state.getEntity(game.player1Id)?.get<LandDropsComponent>()?.remaining shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -5008,6 +5008,67 @@
     ]
 }
 
+// Doppelgang
+{
+    "name": "Doppelgang",
+    "manaCost": "{X}{X}{X}{G}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "For each of X target permanents, create X tokens that are copies of that permanent.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "CreateTokenCopyOfTarget",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                },
+                "count": "XValue"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "permanent"
+                },
+                "dynamicMaxCount": "XValue"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "rarity": "RARE",
+        "artist": "Chris Rallis",
+        "flavorText": "\"Suspect spotted at the Tin Street Market, Yescu Street entrance. And the Oak Street entrance. And somehow also in Lobar Alley!\"\n—Avult of the Foundway Associates",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2daec58-78ed-4da5-b3b0-b04f12b0acbd.jpg?1783912852",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "The tokens copy exactly what was printed on the original permanent and nothing else (unless that permanent is itself copying something else; see below). They don't copy whether that permanent is tapped or untapped, whether it has any counters on it or Auras attached to it, or any non-copy effects that have changed its power, toughness, types, color, and so on."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If the copied permanent is copying something else, then the tokens enter the battlefield as whatever that permanent copied."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If the copied permanent has {X} in its mana cost, X is 0."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Any enters-the-battlefield abilities of the copied permanent will trigger when the tokens enter the battlefield. Any \"as [this permanent] enters the battlefield\" or \"[this permanent] enters the battlefield with\" abilities of the permanent will also work."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Drag the Canal
 {
     "name": "Drag the Canal",
@@ -9372,6 +9433,123 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Judith, Carnage Connoisseur
+{
+    "name": "Judith, Carnage Connoisseur",
+    "manaCost": "{3}{B}{R}",
+    "typeLine": "Legendary Creature — Human Shaman",
+    "oracleText": "Whenever you cast an instant or sorcery spell, choose one —\n• That spell gains deathtouch and lifelink.\n• Create a 2/2 red Imp creature token with \"When this token dies, it deals 2 damage to each opponent.\"",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GrantKeywordToSpell",
+                                        "keyword": "DEATHTOUCH"
+                                    },
+                                    {
+                                        "type": "GrantKeywordToSpell",
+                                        "keyword": "LIFELINK"
+                                    }
+                                ]
+                            },
+                            "description": "That spell gains deathtouch and lifelink"
+                        },
+                        {
+                            "effect": {
+                                "type": "CreateToken",
+                                "power": 2,
+                                "toughness": 2,
+                                "colors": [
+                                    "RED"
+                                ],
+                                "creatureTypes": [
+                                    "Imp"
+                                ],
+                                "imageUri": "https://cards.scryfall.io/normal/front/4/7/47a1385b-2be2-49a8-8400-186cd5525dad.jpg?1783912609",
+                                "triggeredAbilities": [
+                                    {
+                                        "id": "ability_2",
+                                        "trigger": {
+                                            "type": "ZoneChangeEvent",
+                                            "from": "Battlefield",
+                                            "to": "Graveyard"
+                                        },
+                                        "effect": {
+                                            "type": "DealDamage",
+                                            "amount": {
+                                                "type": "Fixed",
+                                                "amount": 2
+                                            },
+                                            "target": {
+                                                "type": "PlayerRef",
+                                                "player": "EachOpponent"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "description": "Create a 2/2 red Imp creature token with \"When this token dies, it deals 2 damage to each opponent.\""
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever you cast an instant or sorcery spell, choose one — that spell gains deathtouch and lifelink; or create a 2/2 red Imp creature token with \"When this token dies, it deals 2 damage to each opponent.\""
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "rarity": "RARE",
+        "artist": "Jodie Muir",
+        "flavorText": "\"I don't make my living hiding the truth, detective. I shout it from the stage.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3eaa19ce-cace-499e-8b23-ef9e56b23700.jpg?1783912849",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Judith, Carnage Connoisseur's triggered ability resolves before the spell that caused it to trigger. The ability will resolve even if that spell is countered."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "An instant or sorcery spell with deathtouch must actually deal damage to a creature for it to be destroyed. If the spell instructs another object to deal damage (for example, Hard-Hitting Question), the spell doesn't deal any damage itself and its instance of deathtouch doesn't apply. Dealing 0 damage isn't dealing damage."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Similarly, an instant or sorcery spell with lifelink must actually deal damage in order to cause its controller to gain life. If the spell instructs another object to deal damage, its controller won't gain life when that damage is dealt."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -389,7 +389,7 @@ object DamageUtils {
                 // dealt damage by this source, so a deathtouch source still marks it for
                 // destruction as an SBA (CR 702.2b / 704.5h) even though nothing is marked as
                 // normal damage. Record the deathtouch flag without marking damage.
-                if (projected.hasKeyword(sourceId, Keyword.DEATHTOUCH)) {
+                if (sourceId != null && sourceHasDeathtouch(newState, projected, sourceId)) {
                     newState = newState.updateEntity(targetId) { container ->
                         val existing = container.get<DamageComponent>()
                         container.with(DamageComponent(
@@ -401,7 +401,7 @@ object DamageUtils {
             } else {
                 val existingDamage = newState.getEntity(targetId)?.get<DamageComponent>()
                 val currentDamage = existingDamage?.amount ?: 0
-                val hasDeathtouch = sourceId != null && projected.hasKeyword(sourceId, Keyword.DEATHTOUCH)
+                val hasDeathtouch = sourceId != null && sourceHasDeathtouch(newState, projected, sourceId)
                 // Excess damage (CR 120.4a) — damage in excess of what was needed to be
                 // lethal. With deathtouch, any amount of damage greater than 1 is excess —
                 // lethal collapses to a flat 1 regardless of marked damage (CR 120.4a refs
@@ -518,7 +518,7 @@ object DamageUtils {
         if (sourceId != null) {
             val projected = newState.projectedState
             if (projected.hasKeyword(sourceId, Keyword.LIFELINK.name) ||
-                sourceHasGrantedLifelink(newState, sourceId)
+                sourceHasGrantedDamageKeyword(newState, sourceId, Keyword.LIFELINK)
             ) {
                 val controllerId = projected.getController(sourceId)
                     ?: newState.getEntity(sourceId)?.get<ControllerComponent>()?.playerId
@@ -686,24 +686,47 @@ object DamageUtils {
     }
 
     /**
-     * Lifelink (and other damage keywords) can be granted onto a spell *object on the stack*, not
-     * just printed on or projected onto a battlefield source. Static keyword projection
+     * A damage keyword can be granted onto a spell *object on the stack*, not just printed on or
+     * projected onto a battlefield source. Static keyword projection
      * ([StateProjector]/[AffectsFilterResolver]) only reaches battlefield permanents, so a spell
-     * that "has lifelink" via a grant is invisible to `projected.hasKeyword`. This mirrors the
-     * wither treatment above by consulting the two spell-grant channels for the noncombat-damage
-     * lifelink check:
+     * that "has lifelink" or "has deathtouch" via a grant is invisible to `projected.hasKeyword`.
+     * This mirrors the wither treatment above by consulting the two spell-grant channels:
      *  - [SpellGrantedKeywordsComponent] — a one-shot keyword stamped onto this specific spell
-     *    (e.g. a copy that "gains lifelink").
-     *  - [GrantKeywordToOwnSpells] — a continuous "<type> spells you control have lifelink" static
+     *    (e.g. Judith, Carnage Connoisseur's "that spell gains deathtouch and lifelink", or a copy
+     *    that "gains lifelink").
+     *  - [GrantKeywordToOwnSpells] — a continuous "<type> spells you control have <keyword>" static
      *    on a permanent the spell's current controller controls (e.g. Lo and Li, Twin Tutors →
      *    Lesson spells). Resolved live via [GrantedKeywordResolver].
      *
      * Only spells on the stack qualify (gated on [SpellOnStackComponent]); battlefield sources are
      * already covered by projected keywords.
+     *
+     * [keyword] is a parameter rather than a hard-coded LIFELINK because both damage keywords that
+     * read off the *source* — lifelink (CR 702.15b) and deathtouch (CR 702.2b) — reach a spell by
+     * exactly these two channels; only the read site differs.
      */
-    private fun sourceHasGrantedLifelink(state: GameState, sourceId: EntityId): Boolean {
+    /**
+     * Does [sourceId] have deathtouch for the purpose of the damage it is dealing right now?
+     *
+     * Projected keywords cover every battlefield source; a *spell* on the stack is not projected,
+     * so a spell that gained deathtouch (Judith, Carnage Connoisseur) has to be read off the
+     * spell-grant channels instead — the same split the lifelink and wither checks already make.
+     */
+    private fun sourceHasDeathtouch(
+        state: GameState,
+        projected: ProjectedState,
+        sourceId: EntityId
+    ): Boolean =
+        projected.hasKeyword(sourceId, Keyword.DEATHTOUCH) ||
+            sourceHasGrantedDamageKeyword(state, sourceId, Keyword.DEATHTOUCH)
+
+    private fun sourceHasGrantedDamageKeyword(
+        state: GameState,
+        sourceId: EntityId,
+        keyword: Keyword
+    ): Boolean {
         val container = state.getEntity(sourceId) ?: return false
-        if (container.get<SpellGrantedKeywordsComponent>()?.keywords?.contains(Keyword.LIFELINK.name) == true) {
+        if (container.get<SpellGrantedKeywordsComponent>()?.keywords?.contains(keyword.name) == true) {
             return true
         }
         // A resolving spell is popped from `state.stack` *before* its effects run, but keeps its
@@ -713,7 +736,7 @@ object DamageUtils {
         val controllerId = container.get<ControllerComponent>()?.playerId ?: spellOnStack.casterId
         val cardDef = container.get<CardComponent>()
             ?.let { cardRegistry.getCard(it.cardDefinitionId) } ?: return false
-        return GrantedKeywordResolver(cardRegistry).hasKeyword(state, controllerId, cardDef, Keyword.LIFELINK)
+        return GrantedKeywordResolver(cardRegistry).hasKeyword(state, controllerId, cardDef, keyword)
     }
 
     /**


### PR DESCRIPTION
Two of MKM's remaining cards, plus the one-line engine gap the first of them exposed.

## Cards

- **Judith, Carnage Connoisseur** ({3}{B}{R}, rare) — a `ModalEffect` on `Triggers.YouCastInstantOrSorcery`. Mode one is two `Effects.GrantKeywordToSpell` grants onto `EffectTarget.TriggeringEntity`; mode two is a `CreateTokenEffect` whose 2/2 red Imp carries its own dies trigger (`DealDamageEffect(2, PlayerRef(EachOpponent))`), so the token is self-contained.
- **Doppelgang** ({X}{X}{X}{G}{U}, rare) — one announced X read in two places. `TargetPermanent.dynamicMaxCount = XValue` clamps the target count (the Builder's Bane shape, `xConstrainsTargetCount` on the legal action), `CreateTokenCopyOfTargetEffect.count = XValue` sets copies per target, and `ForEachTargetEffect` turns one into the other.

## Engine fix

Judith's mode one was inert for half its text. Keywords granted to a *spell* live on the stack object, which static keyword projection never reaches — the damage path already made that exception for wither (inline) and lifelink (its own helper), but deathtouch was still a bare `projected.hasKeyword`.

`sourceHasGrantedLifelink` is generalized to `sourceHasGrantedDamageKeyword(keyword)` — both spell-grant channels were already keyword-agnostic, only the read site differed — and both deathtouch reads in `DamageUtils.applyDamage` now go through `sourceHasDeathtouch`. Combat damage is deliberately untouched: a combat-damage source is always a permanent, which projection already covers. `docs/card-sdk-language-reference.md` updated in the same change.

`JudithCarnageConnoisseurScenarioTest` pins it with Shock into a 3/3 — a 3/3 survives 2 damage unless deathtouch applied, so the kill *is* the assertion — with the same board minus Judith as the control.

## Also here

`KellanInquisitiveProdigyScenarioTest` — Kellan, Inquisitive Prodigy is already implemented (I initially mis-scoped it as missing, because Scryfall names the card by both faces). It had no scenario test, and its attack trigger makes a claim worth pinning: the "if you controlled that permanent" test must run *before* the destruction, or it would read a graveyard card and always answer no. Four tests: your artifact draws, an opponent's does not, "up to one" resolves having chosen nothing, and the Adventure face investigates and grants the second land drop. No change to the card itself.

## Dropped from the batch

**Coveted Falcon** — its turned-face-up trigger needs new vocabulary in two places: `GainControlEffect` has no recipient parameter ("target *opponent* gains control of"), and the count-linked draw would need a per-requirement target count rather than the context-wide `TARGET_COUNT`. That is `add-feature` work and its own PR.

Most of MKM's remaining 32 cards are blocked the same way — 12 of them are Cases, and the "to solve" mechanic does not exist at all.

## Verification

`just build`, then `just test` — full suite green. `just check-card-printing` clean for both cards (MKM is the earliest real printing for each). Snapshot re-blessed; the golden diff is 178 pure insertions and only the two new cards move. Every metadata field and image URI re-checked against Scryfall.