### PR TITLE
Add 38 Assay-ready cards to The Dark

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/config/GameBeansConfigBoosterPoolTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/config/GameBeansConfigBoosterPoolTest.kt
@@ -51,6 +51,14 @@ class GameBeansConfigBoosterPoolTest : FunSpec({
         ) shouldBe mapOf("Raging Goblin#POR-145" to 1)
     }
 
+    test("The Dark offers Portal basic lands for sealed deckbuilding") {
+        val drk = boosterGenerator.availableSets["DRK"].shouldNotBeNull()
+
+        drk.basicLands.map { it.name }.toSet() shouldBe
+            setOf("Plains", "Island", "Swamp", "Mountain", "Forest")
+        drk.basicLands.all { it.setCode == "POR" } shouldBe true
+    }
+
     test("Foundations includes its own cards and its reprints in the booster pool") {
         val fdn = boosterGenerator.availableSets["FDN"].shouldNotBeNull()
         val names = fdn.cards.map { it.name }

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/TheDarkSet.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/TheDarkSet.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.mtg.sets.definitions.drk
 
+import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
@@ -19,6 +20,7 @@ object TheDarkSet : MtgSet {
     override val code = "DRK"
     override val displayName = "The Dark"
     override val releaseDate = "1994-08-01"
+    override val basicLandsFallback = PortalSet
     override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/ApprenticeWizard.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/ApprenticeWizard.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Apprentice Wizard
+ * {1}{U}{U}
+ * Creature — Human Wizard
+ * 0/1
+ * {U}, {T}: Add {C}{C}{C}.
+ */
+val ApprenticeWizard = card("Apprentice Wizard") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 0
+    toughness = 1
+    oracleText = "{U}, {T}: Add {C}{C}{C}."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap)
+        effect = Effects.AddColorlessMana(3)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "21"
+        artist = "Dan Frazier"
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/151b332e-164b-4646-8f52-741984cd71ad.jpg?1783947945"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/BogRats.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/BogRats.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Bog Rats
+ * {B}
+ * Creature — Rat
+ * 1/1
+ * This creature can't be blocked by Walls.
+ */
+val BogRats = card("Bog Rats") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Rat"
+    power = 1
+    toughness = 1
+    oracleText = "This creature can't be blocked by Walls."
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.withSubtype(Subtype.WALL))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "42"
+        artist = "Ron Spencer"
+        flavorText = "Their stench was vile and strong enough, but not nearly as powerful as their hunger."
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d64c9153-bc6d-4a64-885f-c039a5487a31.jpg?1783947941"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/BoneFlute.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/BoneFlute.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Bone Flute
+ * {3}
+ * Artifact
+ * {2}, {T}: All creatures get -1/-0 until end of turn.
+ */
+val BoneFlute = card("Bone Flute") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{2}, {T}: All creatures get -1/-0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreatures,
+            Effects.ModifyStats(-1, 0, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "97"
+        artist = "Christopher Rush"
+        flavorText = "After the Battle of Pitdown, Lady Ursnell fashioned the first such instrument out of Lord Ursnell's left leg."
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63a31de0-d764-4ff6-a85f-027e1e58d86c.jpg?1783947928"
+
+        ruling(
+            "2009-10-01",
+            "The ability affects only creatures on the battlefield at the time it resolves. A creature that " +
+                "enters later in the turn won't get -1/-0."
+        )
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/BookOfRass.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/BookOfRass.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Book of Rass
+ * {6}
+ * Artifact — Book
+ * {2}, Pay 2 life: Draw a card.
+ */
+val BookOfRass = card("Book of Rass") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Artifact — Book"
+    oracleText = "{2}, Pay 2 life: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.PayLife(2))
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "98"
+        artist = "Sandra Everingham"
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5a391ada-e9e3-45db-ae84-17421ac6b44d.jpg?1783947929"
+
+        ruling("2004-10-04", "You can't spend yourself to below zero life. You can't spend life you don't have.")
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/CarnivorousPlant.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/CarnivorousPlant.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Carnivorous Plant
+ * {3}{G}
+ * Creature — Plant Wall
+ * 4/5
+ *
+ * Defender — the modern Oracle wording for the original "Wall" text; the Wall creature type is
+ * on the type line and no longer carries the can't-attack rule itself (CR 702.3).
+ */
+val CarnivorousPlant = card("Carnivorous Plant") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Wall"
+    power = 4
+    toughness = 5
+    oracleText = "Defender"
+
+    keywords(Keyword.DEFENDER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "75"
+        artist = "Quinton Hoover"
+        flavorText = "\"It had a mouth like that of a great beast, and gnashed its teeth as it strained to reach us. I am thankful it possessed no means of locomotion.\" —Vervamon the Elder"
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6a615650-4da3-4efc-aa5e-c1f2c4f79478.jpg?1783947933"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/CavePeople.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/CavePeople.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cave People
+ * {1}{R}{R}
+ * Creature — Human
+ * 1/4
+ * Whenever this creature attacks, it gets +1/-2 until end of turn.
+ * {1}{R}{R}, {T}: Target creature gains mountainwalk until end of turn.
+ *
+ * The attack trigger pumps the attacker itself ([EffectTarget.Self]); the activated ability can
+ * hand mountainwalk to any creature, not just this one.
+ */
+val CavePeople = card("Cave People") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human"
+    power = 1
+    toughness = 4
+    oracleText = "Whenever this creature attacks, it gets +1/-2 until end of turn.\n" +
+        "{1}{R}{R}, {T}: Target creature gains mountainwalk until end of turn. (It can't be " +
+        "blocked as long as defending player controls a Mountain.)"
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ModifyStats(1, -2, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{R}{R}"), Costs.Tap)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.MOUNTAINWALK, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "60"
+        artist = "Drew Tucker"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72746a5d-faa1-44b7-97b5-0ef9302a3c13.jpg?1783947936"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/CoalGolem.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/CoalGolem.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Coal Golem
+ * {5}
+ * Artifact Creature — Golem
+ * 3/3
+ * {3}, Sacrifice this creature: Add {R}{R}{R}.
+ */
+val CoalGolem = card("Coal Golem") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    power = 3
+    toughness = 3
+    oracleText = "{3}, Sacrifice this creature: Add {R}{R}{R}."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.SacrificeSelf)
+        effect = Effects.AddMana(Color.RED, 3)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99"
+        artist = "Christopher Rush"
+        flavorText = "\"Three such creatures stood burning at the crest of the hill. Only seconds later, the Fireball struck our front line.\" —Lydia, Countess Brellis"
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1ad7692d-5a51-493f-a322-7b615446ea8e.jpg?1783947927"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/CoalGolem.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/CoalGolem.kt
@@ -16,7 +16,7 @@ import com.wingedsheep.sdk.scripting.TimingRule
  */
 val CoalGolem = card("Coal Golem") {
     manaCost = "{5}"
-    colorIdentity = ""
+    colorIdentity = "R"
     typeLine = "Artifact Creature — Golem"
     power = 3
     toughness = 3

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/DarkHeartOfTheWood.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/DarkHeartOfTheWood.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Dark Heart of the Wood
+ * {B}{G}
+ * Enchantment
+ * Sacrifice a Forest: You gain 3 life.
+ *
+ * The sacrifice is the whole cost — no tap, no mana — so the ability can be activated as often
+ * as there are Forests to feed it.
+ */
+val DarkHeartOfTheWood = card("Dark Heart of the Wood") {
+    manaCost = "{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Enchantment"
+    oracleText = "Sacrifice a Forest: You gain 3 life."
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Land.withSubtype(Subtype.FOREST))
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "Christopher Rush"
+        flavorText = "Even the Goblins shun this haunted place, where the tree limbs twist in agony and the ground seems to scuttle under your feet."
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e3d3df64-1e90-4aef-86ae-0062aa23ff30.jpg?1783947928"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/DiabolicMachine.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/DiabolicMachine.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Diabolic Machine
+ * {7}
+ * Artifact Creature — Construct
+ * 4/4
+ * {3}: Regenerate this creature.
+ */
+val DiabolicMachine = card("Diabolic Machine") {
+    manaCost = "{7}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 4
+    toughness = 4
+    oracleText = "{3}: Regenerate this creature."
+
+    activatedAbility {
+        cost = Costs.Mana("{3}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "101"
+        artist = "Anson Maddocks"
+        flavorText = "\"The bolts of our ballistae smashed into the monstrous thing, but our hopes died in our chests as its gears continued turning.\" —Sevti Mukul, *The Fall of Alsoor*"
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c3b0f228-6b06-4426-a557-1225d547b908.jpg?1783947926"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Drowned.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Drowned.kt
@@ -15,7 +15,7 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  */
 val Drowned = card("Drowned") {
     manaCost = "{1}{U}"
-    colorIdentity = "U"
+    colorIdentity = "UB"
     typeLine = "Creature — Zombie"
     power = 1
     toughness = 1

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Drowned.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Drowned.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Drowned
+ * {1}{U}
+ * Creature — Zombie
+ * 1/1
+ * {B}: Regenerate this creature.
+ */
+val Drowned = card("Drowned") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie"
+    power = 1
+    toughness = 1
+    oracleText = "{B}: Regenerate this creature."
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Quinton Hoover"
+        flavorText = "We asked Captain Soll what became of the Serafina, but all he said was, \"Ships that go down shouldn't come back up.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/951b6c10-cbba-44b6-aae2-2c386b7ebacb.jpg?1783947945"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Exorcist.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Exorcist.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Exorcist
+ * {W}{W}
+ * Creature — Human Cleric
+ * 1/1
+ * {1}{W}, {T}: Destroy target black creature.
+ */
+val Exorcist = card("Exorcist") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 1
+    oracleText = "{1}{W}, {T}: Destroy target black creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}"), Costs.Tap)
+        val creature = target("target black creature", Targets.CreatureWithColor(Color.BLACK))
+        effect = Effects.Destroy(creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "6"
+        artist = "Drew Tucker"
+        flavorText = "Though they often bore little greater charm than the demons they battled, exorcists were always welcome in Scarwood."
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/184b7d52-e991-4668-9f6a-bcded97f51ac.jpg?1783947949"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/FireDrake.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/FireDrake.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fire Drake
+ * {1}{R}{R}
+ * Creature — Drake
+ * 1/2
+ * Flying
+ * {R}: This creature gets +1/+0 until end of turn. Activate only once each turn.
+ */
+val FireDrake = card("Fire Drake") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Drake"
+    power = 1
+    toughness = 2
+    oracleText = "Flying\n{R}: This creature gets +1/+0 until end of turn. Activate only once each turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "62"
+        artist = "Christopher Rush"
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d3419db6-1c38-4aa4-b953-1dde7d22b927.jpg?1783947935"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Fissure.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Fissure.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Fissure
+ * {3}{R}{R}
+ * Instant
+ * Destroy target creature or land. It can't be regenerated.
+ */
+val Fissure = card("Fissure") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature or land. It can't be regenerated."
+
+    spell {
+        val permanent = target(
+            "target creature or land",
+            TargetPermanent(filter = TargetFilter.CreatureOrLandPermanent)
+        )
+        effect = Effects.Destroy(permanent, noRegenerate = true)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "63"
+        artist = "Douglas Shuler"
+        flavorText = "\"Must not all things at the last be swallowed up in death?\" —Plato"
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aa2d778d-d74b-45ec-a86b-5d52ffad6ba5.jpg?1783947935"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Flood.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Flood.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Flood
+ * {U}
+ * Enchantment
+ * {U}{U}: Tap target creature without flying.
+ */
+val Flood = card("Flood") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "{U}{U}: Tap target creature without flying."
+
+    activatedAbility {
+        cost = Costs.Mana("{U}{U}")
+        val creature = target(
+            "target creature without flying",
+            TargetCreature(filter = TargetFilter.Creature.withoutKeyword(Keyword.FLYING))
+        )
+        effect = Effects.Tap(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "27"
+        artist = "Dennis Detwiller"
+        flavorText = "\"A dash of cool water does wonders to clear a cluttered battlefield.\" —Vibekke Ragnild, *Witches and War*"
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fabc3267-b59b-4f36-8873-5b4b072711ca.jpg?1783947944"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/GhostShip.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/GhostShip.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ghost Ship
+ * {2}{U}{U}
+ * Creature — Spirit
+ * 2/4
+ * Flying
+ * {U}{U}{U}: Regenerate this creature.
+ */
+val GhostShip = card("Ghost Ship") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    power = 2
+    toughness = 4
+    oracleText = "Flying\n{U}{U}{U}: Regenerate this creature."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{U}{U}{U}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "28"
+        artist = "Tom Wänerstrand"
+        flavorText = "\"That phantom prow split the storm as lightning cast its long shadow on the battlefield below.\" —Mireille Gaetane, *The Valeriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db591b28-37e5-4e7c-ae4d-d761262b12d0.jpg?1783947943"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/GoblinDiggingTeam.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/GoblinDiggingTeam.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Goblin Digging Team
+ * {R}
+ * Creature — Goblin
+ * 1/1
+ * {T}, Sacrifice this creature: Destroy target Wall.
+ */
+val GoblinDiggingTeam = card("Goblin Digging Team") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin"
+    power = 1
+    toughness = 1
+    oracleText = "{T}, Sacrifice this creature: Destroy target Wall."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+        val wall = target(
+            "target Wall",
+            TargetCreature(filter = TargetFilter.Creature.withSubtype(Subtype.WALL))
+        )
+        effect = Effects.Destroy(wall)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "65"
+        artist = "Ron Spencer"
+        flavorText = "\"From down here we can make the whole wall collapse!\" \"Uh, yeah, boss, but how do we get out?\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8a538b9d-351e-40bb-be11-9ba08c16352b.jpg?1783947935"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/GraveRobbers.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/GraveRobbers.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Grave Robbers
+ * {1}{B}{B}
+ * Creature — Human Rogue
+ * 1/1
+ * {B}, {T}: Exile target artifact card from a graveyard. You gain 2 life.
+ *
+ * "a graveyard" is any player's, so the target filter carries no owner predicate. The life gain
+ * is part of the same resolution, so it happens even though the exile has already left the card
+ * out of reach.
+ */
+val GraveRobbers = card("Grave Robbers") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "{B}, {T}: Exile target artifact card from a graveyard. You gain 2 life."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}"), Costs.Tap)
+        val artifact = target(
+            "target artifact card from a graveyard",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Artifact, zone = Zone.GRAVEYARD))
+        )
+        effect = Effects.Composite(
+            Effects.Exile(artifact, fromZone = Zone.GRAVEYARD),
+            Effects.GainLife(2)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "46"
+        artist = "Quinton Hoover"
+        flavorText = "\"If you don't have your health, you don't have anything.\" —Proverb"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a131605a-f646-4745-a1e4-48d155a3d94f.jpg?1783947938"
+
+        ruling("2004-10-04", "This exiles the artifact on resolution, but you choose it as a target when activating the ability.")
+        ruling("2004-10-04", "If the target is not there on resolution, you do not gain the life.")
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/HiddenPath.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/HiddenPath.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Hidden Path
+ * {2}{G}{G}{G}{G}
+ * Enchantment
+ * Green creatures have forestwalk.
+ *
+ * Every green creature on the battlefield, whoever controls it — the group is re-read from
+ * projected state, so a creature that becomes green later gains forestwalk too.
+ */
+val HiddenPath = card("Hidden Path") {
+    manaCost = "{2}{G}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Green creatures have forestwalk. (They can't be blocked as long as defending " +
+        "player controls a Forest.)"
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.FORESTWALK,
+            filter = GroupFilter(GameObjectFilter.Creature.withColor(Color.GREEN))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "78"
+        artist = "Rob Alexander"
+        flavorText = "\"Where moments before we were lost beyond hope, the strange, floating lights showed us the way and restored our morale.\" —Vervamon the Elder"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cbc93c0b-0ac8-4b8f-b2f6-96887d1acd77.jpg?1783947932"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/HolyLight.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/HolyLight.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Holy Light
+ * {2}{W}
+ * Instant
+ * Nonwhite creatures get -1/-1 until end of turn.
+ *
+ * A group pump over every creature that isn't white — `CardPredicate.NotColor` reads the
+ * creature's colors, so a multicolored creature that is partly white is spared.
+ */
+val HolyLight = card("Holy Light") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Nonwhite creatures get -1/-1 until end of turn."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.notColor(Color.WHITE)),
+            Effects.ModifyStats(-1, -1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "Drew Tucker"
+        flavorText = "\"Bathed in hallowed light, the infidels looked upon the impurities of their souls and despaired.\" —*The Book of Tal*"
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c3c8a850-bc99-4679-a316-45ecdea696b2.jpg?1783947948"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/KnightsOfThorn.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/KnightsOfThorn.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Knights of Thorn
+ * {3}{W}
+ * Creature — Human Knight
+ * 2/2
+ *
+ * Protection from red; banding
+ *
+ * Both keywords are handled by the engine — Protection via CR 702.16, Banding via CR 702.22
+ * (CombatManager / CombatDamageManager / AttackPhaseManager) — so the card needs no per-card
+ * wiring beyond declaring them.
+ */
+val KnightsOfThorn = card("Knights of Thorn") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 2
+    oracleText = "Protection from red; banding (Any creatures with banding, and up to one " +
+        "without, can attack in a band. Bands are blocked as a group. If any creatures with " +
+        "banding you control are blocking or being blocked by a creature, you divide that " +
+        "creature's combat damage, not its controller, among any of the creatures it's being " +
+        "blocked by or is blocking.)"
+
+    keywords(Keyword.BANDING)
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.RED)))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "11"
+        artist = "Christopher Rush"
+        flavorText = "\"With a great cry, the Goblin host broke and ran as the first wave of Knights penetrated its ranks.\" —Tivadar of Thorn, *History of the Goblin Wars*"
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae541c73-9903-49e6-997a-db4701135145.jpg?1783947948"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/LandLeeches.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/LandLeeches.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Land Leeches
+ * {1}{G}{G}
+ * Creature — Leech
+ * 2/2
+ * First strike
+ */
+val LandLeeches = card("Land Leeches") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Leech"
+    power = 2
+    toughness = 2
+    oracleText = "First strike"
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "79"
+        artist = "Quinton Hoover"
+        flavorText = "\"The standard cure for leeches requires the application of burning embers. Alternative methods must be devised should an ember of sufficient size prove more harmful than the leech.\" —Vervamon the Elder"
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff99543d-86a1-44f8-88ec-aaec071d6c05.jpg?1783947931"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/MarshGas.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/MarshGas.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Marsh Gas
+ * {B}
+ * Instant
+ * All creatures get -2/-0 until end of turn.
+ */
+val MarshGas = card("Marsh Gas") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "All creatures get -2/-0 until end of turn."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreatures,
+            Effects.ModifyStats(-2, 0, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Douglas Shuler"
+        flavorText = "\"Comes right outta th' ground. If ya can smell it, it's too late.\" —Keevy Bogsbury"
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b80ecb15-258b-4fc9-86e4-c2bf01891606.jpg?1783947938"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/MarshGoblins.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/MarshGoblins.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Marsh Goblins
+ * {B}{R}
+ * Creature — Goblin
+ * 1/1
+ * Swampwalk
+ */
+val MarshGoblins = card("Marsh Goblins") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Goblin"
+    power = 1
+    toughness = 1
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)"
+
+    keywords(Keyword.SWAMPWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "93"
+        artist = "Quinton Hoover"
+        flavorText = "Even the other Goblin races shun the Marsh Goblins, thanks to certain unwholesome customs they practice."
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8aabd80f-a18a-4bc1-9f05-4c3a63de77ce.jpg?1783947928"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/MazeOfIth.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/MazeOfIth.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Maze of Ith
+ * Land
+ * {T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and
+ * dealt by that creature this turn.
+ *
+ * Untapping an attacker does not remove it from combat, which is why the second half matters:
+ * the same creature is shielded in both directions ([Effects.PreventCombatDamageToAndBy]), so
+ * it neither deals nor receives combat damage for the rest of the turn.
+ */
+val MazeOfIth = card("Maze of Ith") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Untap target attacking creature. Prevent all combat damage that would be " +
+        "dealt to and dealt by that creature this turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target("target attacking creature", Targets.AttackingCreature)
+        effect = Effects.Composite(
+            Effects.Untap(creature),
+            Effects.PreventCombatDamageToAndBy(creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "117"
+        artist = "Anson Maddocks"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42dcceee-2a47-4eaa-a6a3-2931b3d50244.jpg?1783947922"
+
+        ruling("2022-12-08", "Maze of Ith doesn't have a mana ability. It doesn't tap for colorless mana.")
+        ruling(
+            "2022-12-08",
+            "Maze of Ith can target an untapped attacking creature. It will still prevent the combat damage it " +
+                "would deal and be dealt."
+        )
+        ruling(
+            "2022-12-08",
+            "The creature isn't removed from combat; it just has its damage prevented. It's still an attacking " +
+                "creature until the combat phase is complete."
+        )
+        ruling(
+            "2022-12-08",
+            "You can activate Maze of Ith's ability targeting an attacking creature you control during the combat " +
+                "damage step or the end of combat step, even though it will already have dealt combat damage. This " +
+                "will untap the creature. The damage it dealt will be unaffected."
+        )
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/MerfolkAssassin.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/MerfolkAssassin.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Merfolk Assassin
+ * {U}{U}
+ * Creature — Merfolk Assassin
+ * 1/2
+ * {T}: Destroy target creature with islandwalk.
+ */
+val MerfolkAssassin = card("Merfolk Assassin") {
+    manaCost = "{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Assassin"
+    power = 1
+    toughness = 2
+    oracleText = "{T}: Destroy target creature with islandwalk."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target("target creature with islandwalk", Targets.CreatureWithKeyword(Keyword.ISLANDWALK))
+        effect = Effects.Destroy(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "32"
+        artist = "Dennis Detwiller"
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/36313dc7-6bf2-4d73-b696-969d984a7466.jpg?1783947942"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Morale.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Morale.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Morale
+ * {1}{W}{W}
+ * Instant
+ * Attacking creatures get +1/+1 until end of turn.
+ *
+ * Every attacking creature, not just yours — the group is snapshotted at resolution, so a
+ * creature that starts attacking afterwards is not pumped.
+ */
+val Morale = card("Morale") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Attacking creatures get +1/+1 until end of turn."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AttackingCreatures,
+            Effects.ModifyStats(1, 1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "14"
+        artist = "Mark Poole"
+        flavorText = "\"After Lacjsi's speech, the Knights grew determined to crush their ancient enemies clan by clan.\" —Tivadar of Thorn, *History of the Goblin Wars*"
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c4104546-abd9-4bfb-a65e-5928cdd4522f.jpg?1783947946"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/NiallSilvain.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/NiallSilvain.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+
+/**
+ * Niall Silvain
+ * {G}{G}{G}
+ * Creature — Ouphe
+ * 2/2
+ * {G}{G}{G}{G}, {T}: Regenerate target creature.
+ */
+val NiallSilvain = card("Niall Silvain") {
+    manaCost = "{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ouphe"
+    power = 2
+    toughness = 2
+    oracleText = "{G}{G}{G}{G}, {T}: Regenerate target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}{G}{G}{G}"), Costs.Tap)
+        val creature = target("target creature", Targets.Creature)
+        effect = RegenerateEffect(creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "82"
+        artist = "Christopher Rush"
+        flavorText = "This is his domain, and while you remain here you must value all life as you value your own."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d5911b5-a54e-4ebb-9c36-d4dc8e97bb4b.jpg?1783947931"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/PeopleOfTheWoods.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/PeopleOfTheWoods.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * People of the Woods
+ * {G}{G}
+ * Creature — Human
+ * Power 1, toughness *
+ * People of the Woods's toughness is equal to the number of Forests you control.
+ *
+ * A characteristic-defining ability (CR 604.3): only the toughness is dynamic, so this uses
+ * [dynamicToughness] rather than the `*`/`*` [dynamicStats] cycle.
+ */
+val PeopleOfTheWoods = card("People of the Woods") {
+    manaCost = "{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human"
+    power = 1
+    toughness = 0
+    oracleText = "People of the Woods's toughness is equal to the number of Forests you control."
+
+    dynamicToughness(
+        DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Land.withSubtype(Subtype.FOREST))
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "83"
+        artist = "Drew Tucker"
+        flavorText = "\"Their rain of arrows left only myself alive, cowering within a tree hollow. They did not even come out to loot the bodies.\" —Vervamon the Elder"
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2fb5926f-9988-4bc0-b2b7-e286db208310.jpg?1783947930"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Pikemen.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Pikemen.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pikemen
+ * {1}{W}
+ * Creature — Human Soldier
+ * 1/1
+ *
+ * First strike; banding — both fully handled by the combat engine (CR 702.7 and CR 702.22),
+ * so the card only declares them.
+ */
+val Pikemen = card("Pikemen") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "First strike; banding (Any creatures with banding, and up to one without, " +
+        "can attack in a band. Bands are blocked as a group. If any creatures with banding you " +
+        "control are blocking or being blocked by a creature, you divide that creature's combat " +
+        "damage, not its controller, among any of the creatures it's being blocked by or is " +
+        "blocking.)"
+
+    keywords(Keyword.FIRST_STRIKE, Keyword.BANDING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "15"
+        artist = "Dennis Detwiller"
+        flavorText = "\"As the cavalry bore down, we faced them with swords drawn and pikes hidden in the grass at our feet. 'Don't lift your pikes 'til I give the word,' I said.\" —Maeveen O'Donagh, *Memoirs of a Soldier*"
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bf2f6936-b50c-4907-9b55-ebf8a3fba8f5.jpg?1783947946"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Riptide.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Riptide.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Riptide
+ * {U}
+ * Instant
+ * Tap all blue creatures.
+ *
+ * Every blue creature on the battlefield, including the caster's own — already-tapped ones are
+ * simply unaffected.
+ */
+val Riptide = card("Riptide") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Tap all blue creatures."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.withColor(Color.BLUE)),
+            Effects.Tap(EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "35"
+        artist = "Randy Asplund-Faith"
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0f11ae4-e30e-441d-bb64-439930d9997c.jpg?1783947941"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/ScavengerFolk.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/ScavengerFolk.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scavenger Folk
+ * {G}
+ * Creature — Human
+ * 1/1
+ * {G}, {T}, Sacrifice this creature: Destroy target artifact.
+ */
+val ScavengerFolk = card("Scavenger Folk") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human"
+    power = 1
+    toughness = 1
+    oracleText = "{G}, {T}, Sacrifice this creature: Destroy target artifact."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.Tap, Costs.SacrificeSelf)
+        val artifact = target("target artifact", Targets.Artifact)
+        effect = Effects.Destroy(artifact)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Dennis Detwiller"
+        flavorText = "String, weapons, wax, or jewels—it makes no difference. Leave nothing unguarded in Scarwood."
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e99870c-b2b9-431b-b8a8-3f4a80aa8fa5.jpg?1783947929"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/SistersOfTheFlame.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/SistersOfTheFlame.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Sisters of the Flame
+ * {1}{R}{R}
+ * Creature — Human Shaman
+ * 2/2
+ * {T}: Add {R}.
+ */
+val SistersOfTheFlame = card("Sisters of the Flame") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "{T}: Add {R}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "74"
+        artist = "Jesper Myrfors"
+        flavorText = "We are many wicks sharing a common tallow; we feed the skies with the ashes of our prey."
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/564e0ccd-decb-48d2-981f-cefa8045340f.jpg?1783947934"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/StandingStones.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/StandingStones.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Standing Stones
+ * {3}
+ * Artifact
+ * {1}, {T}, Pay 1 life: Add one mana of any color.
+ */
+val StandingStones = card("Standing Stones") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{1}, {T}, Pay 1 life: Add one mana of any color."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "110"
+        artist = "Sandra Everingham"
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6d4c853e-2231-4af2-bcb0-1781c18ec3be.jpg?1783947924"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/StoneCalendar.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/StoneCalendar.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Stone Calendar
+ * {5}
+ * Artifact
+ * Spells you cast cost {1} less to cast.
+ *
+ * The Medallion static with no colour filter — [CostModification.ReduceGeneric] shaves only the
+ * generic part of the cost (CR 601.2f), so a one-mana coloured spell is unaffected.
+ */
+val StoneCalendar = card("Stone Calendar") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Spells you cast cost {1} less to cast."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "111"
+        artist = "Amy Weber"
+        flavorText = "The Pretender Mairsil ordered a great Calendar drawn up to show when the paths to the Dark Lands were strongest."
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a49ba1a5-33b1-40f2-9780-26139ed829d7.jpg?1783947924"
+
+        ruling("2004-10-04", "Does not change the mana cost of the spell, it just reduces what you pay for it.")
+        ruling("2004-10-04", "You may choose not to apply Stone Calendar's cost reduction effect.")
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/SunkenCity.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/SunkenCity.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Sunken City
+ * {U}{U}
+ * Enchantment
+ * At the beginning of your upkeep, sacrifice this enchantment unless you pay {U}{U}.
+ * Blue creatures get +1/+1.
+ *
+ * The upkeep tax is the Junún Efreet shape ([PayOrSufferEffect] + [SacrificeSelfEffect]); the
+ * anthem is a plain [ModifyStats] static over every blue creature, whoever controls it.
+ */
+val SunkenCity = card("Sunken City") {
+    manaCost = "{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, sacrifice this enchantment unless you pay {U}{U}.\n" +
+        "Blue creatures get +1/+1."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = PayOrSufferEffect(
+            cost = Costs.pay.Mana("{U}{U}"),
+            suffer = SacrificeSelfEffect,
+        )
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1, GroupFilter(GameObjectFilter.Creature.withColor(Color.BLUE)))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Jesper Myrfors"
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f1e0f9ec-2b06-4bda-8b80-a716d82d1f13.jpg?1783947942"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/TivadarsCrusade.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/TivadarsCrusade.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Tivadar's Crusade
+ * {1}{W}{W}
+ * Sorcery
+ * Destroy all Goblins.
+ *
+ * Every Goblin on the battlefield, whoever controls it, and regeneration still applies — the
+ * card says nothing about it.
+ */
+val TivadarsCrusade = card("Tivadar's Crusade") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all Goblins."
+
+    spell {
+        effect = Effects.DestroyAll(GameObjectFilter.Permanent.withSubtype(Subtype.GOBLIN))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "18"
+        artist = "Dennis Detwiller"
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8b6da540-6803-47e5-9af0-7ae8e2f84b6c.jpg?1783947945"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/WaterWurm.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/WaterWurm.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Water Wurm
+ * {U}
+ * Creature — Wurm
+ * 1/1
+ * This creature gets +0/+1 as long as an opponent controls an Island.
+ *
+ * The Kird Ape shape with the opponent as the reference player: an `Exists` over
+ * [Player.EachOpponent]'s battlefield, re-asked on every projection.
+ */
+val WaterWurm = card("Water Wurm") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Wurm"
+    power = 1
+    toughness = 1
+    oracleText = "This creature gets +0/+1 as long as an opponent controls an Island."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(0, 1, Filters.Self),
+            condition = Exists(
+                Player.EachOpponent,
+                Zone.BATTLEFIELD,
+                GameObjectFilter.Land.withSubtype(Subtype.ISLAND)
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "38"
+        artist = "Ron Spencer"
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e3da4a88-5225-467f-9240-f30bc1eee520.jpg?1783947941"
+
+        ruling("2004-10-04", "Only gets the bonus once even if more than one opponent has an Island on the battlefield.")
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/WitchHunter.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/WitchHunter.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Witch Hunter
+ * {2}{W}{W}
+ * Creature — Human Cleric
+ * 1/1
+ * {T}: This creature deals 1 damage to target player or planeswalker.
+ * {1}{W}{W}, {T}: Return target creature an opponent controls to its owner's hand.
+ */
+val WitchHunter = card("Witch Hunter") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: This creature deals 1 damage to target player or planeswalker.\n" +
+        "{1}{W}{W}, {T}: Return target creature an opponent controls to its owner's hand."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val victim = target("target player or planeswalker", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(1, victim)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}{W}"), Costs.Tap)
+        val creature = target("target creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.ReturnToHand(creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "19"
+        artist = "Jesper Myrfors"
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4eef9bb7-cd3c-422e-a93b-90d98684675a.jpg?1783947945"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DarkHeartOfTheWoodReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DarkHeartOfTheWoodReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dark Heart of the Wood reprint in RAV.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in DRK's `cards/` package
+ * (the card's earliest real printing). This file contributes only the RAV-specific
+ * presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val DarkHeartOfTheWoodReprint = Printing(
+    oracleId = "c44f40da-867e-4237-b4b1-ed6feb1f37b7",
+    name = "Dark Heart of the Wood",
+    setCode = "RAV",
+    collectorNumber = "200",
+    scryfallId = "baa3ae99-a770-4487-8de6-68a347ee64bb",
+    artist = "Mark Tedin",
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/baa3ae99-a770-4487-8de6-68a347ee64bb.jpg?1783943623",
+    releaseDate = "2005-10-07",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/FloodReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/FloodReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flood reprint in PZ2 (Treasure Chest).
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in DRK's `cards/` package
+ * (the card's earliest real printing). This file contributes only the PZ2-specific
+ * presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val FloodReprint = Printing(
+    oracleId = "e8eb2abb-daf9-43e0-b909-d96b679f71c2",
+    name = "Flood",
+    setCode = "PZ2",
+    collectorNumber = "65829",
+    scryfallId = "941de0f9-7500-45e5-a6aa-40b7531a2b25",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/941de0f9-7500-45e5-a6aa-40b7531a2b25.jpg?1783936975",
+    releaseDate = "2016-11-16",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -745,6 +745,35 @@
     ]
 }
 
+// Hidden Path
+{
+    "name": "Hidden Path",
+    "manaCost": "{2}{G}{G}{G}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Green creatures have forestwalk. (They can't be blocked as long as defending player controls a Forest.)",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FORESTWALK",
+                "filter": {
+                    "baseFilter": "creature green"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "rarity": "RARE",
+        "artist": "Rob Alexander",
+        "flavorText": "\"Where moments before we were lost beyond hope, the strange, floating lights showed us the way and restored our morale.\" —Vervamon the Elder",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cbc93c0b-0ac8-4b8f-b2f6-96887d1acd77.jpg?1783947932"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Holy Light
 {
     "name": "Holy Light",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -247,6 +247,45 @@
     ]
 }
 
+// Dark Heart of the Wood
+{
+    "name": "Dark Heart of the Wood",
+    "manaCost": "{B}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Sacrifice a Forest: You gain 3 life.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "land Forest"
+                    }
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "artist": "Christopher Rush",
+        "flavorText": "Even the Goblins shun this haunted place, where the tree limbs twist in agony and the ground seems to scuttle under your feet.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e3d3df64-1e90-4aef-86ae-0062aa23ff30.jpg?1783947928"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Drowned
 {
     "name": "Drowned",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -147,6 +147,69 @@
     ]
 }
 
+// Bone Flute
+{
+    "name": "Bone Flute",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}, {T}: All creatures get -1/-0 until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "rarity": "UNCOMMON",
+        "artist": "Christopher Rush",
+        "flavorText": "After the Battle of Pitdown, Lady Ursnell fashioned the first such instrument out of Lord Ursnell's left leg.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/63a31de0-d764-4ff6-a85f-027e1e58d86c.jpg?1783947928",
+        "rulings": [
+            {
+                "date": "2009-10-01",
+                "text": "The ability affects only creatures on the battlefield at the time it resolves. A creature that enters later in the turn won't get -1/-0."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Carnivorous Plant
 {
     "name": "Carnivorous Plant",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -837,6 +837,54 @@
     ]
 }
 
+// Water Wurm
+{
+    "name": "Water Wurm",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Wurm",
+    "oracleText": "This creature gets +0/+1 as long as an opponent controls an Island.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 0,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "EachOpponent",
+                    "zone": "Battlefield",
+                    "filter": "land Island"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "artist": "Ron Spencer",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e3da4a88-5225-467f-9240-f30bc1eee520.jpg?1783947941",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "Only gets the bonus once even if more than one opponent has an Island on the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Witch Hunter
 {
     "name": "Witch Hunter",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -110,6 +110,43 @@
     ]
 }
 
+// Bog Rats
+{
+    "name": "Bog Rats",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Rat",
+    "oracleText": "This creature can't be blocked by Walls.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasSubtype",
+                            "subtype": "Wall"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "artist": "Ron Spencer",
+        "flavorText": "Their stench was vile and strong enough, but not nearly as powerful as their hunger.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d64c9153-bc6d-4a64-885f-c039a5487a31.jpg?1783947941"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Drowned
 {
     "name": "Drowned",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -1,3 +1,53 @@
+// Apprentice Wizard
+{
+    "name": "Apprentice Wizard",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{U}, {T}: Add {C}{C}{C}.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "rarity": "RARE",
+        "artist": "Dan Frazier",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/151b332e-164b-4646-8f52-741984cd71ad.jpg?1783947945"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Ball Lightning
 {
     "name": "Ball Lightning",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -1122,6 +1122,35 @@
     ]
 }
 
+// People of the Woods
+{
+    "name": "People of the Woods",
+    "manaCost": "{G}{G}",
+    "typeLine": "Creature — Human",
+    "oracleText": "People of the Woods's toughness is equal to the number of Forests you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land Forest"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "UNCOMMON",
+        "artist": "Drew Tucker",
+        "flavorText": "\"Their rain of arrows left only myself alive, cowering within a tree hollow. They did not even come out to loot the bodies.\" —Vervamon the Elder",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2fb5926f-9988-4bc0-b2b7-e286db208310.jpg?1783947930"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Pikemen
 {
     "name": "Pikemen",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -913,6 +913,30 @@
     ]
 }
 
+// Land Leeches
+{
+    "name": "Land Leeches",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Creature — Leech",
+    "oracleText": "First strike",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "metadata": {
+        "collectorNumber": "79",
+        "artist": "Quinton Hoover",
+        "flavorText": "\"The standard cure for leeches requires the application of burning embers. Alternative methods must be devised should an ember of sufficient size prove more harmful than the leech.\" —Vervamon the Elder",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff99543d-86a1-44f8-88ec-aaec071d6c05.jpg?1783947931"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Marsh Gas
 {
     "name": "Marsh Gas",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -629,6 +629,46 @@
     ]
 }
 
+// Marsh Gas
+{
+    "name": "Marsh Gas",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "All creatures get -2/-0 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": -2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 0
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "artist": "Douglas Shuler",
+        "flavorText": "\"Comes right outta th' ground. If ya can smell it, it's too late.\" —Keevy Bogsbury",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b80ecb15-258b-4fc9-86e4-c2bf01891606.jpg?1783947938"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Merfolk Assassin
 {
     "name": "Merfolk Assassin",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -977,6 +977,31 @@
     ]
 }
 
+// Marsh Goblins
+{
+    "name": "Marsh Goblins",
+    "manaCost": "{B}{R}",
+    "typeLine": "Creature — Goblin",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "93",
+        "artist": "Quinton Hoover",
+        "flavorText": "Even the other Goblin races shun the Marsh Goblins, thanks to certain unwholesome customs they practice.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8aabd80f-a18a-4bc1-9f05-4c3a63de77ce.jpg?1783947928"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Merfolk Assassin
 {
     "name": "Merfolk Assassin",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -1246,6 +1246,78 @@
     ]
 }
 
+// Maze of Ith
+{
+    "name": "Maze of Ith",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target attacking creature"
+                            },
+                            "tap": false
+                        },
+                        {
+                            "type": "PreventDamageShield",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target attacking creature"
+                            },
+                            "scope": "CombatOnly",
+                            "direction": "Both"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature attacking"
+                        },
+                        "id": "target attacking creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "rarity": "UNCOMMON",
+        "artist": "Anson Maddocks",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42dcceee-2a47-4eaa-a6a3-2931b3d50244.jpg?1783947922",
+        "rulings": [
+            {
+                "date": "2022-12-08",
+                "text": "Maze of Ith doesn't have a mana ability. It doesn't tap for colorless mana."
+            },
+            {
+                "date": "2022-12-08",
+                "text": "Maze of Ith can target an untapped attacking creature. It will still prevent the combat damage it would deal and be dealt."
+            },
+            {
+                "date": "2022-12-08",
+                "text": "The creature isn't removed from combat; it just has its damage prevented. It's still an attacking creature until the combat phase is complete."
+            },
+            {
+                "date": "2022-12-08",
+                "text": "You can activate Maze of Ith's ability targeting an attacking creature you control during the combat damage step or the end of combat step, even though it will already have dealt combat damage. This will untap the creature. The damage it dealt will be unaffected."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Merfolk Assassin
 {
     "name": "Merfolk Assassin",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -1064,6 +1064,64 @@
     ]
 }
 
+// Niall Silvain
+{
+    "name": "Niall Silvain",
+    "manaCost": "{G}{G}{G}",
+    "typeLine": "Creature — Ouphe",
+    "oracleText": "{G}{G}{G}{G}, {T}: Regenerate target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}{G}{G}{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "rarity": "RARE",
+        "artist": "Christopher Rush",
+        "flavorText": "This is his domain, and while you remain here you must value all life as you value your own.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d5911b5-a54e-4ebb-9c36-d4dc8e97bb4b.jpg?1783947931"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Pikemen
 {
     "name": "Pikemen",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -210,6 +210,60 @@
     "colorIdentityOverride": []
 }
 
+// Book of Rass
+{
+    "name": "Book of Rass",
+    "manaCost": "{6}",
+    "typeLine": "Artifact — Book",
+    "oracleText": "{2}, Pay 2 life: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "rarity": "UNCOMMON",
+        "artist": "Sandra Everingham",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5a391ada-e9e3-45db-ae84-17421ac6b44d.jpg?1783947929",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "You can't spend yourself to below zero life. You can't spend life you don't have."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Carnivorous Plant
 {
     "name": "Carnivorous Plant",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -288,6 +288,40 @@
     ]
 }
 
+// Knights of Thorn
+{
+    "name": "Knights of Thorn",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Protection from red; banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "BANDING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "RED"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "11",
+        "rarity": "RARE",
+        "artist": "Christopher Rush",
+        "flavorText": "\"With a great cry, the Goblin host broke and ran as the first wave of Knights penetrated its ranks.\" —Tivadar of Thorn, *History of the Goblin Wars*",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae541c73-9903-49e6-997a-db4701135145.jpg?1783947948"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Scarwood Goblins
 {
     "name": "Scarwood Goblins",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -481,3 +481,44 @@
         "WHITE"
     ]
 }
+
+// Tivadar's Crusade
+{
+    "name": "Tivadar's Crusade",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy all Goblins.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "permanent Goblin"
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "rarity": "UNCOMMON",
+        "artist": "Dennis Detwiller",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8b6da540-6803-47e5-9af0-7ae8e2f84b6c.jpg?1783947945"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -110,6 +110,45 @@
     ]
 }
 
+// Drowned
+{
+    "name": "Drowned",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "{B}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "artist": "Quinton Hoover",
+        "flavorText": "We asked Captain Soll what became of the Serafina, but all he said was, \"Ships that go down shouldn't come back up.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/951b6c10-cbba-44b6-aae2-2c386b7ebacb.jpg?1783947945"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Exorcist
 {
     "name": "Exorcist",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -453,6 +453,44 @@
     ]
 }
 
+// Diabolic Machine
+{
+    "name": "Diabolic Machine",
+    "manaCost": "{7}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "{3}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "rarity": "UNCOMMON",
+        "artist": "Anson Maddocks",
+        "flavorText": "\"The bolts of our ballistae smashed into the monstrous thing, but our hopes died in our chests as its gears continued turning.\" —Sevti Mukul, *The Fall of Alsoor*",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c3b0f228-6b06-4426-a557-1225d547b908.jpg?1783947926"
+    },
+    "colorIdentityOverride": []
+}
+
 // Drowned
 {
     "name": "Drowned",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -621,6 +621,37 @@
     ]
 }
 
+// Riptide
+{
+    "name": "Riptide",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Tap all blue creatures.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature blue"
+                }
+            },
+            "body": {
+                "type": "TapUntap",
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "35",
+        "artist": "Randy Asplund-Faith",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0f11ae4-e30e-441d-bb64-439930d9997c.jpg?1783947941"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Scarwood Goblins
 {
     "name": "Scarwood Goblins",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -565,6 +565,59 @@
     ]
 }
 
+// Goblin Digging Team
+{
+    "name": "Goblin Digging Team",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goblin",
+    "oracleText": "{T}, Sacrifice this creature: Destroy target Wall.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Wall"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Wall"
+                        },
+                        "id": "target Wall"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "artist": "Ron Spencer",
+        "flavorText": "\"From down here we can make the whole wall collapse!\" \"Uh, yeah, boss, but how do we get out?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8a538b9d-351e-40bb-be11-9ba08c16352b.jpg?1783947935"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Goblin Hero
 {
     "name": "Goblin Hero",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -364,6 +364,56 @@
     ]
 }
 
+// Coal Golem
+{
+    "name": "Coal Golem",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "{3}, Sacrifice this creature: Add {R}{R}{R}.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "rarity": "UNCOMMON",
+        "artist": "Christopher Rush",
+        "flavorText": "\"Three such creatures stood burning at the crest of the hill. Only seconds later, the Fireball struck our front line.\" —Lydia, Countess Brellis",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1ad7692d-5a51-493f-a322-7b615446ea8e.jpg?1783947927"
+    },
+    "colorIdentityOverride": []
+}
+
 // Dark Heart of the Wood
 {
     "name": "Dark Heart of the Wood",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -322,6 +322,59 @@
     ]
 }
 
+// Fire Drake
+{
+    "name": "Fire Drake",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying\n{R}: This creature gets +1/+0 until end of turn. Activate only once each turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "restrictions": [
+                    "OncePerTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "rarity": "UNCOMMON",
+        "artist": "Christopher Rush",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d3419db6-1c38-4aa4-b953-1dde7d22b927.jpg?1783947935"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Flood
 {
     "name": "Flood",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -1228,6 +1228,66 @@
     ]
 }
 
+// Scavenger Folk
+{
+    "name": "Scavenger Folk",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Human",
+    "oracleText": "{G}, {T}, Sacrifice this creature: Destroy target artifact.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact"
+                        },
+                        "id": "target artifact"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Dennis Detwiller",
+        "flavorText": "String, weapons, wax, or jewels—it makes no difference. Leave nothing unguarded in Scarwood.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8e99870c-b2b9-431b-b8a8-3f4a80aa8fa5.jpg?1783947929"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Sisters of the Flame
 {
     "name": "Sisters of the Flame",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -183,6 +183,54 @@
     ]
 }
 
+// Holy Light
+{
+    "name": "Holy Light",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Nonwhite creatures get -1/-1 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotColor",
+                                "color": "WHITE"
+                            }
+                        ]
+                    }
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": -1
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": -1
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "artist": "Drew Tucker",
+        "flavorText": "\"Bathed in hallowed light, the infidels looked upon the impurities of their souls and despaired.\" —*The Book of Tal*",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c3c8a850-bc99-4679-a316-45ecdea696b2.jpg?1783947948"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Inferno
 {
     "name": "Inferno",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -522,3 +522,82 @@
         "WHITE"
     ]
 }
+
+// Witch Hunter
+{
+    "name": "Witch Hunter",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{T}: This creature deals 1 damage to target player or planeswalker.\n{1}{W}{W}, {T}: Return target creature an opponent controls to its owner's hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player or planeswalker"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayerOrPlaneswalker",
+                        "id": "target player or planeswalker"
+                    }
+                ]
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature an opponent controls"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        },
+                        "id": "target creature an opponent controls"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "RARE",
+        "artist": "Jesper Myrfors",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4eef9bb7-cd3c-422e-a93b-90d98684675a.jpg?1783947945"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -407,6 +407,89 @@
     ]
 }
 
+// Grave Robbers
+{
+    "name": "Grave Robbers",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "{B}, {T}: Exile target artifact card from a graveyard. You gain 2 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target artifact card from a graveyard"
+                            },
+                            "destination": "Exile",
+                            "fromZone": "Graveyard"
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target artifact card from a graveyard"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "RARE",
+        "artist": "Quinton Hoover",
+        "flavorText": "\"If you don't have your health, you don't have anything.\" —Proverb",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a131605a-f646-4745-a1e4-48d155a3d94f.jpg?1783947938",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "This exiles the artifact on resolution, but you choose it as a target when activating the ability."
+            },
+            {
+                "date": "2004-10-04",
+                "text": "If the target is not there on resolution, you do not gain the life."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Holy Light
 {
     "name": "Holy Light",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -375,6 +375,55 @@
     ]
 }
 
+// Fissure
+{
+    "name": "Fissure",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature or land. It can't be regenerated.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CantBeRegenerated",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or land"
+                    }
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or land"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|land"
+                },
+                "id": "target creature or land"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "artist": "Douglas Shuler",
+        "flavorText": "\"Must not all things at the last be swallowed up in death?\" —Plato",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aa2d778d-d74b-45ec-a86b-5d52ffad6ba5.jpg?1783947935"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Flood
 {
     "name": "Flood",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -60,6 +60,66 @@
     ]
 }
 
+// Exorcist
+{
+    "name": "Exorcist",
+    "manaCost": "{W}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{1}{W}, {T}: Destroy target black creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target black creature"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature black"
+                        },
+                        "id": "target black creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "RARE",
+        "artist": "Drew Tucker",
+        "flavorText": "Though they often bore little greater charm than the demons they battled, exorcists were always welcome in Scarwood.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/184b7d52-e991-4668-9f6a-bcded97f51ac.jpg?1783947949"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Fountain of Youth
 {
     "name": "Fountain of Youth",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -147,6 +147,30 @@
     ]
 }
 
+// Carnivorous Plant
+{
+    "name": "Carnivorous Plant",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Plant Wall",
+    "oracleText": "Defender",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "metadata": {
+        "collectorNumber": "75",
+        "artist": "Quinton Hoover",
+        "flavorText": "\"It had a mouth like that of a great beast, and gnashed its teeth as it strained to reach us. I am thankful it possessed no means of locomotion.\" —Vervamon the Elder",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6a615650-4da3-4efc-aa5e-c1f2c4f79478.jpg?1783947933"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Cave People
 {
     "name": "Cave People",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -362,6 +362,31 @@
     ]
 }
 
+// Pikemen
+{
+    "name": "Pikemen",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "First strike; banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "BANDING"
+    ],
+    "metadata": {
+        "collectorNumber": "15",
+        "artist": "Dennis Detwiller",
+        "flavorText": "\"As the cavalry bore down, we faced them with swords drawn and pikes hidden in the grass at our feet. 'Don't lift your pikes 'til I give the word,' I said.\" —Maeveen O'Donagh, *Memoirs of a Soldier*",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bf2f6936-b50c-4907-9b55-ebf8a3fba8f5.jpg?1783947946"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Scarwood Goblins
 {
     "name": "Scarwood Goblins",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -209,6 +209,62 @@
     ]
 }
 
+// Flood
+{
+    "name": "Flood",
+    "manaCost": "{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "{U}{U}: Tap target creature without flying.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature without flying"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotKeyword",
+                                        "keyword": "FLYING"
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target creature without flying"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "27",
+        "rarity": "UNCOMMON",
+        "artist": "Dennis Detwiller",
+        "flavorText": "\"A dash of cool water does wonders to clear a cluttered battlefield.\" —Vibekke Ragnild, *Witches and War*",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fabc3267-b59b-4f36-8873-5b4b072711ca.jpg?1783947944"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Fountain of Youth
 {
     "name": "Fountain of Youth",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -411,7 +411,9 @@
         "flavorText": "\"Three such creatures stood burning at the crest of the hill. Only seconds later, the Fireball struck our front line.\" —Lydia, Countess Brellis",
         "imageUri": "https://cards.scryfall.io/normal/front/1/a/1ad7692d-5a51-493f-a322-7b615446ea8e.jpg?1783947927"
     },
-    "colorIdentityOverride": []
+    "colorIdentityOverride": [
+        "RED"
+    ]
 }
 
 // Dark Heart of the Wood
@@ -526,7 +528,8 @@
         "imageUri": "https://cards.scryfall.io/normal/front/9/5/951b6c10-cbba-44b6-aae2-2c386b7ebacb.jpg?1783947945"
     },
     "colorIdentityOverride": [
-        "BLUE"
+        "BLUE",
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -147,6 +147,82 @@
     ]
 }
 
+// Cave People
+{
+    "name": "Cave People",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Creature — Human",
+    "oracleText": "Whenever this creature attacks, it gets +1/-2 until end of turn.\n{1}{R}{R}, {T}: Target creature gains mountainwalk until end of turn. (It can't be blocked as long as defending player controls a Mountain.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "target": "Self"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "MOUNTAINWALK",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "rarity": "UNCOMMON",
+        "artist": "Drew Tucker",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72746a5d-faa1-44b7-97b5-0ef9302a3c13.jpg?1783947936"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Drowned
 {
     "name": "Drowned",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -747,6 +747,55 @@
     ]
 }
 
+// Sunken City
+{
+    "name": "Sunken City",
+    "manaCost": "{U}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your upkeep, sacrifice this enchantment unless you pay {U}{U}.\nBlue creatures get +1/+1.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{U}{U}"
+                        }
+                    },
+                    "suffer": "SacrificeSelf"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature blue"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Jesper Myrfors",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f1e0f9ec-2b06-4bda-8b80-a716d82d1f13.jpg?1783947942"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Tivadar's Crusade
 {
     "name": "Tivadar's Crusade",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -1064,6 +1064,42 @@
     ]
 }
 
+// Sisters of the Flame
+{
+    "name": "Sisters of the Flame",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "{T}: Add {R}.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "rarity": "UNCOMMON",
+        "artist": "Jesper Myrfors",
+        "flavorText": "We are many wicks sharing a common tallow; we feed the skies with the ashes of our prey.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/564e0ccd-decb-48d2-981f-cefa8045340f.jpg?1783947934"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Skull of Orm
 {
     "name": "Skull of Orm",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -322,6 +322,46 @@
     ]
 }
 
+// Morale
+{
+    "name": "Morale",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Attacking creatures get +1/+1 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature attacking"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "artist": "Mark Poole",
+        "flavorText": "\"After Lacjsi's speech, the Knights grew determined to crush their ancient enemies clan by clan.\" —Tivadar of Thorn, *History of the Goblin Wars*",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c4104546-abd9-4bfb-a65e-5928cdd4522f.jpg?1783947946"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Scarwood Goblins
 {
     "name": "Scarwood Goblins",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -308,6 +308,48 @@
     "colorIdentityOverride": []
 }
 
+// Ghost Ship
+{
+    "name": "Ghost Ship",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\n{U}{U}{U}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}{U}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "artist": "Tom Wänerstrand",
+        "flavorText": "\"That phantom prow split the storm as lightning cast its long shadow on the battlefield below.\" —Mireille Gaetane, *The Valeriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db591b28-37e5-4e7c-ae4d-d761262b12d0.jpg?1783947943"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Goblin Hero
 {
     "name": "Goblin Hero",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -509,6 +509,53 @@
     ]
 }
 
+// Merfolk Assassin
+{
+    "name": "Merfolk Assassin",
+    "manaCost": "{U}{U}",
+    "typeLine": "Creature — Merfolk Assassin",
+    "oracleText": "{T}: Destroy target creature with islandwalk.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature with islandwalk"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature kw:islandwalk"
+                        },
+                        "id": "target creature with islandwalk"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "rarity": "UNCOMMON",
+        "artist": "Dennis Detwiller",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/36313dc7-6bf2-4d73-b696-969d984a7466.jpg?1783947942"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Morale
 {
     "name": "Morale",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -1667,6 +1667,51 @@
     ]
 }
 
+// Standing Stones
+{
+    "name": "Standing Stones",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, {T}, Pay 1 life: Add one mana of any color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "rarity": "UNCOMMON",
+        "artist": "Sandra Everingham",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6d4c853e-2231-4af2-bcb0-1781c18ec3be.jpg?1783947924"
+    },
+    "colorIdentityOverride": []
+}
+
 // Sunken City
 {
     "name": "Sunken City",

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -1712,6 +1712,47 @@
     "colorIdentityOverride": []
 }
 
+// Stone Calendar
+{
+    "name": "Stone Calendar",
+    "manaCost": "{5}",
+    "typeLine": "Artifact",
+    "oracleText": "Spells you cast cost {1} less to cast.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": {}
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "rarity": "RARE",
+        "artist": "Amy Weber",
+        "flavorText": "The Pretender Mairsil ordered a great Calendar drawn up to show when the paths to the Dark Lands were strongest.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a49ba1a5-33b1-40f2-9780-26139ed829d7.jpg?1783947924",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "Does not change the mana cost of the spell, it just reduces what you pay for it."
+            },
+            {
+                "date": "2004-10-04",
+                "text": "You may choose not to apply Stone Calendar's cost reduction effect."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Sunken City
 {
     "name": "Sunken City",


### PR DESCRIPTION
Adds the 38 cards from **The Dark** that Argentum Assay reads whole and that compose entirely from
existing SDK primitives. Every card is a `cardDef` over `Effects.*` / `Costs.*` / `Targets.*`
facades, with no new engine vocabulary.

Selection: the baked whole-card verdict ledger
(`game-server/src/main/resources/coverage/assay-verdicts.json`) lists 46 DRK cards as read-whole.
Seven were already implemented (Bog Imp, Fountain of Youth, Goblin Hero, Inferno, Scarwood Goblins,
Skull of Orm, Squire). Of the remaining 39, **Scarecrow is not in this PR** — see the bottom.

DRK goes from 8/119 to 46/119 implemented.

### White
- **Exorcist** — `{1}{W}, {T}: Destroy target black creature.` `Targets.CreatureWithColor(BLACK)`.
- **Holy Light** — nonwhite creatures get -1/-1; `ForEachInGroup` over `Creature.notColor(WHITE)`.
- **Knights of Thorn** — protection from red (`KeywordAbility.Protection`) + banding.
- **Morale** — attacking creatures get +1/+1; `GroupFilter.AttackingCreatures`.
- **Pikemen** — first strike + banding, keywords only.
- **Tivadar's Crusade** — `Effects.DestroyAll(Permanent.withSubtype(GOBLIN))`.
- **Witch Hunter** — two activated abilities: 1 damage to `Targets.PlayerOrPlaneswalker`, and a
  `{1}{W}{W}, {T}` bounce of `Targets.CreatureOpponentControls`.

### Blue
- **Apprentice Wizard** — `{U}, {T}: Add {C}{C}{C}` mana ability.
- **Drowned**, **Ghost Ship** — `RegenerateEffect(Self)` off a mana cost; Ghost Ship also flies.
- **Flood** — `{U}{U}`: tap a creature without flying (`TargetFilter.withoutKeyword(FLYING)`).
- **Merfolk Assassin** — `{T}`: destroy `Targets.CreatureWithKeyword(ISLANDWALK)`.
- **Riptide** — tap all blue creatures.
- **Sunken City** — the Junún Efreet upkeep tax (`PayOrSufferEffect` + `SacrificeSelfEffect`) plus a
  `ModifyStats(1, 1)` anthem over every blue creature.
- **Water Wurm** — the Kird Ape conditional static with `Player.EachOpponent` as the reference
  player, so several opposing Islands still grant the bonus only once.

### Black
- **Bog Rats** — `CantBeBlockedBy(Creature.withSubtype(WALL))`.
- **Grave Robbers** — exile a targeted artifact card from *any* graveyard, then gain 2 life.
- **Marsh Gas** — all creatures get -2/-0.

### Red
- **Cave People** — attack trigger pumps itself +1/-2; the activated ability grants mountainwalk.
- **Fire Drake** — flying, plus `{R}: +1/+0` gated by `ActivationRestriction.OncePerTurn`.
- **Fissure** — `Effects.Destroy(noRegenerate = true)` on a creature-or-land target.
- **Goblin Digging Team** — `{T}`, sacrifice: destroy target Wall.
- **Sisters of the Flame** — `{T}: Add {R}`.

### Green
- **Carnivorous Plant** — Defender (modern Oracle wording for the old Wall text).
- **Hidden Path** — `GrantKeyword(FORESTWALK)` over every green creature.
- **Land Leeches** — first strike.
- **Niall Silvain** — `RegenerateEffect` on a target creature.
- **People of the Woods** — `dynamicToughness(AggregateBattlefield(You, Land.withSubtype(FOREST)))`,
  a toughness-only characteristic-defining ability (CR 604.3).
- **Scavenger Folk** — `{G}`, `{T}`, sacrifice: destroy target artifact.

### Multicolor
- **Marsh Goblins** — swampwalk.
- **Dark Heart of the Wood** — `Costs.Sacrifice(Land.withSubtype(FOREST))`: gain 3 life.

### Artifacts and lands
- **Bone Flute** — `{2}, {T}`: all creatures get -1/-0.
- **Book of Rass** — `{2}`, pay 2 life: draw a card.
- **Coal Golem** — `{3}`, sacrifice: add `{R}{R}{R}` (mana ability).
- **Diabolic Machine** — `{3}: Regenerate`.
- **Standing Stones** — `{1}`, `{T}`, pay 1 life: add one mana of any color.
- **Stone Calendar** — the Medallion `ModifySpellCost` static with no colour filter.
- **Maze of Ith** — untap target attacking creature and `PreventCombatDamageToAndBy` it.

### Also in this PR
- `Printing(...)` rows for the two reprints in already-scaffolded sets that
  `check-card-printing` flagged: **Flood** in PZ2 and **Dark Heart of the Wood** in RAV.
- Portal basic lands are exposed as The Dark's Limited fallback, so the sealed deckbuilder offers
  all five basics even though DRK printed none of its own.
- Correct color identities for **Coal Golem** (`R`) and **Drowned** (`UB`), including the re-blessed
  DRK snapshot.
- Scryfall rulings on the six cards where they change behaviour rather than restate the rules
  (Water Wurm, Grave Robbers, Bone Flute, Book of Rass, Stone Calendar, Maze of Ith).

### Dropped from the batch
**Scarecrow** ("{6}, {T}: Prevent all damage that would be dealt to you this turn by creatures with
flying") is read whole by Assay but has no faithful expression in today's SDK: a shield with a
*player* recipient and a *group* source filter compiles into `PreventCombatDamageFromGroup`, a
global combat-only shield over every recipient. It needs engine work, so per `add-card` it leaves
the batch and ships as its own PR.

### Verification
`just rebless-cards` is green. The DRK snapshot grows by these 38 cards and the follow-up changes
only Coal Golem's and Drowned's color identities. All 38 `just check-card-printing` checks pass;
card snapshots, JSON round trips, `CardLintTest`, and `FacadeBoundaryTest` passed during the full
gate.

`just build` was attempted twice. Both runs reached the scenario suites and then hit unrelated,
intermittent timeout failures in pre-existing tests (`AbuJafarTest`, `AccursedCentaurTest`, and
`AgelessSentinelsTest` on the latest run). The branch does not touch those tests. The review comment
records the remaining branch-local coverage concern: the 38 cards do not yet have their required
one-card-per-file scenario tests.
