### PR TITLE
Add two Murders at Karlov Manor cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1880,9 +1880,12 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   `SerializableModification.SetMustBlock` for `Duration.EndOfTurn`, i.e. the same projected
   `mustBlock` the *static* `MustBlock` (Grand Melee) writes, so
   `BlockPhaseManager.validateProjectedMustBlockRequirements` enforces it with no extra wiring and
-  the generic end-of-turn cleanup expires it. Distinct from `Effects.ForceBlock`, which pins the
-  creature to blocking one *named* attacker and requires the source to be attacking — this one is
-  satisfied by blocking anything. A requirement, not a guarantee (CR 509.1c): a tapped creature, one
+  the generic end-of-turn cleanup expires it. Distinct from
+  `Effects.ForceBlock(target, attacker = EffectTarget.Self)`, which pins the creature to blocking one
+  *named* attacker and requires that attacker to be attacking — this one is satisfied by blocking
+  anything. `attacker` defaults to the ability's own source ("blocks **it**", Avalanche Tusker); pass
+  `EffectTarget.TriggeringEntity` when an ANY-bound trigger pins the blocker to the creature that
+  attacked instead (Tolsimir, Midnight's Light: "blocks **that Wolf** this combat if able"). A requirement, not a guarantee (CR 509.1c): a tapped creature, one
   that can't block, or one whose every block would be illegal is excused, and its controller is
   never forced to pay a cost associated with blocking. Used by Culvert Ambusher (MKM).
 - `Effects.SkipNextTurn(target = Controller, count = Fixed(1))` (`SkipNextTurnEffect`) — target skips their next `count` turns. `count` is a `DynamicAmount`, so it can read a pipeline value (e.g. a coin-flip tally via `DynamicAmount.VariableReference`). Skips accumulate on a `SkipNextTurnComponent(turns)`, decremented one turn per the player's turn-start; a resolved count of 0 is a no-op. Used by Lethal Vapors (one turn) and **Ral Zarek, Guest Lecturer** (skip N turns where N = heads).

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5633,6 +5633,11 @@ staticAbility {
   monocolored (exactly one color, CR 105.2) spells and abilities opponents control. Colorless and
   multicolored sources are unaffected; the controller can still target their own creatures. (Dragonfire
   Blade)
+- `GrantHexproofFromMulticoloredToGroup(filter = attachedCreature())` — the mirror: "[filter] have
+  hexproof from multicolored" — adds the projected keyword `HEXPROOF_FROM_MULTICOLORED`, which blocks
+  targeting by multicolored (two or more colors, CR 105.2b) spells and abilities opponents control.
+  Monocolored and colorless sources are unaffected; the controller can still target their own
+  permanents. Pass `GroupFilter.source()` for the printed-on-itself shape. (Niv-Mizzet, Guildpact)
 - `CantBeTargetedBySourceTypeAbilities(sourceType, filter = attachedCreature())` — "[filter] can't be the
   target of abilities from [sourceType] sources" — hexproof keyed to a source *card type* (e.g.
   `CardType.ARTIFACT`) rather than a controller or color. Projects the keyword
@@ -8983,8 +8988,8 @@ Numbers computed at resolution time.
 - `AggregateBattlefield(player, filter, aggregation?, property?, counterType?)` — aggregate over
   matching permanents. `aggregation` defaults to `COUNT`; other modes: `MAX`/`MIN`/`SUM` over a
   `property` (`POWER`/`TOUGHNESS`/`MANA_VALUE`), and the distinct-set counters
-  `DISTINCT_TYPES`, `DISTINCT_PERMANENT_TYPES`, `DISTINCT_COLORS`, `DISTINCT_NAMES`,
-  `DISTINCT_BASIC_LAND_SUBTYPES`
+  `DISTINCT_TYPES`, `DISTINCT_PERMANENT_TYPES`, `DISTINCT_COLORS`, `DISTINCT_COLOR_PAIRS`,
+  `DISTINCT_NAMES`, `DISTINCT_BASIC_LAND_SUBTYPES`
   (Domain), `DISTINCT_COUNTER_TYPES` (the number of different kinds of counters present
   across the group — same kind on several permanents counts once), and `DISTINCT_VALUES`
   (the number of *distinct values* of the configured `property` — Selvala, Eager Trailblazer's
@@ -8994,6 +8999,14 @@ Numbers computed at resolution time.
   `DISTINCT_NAMES` counts *differently named* matched permanents (two sharing a name count once) —
   "the number of differently named lands you control" (Emil, Vastlands Roamer) via
   `DynamicAmounts.battlefield(Player.You, GameObjectFilter.Land).distinctNames()`.
+  `DISTINCT_COLOR_PAIRS` counts the *color pairs* the group contributes: one unordered pair per
+  matched permanent that is exactly two colors (CR 105.2c), the same pair on several permanents
+  counting once, so the value is bounded by the ten pairs in Magic. Mono-colored, three-or-more
+  colored, and colorless permanents contribute nothing — "exactly two colors" is part of the
+  aggregation rather than something the filter spells — which is what makes it distinct from
+  `DISTINCT_COLORS` (a set of *colors*, bounded by five). Niv-Mizzet, Guildpact's "the number of
+  different color pairs among permanents you control that are exactly two colors" via
+  `DynamicAmounts.colorPairsAmongPermanents()`.
   `excludeSelf = true` drops the aggregate's own source/affected entity ("among *other* …"), e.g.
   Loot, the Key to Everything's "the number of card types among other nonland permanents you control"
   (`filter = GameObjectFilter.NonlandPermanent, aggregation = DISTINCT_TYPES, excludeSelf = true`).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -134,6 +134,20 @@ object DynamicAmounts {
         DynamicAmount.AggregateBattlefield(player, filter, Aggregation.DISTINCT_COLORS)
 
     /**
+     * The number of different *color pairs* among the permanents [player] controls that are
+     * exactly two colors (CR 105.2c) — Niv-Mizzet, Guildpact's X. Maxes out at 10.
+     *
+     * A permanent contributes only if it is exactly two colors; mono-colored, three-or-more
+     * colored, and colorless permanents contribute nothing, and two permanents of the same pair
+     * count once. Reads colors via projected state, so recolor effects apply.
+     */
+    fun colorPairsAmongPermanents(
+        player: Player = Player.You,
+        filter: GameObjectFilter = GameObjectFilter.Permanent
+    ): DynamicAmount =
+        DynamicAmount.AggregateBattlefield(player, filter, Aggregation.DISTINCT_COLOR_PAIRS)
+
+    /**
      * The number of distinct colors of mana spent to cast the source spell (0–5).
      * Backs the Converge ability word and the Sunburst counter rule. Colorless is not a
      * color, so it never contributes.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -4189,11 +4189,18 @@ object Effects {
         com.wingedsheep.sdk.scripting.effects.ProvokeEffect(target)
 
     /**
-     * Force a target creature to block the source creature this combat if able.
+     * Force a target creature to block a named attacker this combat if able.
      * Unlike Provoke, does NOT untap the target.
+     *
+     * [attacker] defaults to the ability's own source — "blocks **it**" on an attack trigger
+     * (Avalanche Tusker). Pass [EffectTarget.TriggeringEntity] when the trigger is ANY-bound and
+     * the creature that must be blocked is the one that attacked rather than the source
+     * (Tolsimir, Midnight's Light: "blocks **that Wolf** this combat if able").
      */
-    fun ForceBlock(target: EffectTarget = EffectTarget.ContextTarget(0)): Effect =
-        com.wingedsheep.sdk.scripting.effects.ForceBlockEffect(target)
+    fun ForceBlock(
+        target: EffectTarget = EffectTarget.ContextTarget(0),
+        attacker: EffectTarget = EffectTarget.Self
+    ): Effect = com.wingedsheep.sdk.scripting.effects.ForceBlockEffect(target, attacker)
 
     /**
      * Insert a single additional combat phase — and *only* a combat phase, no trailing main phase

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ProtectionStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ProtectionStaticAbilities.kt
@@ -126,6 +126,30 @@ data class GrantHexproofFromMonocoloredToGroup(
 }
 
 /**
+ * Grants each affected permanent "hexproof from multicolored" — it can't be the target of
+ * multicolored (two or more colors, CR 105.2b) spells or abilities opponents control. Monocolored
+ * and colorless sources are unaffected.
+ *
+ * The exact mirror of [GrantHexproofFromMonocoloredToGroup], down to the projected keyword idiom
+ * (`HEXPROOF_FROM_MULTICOLORED`) and the targeting sites that read it. Used by Niv-Mizzet,
+ * Guildpact, where the ability is printed on the permanent itself — pass `GroupFilter.source()`
+ * for that self-only shape, or a wider [GroupFilter] for a card that blankets a group.
+ *
+ * @property filter The group of permanents that gain the hexproof
+ */
+@SerialName("GrantHexproofFromMulticoloredToGroup")
+@Serializable
+data class GrantHexproofFromMulticoloredToGroup(
+    val filter: GroupFilter = GroupFilter.attachedCreature()
+) : StaticAbility {
+    override val description: String = "${filter.description} have hexproof from multicolored"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
  * Grants each affected creature protection from the colors of permanents the source's
  * controller currently controls. The protection set is board-derived and re-evaluated at
  * projection (after Layer 5), so it tracks the controller's permanents in real time; a

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
@@ -351,14 +351,29 @@ data class GrantCantBeBlockedByChosenColorEffect(
  * Unlike Provoke, this does NOT untap the target creature.
  * "Target creature defending player controls blocks this creature this combat if able."
  *
+ * [attacker] is the creature that must be blocked. It defaults to [EffectTarget.Self] — the
+ * ability's own source, which is the Avalanche Tusker shape ("blocks **it**", the attacking
+ * permanent that carries the trigger). An ANY-bound trigger that fires off *another* attacker and
+ * pins the blocker to that one instead passes [EffectTarget.TriggeringEntity]: Tolsimir, Midnight's
+ * Light says "whenever a Wolf you control attacks … target creature an opponent controls blocks
+ * **that Wolf** this combat if able", where the Wolf is the triggering entity and Tolsimir is the
+ * source. Any attacking creature the effect context can name works; the executor requires only that
+ * the resolved attacker is actually attacking.
+ *
  * @property target The creature forced to block
+ * @property attacker The attacking creature that must be blocked
  */
 @SerialName("ForceBlock")
 @Serializable
 data class ForceBlockEffect(
-    val target: EffectTarget = EffectTarget.ContextTarget(0)
+    val target: EffectTarget = EffectTarget.ContextTarget(0),
+    val attacker: EffectTarget = EffectTarget.Self
 ) : Effect {
-    override val description: String = "Target creature blocks ${target.description} this combat if able"
+    override val description: String = if (attacker == EffectTarget.Self) {
+        "Target creature blocks ${target.description} this combat if able"
+    } else {
+        "${target.description} blocks ${attacker.description} this combat if able"
+    }
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/CardNumericProperty.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/CardNumericProperty.kt
@@ -32,6 +32,18 @@ enum class Aggregation {
     DISTINCT_PERMANENT_TYPES,
     /** Count distinct colors across all matched entities */
     DISTINCT_COLORS,
+    /**
+     * Count the distinct *color pairs* contributed by the matched entities — one pair per entity
+     * that is exactly two colors (CR 105.2c), the same pair on two entities counting once. There
+     * are ten pairs in Magic, so the value is bounded by 10.
+     *
+     * Entities of one, three, four, or five colors — and colorless ones — contribute nothing:
+     * "color pair" names an *exactly two colors* object, so the "that are exactly two colors"
+     * clause is part of this aggregation rather than something the filter has to spell.
+     * Used for "the number of different color pairs among permanents you control that are
+     * exactly two colors" (Niv-Mizzet, Guildpact).
+     */
+    DISTINCT_COLOR_PAIRS,
     /** Count distinct English card names across all matched entities */
     DISTINCT_NAMES,
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -1110,6 +1110,11 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
                     if (excludeSelf) append("other ")
                     append(pluralize(filter.description))
                 }
+                Aggregation.DISTINCT_COLOR_PAIRS -> {
+                    append("the number of different color pairs among ")
+                    if (excludeSelf) append("other ")
+                    append(pluralize(filter.description))
+                }
                 Aggregation.DISTINCT_NAMES -> {
                     append("the number of differently named ")
                     if (excludeSelf) append("other ")
@@ -1206,6 +1211,10 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
                 }
                 Aggregation.DISTINCT_COLORS -> {
                     append("the number of colors among ")
+                    append(pluralize(filter.description))
+                }
+                Aggregation.DISTINCT_COLOR_PAIRS -> {
+                    append("the number of different color pairs among ")
                     append(pluralize(filter.description))
                 }
                 Aggregation.DISTINCT_NAMES -> {

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/NivMizzetGuildpact.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/NivMizzetGuildpact.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantHexproofFromMulticoloredToGroup
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Niv-Mizzet, Guildpact — Murders at Karlov Manor #220
+ * {W}{U}{B}{R}{G} · Legendary Creature — Dragon Avatar · 6/6 · Rare
+ *
+ * X is the number of *different color pairs* among permanents the controller controls that are
+ * exactly two colors (CR 105.2c) — ten pairs exist, so X is bounded by 10, and two Boros
+ * permanents count once. Mono-colored, three-or-more-colored, and colorless permanents contribute
+ * nothing; Niv-Mizzet itself is five colors and so never counts toward its own trigger.
+ *
+ * Per the 2024-02-02 ruling X is checked once, as the ability resolves. The three sub-effects each
+ * read the amount, which is the same value: state-based actions don't run mid-resolution, so
+ * nothing the damage does can remove a permanent from the count before the draw and the life gain
+ * read it.
+ */
+val NivMizzetGuildpact = card("Niv-Mizzet, Guildpact") {
+    manaCost = "{W}{U}{B}{R}{G}"
+    colorIdentity = "WUBRG"
+    typeLine = "Legendary Creature — Dragon Avatar"
+    oracleText = "Flying, hexproof from multicolored\n" +
+        "Whenever Niv-Mizzet deals combat damage to a player, it deals X damage to any target, " +
+        "target player draws X cards, and you gain X life, where X is the number of different " +
+        "color pairs among permanents you control that are exactly two colors."
+    power = 6
+    toughness = 6
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = GrantHexproofFromMulticoloredToGroup(GroupFilter.source())
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        val damaged = target("any target", Targets.Any)
+        val drawer = target("target player", Targets.Player)
+        val colorPairs = DynamicAmounts.colorPairsAmongPermanents()
+        effect = Effects.Composite(
+            Effects.DealDamage(colorPairs, damaged),
+            Effects.DrawCards(colorPairs, drawer),
+            Effects.GainLife(colorPairs),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "220"
+        artist = "Chris Rallis"
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/32a8fda6-8614-45cd-879c-0cb7fa29647e.jpg?1783912843"
+        ruling(
+            "2024-02-02",
+            "A \"color pair\" is exactly two colors. There are ten color pairs in Magic: " +
+                "white-blue, white-black, blue-black, blue-red, black-red, black-green, red-green, " +
+                "red-white, green-white, and green-blue.",
+        )
+        ruling("2024-02-02", "The value of X is checked only once, as Niv-Mizzet, Guildpact's triggered ability resolves.")
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/TolsimirMidnightsLight.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/TolsimirMidnightsLight.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tolsimir, Midnight's Light — Murders at Karlov Manor #236
+ * {2}{G}{W}{W} · Legendary Creature — Elf Scout · 3/2 · Rare
+ *
+ * The attack trigger is ANY-bound over Wolves the controller controls, so it fires once for each
+ * attacking Wolf — including Voja Fenstalker, the token the enters trigger makes. Tolsimir itself
+ * is an Elf Scout and never triggers it.
+ *
+ * "If Tolsimir attacked this combat" is a CR 603.4 intervening-if: it is checked both when the
+ * Wolves are declared and again on resolution, and it reads the per-entity "attacked this combat"
+ * marker rather than the live attacking state — so Tolsimir dying after attackers are declared
+ * still leaves the requirement in place, while a Wolf attacking in a *second* combat Tolsimir sat
+ * out does nothing.
+ *
+ * The blocker is pinned to the triggering Wolf, not to Tolsimir, which is what
+ * `Effects.ForceBlock`'s `attacker` parameter names.
+ */
+val TolsimirMidnightsLight = card("Tolsimir, Midnight's Light") {
+    manaCost = "{2}{G}{W}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Elf Scout"
+    oracleText = "Lifelink\n" +
+        "When Tolsimir enters, create Voja Fenstalker, a legendary 5/5 green and white Wolf " +
+        "creature token with trample.\n" +
+        "Whenever a Wolf you control attacks, if Tolsimir attacked this combat, target creature " +
+        "an opponent controls blocks that Wolf this combat if able."
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 5,
+            toughness = 5,
+            colors = setOf(Color.GREEN, Color.WHITE),
+            creatureTypes = setOf(Subtype.WOLF.value),
+            keywords = setOf(Keyword.TRAMPLE),
+            name = "Voja Fenstalker",
+            legendary = true,
+            imageUri = "https://cards.scryfall.io/normal/front/2/1/2175200f-3ed4-4b39-ac76-a7d25967aa8a.jpg?1783912604",
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.attacks(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.WOLF).youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        interveningIf = Conditions.SourceAttackedThisCombat
+        val blocker = target("creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.ForceBlock(blocker, attacker = EffectTarget.TriggeringEntity)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "236"
+        artist = "Uriah Voth"
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/08d22402-c41d-43d7-be1f-42be1e300726.jpg?1783912835"
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NivMizzetGuildpactScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NivMizzetGuildpactScenarioTest.kt
@@ -1,0 +1,169 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.targeting.TargetValidator
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.ClientStateTransformer
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.NivMizzetGuildpact
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Niv-Mizzet, Guildpact (MKM) — {W}{U}{B}{R}{G} Legendary Creature — Dragon Avatar 6/6.
+ *
+ * Flying, hexproof from multicolored.
+ * Whenever Niv-Mizzet deals combat damage to a player, it deals X damage to any target, target
+ * player draws X cards, and you gain X life, where X is the number of different color pairs among
+ * permanents you control that are exactly two colors.
+ *
+ * Covers both primitives the card introduced: [com.wingedsheep.sdk.scripting.values.Aggregation.DISTINCT_COLOR_PAIRS]
+ * (which permanents count, and that duplicates collapse) and
+ * [com.wingedsheep.sdk.scripting.GrantHexproofFromMulticoloredToGroup].
+ */
+class NivMizzetGuildpactScenarioTest : FunSpec({
+
+    // Vanilla creatures whose colors derive from their mana cost.
+    val izzetDrake = CardDefinition.creature("Test Izzet Drake", ManaCost.parse("{U}{R}"), emptySet(), 2, 2)
+    val borosSoldier = CardDefinition.creature("Test Boros Soldier", ManaCost.parse("{R}{W}"), emptySet(), 2, 2)
+    val izzetWeird = CardDefinition.creature("Test Izzet Weird", ManaCost.parse("{U}{R}"), emptySet(), 1, 1)
+    val monoBear = CardDefinition.creature("Test Mono Bear", ManaCost.parse("{G}"), emptySet(), 2, 2)
+    val nayaHydra = CardDefinition.creature("Test Naya Hydra", ManaCost.parse("{R}{G}{W}"), emptySet(), 3, 3)
+    val colorlessGolem = CardDefinition.creature("Test Golem", ManaCost.parse("{2}"), emptySet(), 2, 2)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(
+                NivMizzetGuildpact, izzetDrake, borosSoldier, izzetWeird, monoBear, nayaHydra, colorlessGolem,
+            )
+        )
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Attack the opponent with Niv-Mizzet and answer the resulting target prompt. */
+    fun GameTestDriver.connectAndTarget(
+        niv: EntityId,
+        me: EntityId,
+        opponent: EntityId,
+        damageTarget: EntityId,
+        drawer: EntityId,
+    ) {
+        passPriorityUntil(Step.DECLARE_ATTACKERS)
+        declareAttackers(me, listOf(niv), defendingPlayer = opponent).error shouldBe null
+        passPriorityUntil(Step.COMBAT_DAMAGE)
+        bothPass() // combat damage — 6 to the opponent
+
+        var guard = 0
+        while (pendingDecision !is ChooseTargetsDecision && state.stack.isNotEmpty() && guard++ < 10) bothPass()
+        (pendingDecision as ChooseTargetsDecision)
+        submitMultiTargetSelection(me, mapOf(0 to listOf(damageTarget), 1 to listOf(drawer))).error shouldBe null
+        guard = 0
+        while (state.stack.isNotEmpty() && guard++ < 10) bothPass()
+    }
+
+    test("X counts distinct color pairs — two Izzet permanents and one Boros permanent give X = 2") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val niv = driver.putCreatureOnBattlefield(me, "Niv-Mizzet, Guildpact")
+        driver.removeSummoningSickness(niv)
+        // Two Izzet permanents collapse to one pair; Boros adds a second.
+        driver.putCreatureOnBattlefield(me, "Test Izzet Drake")
+        driver.putCreatureOnBattlefield(me, "Test Izzet Weird")
+        driver.putCreatureOnBattlefield(me, "Test Boros Soldier")
+        // None of these contribute: one color, three colors, colorless — and Niv itself is five.
+        driver.putCreatureOnBattlefield(me, "Test Mono Bear")
+        driver.putCreatureOnBattlefield(me, "Test Naya Hydra")
+        driver.putCreatureOnBattlefield(me, "Test Golem")
+
+        val myHandBefore = driver.getHandSize(me)
+        driver.connectAndTarget(niv, me, opponent, damageTarget = opponent, drawer = me)
+
+        // 6 combat damage + X = 2 from the trigger.
+        driver.getLifeTotal(opponent) shouldBe 12
+        driver.getLifeTotal(me) shouldBe 22
+        driver.getHandSize(me) shouldBe myHandBefore + 2
+    }
+
+    test("X is 0 when no permanent you control is exactly two colors — no draw, no life, no damage") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val niv = driver.putCreatureOnBattlefield(me, "Niv-Mizzet, Guildpact")
+        driver.removeSummoningSickness(niv)
+        driver.putCreatureOnBattlefield(me, "Test Mono Bear")
+        driver.putCreatureOnBattlefield(me, "Test Naya Hydra")
+        // A two-color permanent the *opponent* controls must not count.
+        driver.putCreatureOnBattlefield(opponent, "Test Izzet Drake")
+
+        val myHandBefore = driver.getHandSize(me)
+        driver.connectAndTarget(niv, me, opponent, damageTarget = opponent, drawer = me)
+
+        driver.getLifeTotal(opponent) shouldBe 14 // combat damage only
+        driver.getLifeTotal(me) shouldBe 20
+        driver.getHandSize(me) shouldBe myHandBefore
+    }
+
+    test("the damage and the draw can point at different players") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val niv = driver.putCreatureOnBattlefield(me, "Niv-Mizzet, Guildpact")
+        driver.removeSummoningSickness(niv)
+        driver.putCreatureOnBattlefield(me, "Test Izzet Drake")
+        val bear = driver.putCreatureOnBattlefield(opponent, "Test Mono Bear")
+
+        val oppHandBefore = driver.getHandSize(opponent)
+        // X = 1: one damage onto the opponent's bear, the opponent draws.
+        driver.connectAndTarget(niv, me, opponent, damageTarget = bear, drawer = opponent)
+
+        driver.getLifeTotal(opponent) shouldBe 14 // combat damage only — the X damage hit the bear
+        driver.getLifeTotal(me) shouldBe 21
+        driver.getHandSize(opponent) shouldBe oppHandBefore + 1
+    }
+
+    test("hexproof from multicolored — a two-or-more-color opponent source can't target Niv-Mizzet") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val niv = driver.putCreatureOnBattlefield(me, "Niv-Mizzet, Guildpact")
+
+        val validator = TargetValidator()
+        val target = listOf<ChosenTarget>(ChosenTarget.Permanent(niv))
+        val req = listOf(TargetCreature())
+
+        // A multicolored opponent source is blocked.
+        validator.validateTargets(driver.state, target, req, casterId = opponent, sourceColors = setOf(Color.RED, Color.WHITE))
+            .shouldNotBeNull()
+        // A monocolored one isn't — CR 105.2b, multicolored is two *or more* colors.
+        validator.validateTargets(driver.state, target, req, casterId = opponent, sourceColors = setOf(Color.RED))
+            .shouldBeNull()
+        // Nor is a colorless one.
+        validator.validateTargets(driver.state, target, req, casterId = opponent, sourceColors = emptySet())
+            .shouldBeNull()
+        // Hexproof never stops the permanent's own controller.
+        validator.validateTargets(driver.state, target, req, casterId = me, sourceColors = setOf(Color.RED, Color.WHITE))
+            .shouldBeNull()
+
+        // The client DTO carries the quality so the FE renders the shield chip.
+        val view = ClientStateTransformer(cardRegistry = driver.cardRegistry).transform(driver.state, viewingPlayerId = opponent)
+        view.cards[niv]?.hexproofFromMulticolored shouldBe true
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TolsimirMidnightsLightScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TolsimirMidnightsLightScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.TolsimirMidnightsLight
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tolsimir, Midnight's Light (MKM) — {2}{G}{W}{W} Legendary Creature — Elf Scout 3/2.
+ *
+ * Lifelink.
+ * When Tolsimir enters, create Voja Fenstalker, a legendary 5/5 green and white Wolf creature
+ * token with trample.
+ * Whenever a Wolf you control attacks, if Tolsimir attacked this combat, target creature an
+ * opponent controls blocks that Wolf this combat if able.
+ *
+ * The last ability is what `ForceBlockEffect.attacker` was added for: the requirement pins the
+ * chosen blocker to the *triggering Wolf*, not to the ability's source. These tests prove exactly
+ * that split — the blocker may not satisfy the requirement by blocking Tolsimir.
+ */
+class TolsimirMidnightsLightScenarioTest : FunSpec({
+
+    val bear = CardDefinition.creature("Test Blocking Bear", ManaCost.parse("{1}{G}"), emptySet(), 2, 2)
+    val ox = CardDefinition.creature("Test Second Ox", ManaCost.parse("{2}{W}"), emptySet(), 1, 4)
+
+    // Stands in for Voja Fenstalker in the force-block tests: the ability keys off "a Wolf you
+    // control", so a plain Wolf isolates the requirement from token creation. `putCreatureOnBattlefield`
+    // bypasses enters triggers, so the token itself only appears in the cast test below.
+    val fenwolf = CardDefinition.creature("Test Fenwolf", ManaCost.parse("{3}{G}"), setOf(Subtype.WOLF), 5, 5)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TolsimirMidnightsLight, bear, ox, fenwolf))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("entering creates Voja Fenstalker — a legendary 5/5 green and white Wolf with trample") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val card = driver.putCardInHand(me, "Tolsimir, Midnight's Light")
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveMana(me, Color.WHITE, 2)
+        driver.giveColorlessMana(me, 2)
+        driver.castSpell(me, card).isSuccess shouldBe true
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && guard++ < 10) driver.bothPass()
+
+        val voja = driver.findPermanent(me, "Voja Fenstalker")
+        voja.shouldNotBeNull()
+        val container = driver.state.getEntity(voja)!!
+        container.has<TokenComponent>() shouldBe true
+
+        val tokenCard = container.get<CardComponent>()!!
+        tokenCard.typeLine.isLegendary shouldBe true
+        tokenCard.typeLine.subtypes.contains(Subtype.WOLF) shouldBe true
+
+        val projected = driver.state.projectedState
+        projected.getPower(voja) shouldBe 5
+        projected.getToughness(voja) shouldBe 5
+        projected.hasKeyword(voja, Keyword.TRAMPLE) shouldBe true
+        projected.getColors(voja) shouldBe setOf("GREEN", "WHITE")
+    }
+
+    test("the chosen blocker must block the triggering Wolf, not Tolsimir") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val tolsimir = driver.putCreatureOnBattlefield(me, "Tolsimir, Midnight's Light")
+        val voja = driver.putCreatureOnBattlefield(me, "Test Fenwolf")
+        driver.removeSummoningSickness(tolsimir)
+        driver.removeSummoningSickness(voja)
+
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Test Blocking Bear")
+        // A second creature that is under no requirement at all.
+        val free = driver.putCreatureOnBattlefield(opponent, "Test Second Ox")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(tolsimir, voja), defendingPlayer = opponent).error shouldBe null
+
+        // One trigger — Voja is the only attacking Wolf. Point it at the bear.
+        var guard = 0
+        while (driver.pendingDecision !is ChooseTargetsDecision && guard++ < 10) driver.bothPass()
+        (driver.pendingDecision as ChooseTargetsDecision)
+        driver.submitTargetSelection(me, listOf(blocker)).error shouldBe null
+        guard = 0
+        while (driver.state.stack.isNotEmpty() && guard++ < 10) driver.bothPass()
+
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        // Blocking nothing ignores the requirement.
+        driver.declareBlockers(opponent, emptyMap()).isSuccess shouldBe false
+        // Blocking *Tolsimir* does not satisfy it — the requirement names the Wolf.
+        driver.declareBlockers(opponent, mapOf(blocker to listOf(tolsimir))).isSuccess shouldBe false
+        // Blocking the Wolf does. The unpinned creature is free to do anything, including nothing.
+        driver.declareBlockers(opponent, mapOf(blocker to listOf(voja))).error shouldBe null
+
+        driver.state.getEntity(free).shouldNotBeNull()
+    }
+
+    test("no trigger when Tolsimir sits out the combat — the intervening if fails") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val tolsimir = driver.putCreatureOnBattlefield(me, "Tolsimir, Midnight's Light")
+        val voja = driver.putCreatureOnBattlefield(me, "Test Fenwolf")
+        driver.removeSummoningSickness(tolsimir)
+        driver.removeSummoningSickness(voja)
+
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Test Blocking Bear")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        // Voja attacks alone; Tolsimir stays home.
+        driver.declareAttackers(me, listOf(voja), defendingPlayer = opponent).error shouldBe null
+
+        // CR 603.4: the condition is false when the trigger event happens, so nothing triggers —
+        // no target prompt, and the bear is under no requirement.
+        driver.pendingDecision shouldBe null
+        driver.state.stack.size shouldBe 0
+
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, emptyMap()).error shouldBe null
+        driver.state.getEntity(blocker).shouldNotBeNull()
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -11939,6 +11939,115 @@
     ]
 }
 
+// Niv-Mizzet, Guildpact
+{
+    "name": "Niv-Mizzet, Guildpact",
+    "manaCost": "{W}{U}{B}{R}{G}",
+    "typeLine": "Legendary Creature — Dragon Avatar",
+    "oracleText": "Flying, hexproof from multicolored\nWhenever Niv-Mizzet deals combat damage to a player, it deals X damage to any target, target player draws X cards, and you gain X life, where X is the number of different color pairs among permanents you control that are exactly two colors.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "permanent",
+                                "aggregation": "DISTINCT_COLOR_PAIRS"
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "any target"
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "permanent",
+                                "aggregation": "DISTINCT_COLOR_PAIRS"
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "permanent",
+                                "aggregation": "DISTINCT_COLOR_PAIRS"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ]
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantHexproofFromMulticoloredToGroup",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "rarity": "RARE",
+        "artist": "Chris Rallis",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/32a8fda6-8614-45cd-879c-0cb7fa29647e.jpg?1783912843",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "A \"color pair\" is exactly two colors. There are ten color pairs in Magic: white-blue, white-black, blue-black, blue-red, black-red, black-green, red-green, red-white, green-white, and green-blue."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "The value of X is checked only once, as Niv-Mizzet, Guildpact's triggered ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK",
+        "RED",
+        "GREEN"
+    ]
+}
+
 // No More Lies
 {
     "name": "No More Lies",
@@ -17085,6 +17194,92 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Tolsimir, Midnight's Light
+{
+    "name": "Tolsimir, Midnight's Light",
+    "manaCost": "{2}{G}{W}{W}",
+    "typeLine": "Legendary Creature — Elf Scout",
+    "oracleText": "Lifelink\nWhen Tolsimir enters, create Voja Fenstalker, a legendary 5/5 green and white Wolf creature token with trample.\nWhenever a Wolf you control attacks, if Tolsimir attacked this combat, target creature an opponent controls blocks that Wolf this combat if able.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 5,
+                    "toughness": 5,
+                    "colors": [
+                        "GREEN",
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Wolf"
+                    ],
+                    "keywords": [
+                        "TRAMPLE"
+                    ],
+                    "name": "Voja Fenstalker",
+                    "imageUri": "https://cards.scryfall.io/normal/front/2/1/2175200f-3ed4-4b39-ac76-a7d25967aa8a.jpg?1783912604",
+                    "legendary": true
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "filter": "creature Wolf ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForceBlock",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature an opponent controls"
+                    },
+                    "attacker": "TriggeringEntity"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "creature an opponent controls"
+                },
+                "interveningIf": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "AttackedThisCombat"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "rarity": "RARE",
+        "artist": "Uriah Voth",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/08d22402-c41d-43d7-be1f-42be1e300726.jpg?1783912835"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -986,6 +986,17 @@ class DynamicAmountEvaluator(
                         ?: emptySet()
                 }
             }.size
