### PR TITLE
Add create-backlog-for-set skill

### DIFF
--- a/.agents/skills/create-backlog-for-set/SKILL.md
+++ b/.agents/skills/create-backlog-for-set/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: create-backlog-for-set
+description: Create the `backlog/sets/<set-name>/` entry for a Magic set — download the whole set from Scryfall (cached alongside Assay's cache), write `cards.md` as a per-colour checklist with the already-implemented cards ticked, scaffold the set's `definitions/<code>/` module if it doesn't exist, and write `mechanics.md` ordering every mechanic the set uses with a checkbox, a description, and its card list. Use when asked to "create a backlog for set X", "add set X to the backlog", "start work on set X", "scaffold set X", or when a set has no `backlog/sets/` entry yet.
+argument-hint: <SET code or name>
+---
+
+# Create a set's backlog
+
+Turn a set name or code into the three things the rest of the tooling needs: a scaffolded set
+module, `backlog/sets/<set-name>/cards.md` (the checklist `add-card`, `add-random-card`, `set-loop`
+and `just check-backlog` all read), and `backlog/sets/<slug>/mechanics.md` (the mechanic-by-mechanic
+map that says what `add-feature` work the set implies).
+
+The mechanical half is [`bootstrap-set.py`](bootstrap-set.py) — set resolution, the Scryfall
+download, the draft/extras split, colour grouping, ticking what's already implemented, counting.
+The judgement half is yours: what each mechanic *means*, whether the engine already models it, and
+the set themes Scryfall has no keyword for. **Never hand-roll the mechanical half** — the counts
+have to match `scripts/card-status` exactly or `just check-backlog` goes red.
+
+## Step 1 — run the bootstrap
+
+```bash
+python3 .agents/skills/create-backlog-for-set/bootstrap-set.py "<code or name>"
+```
+
+Accepts either form: `DRK` or `"The Dark"`. An ambiguous name exits with the matching codes — pick
+one and re-run. Useful flags:
+
+| Flag | When |
+|------|------|
+| `--slug <name>` | the backlog directory should not be the kebab-cased set name |
+| `--no-scaffold` | backlog files only; don't touch `mtg-sets/` |
+| `--refresh` | re-download the dump (a set still in spoiler season, or a suspect cache) |
+| `--force` | overwrite an existing `cards.md` / `mechanics.md` |
+| `--object-name` | the derived Kotlin object name is wrong or invalid |
+
+It prints one line per artifact. What it writes:
+
+- `~/.cache/scryfall/_setdump-<code>.json` — every printing in the set, `unique=prints`. Cached in
+  the same directory `scripts/card-status`, `:mtgish-tooling` and Argentum Assay use, under a
+  `_setdump-` prefix that can't collide with a set code. Released sets are frozen, so a second run
+  costs no network. Not committed.
+- `mtg-sets/<era>/…/definitions/<code>/<Name>Set.kt` + an empty `cards/`, if the set had no module.
+  The era comes from the release year; a year past the newest era module is an error, not a guess
+  (a new era needs `settings.gradle.kts`, which is `add-feature` work).
+- `backlog/sets/<slug>/cards.md` — the checklist.
+- `backlog/sets/<slug>/mechanics.md` — a **draft**, marked as one. Step 3 is what finishes it.
+- `build/backlog/<code>-oracle.tsv` — one row per card (name, rarity, cost, type, keywords, reprint
+  flag, oracle text on one line). Gitignored; it exists so Step 3 can read a whole set's text
+  cheaply.
+
+**`--force` overwrites a hand-maintained file.** Without it the script skips files that already
+exist, which is the right default when re-running against a set someone has been curating. Only
+force when you mean to discard what's there.
+
+## Step 2 — finish the scaffold (only if it created one)
+
+The generated `<Name>Set.kt` carries `code`, `displayName`, `releaseDate` and `incomplete = true`.
+Three fields need a human decision, so the script leaves them off:
+
+- **`block`** — the block the set belongs to, if any (`override val block = "Shadowmoor"`).
+- **`basicLandsFallback`** — only when the set prints no basics of its own. Point it at the set
+  whose lands should be registered alongside it: its block's base set, else `PortalSet`.
+  Check the dump: `grep -o '"type_line":"Basic Land[^"]*"' ~/.cache/scryfall/_setdump-<code>.json | sort -u`.
+- **`sealedSupported = false`** — for sets that can't carry a limited environment at all
+  (Commander/duel decks, planar sets, promo sets). A merely unfinished set doesn't need it;
+  `incomplete = true` already keeps it out of the picker's default list.
+
+Confirm the set is discoverable before moving on — `scripts/card-status --set <CODE>` must report
+it (it reads `code` out of the Kotlin source, so a set that doesn't show up is a scaffold problem).
+Gate with `scripts/gradle-locked :mtg-sets:<era>:compileKotlin` — a scaffold-only change reaches nothing
+else, so a full `just test` is wasted time (see CLAUDE.local.md's gate table).
+
+> **Do not run `scripts/gen-set-totals` to "register" the new set.** It rewrites the committed
+> 6 MB `coverage/set-totals.json` for *every* set from the local Scryfall cache, so running it with
+> a partly-populated cache silently empties other sets' totals. It's a separate, full-cache chore.
+
+## Step 3 — write `mechanics.md` properly
+
+The draft lists what Scryfall names: `keywords`, plus any `Word —` ability-word headers found in
+oracle text, each ordered by card count with its card list. That's the skeleton. Three passes turn
+it into the document:
+
+**a. Read the set.** `build/backlog/<code>-oracle.tsv` is the whole set's text in one file. For a
+set up to ~150 cards read it directly. For a bigger one, dispatch subagents over batches of 30–40
+rows — "return only: recurring templates you saw, each as `NAME | one-line description | card
+names`" — and merge. Same doctrine as `verify-set`: they read, you hold the verdicts.
+
+**b. Prune and fill the drafted entries.** For each one, write the description (what it does, and
+the CR rule number that defines it — verify the number in the local `MagicCompRules_*.txt`, never
+from memory) and replace `**Engine support:** _unverified_` with a real verdict:
+
+- **Supported** → tick the box and name the primitive that models it, e.g.
+  **Engine support:** ✅ `Keyword.TRAMPLE` — checked against
+  [`docs/card-sdk-language-reference.md`](../../../docs/card-sdk-language-reference.md) and the SDK
+  `Keyword` enum, not against your recollection.
+- **Not supported** → leave the box unticked and say in one line what's missing. That entry is now
+  an `add-feature` unit, and the cards under it are blocked.
+
+Ability-word rows are noisy by construction — level-up rows and flavour lines match the same shape.
+Delete the ones that aren't mechanics.
+
+**c. Add the set themes.** The mechanics that carry a set are often the ones with no keyword: an
+artifact-matters axis, sacrifice-as-cost fuel, a tribal payoff, an unusual timing restriction. Add
+one section per theme in the same shape (checkbox, description, card list), and order every section
+— named and unnamed together — by card count, most cards first. `backlog/sets/antiquities/MECHANICS.md`
+is the reference for what a good one reads like on a set with no named keywords at all.
+
+Keep the card lists complete. Their job is to answer "if I build this, what does it unlock?" — a
+truncated list makes the whole file unusable for backlog triage.
+
+## Step 4 — verify and commit
+
+```bash
+scripts/check-card-counts.py --check              # cards.md headers match the checkboxes
+scripts/check-backlog-implementations.py --check  # no [ ] entry is actually implemented
+scripts/card-status --set <CODE>                  # the authoritative Done / Total
+```
+
+The first two also report **pre-existing** drift in other sets' backlogs — read the paths before
+reacting, and don't fix someone else's file (AGENTS.md → "Focus on your own work"). `card-status`'s
+Done/Total must equal `cards.md`'s `**Implemented:**` line; if it doesn't, run
+`scripts/check-card-counts.py --fix` and find out why they disagreed before committing.
+
+Commit `backlog/sets/<slug>/` and any scaffolded `<Name>Set.kt`. Do **not** commit the Scryfall
+dump or the TSV worksheet — the dump lives in the cache and `build/` is gitignored.
+
+## Format rules that other tooling depends on
+
+Change these and the repo's checkers stop working:
+
+- The `cards.md` H1 is exactly `# <Set Name> (<CODE>) - Card Checklist` — an ASCII hyphen, and the
+  code in parentheses. `scripts/check-backlog-implementations.py` finds the set by that regex.
+- A card line is `- [x] Name` / `- [ ] Name` and **nothing after the name**. No annotations, no
+  `(reprint)` suffixes: the name is matched verbatim against `card("Name")` and `name = "Name"` in
+  the Kotlin sources, so a suffix makes the entry invisible to the checker and to `--fix`.
+- DFC and Adventure cards use the full `Front // Back` name; only the front face is matched.
+- `**Implemented:** N / M` on its own line, N = `[x]` count, M = `[x]` + `[ ]`. `[-]` (not planned,
+  from `coverage/card-exclusions.json`) is deliberately outside both counts.
+- Cards a set prints but boosters don't contain go under `### Extras` — that's the same draft /
+  extra split `scripts/card-status` reports, and mixing them corrupts the denominator.

--- a/.agents/skills/create-backlog-for-set/SKILL.md
+++ b/.agents/skills/create-backlog-for-set/SKILL.md
@@ -32,7 +32,7 @@ one and re-run. Useful flags:
 | `--no-scaffold` | backlog files only; don't touch `mtg-sets/` |
 | `--refresh` | re-download the dump (a set still in spoiler season, or a suspect cache) |
 | `--force` | overwrite an existing `cards.md` / `mechanics.md` |
-| `--object-name` | the derived Kotlin object name is wrong or invalid |
+| `--object-name` | the derived Kotlin object name is wrong or invalid — the repo shortens long titles (`LostCavernsOfIxalanSet`, `DuskmournSet`), so a set with a subtitle usually wants this |
 
 It prints one line per artifact. What it writes:
 

--- a/.agents/skills/create-backlog-for-set/bootstrap-set.py
+++ b/.agents/skills/create-backlog-for-set/bootstrap-set.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env python3
+"""
+Bootstrap a set's backlog: Scryfall dump -> `backlog/sets/<set-name>/cards.md`, a
+`mechanics.md` draft, an oracle-text worksheet, and (optionally) the `definitions/<dir>/`
+Kotlin scaffold.
+
+This is the mechanical half of the `create-backlog-for-set` skill. It does the parts that
+must be exact — resolving the set, downloading every printing, partitioning draft vs.
+extras the way `scripts/card-status` does, grouping by colour, ticking cards that already
+have a `CardDefinition`, counting. It deliberately does NOT do the parts that need
+judgement: the mechanics descriptions, the engine-support verdicts, `block` /
+`basicLandsFallback` on the scaffolded set object. Those are the agent's job, and the
+files this writes are marked where they need it.
+
+Cache: the full dump lives at `~/.cache/scryfall/_setdump-<code>.json` — the same directory
+`scripts/card-status`, `:mtgish-tooling` and Argentum Assay use, under a `_setdump-` prefix
+that can't collide with a set code (Assay's own entries use `_bulk-` / `_setlist-`). A set
+released more than 30 days ago is frozen, so its dump is never re-fetched without
+`--refresh`; a set still in spoiler season re-fetches every run.
+
+Usage:
+  bootstrap-set.py DRK                      # by code
+  bootstrap-set.py "The Dark"               # or by name
+  bootstrap-set.py DRK --slug the-dark      # override the backlog directory name
+  bootstrap-set.py EVE --no-scaffold        # backlog files only
+  bootstrap-set.py TMP --refresh --force    # re-fetch, overwrite existing backlog files
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import unicodedata
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from datetime import date, timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from card_exclusions import load_exclusions  # noqa: E402
+from set_dirs import definitions_roots, dir_for_codes, set_dir_paths  # noqa: E402
+
+CACHE_ROOT = Path.home() / ".cache" / "scryfall"
+SCRYFALL_BASE = "https://api.scryfall.com"
+USER_AGENT = "argentum-engine-backlog-bootstrap/1.0"
+REQUEST_DELAY_SEC = 0.15
+REQUEST_TIMEOUT_SEC = 30
+REFRESH_WINDOW_DAYS = 30
+DUMP_SCHEMA_VERSION = 1
+
+CARD_DSL_RE = re.compile(r'\bcard\(\s*"([^"]+)"')
+PRINTING_NAME_RE = re.compile(r'\bname\s*=\s*"([^"]+)"')
+ABILITY_WORD_RE = re.compile(r"^([A-Z][A-Za-z'\-]*(?: [a-z'\-]+){0,3}) —", re.MULTILINE)
+
+# `con` is a DOS device name and can't be a directory on Windows; Conflux lives in `conflux/`.
+RESERVED_DIR_NAMES = {
+    "con": "conflux",
+    "prn": "prn-set",
+    "aux": "aux-set",
+    "nul": "nul-set",
+    **{f"com{i}": f"com{i}-set" for i in range(1, 10)},
+    **{f"lpt{i}": f"lpt{i}-set" for i in range(1, 10)},
+}
+
+COLOR_SECTIONS = [
+    ("White", "W"),
+    ("Blue", "U"),
+    ("Black", "B"),
+    ("Red", "R"),
+    ("Green", "G"),
+]
+
+
+# --------------------------------------------------------------------------- Scryfall
+
+
+def scryfall_get(url: str, *, max_retries: int = 5) -> dict:
+    delay = 1.0
+    for attempt in range(max_retries):
+        req = urllib.request.Request(
+            url, headers={"User-Agent": USER_AGENT, "Accept": "application/json"}
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SEC) as resp:
+                time.sleep(REQUEST_DELAY_SEC)
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            if e.code == 429 and attempt < max_retries - 1:
+                time.sleep(delay)
+                delay *= 2
+                continue
+            raise
+        except (urllib.error.URLError, TimeoutError):
+            if attempt < max_retries - 1:
+                time.sleep(delay)
+                delay *= 2
+                continue
+            raise
+    raise RuntimeError("unreachable")
+
+
+def resolve_set(query: str) -> dict:
+    """Set metadata for a code or a name. Ambiguous names exit with the candidates."""
+    slug = query.strip().lower()
+    if re.fullmatch(r"[a-z0-9]{3,6}", slug):
+        try:
+            return scryfall_get(f"{SCRYFALL_BASE}/sets/{urllib.parse.quote(slug)}")
+        except urllib.error.HTTPError as e:
+            if e.code != 404:
+                raise
+    all_sets = scryfall_get(f"{SCRYFALL_BASE}/sets").get("data", [])
+    exact = [s for s in all_sets if s.get("name", "").lower() == slug]
+    if len(exact) == 1:
+        return exact[0]
+    partial = [s for s in all_sets if slug in s.get("name", "").lower()]
+    if len(partial) == 1:
+        return partial[0]
+    candidates = exact or partial
+    if not candidates:
+        sys.exit(f"bootstrap-set: no Scryfall set matches '{query}'")
+    lines = "\n".join(
+        f"  {s['code']}  {s['name']}  ({s.get('released_at', '?')}, {s.get('set_type', '?')})"
+        for s in sorted(candidates, key=lambda s: s.get("released_at") or "")
+    )
+    sys.exit(
+        f"bootstrap-set: '{query}' is ambiguous — re-run with one of these codes:\n{lines}"
+    )
+
+
+def dump_path(code: str) -> Path:
+    return CACHE_ROOT / f"_setdump-{code.lower()}.json"
+
+
+def is_dump_fresh(payload: dict) -> bool:
+    if payload.get("_v") != DUMP_SCHEMA_VERSION:
+        return False
+    released = (payload.get("set") or {}).get("released_at")
+    if not released:
+        return False
+    try:
+        released_date = date.fromisoformat(released)
+    except ValueError:
+        return False
+    # Released sets are frozen; a set in (or before) spoiler season still moves.
+    return released_date < date.today() - timedelta(days=REFRESH_WINDOW_DAYS)
+
+
+def load_dump(set_meta: dict, *, refresh: bool) -> list[dict]:
+    """Every printing in the set, cached. `unique=prints` — one card can have several
+    printings inside a single set, and `booster` has to be OR-ed across all of them."""
+    code = set_meta["code"].lower()
+    path = dump_path(code)
+    if not refresh and path.is_file():
+        try:
+            cached = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            cached = None
+        if cached and is_dump_fresh(cached):
+            return cached["data"]
+
+    cards: list[dict] = []
+    url = (
+        f"{SCRYFALL_BASE}/cards/search"
+        f"?q={urllib.parse.quote(f'set:{code} -is:rebalanced')}"
+        f"&unique=prints&order=set"
+    )
+    while url:
+        page = scryfall_get(url)
+        cards.extend(page.get("data", []))
+        url = page.get("next_page") if page.get("has_more") else None
+    CACHE_ROOT.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"_v": DUMP_SCHEMA_VERSION, "set": set_meta, "data": cards}),
+        encoding="utf-8",
+    )
+    return cards
+
+
+# --------------------------------------------------------------------------- card model
+
+
+def front_face(name: str) -> str:
+    return name.split(" // ", 1)[0].strip()
+
+
+def face_field(card: dict, field: str) -> str:
+    """A card-level field, falling back to the front face for multi-faced layouts."""
+    value = card.get(field)
+    if value not in (None, ""):
+        return value
+    faces = card.get("card_faces") or []
+    if faces and isinstance(faces[0], dict):
+        return faces[0].get(field) or ""
+    return ""
+
+
+def joined_oracle(card: dict) -> str:
+    text = card.get("oracle_text")
+    if text is not None:
+        return text
+    faces = card.get("card_faces") or []
+    return "\n//\n".join(f.get("oracle_text", "") for f in faces if isinstance(f, dict))
+
+
+def card_colors(card: dict) -> set[str]:
+    colors = card.get("colors")
+    if colors is None:
+        faces = card.get("card_faces") or []
+        colors = sorted({c for f in faces for c in (f.get("colors") or [])})
+    return set(colors or [])
+
+
+def section_for(card: dict) -> str:
+    """The cards.md heading a card belongs under — colour first, then type."""
+    type_line = face_field(card, "type_line") or card.get("type_line", "")
+    colors = card_colors(card)
+    if len(colors) > 1:
+        return "Multicolor"
+    if len(colors) == 1:
+        return next(name for name, sym in COLOR_SECTIONS if sym in colors)
+    if "Land" in type_line:
+        return "Land"
+    if "Artifact" in type_line:
+        return "Artifact"
+    return "Colorless"
+
+
+def section_order(payload_sections: set[str]) -> list[str]:
+    order = [name for name, _ in COLOR_SECTIONS] + [
+        "Multicolor",
+        "Artifact",
+        "Colorless",
+        "Land",
+    ]
+    return [s for s in order if s in payload_sections]
+
+
+class SetCards:
+    """The set's canonical cards, partitioned the way `scripts/card-status` partitions them."""
+
+    def __init__(self, printings: list[dict]) -> None:
+        by_name: dict[str, list[dict]] = defaultdict(list)
+        for card in printings:
+            by_name[card["name"]].append(card)
+        self.draft: dict[str, dict] = {}
+        self.extra: dict[str, dict] = {}
+        for name, group in by_name.items():
+            # `booster` is a property of a printing; a card is draft if ANY of its printings
+            # in this set is a booster printing.
+            representative = min(
+                group,
+                key=lambda c: (
+                    0 if c.get("booster") else 1,
+                    c.get("collector_number", ""),
+                ),
+            )
+            target = self.draft if any(c.get("booster") for c in group) else self.extra
+            target[front_face(name)] = representative
+
+    @property
+    def all(self) -> dict[str, dict]:
+        return {**self.draft, **self.extra}
+
+
+def scan_implemented(cards_dir: Path | None) -> set[str]:
+    """Front-face names that already have a `CardDefinition` or a `Printing` row."""
+    names: set[str] = set()
+    if cards_dir is None or not cards_dir.is_dir():
+        return names
+    for kt in cards_dir.glob("*.kt"):
+        text = kt.read_text(encoding="utf-8", errors="replace")
+        names.update(CARD_DSL_RE.findall(text))
+        names.update(PRINTING_NAME_RE.findall(text))
+    return {front_face(n) for n in names}
+
+
+# --------------------------------------------------------------------------- scaffold
+
+
+def kotlin_object_name(display_name: str) -> str:
+    ascii_name = (
+        unicodedata.normalize("NFKD", display_name).encode("ascii", "ignore").decode()
+    )
+    words = re.findall(r"[A-Za-z0-9]+", ascii_name)
+    ident = "".join(w[:1].upper() + w[1:] for w in words) + "Set"
+    if ident[:1].isdigit():
+        sys.exit(
+            f"bootstrap-set: '{display_name}' produces the invalid Kotlin identifier '{ident}' — "
+            "pass --object-name to choose one (e.g. TenthEditionSet)"
+        )
+    return ident
+
+
+def era_module_for(year: int) -> Path:
+    """The `mtg-sets/<era>` module owning a release year. Era ranges are fixed; a year past
+    the newest module needs a new module in settings.gradle.kts, which is not this script's job."""
+    modules: list[tuple[int, int, Path]] = []
+    for root in definitions_roots():
+        # root is `<module>/src/main/kotlin/com/wingedsheep/mtg/sets/definitions`
+        module = next(
+            p for p in root.parents if p.name != "src" and (p / "src").is_dir()
+        )
+        name = module.name
+        if name == "core":
+            continue
+        m = re.fullmatch(r"(\d{4})(?:-(\d{4}))?", name)
+        if not m:
+            continue
+        start = int(m.group(1))
+        end = int(m.group(2) or m.group(1))
+        modules.append((start, end, module))
+    for start, end, module in sorted(modules):
+        if start <= year <= end:
+            return module
+    newest = max(modules)[2].name if modules else "?"
+    sys.exit(
+        f"bootstrap-set: release year {year} is past the newest era module ({newest}). "
+        "Add the era to settings.gradle.kts and mtg-sets/ first — see AGENTS.md 'Module layout'."
+    )
+
+
+def scaffold_set(set_meta: dict, dir_name: str, object_name: str) -> tuple[Path, bool]:
+    """Write `definitions/<dir>/<Object>.kt` + an empty `cards/`. Returns (path, created)."""
+    existing = set_dir_paths().get(dir_name)
+    year = int((set_meta.get("released_at") or "0000")[:4])
+    root = (
+        existing.parent
+        if existing
+        else era_module_for(year)
+        / ("src/main/kotlin/com/wingedsheep/mtg/sets/definitions")
+    )
+    set_dir = root / dir_name
+    kt = set_dir / f"{object_name}.kt"
+    if kt.is_file():
+        return kt, False
+    (set_dir / "cards").mkdir(parents=True, exist_ok=True)
+    package = f"com.wingedsheep.mtg.sets.definitions.{dir_name}"
+    released = set_meta.get("released_at")
+    kt.write_text(
+        f"""package {package}
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * {set_meta["name"]} ({released[:4] if released else "?"})
+ *
+ * Scaffolded to hold the canonical [CardDefinition]s of cards whose earliest real printing is
+ * {set_meta["name"]}, with later sets contributing reprint [Printing] rows. Intentionally
+ * incomplete relative to the official set.
+ *
+ * Set Code: {set_meta["code"].upper()}
+ * Release Date: {released or "unknown"}
+ */
+object {object_name} : MtgSet {{
+
+    override val code = "{set_meta["code"].upper()}"
+    override val displayName = "{set_meta["name"]}"
+    override val releaseDate = {f'"{released}"' if released else "null"}
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {{
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }}
+
+    override val basicLands: List<CardDefinition> by lazy {{
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }}
+
+    override val printings: List<Printing> by lazy {{
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }}
+
+    private const val CARDS_PACKAGE = "{package}.cards"
+}}
+""",
+        encoding="utf-8",
+    )
+    return kt, True
+
+
+# --------------------------------------------------------------------------- writers
+
+
+def format_release(released: str | None) -> str:
+    if not released:
+        return "unknown"
+    try:
+        d = date.fromisoformat(released)
+    except ValueError:
+        return released
+    return f"{d.strftime('%B')} {d.day}, {d.year}"
+
+
+def card_line(name: str, implemented: set[str], exclusions: dict[str, str]) -> str:
+    if name in implemented:
+        return f"- [x] {name}"
+    if name in exclusions:
+        # `[-]` is card-status's "not planned" marker: off the denominator, still visible.
+        return f"- [-] {name}  (not planned: {exclusions[name]})"
+    return f"- [ ] {name}"
+
+
+def write_cards_md(
+    path: Path,
+    set_meta: dict,
+    cards: SetCards,
+    implemented: set[str],
+    exclusions: dict[str, str],
+) -> tuple[int, int]:
+    grouped: dict[str, list[str]] = defaultdict(list)
+    for name, card in cards.draft.items():
+        grouped[section_for(card)].append(name)
+
+    countable = [n for n in cards.all if n not in exclusions or n in implemented]
+    done = len([n for n in countable if n in implemented])
+
+    rows = []
+    for section in section_order(set(grouped)):
+        names = grouped[section]
+        rows.append((section, len(names), len([n for n in names if n in implemented])))
+    if cards.extra:
+        rows.append(
+            (
+                "Extras",
+                len(cards.extra),
+                len([n for n in cards.extra if n in implemented]),
+            )
+        )
+
+    out: list[str] = []
+    out.append(f"# {set_meta['name']} ({set_meta['code'].upper()}) - Card Checklist")
+    out.append("")
+    out.append(f"**Set Size:** {len(countable)} cards")
+    out.append(f"**Release Date:** {format_release(set_meta.get('released_at'))}")
+    out.append(f"**Implemented:** {done} / {len(countable)}")
+    out.append("")
+    out.append("| Section    | Total | Done |")
+    out.append("|------------|-------|------|")
+    for section, total, hits in rows:
+        out.append(f"| {section:<10} | {total:<5} | {hits:<4} |")
+    out.append("")
+    out.append(
+        "> Verify status anytime with `scripts/card-status --set "
+        f"{set_meta['code'].upper()}` (and `--list`). That command's count is authoritative — "
+        "keep this file's `Implemented:` line in sync (`just fix-backlog`) as boxes are checked. "
+        "The set's mechanics are catalogued in [`mechanics.md`](mechanics.md)."
+    )
+    out.append("")
+    out.append("---")
+    for section in section_order(set(grouped)):
+        out.append("")
+        out.append(f"### {section}")
+        for name in sorted(grouped[section]):
+            out.append(card_line(name, implemented, exclusions))
+    if cards.extra:
+        out.append("")
+        out.append("### Extras")
+        out.append("")
+        out.append(
+            "> Not in boosters — starter decks, promos, bonus sheets. Counted separately by "
+            "`scripts/card-status`."
+        )
+        out.append("")
+        for name in sorted(cards.extra):
+            out.append(card_line(name, implemented, exclusions))
+    out.append("")
+    path.write_text("\n".join(out), encoding="utf-8")
+    return done, len(countable)
+
+
+def tally_mechanics(
+    cards: SetCards,
+) -> tuple[list[tuple[str, list[str]]], list[tuple[str, list[str]]]]:
+    """(keyword, cards) and (ability word, cards), each ordered by card count then name."""
+    keywords: dict[str, list[str]] = defaultdict(list)
+    ability_words: dict[str, list[str]] = defaultdict(list)
+    for name, card in sorted(cards.all.items()):
+        for kw in card.get("keywords") or []:
+            keywords[kw].append(name)
+        for match in ABILITY_WORD_RE.finditer(joined_oracle(card)):
+            word = match.group(1)
+            if word not in (card.get("keywords") or []):
+                ability_words[word].append(name)
+
+    def ordered(d: dict[str, list[str]]) -> list[tuple[str, list[str]]]:
+        return sorted(d.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+
+    return ordered(keywords), ordered(ability_words)
+
+
+def plural_cards(n: int) -> str:
+    return "1 card" if n == 1 else f"{n} cards"
+
+
+def write_mechanics_md(path: Path, set_meta: dict, cards: SetCards) -> int:
+    keywords, ability_words = tally_mechanics(cards)
+    code = set_meta["code"].upper()
+    out: list[str] = []
+    out.append(f"# {set_meta['name']} ({code}) — Mechanics")
+    out.append("")
+    out.append(
+        f"**DRAFT — needs a pass.** Generated from the Scryfall dump of {len(cards.all)} cards "
+        "(`keywords` + ability-word headers only). Every entry below still needs its description "
+        "written, its engine-support verdict checked against the SDK, and the mechanics Scryfall "
+        "does not name — the set's themes — added by reading the oracle text. Delete this "
+        "paragraph once that pass is done."
+    )
+    out.append("")
+    out.append(
+        "A box is ticked when the engine already models the mechanic (an SDK primitive exists "
+        "and a card in the corpus uses it). An unticked box is `add-feature` work that blocks "
+        "the cards listed under it."
+    )
+    out.append("")
+    out.append("---")
+    out.append("")
+    out.append("## Keyword mechanics")
+    if not keywords:
+        out.append("")
+        out.append("_Scryfall names no keywords in this set._")
+    for keyword, names in keywords:
+        out.append("")
+        out.append(f"### - [ ] {keyword} ({plural_cards(len(names))})")
+        out.append("")
+        out.append("_Description: what it does, and the CR rule that defines it._")
+        out.append("")
+        out.append("**Engine support:** _unverified_")
+        out.append("")
+        out.append(f"Cards: {', '.join(names)}")
+    if ability_words:
+        out.append("")
+        out.append("## Ability words / named triggers")
+        out.append("")
+        out.append(
+            "_Harvested from `Word —` headers in the oracle text. Some are real ability words, "
+            "some are flavour lines or level-up rows — prune before filling in._"
+        )
+        for word, names in ability_words:
+            out.append("")
+            out.append(f"### - [ ] {word} ({plural_cards(len(names))})")
+            out.append("")
+            out.append("_Description._")
+            out.append("")
+            out.append("**Engine support:** _unverified_")
+            out.append("")
+            out.append(f"Cards: {', '.join(names)}")
+    out.append("")
+    out.append("## Set themes")
+    out.append("")
+    out.append(
+        "_Unnamed mechanics the set leans on — the recurring templates Scryfall has no keyword "
+        "for (artifact-matters, sacrifice fuel, a tribal axis, an unusual cost). Read the oracle "
+        "worksheet and add one `### - [ ] Theme (N cards)` section each, in the same shape as "
+        "above._"
+    )
+    out.append("")
+    path.write_text("\n".join(out), encoding="utf-8")
+    return len(keywords) + len(ability_words)
+
+
+def write_worksheet(path: Path, cards: SetCards) -> None:
+    """One TSV row per card — the cheapest way to read a whole set's oracle text."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        "name\tpartition\trarity\tmana_cost\ttype_line\tkeywords\treprint\toracle_text"
+    ]
+    for partition, group in (("draft", cards.draft), ("extra", cards.extra)):
+        for name, card in sorted(group.items()):
+            oracle = joined_oracle(card).replace("\t", " ").replace("\n", " | ")
+            rows.append(
+                "\t".join(
+                    [
+                        name,
+                        partition,
+                        card.get("rarity", ""),
+                        face_field(card, "mana_cost"),
+                        face_field(card, "type_line") or card.get("type_line", ""),
+                        ",".join(card.get("keywords") or []),
+                        "yes" if card.get("reprint") else "no",
+                        oracle,
+                    ]
+                )
+            )
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- main
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("set", help='set code (DRK) or name ("The Dark")')
+    ap.add_argument(
+        "--slug",
+        help="backlog/sets/<slug> directory name (default: the set name, kebab-cased)",
+    )
+    ap.add_argument(
+        "--dir-name", help="definitions/<dir> name (default: the lowercase set code)"
+    )
+    ap.add_argument(
+        "--object-name", help="Kotlin object name (default: derived from the set name)"
+    )
+    ap.add_argument(
+        "--refresh", action="store_true", help="re-download the dump even if cached"
+    )
+    ap.add_argument(
+        "--no-scaffold", action="store_true", help="write backlog files only"
+    )
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite existing cards.md / mechanics.md",
+    )
+    args = ap.parse_args(argv)
+
+    set_meta = resolve_set(args.set)
+    code = set_meta["code"].lower()
+    printings = load_dump(set_meta, refresh=args.refresh)
+    if not printings:
+        sys.exit(f"bootstrap-set: Scryfall returned no cards for set '{code}'")
+    cards = SetCards(printings)
+
+    slug = args.slug or re.sub(r"[^a-z0-9]+", "-", set_meta["name"].lower()).strip("-")
+    dir_name = args.dir_name or RESERVED_DIR_NAMES.get(code, code)
+    object_name = args.object_name or kotlin_object_name(set_meta["name"])
+
+    print(
+        f"{set_meta['name']} ({code.upper()}) — {set_meta.get('released_at', '?')}, "
+        f"{len(cards.draft)} draft + {len(cards.extra)} extra, {len(printings)} printings"
+    )
+
+    # --- scaffold ---------------------------------------------------------
+    scaffolded_dir = dir_for_codes().get(code)
+    if scaffolded_dir:
+        dir_name = scaffolded_dir
+    if not args.no_scaffold:
+        kt, created = scaffold_set(set_meta, dir_name, object_name)
+        print(
+            ("scaffolded " if created else "set exists  ")
+            + str(kt.relative_to(REPO_ROOT))
+        )
+        if created:
+            print(
+                "  ^ review `block` / `basicLandsFallback` / `sealedSupported` by hand"
+            )
+    cards_dir = set_dir_paths().get(dir_name)
+    cards_dir = (cards_dir / "cards") if cards_dir else None
+
+    implemented = scan_implemented(cards_dir) & set(cards.all)
+    exclusions = {
+        n: reason for n, reason in load_exclusions().items() if n in cards.all
+    }
+
+    # --- backlog files ----------------------------------------------------
+    backlog_dir = REPO_ROOT / "backlog" / "sets" / slug
+    backlog_dir.mkdir(parents=True, exist_ok=True)
+    cards_md = backlog_dir / "cards.md"
+    mechanics_md = backlog_dir / "mechanics.md"
+
+    if cards_md.is_file() and not args.force:
+        print(
+            f"skipped     {cards_md.relative_to(REPO_ROOT)} (exists; --force to overwrite)"
+        )
+    else:
+        done, total = write_cards_md(cards_md, set_meta, cards, implemented, exclusions)
+        print(
+            f"wrote       {cards_md.relative_to(REPO_ROOT)} ({done} / {total} implemented)"
+        )
+
+    if mechanics_md.is_file() and not args.force:
+        print(
+            f"skipped     {mechanics_md.relative_to(REPO_ROOT)} (exists; --force to overwrite)"
+        )
+    else:
+        count = write_mechanics_md(mechanics_md, set_meta, cards)
+        print(
+            f"wrote       {mechanics_md.relative_to(REPO_ROOT)} ({count} mechanics — DRAFT)"
+        )
+
+    worksheet = REPO_ROOT / "build" / "backlog" / f"{code}-oracle.tsv"
+    write_worksheet(worksheet, cards)
+    print(
+        f"wrote       {worksheet.relative_to(REPO_ROOT)} (oracle worksheet, gitignored)"
+    )
+    print(f"cache       {dump_path(code)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.agents/skills/create-backlog-for-set/bootstrap-set.py
+++ b/.agents/skills/create-backlog-for-set/bootstrap-set.py
@@ -288,8 +288,12 @@ def kotlin_object_name(display_name: str) -> str:
     ascii_name = (
         unicodedata.normalize("NFKD", display_name).encode("ascii", "ignore").decode()
     )
-    words = re.findall(r"[A-Za-z0-9]+", ascii_name)
-    ident = "".join(w[:1].upper() + w[1:] for w in words) + "Set"
+    # Drop apostrophes before splitting, or "Urza's Saga" derives `UrzaSSagaSet` instead of the
+    # repo's `UrzasSagaSet`; the possessive is part of the word, not a separator.
+    words = re.findall(r"[A-Za-z0-9]+", ascii_name.replace("'", "").replace("\u2019", ""))
+    ident = "".join(w[:1].upper() + w[1:] for w in words)
+    if not ident.endswith("Set"):  # "Arena Beginner Set" is already one
+        ident += "Set"
     if ident[:1].isdigit():
         sys.exit(
             f"bootstrap-set: '{display_name}' produces the invalid Kotlin identifier '{ident}' — "
@@ -337,9 +341,14 @@ def scaffold_set(set_meta: dict, dir_name: str, object_name: str) -> tuple[Path,
         / ("src/main/kotlin/com/wingedsheep/mtg/sets/definitions")
     )
     set_dir = root / dir_name
+    # A scaffolded set is identified by *any* `*Set.kt` in its directory, not by the name this
+    # script would derive. The repo shortens long titles (`LostCavernsOfIxalanSet` for "The Lost
+    # Caverns of Ixalan"), so keying on the derived name would drop a second `MtgSet` object into
+    # the same package and `MtgSetCatalog` would discover both.
+    already = next((p for p in sorted(set_dir.glob("*Set.kt")) if p.is_file()), None)
+    if already is not None:
+        return already, False
     kt = set_dir / f"{object_name}.kt"
-    if kt.is_file():
-        return kt, False
     (set_dir / "cards").mkdir(parents=True, exist_ok=True)
     package = f"com.wingedsheep.mtg.sets.definitions.{dir_name}"
     released = set_meta.get("released_at")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ docs it points at; load those when the work needs them.
     lookup, oracle errata, canonical-printing placement, scenario test).
   - Any engine/SDK/server/client capability that isn't a single card — effect, trigger, condition,
     keyword, decision flow → **`add-feature`** (composition-first design, cross-layer tracing, perf + UX).
+  - Starting a set that has no `backlog/sets/` entry yet → **`create-backlog-for-set`** (Scryfall dump,
+    `cards.md` checklist, `definitions/<code>/` scaffold, `mechanics.md`). It runs *before* `set-loop`.
   - Running the build/test gates and reading the results → **`verify`**.
   - Working autonomously through a whole set, one PR at a time, until it's done → **`set-loop`** (launches
     the harness's own loop — Claude Code `/loop`, Codex `/goal`; every PR it opens is titled


### PR DESCRIPTION
# Add create-backlog-for-set skill

Starting work on a set means producing its `backlog/sets/<slug>/` entry, and until now that was
hand-rolled every time: paginate Scryfall, split booster cards from extras the way
`scripts/card-status` splits them, group by colour, cross-reference the Kotlin sources for what's
already implemented, and get the `cards.md` header format exactly right so `just check-backlog`
stays green. Done by hand it's slow, and it drifts from `card-status` — which is the number the
rest of the tooling treats as authoritative.

This adds a skill that does it, split so the machine does the mechanical half and the agent does
the judgement half.

## `bootstrap-set.py` — the mechanical half

Takes a set code or a name (`DRK` or `"The Dark"`; an ambiguous name exits with the candidate codes
rather than guessing) and writes:

- **`~/.cache/scryfall/_setdump-<code>.json`** — every printing in the set, `unique=prints`. It goes
  in the cache directory `scripts/card-status`, `:mtgish-tooling` and Argentum Assay already share,
  under a `_setdump-` prefix that can't collide with a set code (Assay's own entries use `_bulk-` /
  `_setlist-`). Freshness follows `card-status`: a set released more than 30 days ago is frozen, so a
  second run costs no network. Not committed.
- **`mtg-sets/<era>/…/definitions/<code>/<Name>Set.kt`** plus an empty `cards/`, when the set has no
  module yet. The era module is selected from the release year by parsing the existing
  `mtg-sets/<era>` directories, so it keeps working when a new era is appended; a year past the
  newest module is a hard error naming `settings.gradle.kts`, not a guess. `con`-style
  Windows-reserved codes map to the same alternate directory names the repo already uses.
- **`backlog/sets/<slug>/cards.md`** — the checklist, with colour sections, an `### Extras` section
  for non-booster cards, `[-] … (not planned: …)` for `coverage/card-exclusions.json` entries, and
  every already-implemented card pre-ticked by scanning `card("Name")` / `name = "Name"` out of the
  set's Kotlin sources.
- **`backlog/sets/<slug>/mechanics.md`** — a draft, marked as one.
- **`build/backlog/<code>-oracle.tsv`** — one row per card (name, rarity, cost, type, keywords,
  reprint flag, oracle text on a single line). Gitignored; it exists so the mechanics pass can read a
  whole set's text cheaply instead of 300 Scryfall lookups.

The draft/extras split and the exclusion handling deliberately mirror `scripts/card-status` rather
than reinventing a denominator, and the script imports `card_exclusions` and `set_dirs` from
`scripts/` instead of copying their logic.

## `SKILL.md` — the judgement half

The parts a script shouldn't decide are left to the agent and documented: what each mechanic means
and which CR rule defines it (verified against the local `MagicCompRules_*.txt`, never recalled),
whether the engine already models it (checked against `docs/card-sdk-language-reference.md` and the
SDK `Keyword` enum, with the primitive named), the set themes Scryfall has no keyword for, and the
three set-object fields that are a decision rather than a lookup — `block`, `basicLandsFallback`,
`sealedSupported`.

It also writes down the format rules other tooling depends on, because they're invisible failure
modes: `check-backlog-implementations.py` finds a set by the exact `# <Name> (<CODE>) - Card
Checklist` heading and matches card names verbatim, so an annotated entry like `- [ ] Foo (reprint)`
silently stops matching and can never be ticked by `--fix`.

Two guards worth calling out. Existing `cards.md` / `mechanics.md` are skipped unless `--force`, so
re-running against a curated backlog can't clobber it. And the skill explicitly says **not** to run
`scripts/gen-set-totals` to "register" a new set: it rewrites the committed 6 MB
`coverage/set-totals.json` for every set from the local Scryfall cache, so running it with a
partly-populated cache would silently empty other sets' totals.

## Verification

No Kotlin, TypeScript or Gradle-visible code changes: the diff is one markdown skill file, one
Python script under `.agents/skills/`, and two lines of `AGENTS.md`. Per `CLAUDE.local.md`'s gate
table that's a docs/tooling change, so no Kotlin suite was run — and a green Kotlin suite would say
nothing about this diff anyway.

What was actually exercised, end to end against live Scryfall:

- **`DRK` (scaffolded set, partially implemented)** — produced `46 / 119` with the per-colour
  breakdown, matching `scripts/card-status --set DRK` exactly. `scripts/check-card-counts.py
  --check` reports all 14 backlog headers in sync, and `scripts/check-backlog-implementations.py
  --check` reports no drift for the generated file (the drift it does print is pre-existing in
  `bloomburrow-commander`).
- **`S00` (unscaffolded set, by name — "Starter 2000")** — exercised name resolution, the scaffold
  path and era selection (2000 → `mtg-sets/2000-2002`), and the all-extras case (0 draft / 20
  extra). This surfaced a wrong era-module path calculation, which is fixed. Those test artifacts
  were then deleted.
- **Idempotency** — a second run re-uses the cached dump, reports `set exists`, and skips both
  backlog files.
- **Every scaffolded set (163 of them)** — the review pass checked the derived Kotlin object name
  and the "already scaffolded?" guard against each one. That found a real defect: the guard keyed on
  the derived name, but the repo shortens long titles (`LostCavernsOfIxalanSet`), so running against
  one of those 19 sets would have written a *second* `MtgSet` object into the same package for
  `MtgSetCatalog` to discover. Fixed in the second commit, along with apostrophe handling
  ("Urza's Saga" derived `UrzaSSagaSet`). Re-verified across all 163 afterwards.
- `python3 -m ast` parse and `--help` on the committed file.

Not covered: no automated test asserts the generated markdown shape. The three repo checkers above
are the real guard on it, and they run against the output.

## Deliberately not included

- **`backlog/sets/the-dark/`** — the DRK backlog produced while testing the skill is real, useful
  content, but it's set content rather than tooling, so it stays out of this PR.
- The script lives in the skill directory rather than `scripts/`. It's skill-specific bootstrap that
  nothing else calls, not a gate; if it earns wider use it can move.
