### PR TITLE
Add two Mirrodin cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GoblinCharbelcher.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GoblinCharbelcher.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Goblin Charbelcher — Mirrodin #176 (canonical printing)
+ * {4} · Artifact
+ *
+ * {3}, {T}: Reveal cards from the top of your library until you reveal a land card. This artifact
+ * deals damage equal to the number of nonland cards revealed this way to any target. If the
+ * revealed land card was a Mountain, this artifact deals double that damage instead. Put the
+ * revealed cards on the bottom of your library in any order.
+ *
+ * The Erratic Explosion shape with the partition inverted: [GatherUntilMatchEffect] walks the
+ * library until it hits a *land* rather than a nonland, so the "revealed this way" pile is every
+ * card seen and `landCard` holds the single stopper. A [FilterCollectionEffect] splits the
+ * nonlands back out because the damage counts them, not the whole reveal — and the two differ by
+ * exactly one whenever a land was actually found.
+ *
+ * The Mountain clause is a [DynamicAmount.Conditional] over that stopper rather than a separate
+ * effect branch: "double that damage instead" replaces the amount, so it has to be one damage
+ * event. `withSubtype("Mountain")` is the land *type*, not the card name — a Sacred Foundry or a
+ * Mountain-typed Blinkmoth Nexus doubles the damage just as a basic Mountain does.
+ *
+ * Running the library out is the same code path with no stopper: `landCard` stays empty, the
+ * condition is false, and every card revealed was nonland, which is the 2016-06-08 ruling
+ * ("If you reveal no land cards, Goblin Charbelcher deals damage equal to the number of cards
+ * revealed"). The target is chosen at activation, before anything is revealed.
+ */
+val GoblinCharbelcher = card("Goblin Charbelcher") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{3}, {T}: Reveal cards from the top of your library until you reveal a land card. " +
+        "This artifact deals damage equal to the number of nonland cards revealed this way to any target. " +
+        "If the revealed land card was a Mountain, this artifact deals double that damage instead. " +
+        "Put the revealed cards on the bottom of your library in any order."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        val victim = target("any target", AnyTarget())
+
+        val nonlandsRevealed = DynamicAmounts.distinctEntitiesIn("nonlands")
+
+        effect = Effects.Composite(
+            listOf(
+                GatherUntilMatchEffect(
+                    filter = GameObjectFilter.Land,
+                    storeMatch = "landCard",
+                    storeRevealed = "revealed"
+                ),
+                RevealCollectionEffect(from = "revealed"),
+                FilterCollectionEffect(
+                    from = "revealed",
+                    filter = CollectionFilter.MatchesFilter(GameObjectFilter.Nonland),
+                    storeMatching = "nonlands"
+                ),
+                Effects.DealDamage(
+                    amount = DynamicAmount.Conditional(
+                        condition = Conditions.CollectionContainsMatch(
+                            collection = "landCard",
+                            filter = GameObjectFilter.Land.withSubtype("Mountain")
+                        ),
+                        ifTrue = DynamicAmount.Multiply(nonlandsRevealed, 2),
+                        ifFalse = nonlandsRevealed
+                    ),
+                    target = victim
+                ),
+                MoveCollectionEffect(
+                    from = "revealed",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.ControllerChooses
+                )
+            )
+        )
+        description = "{3}, {T}: Reveal cards from the top of your library until you reveal a land card. " +
+            "This artifact deals damage equal to the number of nonland cards revealed this way to any target. " +
+            "If the revealed land card was a Mountain, this artifact deals double that damage instead. " +
+            "Put the revealed cards on the bottom of your library in any order."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "176"
+        artist = "Stephen Tappin"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6c37fc1-4842-4bc5-93ed-83fff9e420f2.jpg?1783944520"
+        ruling("2016-06-08", "You must choose a target for Goblin Charbelcher's ability as you activate it, before you reveal any cards.")
+        ruling("2016-06-08", "If you reveal no land cards, Goblin Charbelcher deals damage equal to the number of cards revealed, and then you may order your library as you like.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SpoilsOfTheVault.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SpoilsOfTheVault.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Spoils of the Vault — Mirrodin #78 (canonical printing)
+ * {B} · Instant
+ *
+ * Choose a card name. Reveal cards from the top of your library until you reveal a card with that
+ * name, then put that card into your hand. Exile all other cards revealed this way, and you lose 1
+ * life for each of the exiled cards.
+ *
+ * The Desperate Research pieces with the fixed seven-card window swapped for a walk: naming stores
+ * the choice in `chosenValues`, and [GameObjectFilter.namedFromVariable] reads it back both as the
+ * stopper for [GatherUntilMatchEffect] and as the partition for the pile it stopped on.
+ *
+ * Unlike Desperate Research this one names *any* card — the basic land names are legal choices, and
+ * the 2018-12-07 ruling is explicit that the name need not be in the library or even the deck. That
+ * case needs no branch: the walk runs the library out, the partition selects nothing, and every card
+ * revealed lands in the exile pile whose size is the life payment. Naming a card that *is* on top
+ * costs zero life the same way, because the matching card never enters that pile.
+ */
+val SpoilsOfTheVault = card("Spoils of the Vault") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Choose a card name. Reveal cards from the top of your library until you reveal a card " +
+        "with that name, then put that card into your hand. Exile all other cards revealed this way, " +
+        "and you lose 1 life for each of the exiled cards."
+
+    spell {
+        val named = GameObjectFilter.Any.namedFromVariable("chosenName")
+
+        effect = Effects.Composite(
+            listOf(
+                // 1. Choose a card name — any name, basic lands included.
+                Effects.ChooseCardName(
+                    storeAs = "chosenName",
+                    prompt = "Choose a card name"
+                ),
+                // 2. Walk the top of the library until that name shows up (or it runs out).
+                GatherUntilMatchEffect(
+                    player = Player.You,
+                    filter = named,
+                    storeMatch = "match",
+                    storeRevealed = "revealed"
+                ),
+                RevealCollectionEffect(from = "revealed"),
+                // 3. Partition the reveal: the named card vs. everything seen on the way to it.
+                SelectFromCollectionEffect(
+                    from = "revealed",
+                    selection = SelectionMode.All,
+                    filter = named,
+                    storeSelected = "toHand",
+                    storeRemainder = "toExile"
+                ),
+                MoveCollectionEffect(
+                    from = "toHand",
+                    destination = CardDestination.ToZone(Zone.HAND, Player.You)
+                ),
+                MoveCollectionEffect(
+                    from = "toExile",
+                    destination = CardDestination.ToZone(Zone.EXILE, Player.You)
+                ),
+                // 4. One life per exiled card — counted after the move, by entity id.
+                Effects.LoseLife(
+                    amount = DynamicAmounts.distinctEntitiesIn("toExile"),
+                    target = EffectTarget.Controller
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "78"
+        artist = "Thomas M. Baxa"
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b9d100d-d20b-4018-8518-609113ec36d7.jpg?1783944544"
+        ruling("2018-12-07", "You don't have to choose the name of a card that's still in your library, or even a card that's in your deck at all. If no card with the chosen name is in your library, you exile your library and lose 1 life for each of those cards.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinCharbelcherScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinCharbelcherScenarioTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.GoblinCharbelcher
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Goblin Charbelcher (MRD #176) — "{3}, {T}: Reveal cards from the top of your library until you
+ * reveal a land card. This artifact deals damage equal to the number of nonland cards revealed this
+ * way to any target. If the revealed land card was a Mountain, this artifact deals double that
+ * damage instead. Put the revealed cards on the bottom of your library in any order."
+ *
+ * Three things can quietly go wrong here and only one of them is the Mountain clause. The damage
+ * counts the *nonlands*, not the reveal — those differ by exactly one whenever a stopper was found,
+ * so a card that fed the whole pile into the damage amount would look right on a Mountain-less
+ * board and be off by one everywhere. The doubling has to replace the amount rather than add a
+ * second damage event ("double that damage instead"). And running the library out is the no-stopper
+ * path: the Mountain condition must read false off an *empty* match collection rather than throw,
+ * which is the 2016-06-08 ruling.
+ *
+ * Each test drives a hand-built library so the reveal window is exact, and checks the bottoming as
+ * well — the library must come back the same size with the revealed cards moved underneath.
+ */
+class GoblinCharbelcherScenarioTest : FunSpec({
+
+    val belchAbility = GoblinCharbelcher.activatedAbilities.single().id
+
+    /** Player 1's precombat main, with their library emptied so the test can stack it exactly. */
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + GoblinCharbelcher)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 30, "Forest" to 30), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val library = ZoneKey(d.player1, Zone.LIBRARY)
+        d.replaceState(d.state.copy(zones = d.state.zones + (library to emptyList())))
+        return d
+    }
+
+    fun GameTestDriver.library(): List<EntityId> = state.getZone(ZoneKey(player1, Zone.LIBRARY))
+
+    /** Activate the belcher at the opponent's face and let it resolve. */
+    fun GameTestDriver.belchAt(opponent: EntityId): EntityId {
+        val belcher = putPermanentOnBattlefield(player1, "Goblin Charbelcher")
+        giveColorlessMana(player1, 3)
+        submit(
+            ActivateAbility(player1, belcher, belchAbility, targets = listOf(ChosenTarget.Player(opponent)))
+        ).isSuccess shouldBe true
+        bothPass()
+        return belcher
+    }
+
+    test("damage counts the nonlands revealed, not the whole reveal") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+
+        // Bottom-up, because putCardOnTopOfLibrary prepends:
+        // top -> Lightning Bolt, Grizzly Bears, Island (the stopper), Centaur Courser.
+        val deepCard = d.putCardOnTopOfLibrary(d.player1, "Centaur Courser")
+        val stopper = d.putCardOnTopOfLibrary(d.player1, "Island")
+        val nonland2 = d.putCardOnTopOfLibrary(d.player1, "Grizzly Bears")
+        val nonland1 = d.putCardOnTopOfLibrary(d.player1, "Lightning Bolt")
+
+        d.belchAt(opponent)
+
+        withClue("two nonlands revealed above a non-Mountain land — three cards seen, two counted") {
+            d.getLifeTotal(opponent) shouldBe 18
+        }
+
+        // Bottoming the three revealed cards asks for an order.
+        d.pendingDecision.shouldBeInstanceOf<ReorderLibraryDecision>()
+        val reorder = d.pendingDecision as ReorderLibraryDecision
+        reorder.cards.toSet() shouldBe setOf(nonland1, nonland2, stopper)
+        d.submitOrderedResponse(d.player1, listOf(nonland1, nonland2, stopper))
+        d.isPaused shouldBe false
+
+        withClue("the reveal is bottomed, not drawn or exiled — same four cards, new order") {
+            d.library().size shouldBe 4
+            d.library().first() shouldBe deepCard
+            d.library().takeLast(3) shouldBe listOf(nonland1, nonland2, stopper)
+        }
+    }
+
+    test("a Mountain stopper doubles the damage") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+
+        // Same shape as above, with the stopper swapped for a Mountain.
+        d.putCardOnTopOfLibrary(d.player1, "Centaur Courser")
+        val stopper = d.putCardOnTopOfLibrary(d.player1, "Mountain")
+        val nonland2 = d.putCardOnTopOfLibrary(d.player1, "Grizzly Bears")
+        val nonland1 = d.putCardOnTopOfLibrary(d.player1, "Lightning Bolt")
+
+        d.belchAt(opponent)
+
+        withClue("\"double that damage instead\" replaces the amount: 2 nonlands -> 4") {
+            d.getLifeTotal(opponent) shouldBe 16
+        }
+
+        d.submitOrderedResponse(d.player1, listOf(nonland1, nonland2, stopper))
+        d.isPaused shouldBe false
+        d.library().size shouldBe 4
+    }
+
+    test("a landless library is revealed whole and every card counts") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+
+        val third = d.putCardOnTopOfLibrary(d.player1, "Centaur Courser")
+        val second = d.putCardOnTopOfLibrary(d.player1, "Grizzly Bears")
+        val first = d.putCardOnTopOfLibrary(d.player1, "Lightning Bolt")
+
+        d.belchAt(opponent)
+
+        withClue("no stopper: the Mountain condition reads false off an empty match, all 3 count") {
+            d.getLifeTotal(opponent) shouldBe 17
+        }
+
+        val reorder = d.pendingDecision as ReorderLibraryDecision
+        reorder.cards.toSet() shouldBe setOf(first, second, third)
+        d.submitOrderedResponse(d.player1, listOf(third, second, first))
+        d.isPaused shouldBe false
+
+        withClue("the whole library was revealed, so bottoming it just reorders it") {
+            d.library() shouldBe listOf(third, second, first)
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SpoilsOfTheVaultScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SpoilsOfTheVaultScenarioTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.SpoilsOfTheVault
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Spoils of the Vault (MRD #78) — "Choose a card name. Reveal cards from the top of your library
+ * until you reveal a card with that name, then put that card into your hand. Exile all other cards
+ * revealed this way, and you lose 1 life for each of the exiled cards."
+ *
+ * The whole card is one partition and the life total is the audit of it. The named card must land in
+ * hand and *not* in the exile pile, because the pile is the life payment — an off-by-one there is a
+ * point of life, invisible on any board where you weren't at exactly lethal. So the three tests are
+ * the three sizes that partition can take: some cards above the hit (pay for them), zero cards above
+ * it (pay nothing), and no hit at all, where the walk runs the library out and the pile is the whole
+ * deck. That last one is the 2018-12-07 ruling and needs no branch in the card — it only works if
+ * the "stop here" filter and the "this is the one" filter are the same filter.
+ */
+class SpoilsOfTheVaultScenarioTest : FunSpec({
+
+    /** Player 1's precombat main with a black mana floating and Spoils in hand. */
+    fun driver(startingLife: Int = 20): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + SpoilsOfTheVault)
+        d.initMirrorMatch(
+            deck = Deck.of("Swamp" to 30, "Forest" to 30),
+            startingLife = startingLife,
+            startingPlayer = 0
+        )
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** Cast Spoils and answer its "name a card" prompt with [cardName]. */
+    fun GameTestDriver.castSpoilsNaming(cardName: String) {
+        val spoils = putCardInHand(player1, "Spoils of the Vault")
+        giveMana(player1, Color.BLACK, 1)
+        castSpell(player1, spoils)
+        bothPass()
+
+        val decision = pendingDecision
+        decision shouldNotBe null
+        decision as ChooseOptionDecision
+        val index = decision.options.indexOf(cardName)
+        withClue("\"$cardName\" must be offered — any card name is a legal choice") {
+            index shouldNotBe -1
+        }
+        submitDecision(player1, OptionChosenResponse(decision.id, index))
+    }
+
+    fun GameTestDriver.library(): List<EntityId> = state.getZone(ZoneKey(player1, Zone.LIBRARY))
+
+    test("the named card goes to hand and the cards above it are exiled for a life each") {
+        val d = driver()
+
+        // top -> Grizzly Bears, Lightning Bolt, Centaur Courser (the name), then the deck.
+        d.putCardOnTopOfLibrary(d.player1, "Centaur Courser")
+        d.putCardOnTopOfLibrary(d.player1, "Lightning Bolt")
+        d.putCardOnTopOfLibrary(d.player1, "Grizzly Bears")
+
+        d.castSpoilsNaming("Centaur Courser")
+        d.isPaused shouldBe false
+
+        d.findCardsInHand(d.player1, "Centaur Courser").size shouldBe 1
+        withClue("the two cards seen on the way down are the exile pile") {
+            d.getExileCardNames(d.player1).sorted() shouldContainExactly
+                listOf("Grizzly Bears", "Lightning Bolt")
+        }
+        withClue("one life per exiled card — the named card is not in that pile") {
+            d.getLifeTotal(d.player1) shouldBe 18
+        }
+    }
+
+    test("naming the top card costs no life") {
+        val d = driver()
+
+        d.putCardOnTopOfLibrary(d.player1, "Grizzly Bears")
+        d.putCardOnTopOfLibrary(d.player1, "Lightning Bolt")
+
+        d.castSpoilsNaming("Lightning Bolt")
+        d.isPaused shouldBe false
+
+        d.findCardsInHand(d.player1, "Lightning Bolt").size shouldBe 1
+        withClue("the reveal stopped on the first card, so nothing was exiled") {
+            d.getExileCardNames(d.player1) shouldContainExactly emptyList()
+            d.getLifeTotal(d.player1) shouldBe 20
+        }
+    }
+
+    test("naming a card that isn't in the library exiles the whole library (2018-12-07 ruling)") {
+        // 30 life so the payment lands without ending the game — the point is the count, not a loss.
+        val d = driver(startingLife = 30)
+
+        // A five-card library, none of them the named card.
+        val libraryZone = ZoneKey(d.player1, Zone.LIBRARY)
+        d.replaceState(d.state.copy(zones = d.state.zones + (libraryZone to emptyList())))
+        repeat(3) { d.putCardOnTopOfLibrary(d.player1, "Grizzly Bears") }
+        repeat(2) { d.putCardOnTopOfLibrary(d.player1, "Swamp") }
+        d.library().size shouldBe 5
+
+        d.castSpoilsNaming("Force of Nature")
+        d.isPaused shouldBe false
+
+        withClue("no match means the walk runs the library out and every card revealed is 'other'") {
+            d.library() shouldContainExactly emptyList()
+            d.getExileCardNames(d.player1).size shouldBe 5
+            d.findCardsInHand(d.player1, "Force of Nature").size shouldBe 0
+        }
+        withClue("one life per exiled card: 30 - 5") {
+            d.getLifeTotal(d.player1) shouldBe 25
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -3661,6 +3661,123 @@
     ]
 }
 
+// Goblin Charbelcher
+{
+    "name": "Goblin Charbelcher",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "{3}, {T}: Reveal cards from the top of your library until you reveal a land card. This artifact deals damage equal to the number of nonland cards revealed this way to any target. If the revealed land card was a Mountain, this artifact deals double that damage instead. Put the revealed cards on the bottom of your library in any order.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherUntilMatch",
+                            "filter": "land",
+                            "storeMatch": "landCard",
+                            "storeRevealed": "revealed"
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "revealed"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "revealed",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "nonland"
+                            },
+                            "storeMatching": "nonlands"
+                        },
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Conditional",
+                                "condition": {
+                                    "type": "CollectionContainsMatch",
+                                    "collection": "landCard",
+                                    "filter": "land Mountain"
+                                },
+                                "ifTrue": {
+                                    "type": "Multiply",
+                                    "amount": {
+                                        "type": "DistinctEntitiesInCollections",
+                                        "collections": [
+                                            "nonlands"
+                                        ]
+                                    },
+                                    "multiplier": 2
+                                },
+                                "ifFalse": {
+                                    "type": "DistinctEntitiesInCollections",
+                                    "collections": [
+                                        "nonlands"
+                                    ]
+                                }
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "any target"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "revealed",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ],
+                "descriptionOverride": "{3}, {T}: Reveal cards from the top of your library until you reveal a land card. This artifact deals damage equal to the number of nonland cards revealed this way to any target. If the revealed land card was a Mountain, this artifact deals double that damage instead. Put the revealed cards on the bottom of your library in any order."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "176",
+        "rarity": "RARE",
+        "artist": "Stephen Tappin",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6c37fc1-4842-4bc5-93ed-83fff9e420f2.jpg?1783944520",
+        "rulings": [
+            {
+                "date": "2016-06-08",
+                "text": "You must choose a target for Goblin Charbelcher's ability as you activate it, before you reveal any cards."
+            },
+            {
+                "date": "2016-06-08",
+                "text": "If you reveal no land cards, Goblin Charbelcher deals damage equal to the number of cards revealed, and then you may order your library as you like."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Goblin Dirigible
 {
     "name": "Goblin Dirigible",
@@ -10728,6 +10845,100 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Spoils of the Vault
+{
+    "name": "Spoils of the Vault",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Choose a card name. Reveal cards from the top of your library until you reveal a card with that name, then put that card into your hand. Exile all other cards revealed this way, and you lose 1 life for each of the exiled cards.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ChooseOption",
+                    "optionType": "CARD_NAME",
+                    "storeAs": "chosenName",
+                    "prompt": "Choose a card name"
+                },
+                {
+                    "type": "GatherUntilMatch",
+                    "filter": {
+                        "cardPredicates": [
+                            {
+                                "type": "NameEqualsChosen",
+                                "variableName": "chosenName"
+                            }
+                        ]
+                    },
+                    "storeMatch": "match",
+                    "storeRevealed": "revealed"
+                },
+                {
+                    "type": "RevealCollection",
+                    "from": "revealed"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "revealed",
+                    "selection": "SelectAll",
+                    "filter": {
+                        "cardPredicates": [
+                            {
+                                "type": "NameEqualsChosen",
+                                "variableName": "chosenName"
+                            }
+                        ]
+                    },
+                    "storeSelected": "toHand",
+                    "storeRemainder": "toExile"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toHand",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toExile",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Exile"
+                    }
+                },
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "DistinctEntitiesInCollections",
+                        "collections": [
+                            "toExile"
+                        ]
+                    },
+                    "target": "Controller"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "rarity": "RARE",
+        "artist": "Thomas M. Baxa",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b9d100d-d20b-4018-8518-609113ec36d7.jpg?1783944544",
+        "rulings": [
+            {
+                "date": "2018-12-07",
+                "text": "You don't have to choose the name of a card that's still in your library, or even a card that's in your deck at all. If no card with the chosen name is in your library, you exile your library and lose 1 life for each of those cards."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 


### PR DESCRIPTION
Two Mirrodin cards that share one idea — reveal from the top of a library until you hit a match — built on the `GatherUntilMatch` → reveal → partition → move pipeline that Polymorph and Erratic Explosion already use. No new SDK vocabulary.

## Cards

- **Goblin Charbelcher** (#176) — `{3}, {T}`: reveal until a land; damage equal to the *nonland* cards revealed, to any target; doubled if that land was a Mountain; the reveal goes to the bottom in any order. `GatherUntilMatchEffect` + `FilterCollectionEffect` + `DynamicAmounts.distinctEntitiesIn`, with the Mountain clause as a `DynamicAmount.Conditional` over `Conditions.CollectionContainsMatch` so "double that damage instead" stays one damage event rather than a second one. `withSubtype("Mountain")` is the land *type*, so a Mountain-typed dual doubles too.
- **Spoils of the Vault** (#78) — name a card, reveal until that name, it goes to hand, everything else revealed is exiled, one life per exiled card. `Effects.ChooseCardName` + `GameObjectFilter.namedFromVariable` used twice: as the walk's stopper and as the partition over the pile it stopped on.

Both cards' "no match anywhere in the library" case needs no branch — the walk empties the library, the partition selects nothing, and the arithmetic lands where the rulings say it should (Charbelcher's 2016-06-08 ruling, Spoils' 2018-12-07 ruling).

## Dropped from the batch

**Proteus Staff** was implemented and its scenario tests pass, but it is held back for its own PR: it is the first card that bottoms cards into *another player's* library with an "in any order" choice, and `MoveCollectionExecutor.pauseForOrderDecision` routes that `ReorderLibraryDecision` to `context.controllerId` rather than the destination player. Proteus Staff says "**the player** puts … the rest on the bottom of *their* library in any order", so targeting an opponent's creature would prompt the wrong player.

This can't be fixed by redirecting the decision, because Cruel Fate genuinely wants the current behaviour (the caster orders the opponent's library). The fix is a new `CardOrder` case alongside `ControllerChooses` — new SDK vocabulary, so it earns its own PR with tests for the primitive.

## Verification

- `just build` green (full build + every scenario suite).
- Six new scenario tests, one file per card, all passing: nonland-count vs. whole reveal, the Mountain doubling, a landless library; the named card deep in the library, on top, and absent entirely.
- Scryfall field verification for both cards — name, mana cost, type line, oracle text, rarity, collector number, artist, image URI all match the MRD printing; both image URIs return HTTP 200.
- `just check-card-printing` green for both — MRD is the earliest real expansion, so both canonicals belong here.
- `MRD.json` snapshot re-blessed; only these two cards moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)