+            // "Different color pairs among <group> that are exactly two colors" (Niv-Mizzet,
+            // Guildpact). Only an entity whose *projected* colour set is exactly two contributes,
+            // and it contributes one unordered pair; the same pair on several permanents counts
+            // once. Bounded by the ten pairs of CR 105.2c.
+            Aggregation.DISTINCT_COLOR_PAIRS -> matchingEntities.mapNotNullTo(mutableSetOf()) { entityId ->
+                val colors = projection.getColors(entityId).ifEmpty {
+                    state.getEntity(entityId)?.get<CardComponent>()?.colors?.map { it.name }?.toSet()
+                        ?: emptySet()
+                }
+                if (colors.size == 2) colors.sorted().joinToString("/") else null
+            }.size
             Aggregation.DISTINCT_NAMES -> matchingEntities.mapNotNullTo(mutableSetOf()) { entityId ->
                 state.getEntity(entityId)?.get<CardComponent>()?.name
             }.size
@@ -1066,6 +1077,15 @@ class DynamicAmountEvaluator(
                 matchingEntities.flatMapTo(mutableSetOf()) { entityId ->
                     state.getEntity(entityId)?.get<CardComponent>()?.colors?.map { it.name }?.toSet()
                         ?: emptySet()
+                }.size
+            }
+            // Zone counterpart of the battlefield branch: cards outside the battlefield have no
+            // projection entry, so their printed colours are the only ones there are.
+            Aggregation.DISTINCT_COLOR_PAIRS -> {
+                matchingEntities.mapNotNullTo(mutableSetOf()) { entityId ->
+                    val colors = state.getEntity(entityId)?.get<CardComponent>()?.colors?.map { it.name }?.toSet()
+                        ?: emptySet()
+                    if (colors.size == 2) colors.sorted().joinToString("/") else null
                 }.size
             }
             Aggregation.DISTINCT_NAMES -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
