### PR TITLE
Add three Mirrodin cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6035,7 +6035,13 @@ staticAbility {
   `IncreaseGenericIfAnyTargetMatches(amount, filter)` (target-gated tax — "{N} more if it targets
   a Dragon", Dragon's Prey; the increase analogue of the `FixedIfAnyTargetMatches` reduction;
   applies only once a matching target is chosen, so affordability enumeration treats it as not
-  applying), `IncreaseLife(amount)`.
+  applying), `IncreaseGenericBy(source)` (the tax mirror of `ReduceGenericBy`, reading the same
+  `CostReductionSource` vocabulary — Hum of the Radix's "Each artifact spell costs {1} more to cast
+  for each artifact its controller controls" is `AnyCaster(Artifact)` +
+  `IncreaseGenericBy(ArtifactsYouControl)`. The source is evaluated against the **casting** player,
+  exactly as on the reduction side, which is what makes "its controller controls" fall out without a
+  second vocabulary: an opponent pays for *their* artifacts. Applies to alternative base costs too,
+  per CR 118.9a), `IncreaseLife(amount)`.
   Reduction `source: CostReductionSource` covers fixed amounts, counts of permanents/cards in
   zones, target gates, and a few mechanic-specific shapes — e.g. `Fixed`, `CreaturesYouControl`,
   `ArtifactsYouControl`, `PermanentsYouControlMatching(filter)` (the filtered "you control" count —

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -407,6 +407,14 @@ excluded.
   `ModifyMillAmount` replacement (Bruvac) still applies to the announced count when the cost is
   actually paid, and the library→graveyard moves go through `ZoneTransitionService`, so mill triggers
   fire exactly as they do for an effect's mill.
+- `Costs.ExileTopOfLibrary(count)` — exile the top `count` cards of your library as a cost
+  ("{R}, Exile the top ten cards of your library" — Arc-Slogger). The exile twin of `Costs.Mill`:
+  no player selection (the cards are the top of the library), and per **CR 118.3** — a player can't
+  pay a cost without the resources to pay it fully — the cost is **unpayable** on a short library and
+  gates legal-action enumeration, rather than exiling as many as possible the way the exile *effect*
+  would. Unlike mill, no `ModifyMillAmount` replacement applies: exiling from the top is not milling
+  (CR 701.17a), so the announced count is the paid count. Distinct from the `ExileFromGraveyard`-style
+  *chosen*-card costs, which mean "choose N", not "the top N".
 - `Costs.ExileSelf` — exile this permanent (or graveyard card, for graveyard-activated abilities).
 - `Costs.ReturnSelfToHand` — return this permanent to its owner's hand (Maze's End: "{3}, {T},
   Return this land to its owner's hand: …"). The bounce-to-hand sibling of `Costs.SacrificeSelf` /

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5915,6 +5915,17 @@ staticAbility {
   declaration pauses for the same mana-source confirmation as the attack tax. The pre-existing
   per-creature-type block tax (Whipgrass Entangler) uses `AttackBlockTaxPerCreatureType` floating
   effects instead.
+- `CantAttackOrBlockUnlessPay(amount: DynamicAmount)` — the **self-scoped** tax: this permanent
+  can't attack or block unless its controller pays `amount` generic mana *for it* (Myr Prototype,
+  "can't attack or block unless you pay {1} for each +1/+1 counter on it"). Where `AttackTax` /
+  `BlockTax` tax other players' creatures from the side of the board they are aimed at, here the
+  taxing permanent and the taxed creature are the same object — so there is no filter and no
+  per-attacker multiplier, and the amount is evaluated with the declared creature as the source
+  (`DynamicAmounts.countersOnSelf(…)` reads *its* counters, not a board aggregate). Priced through
+  the same `CombatTaxes` entry point as the other two, so it stacks with them, pauses declaration
+  for the same `SelectManaSourcesDecision`, and stays monotone in the declared set. Attacking and
+  blocking are charged separately; a card taxing only one half wants its own variant rather than a
+  boolean here.
 - `CantBeAttackedBy(attackerFilter)` — the general **defender-side** attack restriction (CR
   508.1c): creatures matching `attackerFilter` can't attack the controller of the permanent carrying
   it. Resolved by `CantBeAttackedByDefenderRule`, which scans the *defending* player's projected

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -176,6 +176,17 @@ object Costs {
     fun Mill(count: Int): AbilityCost = AbilityCost.Atom(CostAtom.Mill(count))
 
     /**
+     * Exile the top [count] cards of your library as a cost — "{R}, Exile the top ten cards of
+     * your library" (Arc-Slogger).
+     *
+     * The exile twin of [Mill]: no player selection (the cards are the top of the library), and
+     * unpayable unless the library holds at least [count] cards (CR 118.3). Not to be confused
+     * with [ExileFromGraveyard]-style *chosen*-card costs, which mean "choose N", not "the top N".
+     */
+    fun ExileTopOfLibrary(count: Int): AbilityCost =
+        AbilityCost.Atom(CostAtom.ExileTopOfLibrary(count))
+
+    /**
      * Discard this card (for cycling and similar abilities).
      */
     val DiscardSelf: AbilityCost = AbilityCost.DiscardSelf

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
@@ -347,6 +347,34 @@ data class AttackTax(
 }
 
 /**
+ * This permanent can't attack or block unless its controller pays [amount] generic mana for it
+ * (CR 508.1a / 509.1a — the payment is part of the cost of declaring it).
+ *
+ * The self-scoped counterpart of [AttackTax] and [BlockTax], which tax *other* players' creatures
+ * from the side of the board they are aimed at. Here the taxed creature and the taxing permanent
+ * are the same object, so there is no filter and no per-attacker multiplier: the amount is what
+ * this one creature costs to send.
+ *
+ * Used for Myr Prototype ("This creature can't attack or block unless you pay {1} for each +1/+1
+ * counter on it"), where [amount] counts the source's own counters — the reason the amount is a
+ * [DynamicAmount] rather than an `Int`, since the price changes every upkeep.
+ *
+ * Attack and block are one ability rather than two flags because the printed line is one sentence.
+ * A card that taxes only one half wants its own variant, not a boolean here.
+ *
+ * @property amount Generic mana the controller must pay to declare this creature as an attacker,
+ *           and again to declare it as a blocker. Evaluated with this permanent as the source.
+ */
+@SerialName("CantAttackOrBlockUnlessPay")
+@Serializable
+data class CantAttackOrBlockUnlessPay(
+    val amount: DynamicAmount,
+) : StaticAbility {
+    override val description: String =
+        "can't attack or block unless you pay {${amount.description}}"
+}
+
+/**
  * Creatures can't block unless their controller pays generic mana for each blocking creature.
  * The defending side of Archangel of Tithes' second ability
  * ("creatures can't block unless their controller pays {1} for each of those creatures").

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -59,6 +59,8 @@ data class ModifySpellCost(
             is CostModification.ReduceColoredIfAnyTargetMatches ->
                 "cost ${modification.symbols} less to cast if it targets ${modification.filter.description}"
             is CostModification.IncreaseGeneric -> "cost {${modification.amount}} more"
+            is CostModification.IncreaseGenericBy ->
+                "cost {X} more to cast, where X is ${fromCasterPerspective(modification.source.description)}"
             is CostModification.IncreaseColored -> "cost ${modification.symbols} more to cast"
             is CostModification.IncreaseGenericPerOtherSpellThisTurn ->
                 "cost {${modification.amountPerSpell}} more to cast for each other spell that player has cast this turn"
@@ -76,6 +78,29 @@ data class ModifySpellCost(
         }
         return "$prefix $agreedVerb$perTurn$conditionSuffix"
     }
+
+    /**
+     * Re-person a [CostReductionSource] description for a tax that isn't aimed at its own
+     * controller.
+     *
+     * Every source phrases itself from the *reducing* player's point of view ("the number of
+     * artifacts you control") because a reduction is always something you give yourself. An
+     * increase pointed at [SpellCostTarget.AnyCaster] or at opponents taxes whoever casts the
+     * spell, so "you" names the wrong player — Hum of the Radix reads "for each artifact **its
+     * controller** controls". Rewriting the possessive here keeps that in one place instead of
+     * giving all thirty sources a second-person twin they would otherwise never use.
+     */
+    private fun fromCasterPerspective(sourceDescription: String): String =
+        when (target) {
+            is SpellCostTarget.AnyCaster,
+            is SpellCostTarget.OpponentsCastTargeting,
+            is SpellCostTarget.OpponentsCastFromZones ->
+                sourceDescription
+                    .replace("you control", "its controller controls")
+                    .replace("you own", "its controller owns")
+                    .replace("your ", "its controller's ")
+            else -> sourceDescription
+        }
 
     // A filter that narrows nothing (e.g. GameObjectFilter.Any) describes itself as "card", which
     // reads wrong as an adjective ("the second card spell you cast"). Emit no adjective in that case
@@ -309,6 +334,23 @@ sealed interface CostModification {
     @SerialName("IncreaseGeneric")
     @Serializable
     data class IncreaseGeneric(val amount: Int) : CostModification
+
+    /**
+     * Increase generic mana by a dynamic amount sourced from the game state — the tax mirror of
+     * [ReduceGenericBy], reading the same [CostReductionSource] vocabulary.
+     *
+     * Used for Hum of the Radix ("Each artifact spell costs {1} more to cast for each artifact its
+     * controller controls") as
+     * `IncreaseGenericBy(CostReductionSource.ArtifactsYouControl)`.
+     *
+     * The source is evaluated against the **casting** player, exactly as it is on the reduction
+     * side. That is what makes "its controller controls" work without a second vocabulary: paired
+     * with [SpellCostTarget.AnyCaster] the counted permanents are the taxed player's, not the
+     * taxing permanent's controller's.
+     */
+    @SerialName("IncreaseGenericBy")
+    @Serializable
+    data class IncreaseGenericBy(val source: CostReductionSource) : CostModification
 
     /**
      * Add specific colored mana symbols to the cost (e.g. `"{W}"`), a colored tax effect.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
@@ -88,6 +88,29 @@ sealed interface CostAtom : TextReplaceable<CostAtom> {
     }
 
     /**
+     * Exile the top [count] cards of your library — Arc-Slogger's "{R}, Exile the top ten cards of
+     * your library".
+     *
+     * The exile twin of [Mill], and takes no selection for the same reason: the cards are the top
+     * of the library, not a player choice. Affordability is a plain library-size check (CR 118.3 —
+     * a player can't pay a cost without the resources to pay it fully), so a nine-card library
+     * can't pay a ten-card exile at all rather than exiling as many as possible. That is the split
+     * from the exile *effect*, which takes what it finds.
+     *
+     * Distinct from [ExileFrom], which is a *chosen-cards* cost ("exile two cards from your
+     * graveyard") and so means "choose N" rather than "the top N". The resulting library→exile zone
+     * changes are ordinary ones, and no mill replacement applies: exiling from the top is not
+     * milling (CR 701.17a), so nothing enlarges the announced count.
+     */
+    @SerialName("AtomExileTopOfLibrary")
+    @Serializable
+    data class ExileTopOfLibrary(val count: Int) : CostAtom {
+        override val description: String get() =
+            if (count == 1) "exile the top card of your library"
+            else "exile the top $count cards of your library"
+    }
+
+    /**
      * Sacrifice [count] permanents matching [filter].
      *
      * @property excludeSelf when true the cost's source permanent is excluded from the candidate

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtoms.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtoms.kt
@@ -33,6 +33,7 @@ fun CostAtom.repeated(times: Int): CostAtom {
         is CostAtom.Mana -> copy(cost = cost * times)
         is CostAtom.PayLife -> copy(amount = amount * times)
         is CostAtom.Mill -> copy(count = count * times)
+        is CostAtom.ExileTopOfLibrary -> copy(count = count * times)
         is CostAtom.Sacrifice -> copy(count = count * times)
         is CostAtom.VariablePermanents -> copy(minCount = minCount * times)
         is CostAtom.Discard -> copy(count = count * times)

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CostAtomSerializationTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CostAtomSerializationTest.kt
@@ -35,6 +35,7 @@ class CostAtomSerializationTest : FunSpec({
         CostAtom.Discard(count = 1, filter = GameObjectFilter.Any, random = true),
         CostAtom.ExileFrom(Zone.GRAVEYARD, GameObjectFilter.Creature, count = 3),
         CostAtom.Mill(count = 1),
+        CostAtom.ExileTopOfLibrary(count = 10),
         CostAtom.VariablePermanents(GameObjectFilter.Artifact, minCount = 1, excludeSelf = true),
         CostAtom.TapPermanents(count = 1, filter = GameObjectFilter.Creature),
         CostAtom.ReturnToHand(GameObjectFilter.Any, count = 1),
@@ -94,5 +95,8 @@ class CostAtomSerializationTest : FunSpec({
         CostAtom.Sacrifice(count = 2).selectionCount shouldBe 2
         CostAtom.ExileFrom(Zone.GRAVEYARD, count = 3).selectionCount shouldBe 3
         CostAtom.TapPermanents(count = 1).selectionCount shouldBe 1
+        // Top-of-library costs take no selection: the cards are the top, not a player's pick.
+        CostAtom.Mill(count = 1).selectionCount shouldBe 0
+        CostAtom.ExileTopOfLibrary(count = 10).selectionCount shouldBe 0
     }
 })

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ArcSlogger.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ArcSlogger.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Arc-Slogger — Mirrodin #85 (canonical printing)
+ * {3}{R}{R} · Creature — Beast · 4/5
+ *
+ * {R}, Exile the top ten cards of your library: This creature deals 2 damage to any target.
+ *
+ * The whole card is its cost. Ten cards off the top is a *cost*, not an effect, and the difference
+ * is the one thing an implementation can get wrong: CR 118.3 says a player can't pay a cost without
+ * the resources to pay it fully, so a nine-card library can't activate this at all — it does not
+ * exile nine and fire. [Costs.ExileTopOfLibrary] carries that gate, which is also why it isn't
+ * [Costs.Mill] with the destination swapped: the cards go to exile, and no mill replacement
+ * (Bruvac) touches the count.
+ *
+ * The cards are the top ten, not ten of the player's choosing, so the payment takes no selection —
+ * the same shape as milling as a cost.
+ */
+val ArcSlogger = card("Arc-Slogger") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Beast"
+    power = 4
+    toughness = 5
+    oracleText = "{R}, Exile the top ten cards of your library: This creature deals 2 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.ExileTopOfLibrary(10))
+        val victim = target("any target", AnyTarget())
+        effect = Effects.DealDamage(2, victim)
+        description = "{R}, Exile the top ten cards of your library: This creature deals 2 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "85"
+        artist = "Jeff Easley"
+        flavorText = "A shuffling sound and the smell of ozone follow the slogger as surely as its electric tail."
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d3dd67e0-72b4-4c55-b49b-c69950feccb1.jpg?1783944543"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/HumOfTheRadix.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/HumOfTheRadix.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Hum of the Radix — Mirrodin #122 (canonical printing)
+ * {2}{G}{G} · Enchantment
+ *
+ * Each artifact spell costs {1} more to cast for each artifact its controller controls.
+ *
+ * The Glowrider shape with a *dynamic* tax: [SpellCostTarget.AnyCaster] taxes every player's
+ * artifact spells, and [CostModification.IncreaseGenericBy] scales the tax off the game state
+ * instead of a printed number. It is the exact mirror of [CostModification.ReduceGenericBy] and
+ * reads the same [CostReductionSource] vocabulary, so affinity's counter needs no twin here.
+ *
+ * "its controller controls" falls out of the shared evaluation rule rather than a new source: a
+ * cost source is always evaluated against the *casting* player, which on the reduction side is
+ * the same player as the source's controller and here is the taxed one. So an opponent casting
+ * an artifact spell pays for the artifacts *they* control, not for the enchantment controller's
+ * — the difference this card is entirely built on.
+ *
+ * The counted artifacts include the spell itself only once it has resolved, since a spell on the
+ * stack is not a permanent; the tax is locked in when the total cost is determined (CR 601.2f).
+ */
+val HumOfTheRadix = card("Hum of the Radix") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Each artifact spell costs {1} more to cast for each artifact its controller controls."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.AnyCaster(GameObjectFilter.Artifact),
+            modification = CostModification.IncreaseGenericBy(CostReductionSource.ArtifactsYouControl),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "122"
+        artist = "John Avon"
+        flavorText = "The elves learned long ago that anything left here slowly vanishes. Now it is a sacred " +
+            "site where the dead are laid to rest and where unnatural magic is erased forever."
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/328f3afb-1a56-42a5-bd1e-3e704291972f.jpg?1783944533"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MyrPrototype.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MyrPrototype.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackOrBlockUnlessPay
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Myr Prototype — Mirrodin #214 (canonical printing)
+ * {5} · Artifact Creature — Myr · 2/2
+ *
+ * At the beginning of your upkeep, put a +1/+1 counter on this creature.
+ * This creature can't attack or block unless you pay {1} for each +1/+1 counter on it.
+ *
+ * The two lines are a single joke: every upkeep makes it bigger *and* dearer, so the price of
+ * swinging is always exactly the bonus it has accumulated. That is why
+ * [CantAttackOrBlockUnlessPay] takes a [com.wingedsheep.sdk.scripting.values.DynamicAmount]
+ * instead of an `Int` — a tax frozen at the printed number would be free forever.
+ *
+ * The tax is a *cost of declaring* it (CR 508.1a / 509.1a), not a restriction: the engine prices
+ * the declaration through `CombatTaxes` and pauses for the payment, so declining to pay un-declares
+ * this creature and leaves the rest of the attack standing. Attacking and blocking are charged
+ * separately — a turn cycle where it does both pays twice.
+ */
+val MyrPrototype = card("Myr Prototype") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Myr"
+    power = 2
+    toughness = 2
+    oracleText = "At the beginning of your upkeep, put a +1/+1 counter on this creature.\n" +
+        "This creature can't attack or block unless you pay {1} for each +1/+1 counter on it."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "At the beginning of your upkeep, put a +1/+1 counter on this creature."
+    }
+
+    staticAbility {
+        ability = CantAttackOrBlockUnlessPay(
+            amount = DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.PLUS_ONE_PLUS_ONE))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "214"
+        artist = "Dave Dorman"
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6d929b28-c184-4e77-a40b-ee43b8a37d79.jpg?1783944510"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ArcSloggerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ArcSloggerScenarioTest.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.ArcSlogger
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Arc-Slogger (MRD #85) — "{R}, Exile the top ten cards of your library: This creature deals 2
+ * damage to any target."
+ *
+ * Ten cards off the top is a **cost**, and that is the whole test. CR 118.3 — a player can't pay a
+ * cost without the resources to pay it fully — so a nine-card library can't activate this at all.
+ * The tempting wrong implementation exiles as many as it can and fires anyway, which is what the
+ * exile *effect* does and what a cost must never do; the shallow-library case below is there to
+ * catch exactly that, from the enumerator's side as well as the handler's.
+ *
+ * The destination is the other half: exile, not the graveyard. A cost atom cloned from
+ * [com.wingedsheep.sdk.scripting.costs.CostAtom.Mill] with only the count changed passes a damage
+ * assertion and fails these zone assertions.
+ */
+class ArcSloggerScenarioTest : FunSpec({
+
+    val sloggerAbility = ArcSlogger.activatedAbilities.single().id
+
+    /** Player 1's precombat main with an empty library, ready to be stacked exactly. */
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + ArcSlogger)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val library = ZoneKey(d.player1, Zone.LIBRARY)
+        d.replaceState(d.state.copy(zones = d.state.zones + (library to emptyList())))
+        return d
+    }
+
+    fun GameTestDriver.library(): List<EntityId> = state.getZone(ZoneKey(player1, Zone.LIBRARY))
+    fun GameTestDriver.exile(): List<EntityId> = state.getZone(ZoneKey(player1, Zone.EXILE))
+    fun GameTestDriver.graveyard(): List<EntityId> = state.getZone(ZoneKey(player1, Zone.GRAVEYARD))
+
+    /** Stack [count] cards onto player 1's library, deepest first. */
+    fun GameTestDriver.stackLibrary(count: Int): List<EntityId> =
+        (1..count).map { putCardOnTopOfLibrary(player1, "Grizzly Bears") }
+
+    test("activating exiles the top ten and deals 2") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        d.stackLibrary(12)
+        val slogger = d.putCreatureOnBattlefield(d.player1, "Arc-Slogger")
+        d.giveMana(d.player1, com.wingedsheep.sdk.core.Color.RED, 1)
+
+        d.submit(
+            ActivateAbility(d.player1, slogger, sloggerAbility, targets = listOf(ChosenTarget.Player(opponent)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        withClue("exactly ten leave the library") {
+            d.library().size shouldBe 2
+        }
+        withClue("they go to exile, not the graveyard — this is not a mill cost") {
+            d.exile().size shouldBe 10
+            d.graveyard().size shouldBe 0
+        }
+        d.getLifeTotal(opponent) shouldBe 18
+    }
+
+    test("a library of exactly ten pays, and is emptied doing it") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        d.stackLibrary(10)
+        val slogger = d.putCreatureOnBattlefield(d.player1, "Arc-Slogger")
+        d.giveMana(d.player1, com.wingedsheep.sdk.core.Color.RED, 1)
+
+        d.submit(
+            ActivateAbility(d.player1, slogger, sloggerAbility, targets = listOf(ChosenTarget.Player(opponent)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        withClue("the cost is affordable down to the last card") {
+            d.library().size shouldBe 0
+            d.exile().size shouldBe 10
+            d.getLifeTotal(opponent) shouldBe 18
+        }
+    }
+
+    test("a nine-card library can't activate at all — it does not exile nine and fire") {
+        // CR 118.3. The exile *effect* takes what it finds; a cost may not.
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        d.stackLibrary(9)
+        val slogger = d.putCreatureOnBattlefield(d.player1, "Arc-Slogger")
+        d.giveMana(d.player1, com.wingedsheep.sdk.core.Color.RED, 1)
+
+        withClue("the enumerator must not offer an unpayable activation") {
+            d.legalActions(d.player1).none { it.description.contains("Arc-Slogger") } shouldBe true
+        }
+
+        d.submitExpectFailure(
+            ActivateAbility(d.player1, slogger, sloggerAbility, targets = listOf(ChosenTarget.Player(opponent)))
+        )
+
+        withClue("nothing was paid and nothing was dealt") {
+            d.library().size shouldBe 9
+            d.exile().size shouldBe 0
+            d.getLifeTotal(opponent) shouldBe 20
+        }
+    }
+
+    test("a second activation exiles ten more") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        d.stackLibrary(21)
+        val slogger = d.putCreatureOnBattlefield(d.player1, "Arc-Slogger")
+        d.giveMana(d.player1, com.wingedsheep.sdk.core.Color.RED, 2)
+
+        repeat(2) {
+            d.submit(
+                ActivateAbility(d.player1, slogger, sloggerAbility, targets = listOf(ChosenTarget.Player(opponent)))
+            ).isSuccess shouldBe true
+            d.bothPass()
+        }
+
+        withClue("the cost is re-paid each time, not amortized") {
+            d.library().size shouldBe 1
+            d.exile().size shouldBe 20
+            d.getLifeTotal(opponent) shouldBe 16
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HumOfTheRadixScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HumOfTheRadixScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.HumOfTheRadix
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Hum of the Radix (MRD #122) — "Each artifact spell costs {1} more to cast for each artifact its
+ * controller controls."
+ *
+ * Two things separate this from every tax already in the corpus, and a wrong implementation passes
+ * a naive test on both. The tax is *dynamic*, so it has to be recomputed off the board rather than
+ * read off the card; and it is charged against **the caster's** artifacts, not the enchantment
+ * controller's — a distinction that is invisible whenever one player happens to control all the
+ * artifacts, which is exactly the board a single-player test builds. So the load-bearing case here
+ * is the asymmetric one: the same artifact spell priced for both players at once, each paying for
+ * their own board.
+ *
+ * The remaining cases pin the edges the tax could silently overreach into: no artifacts is no tax
+ * (not a floor of one), and a nonartifact spell is untouched however many artifacts are out.
+ */
+class HumOfTheRadixScenarioTest : FunSpec({
+
+    fun registry(): CardRegistry = CardRegistry().apply {
+        register(TestCards.all)
+        register(HumOfTheRadix)
+    }
+
+    /** Player 1's precombat main with the Hum already resolved under player 1's control. */
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + HumOfTheRadix)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 30), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.putPermanentOnBattlefield(d.player1, "Hum of the Radix")
+        return d
+    }
+
+    /** The generic component of what [caster] would pay for the {2} artifact creature. */
+    fun GameTestDriver.artifactSpellGenericFor(caster: EntityId): Int {
+        val registry = registry()
+        return CostCalculator(registry)
+            .calculateEffectiveCost(state, registry.requireCard("Artifact Creature"), caster)
+            .genericAmount
+    }
+
+    test("an artifact spell is taxed {1} for each artifact its caster controls") {
+        val d = driver()
+        d.putPermanentOnBattlefield(d.player1, "Artifact Creature")
+        d.putPermanentOnBattlefield(d.player1, "Artifact Creature")
+
+        withClue("{2} printed plus {1} per artifact controlled — two artifacts out, so {4}") {
+            d.artifactSpellGenericFor(d.player1) shouldBe 4
+        }
+    }
+
+    test("with no artifacts on the board the tax is zero, not a minimum of one") {
+        val d = driver()
+
+        withClue("the Hum itself is an enchantment, so it never taxes its own controller") {
+            d.artifactSpellGenericFor(d.player1) shouldBe 2
+        }
+    }
+
+    test("each player pays for their own artifacts, not the Hum controller's") {
+        // The whole point of the card: "its controller" is the *casting* player. A tax evaluated
+        // against the enchantment's controller would price both columns at 3.
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        d.putPermanentOnBattlefield(d.player1, "Artifact Creature")
+        d.putPermanentOnBattlefield(opponent, "Artifact Creature")
+        d.putPermanentOnBattlefield(opponent, "Artifact Creature")
+        d.putPermanentOnBattlefield(opponent, "Artifact Creature")
+
+        withClue("player 1 controls one artifact") {
+            d.artifactSpellGenericFor(d.player1) shouldBe 3
+        }
+        withClue("the opponent controls three, and is taxed for those rather than for player 1's") {
+            d.artifactSpellGenericFor(opponent) shouldBe 5
+        }
+    }
+
+    test("nonartifact spells are untouched however many artifacts are on the battlefield") {
+        val d = driver()
+        d.putPermanentOnBattlefield(d.player1, "Artifact Creature")
+        d.putPermanentOnBattlefield(d.player1, "Artifact Creature")
+        d.putPermanentOnBattlefield(d.player1, "Artifact Creature")
+
+        val registry = registry()
+        val cost = CostCalculator(registry)
+            .calculateEffectiveCost(d.state, registry.requireCard("Black Creature"), d.player1)
+
+        withClue("{1}{B} stays {1}{B} — the filter is artifact spells, not all spells") {
+            cost.genericAmount shouldBe 1
+            cost.cmc shouldBe 2
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MyrPrototypeScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MyrPrototypeScenarioTest.kt
@@ -1,0 +1,171 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.mechanics.combat.CombatTaxes
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.MyrPrototype
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Myr Prototype (MRD #214) — "At the beginning of your upkeep, put a +1/+1 counter on this
+ * creature. This creature can't attack or block unless you pay {1} for each +1/+1 counter on it."
+ *
+ * The card is a self-taxer, which is a different animal from Ghostly Prison: the permanent charging
+ * the tax and the creature paying it are the same object, so the amount has to be read off the
+ * *declared* creature rather than off the board. Two mistakes are available and both look fine on a
+ * one-creature board — reading the counters of some other permanent, and charging every declared
+ * creature the Prototype's price. The counter-holding bystander and the untaxed co-attacker below
+ * are there to fail on exactly those.
+ *
+ * The zero-counter case matters too: a Prototype that just resolved owes nothing, so the tax must
+ * be a plain 0 rather than a floor of {1} that quietly stops a fresh Myr from attacking.
+ *
+ * Amounts are asserted through [CombatTaxes] directly, since that is the shared pricing entry point
+ * the AI reads as well; one declaration test then proves the price is actually charged.
+ */
+class MyrPrototypeScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + MyrPrototype)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 30), skipMulligans = true)
+        return d
+    }
+
+    fun GameTestDriver.withCounters(entityId: EntityId, count: Int) =
+        addComponent(entityId, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to count)))
+
+    fun GameTestDriver.counters(entityId: EntityId): Int =
+        state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** What the shared pricing entry point charges to send [attackers] at [defender]. */
+    fun GameTestDriver.attackPrice(attackers: List<EntityId>, defender: EntityId): Int =
+        CombatTaxes.attackTax(
+            state,
+            cardRegistry,
+            attackers.associateWith { defender },
+            state.projectedState,
+        )
+
+    test("a Prototype with no counters attacks for free") {
+        val d = driver()
+        val attacker = d.activePlayer!!
+        val defender = d.getOpponent(attacker)
+        val myr = d.putCreatureOnBattlefield(attacker, "Myr Prototype")
+        d.removeSummoningSickness(myr)
+
+        withClue("{1} per counter, and there are none — not a floor of one") {
+            d.attackPrice(listOf(myr), defender) shouldBe 0
+        }
+    }
+
+    test("the tax is {1} for each +1/+1 counter on the Prototype itself") {
+        val d = driver()
+        val attacker = d.activePlayer!!
+        val defender = d.getOpponent(attacker)
+        val myr = d.putCreatureOnBattlefield(attacker, "Myr Prototype")
+        d.removeSummoningSickness(myr)
+        d.withCounters(myr, 3)
+
+        withClue("three counters, three generic") {
+            d.attackPrice(listOf(myr), defender) shouldBe 3
+        }
+    }
+
+    test("counters on another creature don't raise the price") {
+        // The amount is EntityReference.Source, not a board aggregate: a fat bystander is irrelevant.
+        val d = driver()
+        val attacker = d.activePlayer!!
+        val defender = d.getOpponent(attacker)
+        val myr = d.putCreatureOnBattlefield(attacker, "Myr Prototype")
+        val bear = d.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        d.removeSummoningSickness(myr)
+        d.withCounters(myr, 1)
+        d.withCounters(bear, 5)
+
+        withClue("only the Prototype's own counter is charged") {
+            d.attackPrice(listOf(myr), defender) shouldBe 1
+        }
+    }
+
+    test("a co-attacker without the ability is not charged the Prototype's price") {
+        val d = driver()
+        val attacker = d.activePlayer!!
+        val defender = d.getOpponent(attacker)
+        val myr = d.putCreatureOnBattlefield(attacker, "Myr Prototype")
+        val bear = d.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        d.removeSummoningSickness(myr)
+        d.removeSummoningSickness(bear)
+        d.withCounters(myr, 2)
+
+        withClue("the tax is self-scoped, so two attackers still owe only the Prototype's {2}") {
+            d.attackPrice(listOf(myr, bear), defender) shouldBe 2
+        }
+        withClue("dropping the Prototype drops the whole charge — the tax stays monotone") {
+            d.attackPrice(listOf(bear), defender) shouldBe 0
+        }
+    }
+
+    test("blocking is taxed on the same terms as attacking") {
+        val d = driver()
+        val attacker = d.activePlayer!!
+        val blocker = d.getOpponent(attacker)
+        val myr = d.putCreatureOnBattlefield(blocker, "Myr Prototype")
+        d.withCounters(myr, 2)
+
+        withClue("'can't attack or block' is one sentence and one price") {
+            CombatTaxes.blockTax(d.state, d.cardRegistry, setOf(myr), d.state.projectedState) shouldBe 2
+        }
+    }
+
+    test("declaring a counter-laden Prototype as an attacker pauses to collect the tax") {
+        val d = driver()
+        val attacker = d.activePlayer!!
+        val defender = d.getOpponent(attacker)
+        val myr = d.putCreatureOnBattlefield(attacker, "Myr Prototype")
+        d.removeSummoningSickness(myr)
+        // Two untapped lands so the attacker can actually pay what they now owe.
+        d.putLandOnBattlefield(attacker, "Forest")
+        d.putLandOnBattlefield(attacker, "Forest")
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        // Set the counters after the upkeep trigger has had its turn, so the price is exactly two
+        // whether or not this Myr caught its own upkeep.
+        d.withCounters(myr, 2)
+        val result = d.declareAttackers(attacker, listOf(myr), defender)
+
+        withClue("the price is owed, so the declaration pauses for mana rather than resolving free") {
+            result.newState.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        }
+    }
+
+    test("the upkeep trigger is what makes the price climb") {
+        // The two printed lines are one joke: each upkeep adds the counter that raises the tax.
+        val d = driver()
+        val attacker = d.activePlayer!!
+        val defender = d.getOpponent(attacker)
+        val myr = d.putCreatureOnBattlefield(attacker, "Myr Prototype")
+        d.removeSummoningSickness(myr)
+
+        withClue("before any upkeep has resolved the Myr is free to swing") {
+            d.attackPrice(listOf(myr), defender) shouldBe 0
+        }
+
+        d.passPriorityUntil(Step.UPKEEP)
+        d.bothPass()
+
+        withClue("one upkeep, one counter, {1} to swing") {
+            d.counters(myr) shouldBe 1
+            d.attackPrice(listOf(myr), defender) shouldBe 1
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -263,6 +263,72 @@
     ]
 }
 
+// Arc-Slogger
+{
+    "name": "Arc-Slogger",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "{R}, Exile the top ten cards of your library: This creature deals 2 damage to any target.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomExileTopOfLibrary",
+                                "count": 10
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ],
+                "descriptionOverride": "{R}, Exile the top ten cards of your library: This creature deals 2 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "rarity": "RARE",
+        "artist": "Jeff Easley",
+        "flavorText": "A shuffling sound and the smell of ozone follow the slogger as surely as its electric tail.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d3dd67e0-72b4-4c55-b49b-c69950feccb1.jpg?1783944543"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Assert Authority
 {
     "name": "Assert Authority",
@@ -4528,6 +4594,39 @@
     ]
 }
 
+// Hum of the Radix
+{
+    "name": "Hum of the Radix",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Each artifact spell costs {1} more to cast for each artifact its controller controls.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "AnyCaster",
+                    "filter": "artifact"
+                },
+                "modification": {
+                    "type": "IncreaseGenericBy",
+                    "source": "ArtifactsYouControl"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "rarity": "RARE",
+        "artist": "John Avon",
+        "flavorText": "The elves learned long ago that anything left here slowly vanishes. Now it is a sacred site where the dead are laid to rest and where unnatural magic is erased forever.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/328f3afb-1a56-42a5-bd1e-3e704291972f.jpg?1783944533"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Incite War
 {
     "name": "Incite War",
@@ -7154,6 +7253,60 @@
         "artist": "Dave Dorman",
         "flavorText": "It knows what you are planning, and does not approve.",
         "imageUri": "https://cards.scryfall.io/normal/front/f/9/f98ce711-8f68-4487-b67b-be35796ffcff.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Myr Prototype
+{
+    "name": "Myr Prototype",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Myr",
+    "oracleText": "At the beginning of your upkeep, put a +1/+1 counter on this creature.\nThis creature can't attack or block unless you pay {1} for each +1/+1 counter on it.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, put a +1/+1 counter on this creature."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantAttackOrBlockUnlessPay",
+                "amount": {
+                    "type": "EntityProperty",
+                    "entity": "Source",
+                    "numericProperty": {
+                        "type": "CounterCount",
+                        "counterType": {
+                            "type": "Named",
+                            "name": "+1/+1"
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "UNCOMMON",
+        "artist": "Dave Dorman",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6d929b28-c184-4e77-a40b-ee43b8a37d79.jpg?1783944510"
     },
     "colorIdentityOverride": []
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -611,6 +611,10 @@ class CostHandler {
         // library holds. Checked against the printed count; a ModifyMillAmount replacement only
         // enlarges the mill once the cost is actually being paid.
         is CostAtom.Mill -> state.getZone(ZoneKey(controllerId, Zone.LIBRARY)).size >= atom.count
+        // CR 118.3 — Arc-Slogger with nine cards left can't activate at all; there is no
+        // "exile as many as possible" for a cost.
+        is CostAtom.ExileTopOfLibrary ->
+            state.getZone(ZoneKey(controllerId, Zone.LIBRARY)).size >= atom.count
         is CostAtom.TapPermanents -> {
             val candidates = findUntappedMatchingPermanentsUnified(state, controllerId, atom.filter)
                 .let { targets -> if (atom.excludeSelf) targets.filter { it != sourceId } else targets }
@@ -745,6 +749,14 @@ class CostHandler {
             val effectiveCount = MillAmountModifier.apply(state, controllerId, atom.count)
             val milled = state.getZone(ZoneKey(controllerId, Zone.LIBRARY)).take(effectiveCount)
             val result = ZoneTransitionService.moveToZoneBatch(state, milled, Zone.GRAVEYARD)
+            CostPaymentResult.success(result.state, manaPool, result.events)
+        }
+        is CostAtom.ExileTopOfLibrary -> {
+            // No mill replacement to apply — exiling from the top is not milling (CR 701.17a), so
+            // the announced count is the paid count, and the affordability check above already
+            // guaranteed the library holds it. Emits ordinary library→exile zone changes.
+            val exiled = state.getZone(ZoneKey(controllerId, Zone.LIBRARY)).take(atom.count)
+            val result = ZoneTransitionService.moveToZoneBatch(state, exiled, Zone.EXILE)
             CostPaymentResult.success(result.state, manaPool, result.events)
         }
         is CostAtom.TapPermanents -> payTapPermanents(state, atom, sourceId, controllerId, manaPool, choices)
@@ -1228,7 +1240,8 @@ class CostHandler {
                 // spell additional costs today (put-counters-on-self is inherently ability-scoped —
                 // a spell on the stack has no permanent to put the counters on).
                 is CostAtom.Mana, is CostAtom.ReturnToHand, is CostAtom.RevealFromHand,
-                is CostAtom.PutCountersOnSelf, is CostAtom.Mill -> false
+                is CostAtom.PutCountersOnSelf, is CostAtom.Mill,
+                is CostAtom.ExileTopOfLibrary -> false
             }
             is AdditionalCost.PayLifePerTarget -> {
                 // Always payable: choosing zero targets pays zero life. Per-target life

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1925,6 +1925,7 @@ class CastSpellHandler(
                     is CostAtom.Mana, is CostAtom.RevealFromHand,
                     is CostAtom.PutCountersOnSelf,
                     is CostAtom.ExileFromGraveyardForTotal,
+                    is CostAtom.ExileTopOfLibrary,
                     is CostAtom.Mill -> {}
                     is CostAtom.RemoveCounters -> {
                         val needed = when (val c = atom.count) {
@@ -2750,6 +2751,7 @@ class CastSpellHandler(
                         is CostAtom.PayLife, is CostAtom.Mana, is CostAtom.RevealFromHand,
                         is CostAtom.PutCountersOnSelf,
                         is CostAtom.ExileFromGraveyardForTotal,
+                        is CostAtom.ExileTopOfLibrary,
                         is CostAtom.Mill -> {}
                         is CostAtom.RemoveCounters -> {
                             val resolvedRemovals = resolveDistributedCounterRemovalsForPayment(action)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CostPaymentContinuationResumer.kt
@@ -57,7 +57,9 @@ class CostPaymentContinuationResumer(
         is PayCost.Atom -> when (val atom = cost.atom) {
             // Yes/no costs: mana, life, mill (the milled cards are the top of the library, so
             // there is nothing to select), and random discard.
-            is CostAtom.Mana, is CostAtom.PayLife, is CostAtom.Mill ->
+            is CostAtom.Mana, is CostAtom.PayLife, is CostAtom.Mill,
+            // Exiling the top N takes no selection either, for the same reason Mill doesn't.
+            is CostAtom.ExileTopOfLibrary ->
                 resumeYesNo(state, continuation, cost, response, checkForMore)
             is CostAtom.Discard ->
                 if (atom.random) resumeYesNo(state, continuation, cost, response, checkForMore)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -88,6 +88,8 @@ class PayOrSufferExecutor(
                 is CostAtom.RevealFromHand -> EffectResult.error(state, "RevealCard payment for PayOrSuffer not yet implemented")
                 is CostAtom.PutCountersOnSelf -> EffectResult.error(state, "PutCountersOnSelf is an activated-ability cost, not a PayOrSuffer cost")
                 is CostAtom.Mill -> EffectResult.error(state, "Mill payment for PayOrSuffer not yet implemented")
+                is CostAtom.ExileTopOfLibrary ->
+                    EffectResult.error(state, "ExileTopOfLibrary is an activated-ability cost, not a PayOrSuffer cost")
                 // No printed "unless you collect evidence" exists — Axebane Ferox's
                 // "Ward—Collect evidence 4" runs through WardCost, not PayOrSuffer. Reported
                 // unpayable below rather than handled here, so nothing silently succeeds.
@@ -731,6 +733,9 @@ class PayOrSufferExecutor(
                 // No printed PayOrSuffer cost mills, and the execute branch above has no handler,
                 // so report it unpayable rather than offering a prompt that would error out.
                 is CostAtom.Mill -> false
+                // See the execute branch: no printed "unless you exile the top N" exists, so this
+                // is reported unpayable rather than prompting into an error.
+                is CostAtom.ExileTopOfLibrary -> false
                 // See the execute branch: unpayable rather than prompting into an error.
                 is CostAtom.CollectEvidence -> false
                 is CostAtom.ExileFromGraveyardForTotal -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -339,6 +339,11 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                         is CostAtom.Mill -> {
                             if (state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size < atom.count) continue
                         }
+                        // CR 118.3 — likewise for exiling the top N: a library too shallow to pay
+                        // makes the ability unactivatable, it does not exile what's left.
+                        is CostAtom.ExileTopOfLibrary -> {
+                            if (state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size < atom.count) continue
+                        }
                         is CostAtom.RemoveCounters -> {
                             val needed = when (val count = atom.count) {
                                 is com.wingedsheep.sdk.scripting.values.DynamicAmount.Fixed -> count.amount
@@ -543,6 +548,13 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                     // CR 701.17b — a mill cost is unpayable when the library holds
                                     // fewer cards. No selection: the milled cards are the top.
                                     is CostAtom.Mill -> {
+                                        if (state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size < atom.count) {
+                                            costCanBePaid = false
+                                            break
+                                        }
+                                    }
+                                    // CR 118.3 — same gate for exiling the top N.
+                                    is CostAtom.ExileTopOfLibrary -> {
                                         if (state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size < atom.count) {
                                             costCanBePaid = false
                                             break

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
@@ -177,6 +177,10 @@ class ManaAbilityEnumerator : ActionEnumerator {
                         is CostAtom.Mill -> {
                             if (state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size < atom.count) affordable = false
                         }
+                        // CR 118.3 — same shallow-library gate for exiling the top N.
+                        is CostAtom.ExileTopOfLibrary -> {
+                            if (state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size < atom.count) affordable = false
+                        }
                         // Other atoms (mana, life, discard, …) — engine validates at payment.
                         else -> {}
                     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatTaxes.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatTaxes.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.sdk.core.ManaSymbol
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AttackTax
 import com.wingedsheep.sdk.scripting.BlockTax
+import com.wingedsheep.sdk.scripting.CantAttackOrBlockUnlessPay
 
 /**
  * What a proposed attack or block costs in generic mana before it may be declared — Ghostly Prison,
@@ -84,7 +85,8 @@ object CombatTaxes {
             }
         }
 
-        return totalGenericTax + perCreatureTax(state, attackers.keys, projected)
+        return totalGenericTax + perCreatureTax(state, attackers.keys, projected) +
+            selfTax(state, cardRegistry, attackers.keys, projected)
     }
 
     /**
@@ -119,7 +121,41 @@ object CombatTaxes {
                 totalTax += taxPerBlocker * blockerIds.size
             }
         }
-        return totalTax + perCreatureTax(state, blockerIds, projected)
+        return totalTax + perCreatureTax(state, blockerIds, projected) +
+            selfTax(state, cardRegistry, blockerIds, projected)
+    }
+
+    /**
+     * Tax a creature charges for *itself* — [CantAttackOrBlockUnlessPay], Myr Prototype's "can't
+     * attack or block unless you pay {1} for each +1/+1 counter on it".
+     *
+     * Unlike [AttackTax]/[BlockTax] this doesn't scan the battlefield: only the creatures actually
+     * being declared can charge, and each charges once for itself. That is also what keeps the
+     * whole tax monotone in the declared set — dropping a creature drops exactly its own charge.
+     *
+     * The amount is evaluated with the taxed creature as the source, so a counter-counting amount
+     * reads that creature's counters rather than the declaring player's board. Taxes attackers and
+     * blockers identically, hence one implementation for both.
+     */
+    private fun selfTax(
+        state: GameState,
+        cardRegistry: CardRegistry,
+        creatureIds: Set<EntityId>,
+        projected: ProjectedState,
+    ): Int {
+        var totalTax = 0
+        for (creatureId in creatureIds) {
+            val container = state.getEntity(creatureId) ?: continue
+            val cardComponent = container.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
+            val controllerId = projected.getController(creatureId) ?: continue
+            for (ability in cardDef.staticAbilities) {
+                if (ability !is CantAttackOrBlockUnlessPay) continue
+                val ctx = EffectContext(sourceId = creatureId, controllerId = controllerId)
+                totalTax += maxOf(0, dynamicAmountEvaluator.evaluate(state, ability.amount, ctx, projected))
+            }
+        }
+        return totalTax
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -147,6 +147,10 @@ class CostPaymentService(private val services: EngineServices) {
                 // plain yes/no like paying life.
                 is CostAtom.Mill ->
                     yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "${atom.description.replaceFirstChar { it.uppercase() }}?", atom.description.replaceFirstChar { it.uppercase() })
+                // Same shape as Mill: the cards are the top of the library, so there is nothing to
+                // select and the prompt is a plain yes/no.
+                is CostAtom.ExileTopOfLibrary ->
+                    yesNoPrompt(state, payerId, resolved, sourceId, sourceName, ctx, "${atom.description.replaceFirstChar { it.uppercase() }}?", atom.description.replaceFirstChar { it.uppercase() })
                 is CostAtom.RevealFromHand ->
                     selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, candidates, atom.count, useTargetingUI = false)
                 is CostAtom.Sacrifice ->
@@ -346,6 +350,7 @@ class CostPaymentService(private val services: EngineServices) {
                         CostPaymentExecution(state, emptyList(), success = false)
                 }
             is CostAtom.Mill -> millTop(state, payerId, atom.count)
+            is CostAtom.ExileTopOfLibrary -> exileTop(state, payerId, atom.count)
             is CostAtom.RevealFromHand -> revealSelected(state, payerId, selected.keys.toList())
             is CostAtom.Sacrifice -> sacrificeSelected(state, payerId, selected.keys.toList())
             is CostAtom.ReturnToHand -> returnSelected(state, selected.keys.toList())
@@ -559,6 +564,19 @@ class CostPaymentService(private val services: EngineServices) {
         return CostPaymentExecution(result.state, result.events, success = true)
     }
 
+    /**
+     * The [CostAtom.ExileTopOfLibrary] payment: the top [count] cards straight to exile.
+     *
+     * Mirrors [millTop] except for the destination and the absent mill replacement — exiling from
+     * the top is not milling (CR 701.17a), so the announced count is the paid count. [canAfford]
+     * has already guaranteed the library is deep enough.
+     */
+    private fun exileTop(state: GameState, payerId: EntityId, count: Int): CostPaymentExecution {
+        val exiled = state.getZone(ZoneKey(payerId, Zone.LIBRARY)).take(count)
+        val result = ZoneTransitionService.moveToZoneBatch(state, exiled, Zone.EXILE)
+        return CostPaymentExecution(result.state, result.events, success = true)
+    }
+
     private fun exileSelected(state: GameState, payerId: EntityId, selected: List<EntityId>, zone: Zone): CostPaymentExecution {
         val fromZone = ZoneKey(payerId, zone)
         val exileZone = ZoneKey(payerId, Zone.EXILE)
@@ -673,6 +691,9 @@ class CostPaymentService(private val services: EngineServices) {
                     is CostAtom.ExileFromGraveyardForTotal -> false
                     // CR 701.17b — a mill cost is unpayable when the library holds fewer cards.
                     is CostAtom.Mill -> state.getZone(ZoneKey(payerId, Zone.LIBRARY)).size >= atom.count
+                    // CR 118.3 — the top N cards have to be there to be exiled.
+                    is CostAtom.ExileTopOfLibrary ->
+                        state.getZone(ZoneKey(payerId, Zone.LIBRARY)).size >= atom.count
                     is CostAtom.RevealFromHand -> domain(state, payerId, c, sourceId).size >= atom.count
                     is CostAtom.Sacrifice -> {
                         val candidates = domain(state, payerId, c, sourceId)
@@ -759,6 +780,7 @@ class CostPaymentService(private val services: EngineServices) {
                 // cost — CostHandler owns its selection, and [canAfford] already reports it
                 // unaffordable as a PayCost, so it has no domain on this path.
                 is CostAtom.Mana, is CostAtom.PayLife, is CostAtom.Mill,
+                is CostAtom.ExileTopOfLibrary,
                 is CostAtom.PutCountersOnSelf, is CostAtom.VariablePermanents,
                 is CostAtom.ExileFromGraveyardForTotal -> null
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -93,6 +93,7 @@ import com.wingedsheep.sdk.scripting.AssignCombatDamageAsUnblocked
 import com.wingedsheep.sdk.scripting.AssignDamageEqualToToughness
 import com.wingedsheep.sdk.scripting.AttackTax
 import com.wingedsheep.sdk.scripting.BlockTax
+import com.wingedsheep.sdk.scripting.CantAttackOrBlockUnlessPay
 import com.wingedsheep.sdk.scripting.AttackerCountLimit
 import com.wingedsheep.sdk.scripting.BlockerCountLimit
 import com.wingedsheep.sdk.scripting.CanAttackDespiteDefender
@@ -922,6 +923,7 @@ class StaticAbilityHandler(
             // AttackRestrictionRules / BlockEvasionRules / CombatEnumerator):
             is AttackTax,
             is BlockTax,
+            is CantAttackOrBlockUnlessPay,
             is AttackerCountLimit,
             is BlockerCountLimit,
             is CanAttackDespiteDefender,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -394,6 +394,10 @@ class CostCalculator(
                 }
             }
             is CostModification.IncreaseGeneric -> addGenericIncrease(modification.amount)
+            is CostModification.IncreaseGenericBy ->
+                addGenericIncrease(
+                    evaluateReduction(state, modification.source, casterId, chosenTargets, abilitySourceId)
+                )
             is CostModification.IncreaseColored -> {
                 ManaCost.parse(modification.symbols).symbols
                     .filterIsInstance<ManaSymbol.Colored>()
@@ -1635,6 +1639,13 @@ class CostCalculator(
             if (!matchesCardDefinition(cardDef, target.filter, sourceId, state, state.projectedState)) continue
             when (val mod = ability.modification) {
                 is CostModification.IncreaseGeneric -> totalIncrease += mod.amount
+                is CostModification.IncreaseGenericBy -> {
+                    if (casterId != null) {
+                        totalIncrease += evaluateReduction(
+                            state, mod.source, casterId, abilitySourceId = sourceId
+                        )
+                    }
+                }
                 is CostModification.IncreaseGenericPerOtherSpellThisTurn -> {
                     if (casterId != null) {
                         val spellsCast = state.playerSpellsCastThisTurn[casterId] ?: 0


### PR DESCRIPTION
Mirrodin's tail has no ordinary card work left in it — all 27 remaining cards are blocked on named SDK gaps. These three are the cheapest of those gaps, and they turn out to be the same gap in three places: **paying for something**. Hence one PR rather than three, with the primitive and its card in one commit each so any of them can be dropped without unpicking the others.

MRD goes 264 → 267 / 291.

### Cards

- **Arc-Slogger** {3}{R}{R} 4/5 — "{R}, Exile the top ten cards of your library: This creature deals 2 damage to any target." New `CostAtom.ExileTopOfLibrary(count)`, Mill's exile twin: no selection, and per **CR 118.3** unpayable on a short library, so a nine-card library can't activate this at all rather than exiling nine and firing. No `ModifyMillAmount` applies — exiling from the top isn't milling (CR 701.17a).
- **Hum of the Radix** {2}{G}{G} — "Each artifact spell costs {1} more to cast for each artifact its controller controls." New `CostModification.IncreaseGenericBy(source)`, the exact mirror of `ReduceGenericBy` over the same `CostReductionSource` vocabulary. "Its controller controls" needed no second vocabulary: a cost source is already evaluated against the *casting* player, so an `AnyCaster` tax prices each player against their own board.
- **Myr Prototype** {5} 2/2 — "At the beginning of your upkeep, put a +1/+1 counter on this creature. This creature can't attack or block unless you pay {1} for each +1/+1 counter on it." New `CantAttackOrBlockUnlessPay(amount)`, the self-scoped sibling of `AttackTax`/`BlockTax`: taxing permanent and taxed creature are the same object, so no filter and no per-attacker multiplier, and the amount is evaluated with the declared creature as the source. Priced through the shared `CombatTaxes` entry point, so it stacks with the outward-facing taxes and the AI sees the price before proposing an attack it can't pay for.

### Why these three share a PR

Each is one word of new cost vocabulary sitting on plumbing that already existed — a cost atom, a cost modification, a combat-tax static. Reviewing them together means reading one idea three times. `AGENTS.md` asks for a PR per new primitive; this deviates deliberately, and each commit is self-contained if you'd rather land them separately.

### What each test pins

The interesting failure in all three is the one that passes a naive test:

- **Arc-Slogger** — the shallow-library case, from the enumerator's side *and* the handler's. The tempting wrong implementation exiles what it can and fires, which is what the exile *effect* does and what a cost must never do. Zone assertions catch a Mill clone with the destination unchanged.
- **Hum of the Radix** — the asymmetric board: one artifact spell priced for both players at once, each paying for their own artifacts. A tax evaluated against the enchantment's controller prices both columns the same, and is invisible on any single-player board.
- **Myr Prototype** — a counter-laden bystander and an untaxed co-attacker, against reading someone else's counters and against charging every declared creature the Prototype's price.

### Verification

- `just test` green (full suite, including all per-era scenario modules)
- `just test-class` green for each of the three new scenario tests (15 tests)
- `just rebless-cards` — MRD golden, **only** the three new cards, pure insertions
- `just check-card-printing` ok for each; MRD is the sole printing of all three
- `just assay-differential` — 3,397/3,412 confirmed, 15 divergences, all pre-existing on `main` and none in MRD
- `docs/card-sdk-language-reference.md` updated for all three additions, in the same commits
- Every mechanical field re-verified against Scryfall (mana cost, type line, P/T, rarity, collector number, artist, oracle text, flavor, image URI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)