@@ -634,6 +634,10 @@ class TargetFinder(
         if (sourceColors.size == 1 && projected.hasKeyword(entityId, "HEXPROOF_FROM_MONOCOLORED")) {
             return true
         }
+        // Hexproof from multicolored: a source with two or more colors can't target (CR 105.2b).
+        if (sourceColors.size >= 2 && projected.hasKeyword(entityId, "HEXPROOF_FROM_MULTICOLORED")) {
+            return true
+        }
         return SourceTypeTargeting.sourceCardTypes(state, sourceId).any { cardType ->
             projected.hasKeyword(entityId, "HEXPROOF_FROM_CARDTYPE_${cardType.uppercase()}")
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/ForceBlockExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/ForceBlockExecutor.kt
@@ -17,7 +17,11 @@ import kotlin.reflect.KClass
  * Executor for ForceBlockEffect.
  * "Target creature blocks this creature this combat if able."
  *
- * Creates a floating effect forcing the target to block the source attacker.
+ * Creates a floating effect forcing the target to block the named attacker — the source by
+ * default (Avalanche Tusker), or whichever creature `effect.attacker` resolves to for an
+ * ANY-bound trigger that pins the blocker to the *triggering* attacker (Tolsimir, Midnight's
+ * Light: "blocks that Wolf this combat if able").
+ *
  * Unlike ProvokeExecutor, does NOT untap the target creature.
  */
 class ForceBlockExecutor : EffectExecutor<ForceBlockEffect> {
@@ -40,21 +44,23 @@ class ForceBlockExecutor : EffectExecutor<ForceBlockEffect> {
             return EffectResult.error(state, "Target is not a creature")
         }
 
-        // The source is the creature that must be blocked (the attacker)
-        val sourceId = context.sourceId
-            ?: return EffectResult.error(state, "No source for force block effect")
+        // The creature that must be blocked. Defaults to the ability's source; an ANY-bound
+        // trigger can name the triggering attacker instead.
+        val attackerId = context.resolveTarget(effect.attacker)
+            ?: return EffectResult.error(state, "No valid attacker for force block effect")
 
-        // Verify source is attacking
-        val sourceContainer = state.getEntity(sourceId)
-            ?: return EffectResult.error(state, "Source creature no longer exists")
-        if (!sourceContainer.has<AttackingComponent>()) {
-            return EffectResult.error(state, "Source creature is not attacking")
+        // Verify the attacker is actually attacking — CR 509.1c can only be satisfied against a
+        // declared attacker, and the block-declaration validator reads the requirement per combat.
+        val attackerContainer = state.getEntity(attackerId)
+            ?: return EffectResult.error(state, "Attacking creature no longer exists")
+        if (!attackerContainer.has<AttackingComponent>()) {
+            return EffectResult.error(state, "Named creature is not attacking")
         }
 
-        // Create a floating effect forcing the target to block the source
+        // Create a floating effect forcing the target to block that attacker
         val newState = state.addFloatingEffect(
             layer = Layer.ABILITY,
-            modification = SerializableModification.MustBlockSpecificAttacker(sourceId),
+            modification = SerializableModification.MustBlockSpecificAttacker(attackerId),
             affectedEntities = setOf(targetId),
             duration = Duration.EndOfTurn,
             context = context

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
@@ -166,6 +166,7 @@ class TargetEnumerationUtils(
         }
         if (sourceColors.any { projected.hasKeyword(targetId, "HEXPROOF_FROM_$it") }) return true
         if (sourceColors.size == 1 && projected.hasKeyword(targetId, "HEXPROOF_FROM_MONOCOLORED")) return true
+        if (sourceColors.size >= 2 && projected.hasKeyword(targetId, "HEXPROOF_FROM_MULTICOLORED")) return true
         val sourceTypes = state.getEntity(sourceId)?.get<CardComponent>()?.typeLine?.cardTypes.orEmpty()
         return sourceTypes.any { projected.hasKeyword(targetId, "HEXPROOF_FROM_CARDTYPE_${it.name}") }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
@@ -249,6 +249,9 @@ internal class EffectApplicator(
                 is Modification.GrantHexproofFromMonocolored -> {
                     values.keywords.add("HEXPROOF_FROM_MONOCOLORED")
                 }
+                is Modification.GrantHexproofFromMulticolored -> {
+                    values.keywords.add("HEXPROOF_FROM_MULTICOLORED")
+                }
                 is Modification.GrantProtectionFromControlledColors -> {
                     // Protection from the colors of permanents the source's controller controls
                     // (e.g., Pledge of Loyalty). Read the projected controller + projected colors

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
@@ -515,6 +515,16 @@ sealed interface Modification {
     }
 
     /**
+     * Grants "hexproof from multicolored" to each affected entity — adds the keyword
+     * `HEXPROOF_FROM_MULTICOLORED`, which blocks targeting by multicolored (two or more colors)
+     * spells and abilities opponents control. Used for Niv-Mizzet, Guildpact.
+     */
+    @Serializable
+    data object GrantHexproofFromMulticolored : Modification {
+        override val layer get() = Layer.ABILITY
+    }
+
+    /**
      * Grants each affected entity "protection from the colors of permanents the source's
      * controller controls". Read at apply-time: collects the projected colors of every
      * battlefield permanent controlled by the source's (projected) controller, then adds

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -59,6 +59,7 @@ import com.wingedsheep.sdk.scripting.GrantProtectionFromCardType
 import com.wingedsheep.sdk.scripting.GrantProtectionFromControlledColors
 import com.wingedsheep.sdk.scripting.GrantHexproofFromOwnColorsToGroup
 import com.wingedsheep.sdk.scripting.GrantHexproofFromMonocoloredToGroup
+import com.wingedsheep.sdk.scripting.GrantHexproofFromMulticoloredToGroup
 import com.wingedsheep.sdk.scripting.AnimateLandGroup
 import com.wingedsheep.sdk.scripting.GrantAdditionalTypesToGroup
 import com.wingedsheep.sdk.scripting.SetLandTypesForGroup
@@ -624,6 +625,12 @@ class StaticAbilityHandler(
             is GrantHexproofFromMonocoloredToGroup -> {
                 ContinuousEffectData(
                     modification = Modification.GrantHexproofFromMonocolored,
+                    affectsFilter = convertGroupFilter(ability.filter)
+                )
+            }
+            is GrantHexproofFromMulticoloredToGroup -> {
+                ContinuousEffectData(
+                    modification = Modification.GrantHexproofFromMulticolored,
                     affectsFilter = convertGroupFilter(ability.filter)
                 )
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -500,6 +500,11 @@ class TargetValidator {
                 val cardName = state.getEntity(entityId)?.get<CardComponent>()?.name ?: "target"
                 return "$cardName has hexproof from monocolored"
             }
+            // Hexproof from multicolored: a source with two or more colors can't target (CR 105.2b).
+            if (sourceColors.size >= 2 && projected.hasKeyword(entityId, "HEXPROOF_FROM_MULTICOLORED")) {
+                val cardName = state.getEntity(entityId)?.get<CardComponent>()?.name ?: "target"
+                return "$cardName has hexproof from multicolored"
+            }
         }
         return null
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -248,6 +248,9 @@ data class ClientCard(
     /** Hexproof from monocolored (CR 105.2) — shows an uncolored hexproof shield chip */
     val hexproofFromMonocolored: Boolean = false,
 
+    /** Hexproof from multicolored (CR 105.2b) — shows an uncolored hexproof shield chip */
+    val hexproofFromMulticolored: Boolean = false,
+
     /** Counters on the card */
     val counters: Map<CounterType, Int>,
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -2664,11 +2664,21 @@ class ClientStateTransformer(
                     )
                 }
                 is SerializableModification.MustBlockSpecificAttacker -> {
+                    // Name the attacker. The pinned creature is not always the obvious one — an
+                    // ANY-bound "blocks that Wolf" trigger (Tolsimir, Midnight's Light) pins the
+                    // blocker to a creature other than the ability's source, and a defender who
+                    // guesses wrong only finds out when their declaration is rejected.
+                    val attackerName = state.getEntity(modification.attackerId)
+                        ?.get<CardComponent>()?.name
                     effects.add(
                         ClientCardEffect(
                             effectId = "must_block_${modification.attackerId}",
                             name = "Must Block",
-                            description = "This creature must block a specific attacker if able",
+                            description = if (attackerName != null) {
+                                "This creature must block $attackerName this combat if able"
+                            } else {
+                                "This creature must block a specific attacker if able"
+                            },
                             icon = "must-attack"
                         )
                     )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -799,6 +799,9 @@ class ClientStateTransformer(
         // Hexproof from monocolored (CR 105.2) — a quality, not a color, so it rides its own flag.
         val hexproofFromMonocolored = projectedValues?.keywords?.contains("HEXPROOF_FROM_MONOCOLORED") ?: false
 
+        // Hexproof from multicolored (CR 105.2b) — the other half of the quality pair, same shape.
+        val hexproofFromMulticolored = projectedValues?.keywords?.contains("HEXPROOF_FROM_MULTICOLORED") ?: false
+
         // Add PROTECTION keyword when protections are present
         val keywords = if (protections.isNotEmpty()) rawKeywords + Keyword.PROTECTION else rawKeywords
 
@@ -1338,6 +1341,7 @@ class ClientStateTransformer(
             protections = protections,
             hexproofFromColors = hexproofFromColors,
             hexproofFromMonocolored = hexproofFromMonocolored,
+            hexproofFromMulticolored = hexproofFromMulticolored,
             counters = counters,
             isTapped = isTapped,
             isExerted = isExerted,

--- a/web-client/src/components/game/card/CardOverlays.tsx
+++ b/web-client/src/components/game/card/CardOverlays.tsx
@@ -59,6 +59,7 @@ export function KeywordIcons({
   protections,
   hexproofFromColors,
   hexproofFromMonocolored,
+  hexproofFromMulticolored,
   isSuspected,
   topOffset,
   size,
@@ -69,6 +70,8 @@ export function KeywordIcons({
   hexproofFromColors?: readonly Color[]
   /** Hexproof from monocolored (CR 105.2) — an uncolored hexproof-quality shield. */
   hexproofFromMonocolored?: boolean
+  /** Hexproof from multicolored (CR 105.2b) — an uncolored hexproof-quality shield. */
+  hexproofFromMulticolored?: boolean
   /** Whether the permanent currently has the suspected status (CR 701.60). */
   isSuspected?: boolean
   /** Override the column's top offset (px) so it can clear the ring-bearer badge in the same corner. */
@@ -80,8 +83,11 @@ export function KeywordIcons({
   // already convey the protection set, and showing an uncolored shield alongside misleads the player.
   const hexproofFromList = hexproofFromColors ?? []
   const hasHexproofFromMonocolored = hexproofFromMonocolored === true
-  // Any "hexproof from [quality]" — per-color or monocolored — that conveys the protection set.
-  const hasScopedHexproof = hexproofFromList.length > 0 || hasHexproofFromMonocolored
+  const hasHexproofFromMulticolored = hexproofFromMulticolored === true
+  // Any "hexproof from [quality]" — per-color, monocolored, or multicolored — that conveys the
+  // protection set.
+  const hasScopedHexproof =
+    hexproofFromList.length > 0 || hasHexproofFromMonocolored || hasHexproofFromMulticolored
   const hasFullHexproof = keywords.includes('HEXPROOF' as Keyword)
   const hasDoubleStrike = keywords.includes('DOUBLE_STRIKE' as Keyword)
   const filteredKeywords = keywords.filter(k =>
@@ -164,6 +170,28 @@ export function KeywordIcons({
             boxShadow: `0 0 4px ${HEXPROOF_QUALITY_TINT}`,
           }}
           title="Hexproof from monocolored"
+        >
+          <i
+            className="ms ms-ability-hexproof"
+            style={{
+              fontSize: size,
+              color: HEXPROOF_QUALITY_TINT,
+              display: 'block',
+              lineHeight: 1,
+            }}
+          />
+        </div>
+      )}
+      {hasHexproofFromMulticolored && (
+        <div
+          key="hexproof-multicolored"
+          style={{
+            ...styles.keywordIconWrapper,
+            // Same neutral quality ring as the monocolored chip; the tooltip tells them apart.
+            border: `1px solid ${HEXPROOF_QUALITY_TINT}`,
+            boxShadow: `0 0 4px ${HEXPROOF_QUALITY_TINT}`,
+          }}
+          title="Hexproof from multicolored"
         >
           <i
             className="ms ms-ability-hexproof"

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -2364,7 +2364,7 @@ function GameCardImpl({
 
       {/* Keyword ability icons (shown for face-up cards, and for face-down cards with granted keywords) */}
       {battlefield && !hideKeywordIcons && (card.keywords.length > 0 || (card.abilityFlags && card.abilityFlags.length > 0) || (card.protections && card.protections.length > 0) || (card.hexproofFromColors && card.hexproofFromColors.length > 0) || card.isSuspected) && (
-        <KeywordIcons keywords={card.keywords} abilityFlags={card.abilityFlags ?? []} protections={card.protections ?? []} hexproofFromColors={card.hexproofFromColors ?? []} hexproofFromMonocolored={card.hexproofFromMonocolored ?? false} isSuspected={card.isSuspected ?? false} {...(() => {
+        <KeywordIcons keywords={card.keywords} abilityFlags={card.abilityFlags ?? []} protections={card.protections ?? []} hexproofFromColors={card.hexproofFromColors ?? []} hexproofFromMonocolored={card.hexproofFromMonocolored ?? false} hexproofFromMulticolored={card.hexproofFromMulticolored ?? false} isSuspected={card.isSuspected ?? false} {...(() => {
           // The ring-bearer marker and the "Prepared" badge both pin to the top-left corner; push the
           // keyword icons down past whichever is showing so they aren't hidden beneath the badge.
           const topOffset = (card.isRingBearer && !faceDown ? 3 + responsive.badges.ptFontSize * 1.7 + 3 : 0) + (card.isPrepared ? 22 : 0)

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -204,6 +204,9 @@ export interface ClientCard {
   /** Hexproof from monocolored (CR 105.2) — shows an uncolored hexproof shield chip */
   readonly hexproofFromMonocolored?: boolean
 
+  /** Hexproof from multicolored (CR 105.2b) — shows an uncolored hexproof shield chip */
+  readonly hexproofFromMulticolored?: boolean
+
   /** Counters on the card */
   readonly counters: Partial<Record<CounterType, number>>
 


### PR DESCRIPTION
Two MKM rares, each carrying the one small SDK generalization it needed.

- **Tolsimir, Midnight's Light** ({2}{G}{W}{W} Elf Scout 3/2, #236) — lifelink; an enters trigger creating Voja Fenstalker, a legendary 5/5 GW Wolf token with trample; and "Whenever a Wolf you control attacks, if Tolsimir attacked this combat, target creature an opponent controls blocks *that Wolf* this combat if able." Composes `Triggers.attacks(Wolf.youControl(), ANY)` + `Conditions.SourceAttackedThisCombat` as an intervening "if" + `Effects.ForceBlock`.
- **Niv-Mizzet, Guildpact** ({W}{U}{B}{R}{G} Dragon Avatar 6/6, #220) — flying, hexproof from multicolored, and a combat-damage trigger dealing X damage to any target, having target player draw X, and gaining you X life. Composes `Triggers.DealsCombatDamageToPlayer` + a two-requirement target list + `Effects.Composite(DealDamage, DrawCards, GainLife)`.

## SDK / engine additions

**`ForceBlockEffect.attacker: EffectTarget = Self`.** The effect hard-coded the creature that must be blocked to `context.sourceId` — right for the Avalanche Tusker shape ("blocks **it**", source == attacker), wrong for an ANY-bound trigger that names the *triggering* attacker. The executor now resolves the parameter instead of reading the source, requiring only that it resolves to something attacking. The default reproduces the old behaviour byte-for-byte, including the description string, so no existing card moved in the golden.

**`GrantHexproofFromMulticoloredToGroup`.** The exact mirror of the shipped `…MonocoloredToGroup`: projects `HEXPROOF_FROM_MULTICOLORED` in Layer 6, and the same three targeting sites gate on a source of two *or more* colors (CR 105.2b). Carried to the client as `hexproofFromMulticolored` and rendered with the same neutral quality shield the monocolored chip uses.

**`Aggregation.DISTINCT_COLOR_PAIRS`** (+ `DynamicAmounts.colorPairsAmongPermanents()`). Joins the distinct-set family beside `DISTINCT_COLORS`. A matched permanent contributes one unordered pair only if it is exactly two colors, and the same pair on several permanents counts once — so "that are exactly two colors" belongs to the aggregation rather than to every caller's filter, and the value is bounded by ten rather than five. Both the battlefield and zone evaluator branches are implemented; the battlefield one reads projected colors.

## UX

The client's "Must Block" badge now names the pinned attacker rather than saying "a specific attacker". With a requirement that can point at a creature other than the ability's source, a defender who guesses wrong otherwise only finds out when their block declaration is rejected.

## Verification

`just build`, `just test-rules` (full engine suite + every era's card scenarios), and `web-client` `tsc --noEmit` all green. `just rebless-cards` moved only the two new cards in `MKM.json`. Both cards re-verified field-by-field against Scryfall (mana cost, type line, P/T, rarity, collector number, artist, image 200s, oracle text exact); `just check-card-printing` confirms MKM is the canonical set for both.

- `TolsimirMidnightsLightScenarioTest` — the token's characteristics, that blocking Tolsimir does *not* satisfy a requirement naming the Wolf, and that a Wolf attacking without Tolsimir doesn't trigger at all.
- `NivMizzetGuildpactScenarioTest` — duplicate pairs collapsing, the non-contributing shapes (mono, tri, colorless, opponent-controlled), X = 0, split damage/draw targets, and the hexproof quality against all source-colour counts plus the DTO flag.

## Why only two cards

MKM stands at 243/276 and the remaining 33 are all engine-gap work, not composition — worth recording since a "handful" batch normally lands five. Twelve are Cases (the "to solve" mechanic doesn't exist). Of the rest, each one I triaged needs a named primitive that doesn't exist yet:

| Card | Missing |
|---|---|
| Airtight Alibi | a "can't become suspected" static — awkward because `Effects.Suspect` is a three-effect composite, so the gate has to suppress the menace and can't-block halves too |
| Conspiracy Unraveler | `GrantAlternativeCastingCost` takes a mana string; collect evidence 10 isn't one |
| Fugitive Codebreaker | a *self*-scoped disguise cost reduction (`MorphActivation` cost modification is global and increase-only) |
| Officious Interrogation | a per-*target* cost increase (only per-*mode* exists, via escalate) |
| Urgent Necropsy | `CostAtom.CollectEvidence` takes a fixed Int; the cost is X = total MV of the targets |
| Kylox, Visionary Inventor | no DynamicAmount for the total power of permanents sacrificed this way |
| Tomik, Wielder of Law | `CreaturesAttackYouEvent` deliberately excludes attackers pointed at your planeswalkers |
| Yarus, Roar of the Old Gods | the batch combat-damage detector explicitly skips face-down sources (`if (sourceContainer.has<FaceDownComponent>()) return@filter false`) |

Those are `add-feature` PRs, not card work. Tolsimir and Niv-Mizzet are the two whose gaps were small, additive generalizations of primitives already in the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)