### PR TITLE
Add nine Eldrazi Trudge decklist cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1683,7 +1683,8 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   set-specific-art note below).
 - `CreateFood(count?, controller?)` — Food tokens. `count` accepts an `Int` or a `DynamicAmount` (the latter evaluated at resolution, e.g. `CreateFood(DynamicAmount.Divide(DynamicAmount.CastX, DynamicAmount.Fixed(2), roundUp = true))` for The Goose Mother's "create half X Food tokens, rounded up").
 - `CreateEldraziSpawn(count?, controller?, imageUri?)` — 0/1 colorless Eldrazi Spawn creature tokens
-  ("Sacrifice this creature: Add {C}."), `count: Int` (default 1).
+  ("Sacrifice this creature: Add {C}."). `count` accepts an `Int` (default 1) or a `DynamicAmount`
+  evaluated at resolution, such as `DynamicAmount.XValue` for Kozilek's Command.
 - `CreateBlood(count?, controller?)` — Blood tokens (artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card."). `count` accepts an `Int` or a `DynamicAmount` (the latter evaluated at resolution, e.g. `CreateBlood(DynamicAmount.EntityProperty(EntityReference.Target(0), EntityNumericProperty.ExcessMarkedDamage))` for Lacerate Flesh's "create a number of Blood tokens equal to the amount of excess damage dealt").
 - `CreateClue(count?, controller?)` / `Investigate(count?, controller?)` — Clue tokens (artifact with
   "{2}, Sacrifice this token: Draw a card."). `Investigate` is the keyword-action spelling (CR 701.36) so

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1682,6 +1682,8 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   two Treasure tokens" (An Offer You Can't Refuse). `imageUri` overrides the token art (see the
   set-specific-art note below).
 - `CreateFood(count?, controller?)` — Food tokens. `count` accepts an `Int` or a `DynamicAmount` (the latter evaluated at resolution, e.g. `CreateFood(DynamicAmount.Divide(DynamicAmount.CastX, DynamicAmount.Fixed(2), roundUp = true))` for The Goose Mother's "create half X Food tokens, rounded up").
+- `CreateEldraziSpawn(count?, controller?, imageUri?)` — 0/1 colorless Eldrazi Spawn creature tokens
+  ("Sacrifice this creature: Add {C}."), `count: Int` (default 1).
 - `CreateBlood(count?, controller?)` — Blood tokens (artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card."). `count` accepts an `Int` or a `DynamicAmount` (the latter evaluated at resolution, e.g. `CreateBlood(DynamicAmount.EntityProperty(EntityReference.Target(0), EntityNumericProperty.ExcessMarkedDamage))` for Lacerate Flesh's "create a number of Blood tokens equal to the amount of excess damage dealt").
 - `CreateClue(count?, controller?)` / `Investigate(count?, controller?)` — Clue tokens (artifact with
   "{2}, Sacrifice this token: Draw a card."). `Investigate` is the keyword-action spelling (CR 701.36) so

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -343,6 +343,11 @@ excluded.
 
 ## 3. Costs (`Costs.*`)
 
+Spell mana costs containing Phyrexian symbols (for example `{B/P}`) are paid per pip with either
+one mana of that color or 2 life. Manual payment records the chosen life-paid pip colors as a
+multiset on `PaymentStrategy.Explicit.phyrexianLifePayments`; the engine validates that those pips
+exist in the cost and charges the life through the shared life-payment service.
+
 > **One cost vocabulary (`CostAtom`).** The payable things shared across cost *contexts* — mana, life,
 > sacrifice, discard, exile-from-zone, tap, return-to-hand, reveal — are defined **once** in the
 > `CostAtom` sealed hierarchy (`scripting/costs/CostAtom.kt`). All three context wrappers carry them via
@@ -1114,6 +1119,8 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   ifBeheld = Effects.CreateTreasure())`.
 
 ### Library reveal & free cast
+
+- `PlayFromCollectionWithoutPayingCostEffect(from)` (facade `Effects.PlayFromCollectionWithoutPayingCost(from)`) — play the first card in the pipeline collection immediately during the resolving effect. Nonlands use the free-cast machinery; lands use the normal land-play path, consume a land play for the turn, and remain unplayed when no land play is available. Use this for Oracle text that says **play**, such as **Fight Rigging**; it grants no permission that survives resolution.
 
 - `Effects.Cascade` — CR 702.85a (`CascadeEffect`). Exile from the top of the controller's library
   until a nonland card with mana value **strictly less than** the triggering spell's is exiled,

--- a/manual-scenarios/cards/d/dismember.json
+++ b/manual-scenarios/cards/d/dismember.json
@@ -26,5 +26,6 @@
   "player1StopAtSteps": [],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
 }

--- a/manual-scenarios/cards/d/dismember.json
+++ b/manual-scenarios/cards/d/dismember.json
@@ -1,0 +1,30 @@
+{
+  "player1Name": "Dismember Caster",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Dismember"],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [{"name": "Hill Giant"}],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/d/dryad-arbor.json
+++ b/manual-scenarios/cards/d/dryad-arbor.json
@@ -1,0 +1,26 @@
+{
+  "player1Name": "Arbor Player",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Dryad Arbor"],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/d/dryad-arbor.json
+++ b/manual-scenarios/cards/d/dryad-arbor.json
@@ -22,5 +22,6 @@
   "player1StopAtSteps": [],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
 }

--- a/manual-scenarios/cards/e/elder-gargaroth.json
+++ b/manual-scenarios/cards/e/elder-gargaroth.json
@@ -1,0 +1,26 @@
+{
+  "player1Name": "Gargaroth Controller",
+  "player2Name": "Defender",
+  "player1": {
+    "lifeTotal": 17,
+    "hand": [],
+    "battlefield": [{"name": "Elder Gargaroth", "summoningSickness": false}],
+    "graveyard": [],
+    "library": ["Forest", "Grizzly Bears", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [{"name": "Hill Giant", "summoningSickness": false}],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "COMBAT",
+  "step": "BEGIN_COMBAT",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_ATTACKERS", "DECLARE_BLOCKERS"],
+  "player2StopAtSteps": ["DECLARE_BLOCKERS"],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/e/elder-gargaroth.json
+++ b/manual-scenarios/cards/e/elder-gargaroth.json
@@ -19,8 +19,9 @@
   "step": "BEGIN_COMBAT",
   "activePlayer": 1,
   "priorityPlayer": 1,
-  "player1StopAtSteps": ["DECLARE_ATTACKERS", "DECLARE_BLOCKERS"],
-  "player2StopAtSteps": ["DECLARE_BLOCKERS"],
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
 }

--- a/manual-scenarios/cards/f/fight-rigging.json
+++ b/manual-scenarios/cards/f/fight-rigging.json
@@ -1,0 +1,31 @@
+{
+  "player1Name": "Rigging Controller",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Fight Rigging"],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Ghalta, Primal Hunger", "summoningSickness": false}
+    ],
+    "graveyard": [],
+    "library": ["Grizzly Bears", "Hill Giant", "Sol Ring", "Plains", "Swamp", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["BEGIN_COMBAT"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/f/fight-rigging.json
+++ b/manual-scenarios/cards/f/fight-rigging.json
@@ -3,7 +3,7 @@
   "player2Name": "Opponent",
   "player1": {
     "lifeTotal": 20,
-    "hand": ["Fight Rigging"],
+    "hand": ["Fight Rigging", "Forest"],
     "battlefield": [
       {"name": "Forest"},
       {"name": "Forest"},
@@ -24,8 +24,9 @@
   "step": "PRECOMBAT_MAIN",
   "activePlayer": 1,
   "priorityPlayer": 1,
-  "player1StopAtSteps": ["BEGIN_COMBAT"],
+  "player1StopAtSteps": [],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
 }

--- a/manual-scenarios/cards/f/force-of-vigor.json
+++ b/manual-scenarios/cards/f/force-of-vigor.json
@@ -4,9 +4,16 @@
   "player1": {
     "lifeTotal": 20,
     "hand": ["Force of Vigor", "Grizzly Bears"],
-    "battlefield": [],
+    "battlefield": [
+      { "name": "Forest" },
+      { "name": "Forest" },
+      { "name": "Forest" },
+      { "name": "Forest" },
+      { "name": "Forest" },
+      { "name": "Forest" }
+    ],
     "graveyard": [],
-    "library": ["Forest", "Forest"]
+    "library": ["Forest", "Forest", "Forest", "Forest", "Forest", "Forest"]
   },
   "player2": {
     "lifeTotal": 20,
@@ -25,5 +32,6 @@
   "player1StopAtSteps": [],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
 }

--- a/manual-scenarios/cards/f/force-of-vigor.json
+++ b/manual-scenarios/cards/f/force-of-vigor.json
@@ -1,0 +1,29 @@
+{
+  "player1Name": "Force Caster",
+  "player2Name": "Active Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Force of Vigor", "Grizzly Bears"],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Sol Ring"},
+      {"name": "Fight Rigging"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 2,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/m/malevolent-rumble.json
+++ b/manual-scenarios/cards/m/malevolent-rumble.json
@@ -25,5 +25,6 @@
   "player1StopAtSteps": [],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
 }

--- a/manual-scenarios/cards/m/malevolent-rumble.json
+++ b/manual-scenarios/cards/m/malevolent-rumble.json
@@ -1,0 +1,29 @@
+{
+  "player1Name": "Rumble Caster",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Malevolent Rumble"],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Grizzly Bears", "Lightning Bolt", "Island", "Swamp", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/t/thought-knot-seer.json
+++ b/manual-scenarios/cards/t/thought-knot-seer.json
@@ -1,0 +1,31 @@
+{
+  "player1Name": "Seer Caster",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Thought-Knot Seer"],
+    "battlefield": [
+      {"name": "Wastes"},
+      {"name": "Wastes"},
+      {"name": "Wastes"},
+      {"name": "Wastes"}
+    ],
+    "graveyard": [],
+    "library": ["Wastes", "Wastes"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Lightning Bolt", "Mountain"],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/t/thought-knot-seer.json
+++ b/manual-scenarios/cards/t/thought-knot-seer.json
@@ -15,8 +15,11 @@
   },
   "player2": {
     "lifeTotal": 20,
-    "hand": ["Lightning Bolt", "Mountain"],
-    "battlefield": [],
+    "hand": ["Lightning Bolt", "Mountain", "Terror"],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
     "graveyard": [],
     "library": ["Mountain", "Mountain", "Mountain"]
   },
@@ -27,5 +30,6 @@
   "player1StopAtSteps": [],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
 }

--- a/manual-scenarios/cards/u/ugins-labyrinth.json
+++ b/manual-scenarios/cards/u/ugins-labyrinth.json
@@ -1,0 +1,26 @@
+{
+  "player1Name": "Labyrinth Controller",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Ugin's Labyrinth", "Ulamog, the Ceaseless Hunger", "Grizzly Bears"],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/u/ugins-labyrinth.json
+++ b/manual-scenarios/cards/u/ugins-labyrinth.json
@@ -22,5 +22,6 @@
   "player1StopAtSteps": [],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
 }

--- a/manual-scenarios/cards/u/ulamog-the-ceaseless-hunger.json
+++ b/manual-scenarios/cards/u/ulamog-the-ceaseless-hunger.json
@@ -33,5 +33,6 @@
   "player1StopAtSteps": ["DECLARE_ATTACKERS"],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
 }

--- a/manual-scenarios/cards/u/ulamog-the-ceaseless-hunger.json
+++ b/manual-scenarios/cards/u/ulamog-the-ceaseless-hunger.json
@@ -1,0 +1,37 @@
+{
+  "player1Name": "Ulamog Caster",
+  "player2Name": "Defender",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Ulamog, the Ceaseless Hunger"],
+    "battlefield": [
+      {"name": "Forest"}, {"name": "Forest"}, {"name": "Forest"}, {"name": "Forest"},
+      {"name": "Forest"}, {"name": "Forest"}, {"name": "Forest"}, {"name": "Forest"},
+      {"name": "Forest"}, {"name": "Forest"}, {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Hill Giant"},
+      {"name": "Sol Ring"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain", "Mountain", "Mountain", "Mountain", "Mountain", "Mountain", "Mountain",
+      "Mountain", "Mountain", "Mountain", "Mountain", "Mountain", "Mountain", "Mountain",
+      "Mountain", "Mountain", "Mountain", "Mountain", "Mountain", "Mountain", "Mountain"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_ATTACKERS"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/ManaCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/ManaCost.kt
@@ -51,6 +51,28 @@ data class ManaCost(val symbols: List<ManaSymbol>) {
     val xCount: Int
         get() = symbols.count { it is ManaSymbol.X }
 
+    val phyrexianSymbols: List<ManaSymbol.Phyrexian>
+        get() = symbols.filterIsInstance<ManaSymbol.Phyrexian>()
+
+    /**
+     * Remove the Phyrexian pips the payer chose to satisfy with 2 life instead of mana.
+     * [colors] is a multiset: `{B/P}{B/P}` paid entirely with life is `[BLACK, BLACK]`.
+     * Returns `null` when the choice names more pips of a color than this cost contains.
+     */
+    fun withPhyrexianPaidByLife(colors: List<Color>): ManaCost? {
+        if (colors.isEmpty()) return this
+        val remainingChoices = colors.groupingBy { it }.eachCount().toMutableMap()
+        val kept = mutableListOf<ManaSymbol>()
+        for (symbol in symbols) {
+            if (symbol is ManaSymbol.Phyrexian && (remainingChoices[symbol.color] ?: 0) > 0) {
+                remainingChoices[symbol.color] = remainingChoices.getValue(symbol.color) - 1
+            } else {
+                kept.add(symbol)
+            }
+        }
+        return if (remainingChoices.values.all { it == 0 }) ManaCost(kept) else null
+    }
+
     fun isEmpty(): Boolean = symbols.isEmpty()
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2656,6 +2656,21 @@ object Effects {
         CreatePredefinedTokenEffect("Eldrazi Spawn", count, controller, imageUri = imageUri)
 
     /**
+     * Create a dynamic number of 0/1 colorless Eldrazi Spawn creature tokens.
+     * The count is evaluated at resolution time.
+     */
+    fun CreateEldraziSpawn(
+        count: DynamicAmount,
+        controller: EffectTarget? = null,
+        imageUri: String? = null
+    ): Effect = CreatePredefinedTokenEffect(
+        tokenType = "Eldrazi Spawn",
+        controller = controller,
+        dynamicCount = count,
+        imageUri = imageUri
+    )
+
+    /**
      * "You may behold a [filter]. If you do, [ifBeheld]." — the resolution-time behold
      * (choose a matching permanent you control or reveal a matching card from hand). See
      * [com.wingedsheep.sdk.scripting.effects.BeholdEffect]. Used by Sarkhan, Dragon Ascendant.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -82,6 +82,7 @@ import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
 import com.wingedsheep.sdk.scripting.effects.CopyCardIntoCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.CopyCollectionIntoCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.PlayFromCollectionWithoutPayingCostEffect
 import com.wingedsheep.sdk.scripting.effects.CastAnyNumberFromCollectionWithoutPayingCostEffect
 import com.wingedsheep.sdk.scripting.effects.AnyPlayerMayPayEffect
 import com.wingedsheep.sdk.scripting.costs.PayCost
@@ -3352,6 +3353,14 @@ object Effects {
      */
     fun CastFromCollectionWithoutPayingCost(from: String, storeCastTo: String? = null): Effect =
         CastFromCollectionWithoutPayingCostEffect(from = from, storeCastTo = storeCastTo)
+
+    /**
+     * Play the (0..1) card stored under [from] immediately during resolution without paying its
+     * mana cost. Unlike [CastFromCollectionWithoutPayingCost], this also supports lands; playing
+     * one consumes a land play and is impossible when none remain.
+     */
+    fun PlayFromCollectionWithoutPayingCost(from: String): Effect =
+        PlayFromCollectionWithoutPayingCostEffect(from = from)
 
     /**
      * Cast the (0..1) card stored under [from], **paying its normal mana cost** (the "you may

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2646,6 +2646,16 @@ object Effects {
         CreatePredefinedTokenEffect("Treasure", tapped = tapped, dynamicCount = count, imageUri = imageUri)
 
     /**
+     * Create 0/1 colorless Eldrazi Spawn creature tokens.
+     * "Sacrifice this creature: Add {C}."
+     *
+     * @param count Number of tokens to create
+     * @param controller Who controls the tokens (null = effect controller)
+     */
+    fun CreateEldraziSpawn(count: Int = 1, controller: EffectTarget? = null, imageUri: String? = null): Effect =
+        CreatePredefinedTokenEffect("Eldrazi Spawn", count, controller, imageUri = imageUri)
+
+    /**
      * "You may behold a [filter]. If you do, [ifBeheld]." — the resolution-time behold
      * (choose a matching permanent you control or reveal a matching card from hand). See
      * [com.wingedsheep.sdk.scripting.effects.BeholdEffect]. Used by Sarkhan, Dragon Ascendant.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LibraryEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LibraryEffects.kt
@@ -346,6 +346,19 @@ data class CastFromCollectionWithoutPayingCostEffect(
 }
 
 /**
+ * Play the first card in [from] during this effect's resolution without paying its mana cost.
+ * Spells use the ordinary synthesized-cast pipeline; lands are played as a special action and
+ * still consume one of the controller's land plays for the turn.
+ */
+@SerialName("PlayFromCollectionWithoutPayingCost")
+@Serializable
+data class PlayFromCollectionWithoutPayingCostEffect(
+    val from: String,
+) : Effect {
+    override val description: String = "Play that card without paying its mana cost"
+}
+
+/**
  * Cast ANY NUMBER of cards from a named pipeline collection **during this effect's
  * resolution**, each without paying its mana cost, with timing restrictions based on card
  * type ignored (Rule 608.2 / "cast … while [the source] is resolving").
@@ -452,4 +465,3 @@ data class DiscoverEffect(
 ) : Effect {
     override val description: String = "Discover ${amount.description}"
 }
-

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -575,7 +575,7 @@ object CardLinter {
             "MakePlotted",
             "GrantPlayWithAdditionalCost", "GrantPlayWithCostIncrease", "FilterCollection",
             "ChooseOnePerCategory",
-            "StoreCardName", "CastFromCollectionWithoutPayingCost",
+            "StoreCardName", "CastFromCollectionWithoutPayingCost", "PlayFromCollectionWithoutPayingCost",
             "CastAnyNumberFromCollectionWithoutPayingCost", "ExileFromStorage",
             "CopyCollectionIntoCollection", "RecordChosenLinkedExile",
             "PairWithSource",

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/CreateEldraziSpawnTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/dsl/CreateEldraziSpawnTest.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.scripting.effects.CreatePredefinedTokenEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class CreateEldraziSpawnTest : FunSpec({
+
+    test("dynamic count delegates to the predefined-token effect") {
+        val effect = Effects.CreateEldraziSpawn(
+            count = DynamicAmount.XValue,
+            controller = EffectTarget.TargetController,
+            imageUri = "spawn.jpg"
+        ).shouldBeInstanceOf<CreatePredefinedTokenEffect>()
+
+        effect.tokenType shouldBe "Eldrazi Spawn"
+        effect.dynamicCount shouldBe DynamicAmount.XValue
+        effect.controller shouldBe EffectTarget.TargetController
+        effect.imageUri shouldBe "spawn.jpg"
+    }
+})

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fut/cards/DryadArbor.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fut/cards/DryadArbor.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.fut.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Dryad Arbor — Future Sight #174
+ * Land Creature — Forest Dryad · 1/1 · Uncommon
+ *
+ * (This land isn't a spell, it's affected by summoning sickness, and it has "{T}: Add {G}.")
+ *
+ * Modeling notes:
+ *  - Printed with a green [colorIndicator] (2013-06-07 ruling): with no mana cost, Dryad Arbor
+ *    would otherwise be colorless, so the color comes from the indicator, not from a mana cost
+ *    that doesn't exist. `colorIdentity` follows it (CR 903.4).
+ *  - `typeLine = "Land Creature — Forest Dryad"` is a plain dual-type parse — [TypeLine.parse]
+ *    already unions every recognized card type word, so `isLand` and `isCreature` are both true
+ *    with no engine change. "Forest" is a land type, "Dryad" a creature type (both ruled on
+ *    2021-03-19), so a land-type-changing effect (Sea's Claim) still leaves it a green Dryad.
+ *  - The reminder text is just confirming default engine behavior, not modeling anything new:
+ *    lands are never cast (so "isn't a spell" needs no code), and every creature already gets
+ *    summoning sickness on entry. It is played as a land like any other, using up the turn's land
+ *    drop, and it can't be responded to.
+ *  - The mana ability is the plain "{T}: Add {G}" every Forest has, just spelled out with
+ *    [Effects.AddMana] instead of the `basicLand()` DSL (Dryad Arbor isn't a basic land type
+ *    itself, even though "Forest" is one of its subtypes).
+ */
+val DryadArbor = card("Dryad Arbor") {
+    manaCost = ""
+    colorIdentity = "G"
+    colorIndicator = "G"
+    typeLine = "Land Creature — Forest Dryad"
+    power = 1
+    toughness = 1
+    oracleText = "(This land isn't a spell, it's affected by summoning sickness, and it has " +
+        "\"{T}: Add {G}.\")"
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN, 1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add {G}."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "174"
+        artist = "Eric Fortune"
+        flavorText = "\"Touch no tree, break no branch, and speak only the question you wish " +
+            "answered.\"\n—Von Yomm, elder druid, to her initiates"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8cee476d-42e1-4997-87af-73e18f542167.jpg?1783943089"
+        ruling(
+            "2021-03-19",
+            "Due to its color indicator (appearing to the left of its type line), Dryad Arbor is " +
+                "green. Color indicators apply in all zones, not just the battlefield."
+        )
+        ruling(
+            "2021-03-19",
+            "If Dryad Arbor is changed into another basic land type, it continues to be a green " +
+                "Dryad creature."
+        )
+        ruling(
+            "2021-03-19",
+            "Dryad Arbor is played as a land. It doesn't use the stack, it's not a spell, it " +
+                "can't be responded to, it has no mana cost, and it counts as your land play for " +
+                "the turn."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DryadArborScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DryadArborScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fut.cards.DryadArbor
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dryad Arbor (FUT #174) — Land Creature — Forest Dryad, 1/1.
+ *
+ *   "(This land isn't a spell, it's affected by summoning sickness, and it has
+ *    '{T}: Add {G}.')"
+ *
+ * Two pieces of behaviour to pin down:
+ *  - It's a green 1/1 creature (from its color indicator, since it has no mana cost) as well as
+ *    a land, the moment it's played.
+ *  - Unlike an ordinary land, its mana ability IS gated by summoning sickness (CR 302.6, because
+ *    it's also a creature) — this is the one place the engine's land/creature carve-out for
+ *    tap-ability summoning sickness had to be corrected for a land that's also a creature.
+ */
+class DryadArborScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+    val manaAbilityId = DryadArbor.activatedAbilities[0].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(DryadArbor)
+        return driver
+    }
+
+    test("playing it puts a green 1/1 land creature onto the battlefield") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val arbor = driver.putCardInHand(me, "Dryad Arbor")
+
+        driver.playLand(me, arbor).error shouldBe null
+        driver.findPermanent(me, "Dryad Arbor") shouldBe arbor
+
+        val projected = projector.project(driver.state)
+        projected.getPower(arbor) shouldBe 1
+        projected.getToughness(arbor) shouldBe 1
+        projected.getColors(arbor) shouldBe setOf("GREEN")
+    }
+
+    test("its mana ability is blocked by summoning sickness the turn it's played") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val arbor = driver.putCardInHand(me, "Dryad Arbor")
+        driver.playLand(me, arbor)
+
+        val result = driver.submit(
+            ActivateAbility(playerId = me, sourceId = arbor, abilityId = manaAbilityId)
+        )
+        result.error shouldBe "This creature has summoning sickness"
+        driver.isTapped(arbor) shouldBe false
+    }
+
+    test("once summoning sickness clears, {T}: Add {G} works") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val arbor = driver.putCardInHand(me, "Dryad Arbor")
+        driver.playLand(me, arbor)
+        driver.removeSummoningSickness(arbor)
+
+        val result = driver.submit(
+            ActivateAbility(playerId = me, sourceId = arbor, abilityId = manaAbilityId)
+        )
+        result.isSuccess shouldBe true
+        driver.isTapped(arbor) shouldBe true
+        driver.state.getEntity(me)?.get<ManaPoolComponent>()?.green shouldBe 1
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/Ulamog.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/Ulamog.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Ulamog, the Ceaseless Hunger — Battle for Zendikar #15
+ * {10} · Legendary Creature — Eldrazi · 10/10 · Mythic
+ *
+ * When you cast this spell, exile two target permanents.
+ * Indestructible
+ * Whenever Ulamog attacks, defending player exiles the top twenty cards of their library.
+ *
+ * Modeling notes:
+ *  - The exile is a **cast trigger** ([Triggers.WhenYouCastThisSpell]), not an ETB — per the
+ *    2015-08-25 ruling it resolves independently of Ulamog and before Ulamog itself, and it
+ *    still resolves even if Ulamog is countered (see [com.wingedsheep.mtg.sets.definitions.roe.cards.ArtisanOfKozilek]
+ *    for the same pattern on a smaller Eldrazi titan). Two simultaneous targets use
+ *    [TargetPermanent] with `count = 2` plus [ForEachTargetEffect] so each is exiled
+ *    independently even if one becomes illegal.
+ *  - The attack trigger is the lowering of the (unprinted, purely descriptive here) "mill 20"
+ *    effect via [Patterns.Library.exileTop], targeting [Player.DefendingPlayer] — same shape as
+ *    Malboro's "exile the top N cards of a player's library." Per the 2015-08-25 ruling, if the
+ *    defending player has fewer than twenty cards left, all of them are exiled and the empty
+ *    library alone doesn't cause a loss (only a forced draw from it would).
+ */
+val Ulamog = card("Ulamog, the Ceaseless Hunger") {
+    manaCost = "{10}"
+    colorIdentity = ""
+    typeLine = "Legendary Creature — Eldrazi"
+    power = 10
+    toughness = 10
+    oracleText = "When you cast this spell, exile two target permanents.\n" +
+        "Indestructible\n" +
+        "Whenever Ulamog attacks, defending player exiles the top twenty cards of their library."
+
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        val targets = target("target permanents", TargetPermanent(count = 2))
+        effect = ForEachTargetEffect(
+            listOf(Effects.Exile(EffectTarget.ContextTarget(0)))
+        )
+        description = "When you cast this spell, exile two target permanents."
+    }
+
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Patterns.Library.exileTop(20, EffectTarget.PlayerRef(Player.DefendingPlayer))
+        description = "Whenever Ulamog attacks, defending player exiles the top twenty cards of their library."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "15"
+        artist = "Michael Komarck"
+        flavorText = "A force as voracious as time itself."
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/1192f7a9-102e-4b3a-b154-18c8eb332217.jpg?1783938222"
+        ruling(
+            "2015-08-25",
+            "Ulamog's first ability resolves independently of Ulamog once they've both been put " +
+                "on the stack. If Ulamog is countered, that triggered ability will still resolve. " +
+                "That triggered ability will always resolve before Ulamog does."
+        )
+        ruling(
+            "2015-08-25",
+            "If the player has less than twenty cards in their library, exile all of them. That " +
+                "player won't lose the game until they have to draw a card from an empty library."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/Dismember.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/Dismember.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.nph.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Dismember
+ * {1}{B/P}{B/P}
+ * Instant
+ *
+ * Target creature gets -5/-5 until end of turn.
+ *
+ * ({B/P} can be paid with either {B} or 2 life — CR 107.4f/g.) The Phyrexian mana symbols are
+ * parsed directly by `ManaCost.parse` (same syntax as Skrelv, Defector Mite / Namor, the
+ * Sub-Mariner's activated-ability costs); a Phyrexian pip always contributes 1 to mana value
+ * regardless of how it's paid (2024-06-07 ruling), so no special-casing is needed here.
+ */
+val Dismember = card("Dismember") {
+    manaCost = "{1}{B/P}{B/P}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -5/-5 until end of turn."
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.ModifyStats(-5, -5, t)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "57"
+        artist = "Terese Nielsen"
+        flavorText = "\"You serve Phyrexia. Your pieces would better serve Phyrexia elsewhere.\"\n" +
+            "—Azax-Azog, the Demon Thane"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/064dfdeb-485f-473e-9fa0-8fdb7638cdc6.jpg?1783941314"
+        ruling(
+            "2024-06-07",
+            "A Phyrexian mana symbol contributes 1 toward the mana value of a card, even if life " +
+                "is paid for it. Specifically, Dismember's mana value is always 3."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/Dismember.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/Dismember.kt
@@ -13,7 +13,7 @@ import com.wingedsheep.sdk.scripting.targets.TargetCreature
  *
  * Target creature gets -5/-5 until end of turn.
  *
- * ({B/P} can be paid with either {B} or 2 life — CR 107.4f/g.) The Phyrexian mana symbols are
+ * ({B/P} can be paid with either {B} or 2 life — CR 107.4f.) The Phyrexian mana symbols are
  * parsed directly by `ManaCost.parse` (same syntax as Skrelv, Defector Mite / Namor, the
  * Sub-Mariner's activated-ability costs); a Phyrexian pip always contributes 1 to mana value
  * regardless of how it's paid (2024-06-07 ruling), so no special-casing is needed here.

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/ThoughtKnotSeer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/ThoughtKnotSeer.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thought-Knot Seer
+ * {3}{C}
+ * Creature — Eldrazi
+ * 4/4
+ *
+ * When this creature enters, target opponent reveals their hand. You choose a nonland card from
+ * it and exile that card.
+ * When this creature leaves the battlefield, target opponent draws a card.
+ *
+ * Modeling notes:
+ *  - The ETB is `Patterns.Hand.revealHandAndExileChosen(target = opponent)` — the exact
+ *    "reveal hand → choose a nonland → exile it" shape already used by Cruelclaw's Heist / Soul
+ *    Search (Thoughtseize with exile instead of discard).
+ *  - The LTB is a self `Triggers.LeavesBattlefield` (Goblin Firebug's shape) with its own target
+ *    opponent, drawing them a card as the "give it back" cost.
+ *  - Canonical printing lives here (Oath of the Gatewatch, its earliest real-expansion printing
+ *    per Scryfall — it was never printed in Battle for Zendikar).
+ */
+val ThoughtKnotSeer = card("Thought-Knot Seer") {
+    manaCost = "{3}{C}"
+    colorIdentity = ""
+    typeLine = "Creature — Eldrazi"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature enters, target opponent reveals their hand. You choose a " +
+        "nonland card from it and exile that card.\n" +
+        "When this creature leaves the battlefield, target opponent draws a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Patterns.Hand.revealHandAndExileChosen(target = opponent)
+        description = "When this creature enters, target opponent reveals their hand. You " +
+            "choose a nonland card from it and exile that card."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.DrawCards(1, opponent)
+        description = "When this creature leaves the battlefield, target opponent draws a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "9"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bffc360e-db41-48f3-9365-680d55046e04.jpg?1783937929"
+    }
+}

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DismemberScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DismemberScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Dismember (NPH #57) — {1}{B/P}{B/P} Instant.
+ *
+ *   Target creature gets -5/-5 until end of turn.
+ *
+ * `{B/P}` is Phyrexian black mana, parsed by `ManaCost.parse` like Skrelv, Defector Mite's and
+ * Namor, the Sub-Mariner's activated-ability costs — no card-specific wiring needed. The effect
+ * itself composes the plain `Effects.ModifyStats(-5, -5, target)` used by Last Gasp.
+ */
+class DismemberScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dismember") {
+
+            test("kills a small creature by reducing its toughness to 0 or less") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dismember")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(2, "Hill Giant") // 3/3
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.castSpell(1, "Dismember", giant).error shouldBe null
+                game.resolveStack()
+
+                withClue("-5/-5 kills a 3/3 (0 or less toughness, CR 704.5g)") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                }
+            }
+
+            test("a high-toughness creature survives at reduced stats") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dismember")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(2, "Wall of Stone") // 0/8, Defender
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wall = game.findPermanent("Wall of Stone")!!
+
+                game.castSpell(1, "Dismember", wall).error shouldBe null
+                game.resolveStack()
+
+                withClue("a 0/8 survives -5/-5 as a -5/3 (still alive)") {
+                    game.isOnBattlefield("Wall of Stone") shouldBe true
+                    game.state.projectedState.getPower(wall) shouldBe -5
+                    game.state.projectedState.getToughness(wall) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DismemberScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DismemberScenarioTest.kt
@@ -37,7 +37,7 @@ class DismemberScenarioTest : ScenarioTestBase() {
                 game.castSpell(1, "Dismember", giant).error shouldBe null
                 game.resolveStack()
 
-                withClue("-5/-5 kills a 3/3 (0 or less toughness, CR 704.5g)") {
+                withClue("-5/-5 kills a 3/3 (0 or less toughness, CR 704.5f)") {
                     game.isOnBattlefield("Hill Giant") shouldBe false
                     game.isInGraveyard(2, "Hill Giant") shouldBe true
                 }

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DismemberScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DismemberScenarioTest.kt
@@ -1,31 +1,29 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.nph.cards.Dismember
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 
-/**
- * Scenario tests for Dismember (NPH #57) — {1}{B/P}{B/P} Instant.
- *
- *   Target creature gets -5/-5 until end of turn.
- *
- * `{B/P}` is Phyrexian black mana, parsed by `ManaCost.parse` like Skrelv, Defector Mite's and
- * Namor, the Sub-Mariner's activated-ability costs — no card-specific wiring needed. The effect
- * itself composes the plain `Effects.ModifyStats(-5, -5, target)` used by Last Gasp.
- */
+/** Scenario tests for Dismember (NPH #57) — {1}{B/P}{B/P} Instant. */
 class DismemberScenarioTest : ScenarioTestBase() {
-
     init {
         context("Dismember") {
-
             test("kills a small creature by reducing its toughness to 0 or less") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")
                     .withCardInHand(1, "Dismember")
                     .withLandsOnBattlefield(1, "Swamp", 3)
-                    .withCardOnBattlefield(2, "Hill Giant") // 3/3
+                    .withCardOnBattlefield(2, "Hill Giant")
                     .withCardInLibrary(1, "Swamp")
                     .withCardInLibrary(2, "Swamp")
                     .withActivePlayer(1)
@@ -33,11 +31,10 @@ class DismemberScenarioTest : ScenarioTestBase() {
                     .build()
 
                 val giant = game.findPermanent("Hill Giant")!!
-
                 game.castSpell(1, "Dismember", giant).error shouldBe null
                 game.resolveStack()
 
-                withClue("-5/-5 kills a 3/3 (0 or less toughness, CR 704.5f)") {
+                withClue("-5/-5 kills a 3/3") {
                     game.isOnBattlefield("Hill Giant") shouldBe false
                     game.isInGraveyard(2, "Hill Giant") shouldBe true
                 }
@@ -48,7 +45,7 @@ class DismemberScenarioTest : ScenarioTestBase() {
                     .withPlayers("Player1", "Player2")
                     .withCardInHand(1, "Dismember")
                     .withLandsOnBattlefield(1, "Swamp", 3)
-                    .withCardOnBattlefield(2, "Wall of Stone") // 0/8, Defender
+                    .withCardOnBattlefield(2, "Wall of Stone")
                     .withCardInLibrary(1, "Swamp")
                     .withCardInLibrary(2, "Swamp")
                     .withActivePlayer(1)
@@ -56,15 +53,42 @@ class DismemberScenarioTest : ScenarioTestBase() {
                     .build()
 
                 val wall = game.findPermanent("Wall of Stone")!!
-
                 game.castSpell(1, "Dismember", wall).error shouldBe null
                 game.resolveStack()
 
-                withClue("a 0/8 survives -5/-5 as a -5/3 (still alive)") {
+                withClue("a 0/8 survives -5/-5 as a -5/3") {
                     game.isOnBattlefield("Wall of Stone") shouldBe true
                     game.state.projectedState.getPower(wall) shouldBe -5
                     game.state.projectedState.getToughness(wall) shouldBe 3
                 }
+            }
+
+            test("casts with one mana by paying 4 life for both Phyrexian pips") {
+                val driver = GameTestDriver().apply {
+                    registerCards(TestCards.all)
+                    registerCard(Dismember)
+                    initMirrorMatch(Deck.of("Swamp" to 40), startingLife = 20)
+                }
+                val caster = driver.activePlayer!!
+                val opponent = driver.getOpponent(caster)
+                val swamp = driver.putLandOnBattlefield(caster, "Swamp")
+                val target = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+                val spell = driver.putCardInHand(caster, "Dismember")
+                driver.submit(
+                    CastSpell(
+                        playerId = caster,
+                        cardId = spell,
+                        targets = listOf(ChosenTarget.Permanent(target)),
+                        paymentStrategy = PaymentStrategy.Explicit(
+                            manaAbilitiesToActivate = listOf(swamp),
+                            phyrexianLifePayments = listOf(Color.BLACK, Color.BLACK)
+                        )
+                    )
+                ).isSuccess shouldBe true
+
+                driver.getLifeTotal(caster) shouldBe 16
+                driver.bothPass().isSuccess shouldBe true
+                driver.findPermanent(opponent, "Grizzly Bears") shouldBe null
             }
         }
     }

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ThoughtKnotSeerScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ThoughtKnotSeerScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lea.cards.Terror
+import com.wingedsheep.mtg.sets.definitions.ogw.cards.ThoughtKnotSeer
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Thought-Knot Seer (OGW #9) — {3}{C} Creature — Eldrazi 4/4.
+ *
+ * "When this creature enters, target opponent reveals their hand. You choose a nonland card
+ *  from it and exile that card.
+ *  When this creature leaves the battlefield, target opponent draws a card."
+ *
+ * The ETB is `Patterns.Hand.revealHandAndExileChosen` (Cruelclaw's Heist / Skullcap Snail shape);
+ * the LTB is a self `Triggers.LeavesBattlefield` (Goblin Firebug shape) targeting an opponent.
+ */
+class ThoughtKnotSeerScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ThoughtKnotSeer)
+        driver.registerCard(Terror)
+        driver.initMirrorMatch(deck = Deck.of("Wastes" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("ETB: target opponent reveals hand, I choose and exile a nonland card") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        val bolt = driver.putCardInHand(opp, "Lightning Bolt")
+        val oppHandBefore = driver.getHand(opp).size
+
+        val seer = driver.putCardInHand(me, "Thought-Knot Seer")
+        repeat(4) { driver.putLandOnBattlefield(me, "Wastes") } // {3}{C}
+        driver.castSpell(me, seer)
+
+        var guard = 0
+        while (guard++ < 30) {
+            when (val pd = driver.pendingDecision) {
+                is ChooseTargetsDecision -> driver.submitTargetSelection(pd.playerId, listOf(opp))
+                is SelectCardsDecision -> driver.submitCardSelection(pd.playerId, listOf(bolt))
+                else -> if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+            }
+        }
+
+        driver.findPermanent(me, "Thought-Knot Seer") shouldNotBe null
+        driver.getExileCardNames(opp).contains("Lightning Bolt") shouldBe true
+        driver.getHand(opp).size shouldBe oppHandBefore - 1
+    }
+
+    test("LTB: target opponent draws a card when this leaves the battlefield") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        val bolt = driver.putCardInHand(opp, "Lightning Bolt")
+
+        val seer = driver.putCardInHand(me, "Thought-Knot Seer")
+        repeat(4) { driver.putLandOnBattlefield(me, "Wastes") } // {3}{C}
+        driver.castSpell(me, seer)
+
+        var guard = 0
+        while (guard++ < 30) {
+            when (val pd = driver.pendingDecision) {
+                is ChooseTargetsDecision -> driver.submitTargetSelection(pd.playerId, listOf(opp))
+                is SelectCardsDecision -> driver.submitCardSelection(pd.playerId, listOf(bolt))
+                else -> if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+            }
+        }
+        val tksId = driver.findPermanent(me, "Thought-Knot Seer")
+        tksId shouldNotBe null
+
+        // Destroy it with Terror (nonartifact, nonblack — a legal target); the target opponent of
+        // the seer's controller (me) — i.e. opp — should draw a card as it leaves.
+        val terror = driver.putCardInHand(opp, "Terror")
+        driver.giveMana(opp, Color.BLACK, 2)
+        // Priority is with `me` once the ETB trigger loop above finishes — pass it to `opp`
+        // before they can cast the removal spell.
+        driver.passPriority(me)
+        driver.castSpell(opp, terror, listOf(tksId!!)).error shouldBe null
+
+        val oppHandBeforeLtb = driver.getHand(opp).size
+
+        guard = 0
+        while (guard++ < 30) {
+            when (val pd = driver.pendingDecision) {
+                is ChooseTargetsDecision -> driver.submitTargetSelection(pd.playerId, listOf(opp))
+                else -> if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+            }
+        }
+
+        driver.findPermanent(me, "Thought-Knot Seer") shouldBe null
+        driver.getHand(opp).size shouldBe (oppHandBeforeLtb + 1)
+    }
+})

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/UlamogTheCeaselessHungerScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/UlamogTheCeaselessHungerScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.bfz.cards.Ulamog
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Ulamog, the Ceaseless Hunger (BFZ #15) — {10} Legendary Creature — Eldrazi, 10/10.
+ *
+ *   "When you cast this spell, exile two target permanents.
+ *    Indestructible
+ *    Whenever Ulamog attacks, defending player exiles the top twenty cards of their library."
+ *
+ * Two pieces of behaviour to pin down:
+ *  - The cast trigger resolves *before* Ulamog itself (both targets exiled even though Ulamog is
+ *    still on the stack underneath), matching the 2015-08-25 ruling.
+ *  - The attack trigger reads the *defending* player, not the caster — exiling from the
+ *    opponent's library, not Ulamog's controller's.
+ */
+class UlamogTheCeaselessHungerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(Ulamog)
+        return driver
+    }
+
+    test("cast trigger exiles two target permanents before Ulamog resolves") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+
+        val ulamog = driver.putCardInHand(caster, "Ulamog, the Ceaseless Hunger")
+        driver.giveMana(caster, Color.GREEN, 10)
+
+        val mine = driver.putCreatureOnBattlefield(caster, "Savannah Lions")
+        val theirs = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        val cast = driver.submit(
+            CastSpell(
+                playerId = caster,
+                cardId = ulamog,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        (cast.error == null) shouldBe true
+
+        // The cast trigger's own "target permanents" requirement is chosen when the triggered
+        // ability is put on the stack (CR 603.3d) — a separate decision from casting Ulamog
+        // itself, which has no target requirement of its own.
+        driver.submitTargetSelection(caster, listOf(mine, theirs)).error shouldBe null
+
+        // Top of stack: the cast trigger. Resolve it first — both targets should be exiled
+        // while Ulamog itself is still on the stack underneath.
+        driver.bothPass()
+        driver.getExile(caster).contains(mine) shouldBe true
+        driver.getExile(opponent).contains(theirs) shouldBe true
+        driver.findPermanent(caster, "Ulamog, the Ceaseless Hunger") shouldBe null
+
+        // Now Ulamog resolves and enters the battlefield.
+        driver.bothPass()
+        driver.findPermanent(caster, "Ulamog, the Ceaseless Hunger") shouldNotBe null
+    }
+
+    test("attack trigger makes the defending player exile the top twenty cards of their library") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val ulamog = driver.putCreatureOnBattlefield(attacker, "Ulamog, the Ceaseless Hunger")
+        driver.removeSummoningSickness(ulamog)
+
+        val librarySizeBefore = driver.state.getLibrary(defender).size
+        val attackerLibrarySizeBefore = driver.state.getLibrary(attacker).size
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(ulamog), defender)
+
+        // Resolve the "attacks" trigger.
+        driver.bothPass()
+
+        driver.state.getLibrary(defender).size shouldBe (librarySizeBefore - 20)
+        driver.getExile(defender).size shouldBe 20
+        // The attacking player's own library is untouched.
+        driver.state.getLibrary(attacker).size shouldBe attackerLibrarySizeBefore
+    }
+})

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/ElderGargaroth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/ElderGargaroth.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+
+/**
+ * Elder Gargaroth
+ * {3}{G}{G}
+ * Creature — Beast
+ * 6/6
+ * Reach, vigilance, trample
+ * Whenever this creature attacks or blocks, choose one —
+ * • Create a 3/3 green Beast creature token.
+ * • You gain 3 life.
+ * • Draw a card.
+ */
+val ElderGargaroth = card("Elder Gargaroth") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    oracleText = "Reach, vigilance, trample\n" +
+        "Whenever this creature attacks or blocks, choose one —\n" +
+        "• Create a 3/3 green Beast creature token.\n" +
+        "• You gain 3 life.\n" +
+        "• Draw a card."
+    power = 6
+    toughness = 6
+
+    keywords(Keyword.REACH, Keyword.VIGILANCE, Keyword.TRAMPLE)
+
+    val attackOrBlockChoice = ModalEffect.chooseOne(
+        Mode.noTarget(
+            Effects.CreateToken(
+                power = 3,
+                toughness = 3,
+                colors = setOf(Color.GREEN),
+                creatureTypes = setOf("Beast"),
+                imageUri = "https://cards.scryfall.io/normal/front/8/8/882247ba-99d2-46db-8314-f800f3366b7f.jpg?1783930590"
+            ),
+            "Create a 3/3 green Beast creature token"
+        ),
+        Mode.noTarget(
+            Effects.GainLife(3),
+            "You gain 3 life"
+        ),
+        Mode.noTarget(
+            Effects.DrawCards(1),
+            "Draw a card"
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = attackOrBlockChoice
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = attackOrBlockChoice
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "179"
+        artist = "Nicholas Gregory"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d51269cf-a333-4a64-94cd-245798d840d2.jpg?1783930678"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ForceOfVigor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/ForceOfVigor.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostZone
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.SelfAlternativeCost
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Force of Vigor
+ * {2}{G}{G}
+ * Instant
+ *
+ * If it's not your turn, you may exile a green card from your hand rather than pay this spell's
+ * mana cost.
+ * Destroy up to two target artifacts and/or enchantments.
+ *
+ * The signature "Force" cycle alternative cost (Modern Horizons): a free [SelfAlternativeCost] —
+ * no mana, one non-mana additional cost (exile a green card from hand) — gated by
+ * [Conditions.IsNotYourTurn], mirroring Zahid, Djinn of the Lamp's tap-an-artifact additional cost
+ * and Blasphemous Edict's condition-gated free alternative. The destroy effect follows Rack and
+ * Ruin's "two target artifacts" shape (`ForEachTargetEffect` over a `count = 2` target, applying
+ * `Effects.Destroy` per resolved target via `ContextTarget(0)`), widened to `optional = true` for
+ * "up to two" and to an artifact-or-enchantment filter.
+ */
+val ForceOfVigor = card("Force of Vigor") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "If it's not your turn, you may exile a green card from your hand rather than " +
+        "pay this spell's mana cost.\nDestroy up to two target artifacts and/or enchantments."
+
+    selfAlternativeCost = SelfAlternativeCost(
+        manaCost = ManaCost.parse("{0}"),
+        additionalCosts = listOf(
+            Costs.additional.ExileCards(
+                count = 1,
+                filter = GameObjectFilter.Any.withColor(Color.GREEN),
+                fromZone = CostZone.HAND
+            )
+        ),
+        condition = Conditions.IsNotYourTurn
+    )
+
+    spell {
+        target(
+            "targets",
+            TargetPermanent(
+                count = 2,
+                optional = true,
+                filter = TargetFilter(GameObjectFilter.Artifact or GameObjectFilter.Enchantment)
+            )
+        )
+        effect = ForEachTargetEffect(
+            listOf(Effects.Destroy(EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "164"
+        artist = "Randy Vargas"
+        flavorText = "The vines overgrew the construct, snapping gears and soaking up aether."
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/017c415b-d635-43c6-92b8-8c95d1c4ff8d.jpg?1783933099"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/FightRigging.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/FightRigging.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.GrantPlayWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Fight Rigging
+ * {2}{G}
+ * Enchantment
+ *
+ * Hideaway 5 (When this enchantment enters, look at the top five cards of your library, exile
+ * one face down, then put the rest on the bottom in a random order.)
+ * At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.
+ * Then if you control a creature with power 7 or greater, you may play the exiled card without
+ * paying its mana cost.
+ *
+ * Hideaway is modeled compositionally, same shape as Mosswort Bridge / Evercoat Ursine: the ETB
+ * trigger gathers the top five cards, prompts the controller to exile one face down (linked to
+ * this enchantment), and bottom-randomizes the rest. The beginning-of-combat trigger targets a
+ * creature you control for the mandatory +1/+1 counter, then gates the free-cast grant behind
+ * [ConditionalEffect] testing [Conditions.YouControlAtLeast] on a power-7-or-greater creature —
+ * only the "may play" half is conditional; the counter always happens if there's a legal target.
+ */
+val FightRigging = card("Fight Rigging") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Hideaway 5 (When this enchantment enters, look at the top five cards of your " +
+        "library, exile one face down, then put the rest on the bottom in a random order.)\n" +
+        "At the beginning of combat on your turn, put a +1/+1 counter on target creature you " +
+        "control. Then if you control a creature with power 7 or greater, you may play the " +
+        "exiled card without paying its mana cost."
+
+    keywordAbility(KeywordAbility.hideaway(5))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(
+                        count = DynamicAmount.Fixed(5),
+                        player = Player.You
+                    ),
+                    storeAs = "fightRiggingTop"
+                ),
+                SelectFromCollectionEffect(
+                    from = "fightRiggingTop",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    storeSelected = "fightRiggingPicked",
+                    storeRemainder = "fightRiggingRest",
+                    prompt = "Choose a card to exile face down",
+                    selectedLabel = "Exile face down",
+                    remainderLabel = "Put on bottom of library"
+                ),
+                MoveCollectionEffect(
+                    from = "fightRiggingPicked",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                    faceDown = FaceDownMode.HIDDEN,
+                    linkToSource = true
+                ),
+                MoveCollectionEffect(
+                    from = "fightRiggingRest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val t = target("target", Targets.CreatureYouControl)
+        effect = Effects.Composite(
+            listOf(
+                AddCountersEffect(counterType = Counters.PLUS_ONE_PLUS_ONE, count = 1, target = t),
+                ConditionalEffect(
+                    condition = Conditions.YouControlAtLeast(1, GameObjectFilter.Creature.powerAtLeast(7)),
+                    effect = MayEffect(
+                        Effects.Composite(
+                            listOf(
+                                GatherCardsEffect(
+                                    source = CardSource.FromLinkedExile(),
+                                    storeAs = "fightRiggingLinked"
+                                ),
+                                GrantMayPlayFromExileEffect("fightRiggingLinked"),
+                                GrantPlayWithoutPayingCostEffect("fightRiggingLinked")
+                            )
+                        ),
+                        descriptionOverride = "Play the exiled card without paying its mana cost"
+                    )
+                )
+            )
+        )
+        description = "At the beginning of combat on your turn, put a +1/+1 counter on target " +
+            "creature you control. Then if you control a creature with power 7 or greater, you " +
+            "may play the exiled card without paying its mana cost."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "145"
+        artist = "Daarken"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/86fd3454-efe7-4feb-a6ad-069ae2fdbd18.jpg?1783923103"
+        ruling(
+            "2022-04-29",
+            "\"Hideaway N\" means \"When this permanent enters the battlefield, look at the top N " +
+                "cards of your library. Exile one of them face down and put the rest on the bottom " +
+                "of your library in a random order. The exiled card gains 'The player who controls " +
+                "the permanent that exiled this card may look at this card in the exile zone.'\""
+        )
+        ruling(
+            "2022-04-29",
+            "Any player who has controlled a permanent with a hideaway ability since a card was " +
+                "exiled with it may look at that card."
+        )
+        ruling(
+            "2022-04-29",
+            "Hideaway now causes you to put the rest of the cards on the bottom of your library " +
+                "in a random order instead of any order."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/FightRigging.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/FightRigging.kt
@@ -17,8 +17,6 @@ import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
-import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
-import com.wingedsheep.sdk.scripting.effects.GrantPlayWithoutPayingCostEffect
 import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
@@ -41,7 +39,7 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * Hideaway is modeled compositionally, same shape as Mosswort Bridge / Evercoat Ursine: the ETB
  * trigger gathers the top five cards, prompts the controller to exile one face down (linked to
  * this enchantment), and bottom-randomizes the rest. The beginning-of-combat trigger targets a
- * creature you control for the mandatory +1/+1 counter, then gates the free-cast grant behind
+ * creature you control for the mandatory +1/+1 counter, then gates the immediate free cast behind
  * [ConditionalEffect] testing [Conditions.YouControlAtLeast] on a power-7-or-greater creature —
  * only the "may play" half is conditional; the counter always happens if there's a legal target.
  */
@@ -107,8 +105,7 @@ val FightRigging = card("Fight Rigging") {
                                     source = CardSource.FromLinkedExile(),
                                     storeAs = "fightRiggingLinked"
                                 ),
-                                GrantMayPlayFromExileEffect("fightRiggingLinked"),
-                                GrantPlayWithoutPayingCostEffect("fightRiggingLinked")
+                                Effects.PlayFromCollectionWithoutPayingCost("fightRiggingLinked")
                             )
                         ),
                         descriptionOverride = "Play the exiled card without paying its mana cost"

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ElderGargarothScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ElderGargarothScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Elder Gargaroth (M21).
+ *
+ * {3}{G}{G} Creature — Beast 6/6, Reach, Vigilance, Trample.
+ * "Whenever this creature attacks or blocks, choose one —
+ *  • Create a 3/3 green Beast creature token.
+ *  • You gain 3 life.
+ *  • Draw a card."
+ *
+ * Mode order in the card: 0 create token, 1 gain 3 life, 2 draw a card.
+ */
+class ElderGargarothScenarioTest : ScenarioTestBase() {
+
+    init {
+        fun chooseMode(game: TestGame, modeIndex: Int) {
+            val modeDecision = game.getPendingDecision() as ChooseOptionDecision
+            game.submitDecision(OptionChosenResponse(modeDecision.id, modeIndex))
+        }
+
+        context("Elder Gargaroth attacking") {
+
+            test("attacking triggers the modal choice; choosing token creation makes a 3/3 Beast") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Elder Gargaroth", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Elder Gargaroth" to 2)).error shouldBe null
+                game.resolveStack()
+
+                chooseMode(game, 0)
+                game.resolveStack()
+
+                val beasts = game.findPermanents("Beast Token")
+                withClue("A 3/3 green Beast token was created") {
+                    beasts.size shouldBe 1
+                }
+            }
+
+            test("attacking triggers the modal choice; choosing gain life adds 3 life") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Elder Gargaroth", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val lifeBefore = game.getLifeTotal(1)
+
+                game.declareAttackers(mapOf("Elder Gargaroth" to 2)).error shouldBe null
+                game.resolveStack()
+
+                chooseMode(game, 1)
+                game.resolveStack()
+
+                withClue("Gains exactly 3 life") {
+                    game.getLifeTotal(1) shouldBe lifeBefore + 3
+                }
+            }
+
+            test("attacking triggers the modal choice; choosing draw a card draws one card") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Elder Gargaroth", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val handSizeBefore = game.handSize(1)
+
+                game.declareAttackers(mapOf("Elder Gargaroth" to 2)).error shouldBe null
+                game.resolveStack()
+
+                chooseMode(game, 2)
+                game.resolveStack()
+
+                withClue("Drew exactly one card") {
+                    game.handSize(1) shouldBe handSizeBefore + 1
+                }
+            }
+        }
+
+        context("Elder Gargaroth blocking") {
+
+            test("blocking also triggers the modal choice") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Elder Gargaroth", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val lifeBefore = game.getLifeTotal(2)
+
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                game.declareBlockers(mapOf("Elder Gargaroth" to listOf("Grizzly Bears"))).error shouldBe null
+                game.resolveStack()
+
+                chooseMode(game, 1)
+                game.resolveStack()
+
+                withClue("Blocking controller gains 3 life from the chosen mode") {
+                    game.getLifeTotal(2) shouldBe lifeBefore + 3
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FightRiggingScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FightRiggingScenarioTest.kt
@@ -1,9 +1,11 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.PlayLand
 import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Phase
@@ -98,7 +100,7 @@ class FightRiggingScenarioTest : ScenarioTestBase() {
                 }
             }
 
-            test("begin combat: with a power-7+ creature, offers and completes the free cast of the exiled card") {
+            test("begin combat: accepting casts the exiled card immediately during resolution") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")
                     .withCardInHand(1, "Fight Rigging")
@@ -133,27 +135,83 @@ class FightRiggingScenarioTest : ScenarioTestBase() {
                 game.answerYesNo(true)
                 game.resolveStack()
 
-                withClue("accepting grants a may-play-without-cost permission for the exiled card") {
-                    val exiledBears = game.state.getExile(game.player1Id).single()
-                    game.state.mayPlayPermissions.flatMap { it.cardIds } shouldNotBe emptyList<Any>()
-                    game.state.mayPlayPermissions.flatMap { it.cardIds }.contains(exiledBears) shouldBe true
+                withClue("accepting casts Grizzly Bears during the beginning-of-combat trigger") {
+                    game.state.getExile(game.player1Id) shouldBe emptyList()
+                    game.state.step shouldBe Step.BEGIN_COMBAT
+                    game.findPermanent("Grizzly Bears") shouldNotBe null
                 }
+            }
 
-                // Grizzly Bears is a creature (sorcery speed, CR 117.1a) — the granted permission is
-                // an ordinary "may play" grant (CR 118.9), not "as though it had flash",
-                // so it can't actually be cast during the beginning-of-combat step it was offered in.
-                // It's only usable once a main phase with an empty stack comes around again — here,
-                // the postcombat main phase later this same turn.
-                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+            test("begin combat: declining leaves no permission to cast the exiled card later") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Fight Rigging")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardOnBattlefield(1, "Ghalta, Primal Hunger", summoningSickness = false)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Sol Ring")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
 
-                val cast = game.castSpellFromExile(1, "Grizzly Bears")
-                withClue("the granted permission lets Grizzly Bears be cast from exile for free: ${cast.error}") {
-                    cast.error shouldBe null
-                }
+                val ghalta = game.findPermanent("Ghalta, Primal Hunger")!!
+                resolveHideaway(game)
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                if (game.getPendingDecision() is ChooseTargetsDecision) game.selectTargets(listOf(ghalta))
+                game.resolveStack()
+                game.answerYesNo(false)
                 game.resolveStack()
 
-                withClue("Grizzly Bears resolved onto the battlefield without paying its mana cost") {
-                    game.findPermanent("Grizzly Bears") shouldNotBe null
+                withClue("declining leaves the card exiled and grants no lingering permission") {
+                    game.state.getExile(game.player1Id).size shouldBe 1
+                    game.state.mayPlayPermissions.flatMap { it.cardIds } shouldBe emptyList()
+                }
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                withClue("the declined card cannot be cast later in the turn") {
+                    game.castSpellFromExile(1, "Grizzly Bears").error shouldNotBe null
+                }
+            }
+
+            test("begin combat: an exiled land is played immediately and consumes the land play") {
+                val game = fightRiggingWithHiddenForest()
+                val ghalta = game.findPermanent("Ghalta, Primal Hunger")!!
+                resolveHideaway(game)
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                if (game.getPendingDecision() is ChooseTargetsDecision) game.selectTargets(listOf(ghalta))
+                game.resolveStack()
+                game.answerYesNo(true)
+
+                withClue("the Forest is played during resolution, despite combat timing") {
+                    game.state.getBattlefield(game.player1Id).count {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Forest"
+                    } shouldBe 4
+                    game.state.getExile(game.player1Id) shouldBe emptyList()
+                    game.state.step shouldBe Step.BEGIN_COMBAT
+                }
+            }
+
+            test("begin combat: an exiled land stays exiled when the land play was already used") {
+                val game = fightRiggingWithHiddenForest(includeLandInHand = true)
+                val ghalta = game.findPermanent("Ghalta, Primal Hunger")!!
+                resolveHideaway(game)
+                val handLand = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Plains"
+                }
+                game.execute(PlayLand(game.player1Id, handLand)).error shouldBe null
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                if (game.getPendingDecision() is ChooseTargetsDecision) game.selectTargets(listOf(ghalta))
+                game.resolveStack()
+                game.answerYesNo(true)
+
+                withClue("Fight Rigging cannot provide an additional land play") {
+                    game.state.getExile(game.player1Id).size shouldBe 1
+                    game.state.mayPlayPermissions.flatMap { it.cardIds } shouldBe emptyList()
                 }
             }
         }
@@ -166,5 +224,22 @@ class FightRiggingScenarioTest : ScenarioTestBase() {
         val decision = game.getPendingDecision() as? SelectCardsDecision
             ?: error("expected a hideaway selection, got ${game.getPendingDecision()}")
         game.selectCards(listOf(decision.options.first()))
+    }
+
+    private fun fightRiggingWithHiddenForest(includeLandInHand: Boolean = false): TestGame {
+        val builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardInHand(1, "Fight Rigging")
+            .withLandsOnBattlefield(1, "Forest", 3)
+            .withCardOnBattlefield(1, "Ghalta, Primal Hunger", summoningSickness = false)
+            .withCardInLibrary(1, "Forest")
+            .withCardInLibrary(1, "Hill Giant")
+            .withCardInLibrary(1, "Sol Ring")
+            .withCardInLibrary(1, "Island")
+            .withCardInLibrary(1, "Swamp")
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        if (includeLandInHand) builder.withCardInHand(1, "Plains")
+        return builder.build()
     }
 }

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FightRiggingScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FightRiggingScenarioTest.kt
@@ -1,0 +1,170 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Fight Rigging (SNC #145) — {2}{G} Enchantment.
+ *
+ *   Hideaway 5 (When this enchantment enters, look at the top five cards of your library, exile
+ *   one face down, then put the rest on the bottom in a random order.)
+ *   At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.
+ *   Then if you control a creature with power 7 or greater, you may play the exiled card without
+ *   paying its mana cost.
+ *
+ * Covers: Hideaway exiles exactly one of the top five cards on ETB, the begin-combat trigger
+ * always adds the +1/+1 counter to its target, and the free-cast offer only appears (and can
+ * actually be completed) once a power-7-or-greater creature is controlled after the counter
+ * resolves.
+ */
+class FightRiggingScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Fight Rigging") {
+
+            test("Hideaway exiles exactly one of the top five library cards on ETB") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Fight Rigging")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withCardInLibrary(1, "Sol Ring")
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Fight Rigging").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision() as? SelectCardsDecision
+                withClue("Hideaway pauses to choose one of the top five cards to exile face down") {
+                    decision shouldNotBe null
+                    decision!!.options.size shouldBe 5
+                    decision.minSelections shouldBe 1
+                    decision.maxSelections shouldBe 1
+                }
+
+                game.selectCards(listOf(decision!!.options.first()))
+
+                withClue("exactly one card is exiled, and Fight Rigging resolved onto the battlefield") {
+                    game.state.getExile(game.player1Id).size shouldBe 1
+                    game.findPermanent("Fight Rigging") shouldNotBe null
+                }
+                withClue("the other four go to the bottom of the library: net library size -1") {
+                    game.librarySize(1) shouldBe 4
+                }
+            }
+
+            test("begin combat: adds the +1/+1 counter; without a power-7+ creature, no free-play offer") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Fight Rigging")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // 2/2
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withCardInLibrary(1, "Sol Ring")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                resolveHideaway(game)
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                if (game.getPendingDecision() is ChooseTargetsDecision) game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("the +1/+1 counter always lands on the (mandatory) target") {
+                    game.state.getEntity(bears)!!.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                }
+                withClue("a 3-power Grizzly Bears doesn't clear the power-7 bar: no free-play offer") {
+                    game.getPendingDecision() shouldBe null
+                }
+            }
+
+            test("begin combat: with a power-7+ creature, offers and completes the free cast of the exiled card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Fight Rigging")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardOnBattlefield(1, "Ghalta, Primal Hunger", summoningSickness = false) // 12/12
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Sol Ring")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ghalta = game.findPermanent("Ghalta, Primal Hunger")!!
+                // resolveHideaway always exiles the top library card — Grizzly Bears here — so the
+                // free cast below has a known, targetless card to replay.
+                resolveHideaway(game)
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                if (game.getPendingDecision() is ChooseTargetsDecision) game.selectTargets(listOf(ghalta))
+                game.resolveStack()
+
+                withClue("the +1/+1 counter lands on Ghalta") {
+                    game.state.getEntity(ghalta)!!.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                }
+                withClue("controlling a 13-power creature offers the free-cast of the exiled card") {
+                    (game.getPendingDecision() is YesNoDecision) shouldBe true
+                }
+
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("accepting grants a may-play-without-cost permission for the exiled card") {
+                    val exiledBears = game.state.getExile(game.player1Id).single()
+                    game.state.mayPlayPermissions.flatMap { it.cardIds } shouldNotBe emptyList<Any>()
+                    game.state.mayPlayPermissions.flatMap { it.cardIds }.contains(exiledBears) shouldBe true
+                }
+
+                // Grizzly Bears is a creature (sorcery speed, CR 117.1a) — the granted permission is
+                // an ordinary "may play" grant (CR 118.9/601.3i-style), not "as though it had flash",
+                // so it can't actually be cast during the beginning-of-combat step it was offered in.
+                // It's only usable once a main phase with an empty stack comes around again — here,
+                // the postcombat main phase later this same turn.
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                val cast = game.castSpellFromExile(1, "Grizzly Bears")
+                withClue("the granted permission lets Grizzly Bears be cast from exile for free: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears resolved onto the battlefield without paying its mana cost") {
+                    game.findPermanent("Grizzly Bears") shouldNotBe null
+                }
+            }
+        }
+    }
+
+    /** Cast Fight Rigging from hand and resolve Hideaway, exiling the first of the top five cards. */
+    private fun resolveHideaway(game: TestGame) {
+        game.castSpell(1, "Fight Rigging").error shouldBe null
+        game.resolveStack()
+        val decision = game.getPendingDecision() as? SelectCardsDecision
+            ?: error("expected a hideaway selection, got ${game.getPendingDecision()}")
+        game.selectCards(listOf(decision.options.first()))
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FightRiggingScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FightRiggingScenarioTest.kt
@@ -140,7 +140,7 @@ class FightRiggingScenarioTest : ScenarioTestBase() {
                 }
 
                 // Grizzly Bears is a creature (sorcery speed, CR 117.1a) — the granted permission is
-                // an ordinary "may play" grant (CR 118.9/601.3i-style), not "as though it had flash",
+                // an ordinary "may play" grant (CR 118.9), not "as though it had flash",
                 // so it can't actually be cast during the beginning-of-combat step it was offered in.
                 // It's only usable once a main phase with an empty stack comes around again — here,
                 // the postcombat main phase later this same turn.

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ForceOfVigorScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ForceOfVigorScenarioTest.kt
@@ -46,6 +46,13 @@ class ForceOfVigorScenarioTest : FunSpec({
                 action.alternativeCostType == AlternativeCostType.SELF_ALTERNATIVE
         }
 
+    fun altCastAction(driver: GameTestDriver, player: EntityId, cardId: EntityId): LegalAction =
+        driver.legalActions(player).first { legal ->
+            val action = legal.action
+            action is CastSpell && action.cardId == cardId &&
+                action.alternativeCostType == AlternativeCostType.SELF_ALTERNATIVE
+        }
+
     test("on your own turn: the alternative cost is not offered, and paying full mana cost destroys the chosen targets") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
@@ -103,6 +110,11 @@ class ForceOfVigorScenarioTest : FunSpec({
         val spell = driver.putCardInHand(you, "Force of Vigor")
 
         altCastOffered(driver, you, spell) shouldBe true
+        val cost = altCastAction(driver, you, spell).additionalCostInfo!!
+        cost.costType shouldBe "ExileFromHand"
+        cost.validExileTargets shouldBe listOf(greenFodder)
+        cost.exileMinCount shouldBe 1
+        cost.exileMaxCount shouldBe 1
 
         driver.submit(
             CastSpell(
@@ -119,6 +131,20 @@ class ForceOfVigorScenarioTest : FunSpec({
         // No mana was ever given to "you" — the spell resolved for free.
         driver.getExileCardNames(you) shouldBe listOf("Llanowar Elves")
         driver.state.getBattlefield(opponentTurn).contains(artifact) shouldBe false
+    }
+
+    test("off your turn: the alternative cost is not offered without another green card in hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20, startingPlayer = 1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val opponentTurn = driver.activePlayer!!
+        val you = driver.getOpponent(opponentTurn)
+        driver.passPriority(opponentTurn)
+
+        driver.putCardInHand(you, "Artifact Creature")
+        val spell = driver.putCardInHand(you, "Force of Vigor")
+
+        altCastOffered(driver, you, spell) shouldBe false
     }
 
     test("up to two targets: choosing only one, or none, still resolves without fizzling") {

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ForceOfVigorScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ForceOfVigorScenarioTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.AlternativeCostType
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mh1.cards.ForceOfVigor
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Force of Vigor {2}{G}{G} — Instant.
+ *
+ * "If it's not your turn, you may exile a green card from your hand rather than pay this spell's
+ *  mana cost.
+ *  Destroy up to two target artifacts and/or enchantments."
+ *
+ * The Force cycle's alternative cost is only legal off-turn (mirrors Blasphemous Edict's
+ * condition-gated `SelfAlternativeCost`, here gated by `Conditions.IsNotYourTurn` instead of a
+ * board-state count). The destroy half is "up to two" — an optional multi-target requirement, so
+ * zero or one chosen target must resolve without fizzling, same as Rack and Ruin's mandatory
+ * two-target shape widened with `optional = true`.
+ */
+class ForceOfVigorScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ForceOfVigor))
+        return driver
+    }
+
+    /** True when the enumerator is currently offering the self-alternative cast of [cardId]. */
+    fun altCastOffered(driver: GameTestDriver, player: EntityId, cardId: EntityId): Boolean =
+        driver.legalActions(player).any { legal: LegalAction ->
+            val action = legal.action
+            action is CastSpell &&
+                action.cardId == cardId &&
+                action.useAlternativeCost &&
+                action.alternativeCostType == AlternativeCostType.SELF_ALTERNATIVE
+        }
+
+    test("on your own turn: the alternative cost is not offered, and paying full mana cost destroys the chosen targets") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        val artifact = driver.putPermanentOnBattlefield(opponent, "Artifact Creature")
+        val enchantment = driver.putPermanentOnBattlefield(opponent, "Test Enchantment")
+
+        driver.giveMana(you, Color.GREEN, 4)
+        val spell = driver.putCardInHand(you, "Force of Vigor")
+
+        altCastOffered(driver, you, spell) shouldBe false
+
+        driver.castSpell(you, spell, targets = listOf(artifact, enchantment)).error shouldBe null
+        while (driver.stackSize > 0) driver.bothPass()
+
+        driver.state.getBattlefield(opponent).contains(artifact) shouldBe false
+        driver.state.getBattlefield(opponent).contains(enchantment) shouldBe false
+        driver.getGraveyardCardNames(opponent).sorted() shouldBe listOf("Artifact Creature", "Test Enchantment")
+    }
+
+    test("on your own turn: the alternative cost is not authorized even if attempted directly") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val greenFodder = driver.putCardInHand(you, "Llanowar Elves")
+        val spell = driver.putCardInHand(you, "Force of Vigor")
+
+        driver.submit(
+            CastSpell(
+                playerId = you,
+                cardId = spell,
+                useAlternativeCost = true,
+                alternativeCostType = AlternativeCostType.SELF_ALTERNATIVE,
+                additionalCostPayment = AdditionalCostPayment(exiledCards = listOf(greenFodder))
+            )
+        ).error shouldBe "Alternative cost is not available: ${ForceOfVigor.script.selfAlternativeCost!!.condition!!.description}"
+    }
+
+    test("off your turn: exiling a green card from hand pays for the spell and destroys the chosen targets") {
+        val driver = createDriver()
+        // Opponent is active, so "you" acts off-turn once the opponent passes priority.
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20, startingPlayer = 1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val opponentTurn = driver.activePlayer!!
+        val you = driver.getOpponent(opponentTurn)
+        driver.passPriority(opponentTurn)
+
+        val artifact = driver.putPermanentOnBattlefield(opponentTurn, "Artifact Creature")
+        val greenFodder = driver.putCardInHand(you, "Llanowar Elves")
+        val spell = driver.putCardInHand(you, "Force of Vigor")
+
+        altCastOffered(driver, you, spell) shouldBe true
+
+        driver.submit(
+            CastSpell(
+                playerId = you,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(artifact)),
+                useAlternativeCost = true,
+                alternativeCostType = AlternativeCostType.SELF_ALTERNATIVE,
+                additionalCostPayment = AdditionalCostPayment(exiledCards = listOf(greenFodder))
+            )
+        ).error shouldBe null
+        while (driver.stackSize > 0) driver.bothPass()
+
+        // No mana was ever given to "you" — the spell resolved for free.
+        driver.getExileCardNames(you) shouldBe listOf("Llanowar Elves")
+        driver.state.getBattlefield(opponentTurn).contains(artifact) shouldBe false
+    }
+
+    test("up to two targets: choosing only one, or none, still resolves without fizzling") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        val artifact = driver.putPermanentOnBattlefield(opponent, "Artifact Creature")
+
+        driver.giveMana(you, Color.GREEN, 4)
+        val spell = driver.putCardInHand(you, "Force of Vigor")
+
+        // Only one legal target on the battlefield — the requirement is "up to two", not "exactly two".
+        driver.castSpell(you, spell, targets = listOf(artifact)).error shouldBe null
+        while (driver.stackSize > 0) driver.bothPass()
+
+        driver.state.getBattlefield(opponent).contains(artifact) shouldBe false
+
+        // Choosing zero targets is legal too — the spell still resolves.
+        driver.giveMana(you, Color.GREEN, 4)
+        val secondCast = driver.putCardInHand(you, "Force of Vigor")
+        driver.castSpell(you, secondCast, targets = emptyList()).error shouldBe null
+        while (driver.stackSize > 0) driver.bothPass()
+
+        driver.getGraveyardCardNames(you).count { it == "Force of Vigor" } shouldBe 2
+    }
+})

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh3/cards/MalevolentRumble.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh3/cards/MalevolentRumble.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.mh3.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Malevolent Rumble
+ * {1}{G}
+ * Sorcery
+ *
+ * Reveal the top four cards of your library. You may put a permanent card from among them into
+ * your hand. Put the rest into your graveyard. Create a 0/1 colorless Eldrazi Spawn creature
+ * token with "Sacrifice this token: Add {C}."
+ *
+ * Modeling notes:
+ *  - Unlike Cache Grab (which mills first, then moves a chosen card back out of the graveyard),
+ *    Malevolent Rumble only *reveals* — the card put into hand never touches the graveyard. So
+ *    this is Gather(revealed) → Select(up to one permanent, storeRemainder) → Move(selected →
+ *    hand) → Move(remainder → graveyard), not Cache Grab's mill-then-recall shape.
+ *  - `Effects.CreateEldraziSpawn()` mints the token (see `PredefinedTokens.EldraziSpawn`).
+ */
+val MalevolentRumble = card("Malevolent Rumble") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Reveal the top four cards of your library. You may put a permanent card from " +
+        "among them into your hand. Put the rest into your graveyard. Create a 0/1 colorless " +
+        "Eldrazi Spawn creature token with \"Sacrifice this token: Add {C}.\""
+
+    spell {
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(4)),
+                    storeAs = "revealed",
+                    revealed = true
+                ),
+                SelectFromCollectionEffect(
+                    from = "revealed",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    filter = GameObjectFilter.Permanent,
+                    storeSelected = "toHand",
+                    storeRemainder = "toGraveyard",
+                    showAllCards = true,
+                    prompt = "You may put a permanent card into your hand",
+                    selectedLabel = "Put into hand",
+                    remainderLabel = "Put into graveyard"
+                ),
+                MoveCollectionEffect(
+                    from = "toHand",
+                    destination = CardDestination.ToZone(Zone.HAND)
+                ),
+                MoveCollectionEffect(
+                    from = "toGraveyard",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD)
+                ),
+                Effects.CreateEldraziSpawn()
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "161"
+        artist = "Néstor Ossandón Leal"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a178cfe8-f9fa-4255-88d0-54a0bed079f5.jpg?1783911259"
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh3/cards/UginsLabyrinth.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh3/cards/UginsLabyrinth.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.mtg.sets.definitions.mh3.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ugin's Labyrinth — Modern Horizons 3 #233
+ * Land · Mythic
+ *
+ * Imprint — When this land enters, you may exile a colorless card with mana value 7 or greater
+ * from your hand.
+ * {T}: Add {C}. If a card is exiled with this land, add {C}{C} instead.
+ * {T}: Return the exiled card to its owner's hand.
+ *
+ * Modeling notes:
+ *  - "Imprint" (CR 207.2c) is an ability word here, not a rules keyword — it just labels the ETB
+ *    exile-and-link ability, same as the SDK's other linked-exile cards (Clive's Hideaway).
+ *  - The ETB gathers hand cards already filtered to colorless + mana value 7 or greater, then
+ *    offers an optional (`ChooseUpTo(1)`) pick — modelling "you may exile a [filter] card" as a
+ *    gather-then-optional-select rather than a mandatory `EntersWithChoice`, since declining is
+ *    legal and leaves the hand untouched. The picked card is exiled linked to this land
+ *    ([MoveCollectionEffect.linkToSource]).
+ *  - The mana ability reads back [ContextPropertyKey.LINKED_EXILE_CARD_COUNT] (0 normally, 1 once
+ *    a card is imprinted) via `1 + min(count, 1)`, so it's {C} until something is exiled and {C}{C}
+ *    from then on — exactly "If a card is exiled with this land, add {C}{C} instead," and it stays
+ *    that way even after a subsequent activation of the third ability (Ugin's Labyrinth has no way
+ *    to un-link the card short of the third ability actually returning it).
+ *  - The third ability is [Patterns.Exile.returnLinkedExileToHand] — a no-op if nothing is linked
+ *    (legal to activate, per the 2024-06-07 ruling it returns *every* linked card if more than one
+ *    was ever exiled, e.g. via a copied trigger).
+ */
+private val imprintFilter = GameObjectFilter(cardPredicates = listOf(CardPredicate.IsColorless))
+    .manaValueAtLeast(7)
+
+val UginsLabyrinth = card("Ugin's Labyrinth") {
+    typeLine = "Land"
+    colorIdentity = ""
+    oracleText = "Imprint — When this land enters, you may exile a colorless card with mana " +
+        "value 7 or greater from your hand.\n" +
+        "{T}: Add {C}. If a card is exiled with this land, add {C}{C} instead.\n" +
+        "{T}: Return the exiled card to its owner's hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.You, imprintFilter),
+                    storeAs = "labyrinthEligible"
+                ),
+                SelectFromCollectionEffect(
+                    from = "labyrinthEligible",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "labyrinthPicked",
+                    prompt = "Exile a colorless card with mana value 7 or greater?",
+                    selectedLabel = "Exile"
+                ),
+                MoveCollectionEffect(
+                    from = "labyrinthPicked",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                    linkToSource = true
+                )
+            )
+        )
+        description = "Imprint — When this land enters, you may exile a colorless card with " +
+            "mana value 7 or greater from your hand."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(
+            DynamicAmount.Add(
+                DynamicAmount.Fixed(1),
+                DynamicAmount.Min(
+                    DynamicAmount.ContextProperty(ContextPropertyKey.LINKED_EXILE_CARD_COUNT),
+                    DynamicAmount.Fixed(1)
+                )
+            )
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add {C}. If a card is exiled with this land, add {C}{C} instead."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Patterns.Exile.returnLinkedExileToHand()
+        description = "{T}: Return the exiled card to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "233"
+        artist = "Mark Poole"
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/020e1348-1a35-4cc8-bad6-9fbddfa79277.jpg?1783911233"
+        ruling(
+            "2024-06-07",
+            "In the rare case where more than one card is exiled with Ugin's Labyrinth's imprint " +
+                "ability (likely because the triggered ability was copied or the ability triggered " +
+                "a second time), its last ability will return all such cards to their owners' hands."
+        )
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MalevolentRumbleScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MalevolentRumbleScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Malevolent Rumble.
+ *
+ * Card reference:
+ * - Malevolent Rumble ({1}{G}): Sorcery
+ *   "Reveal the top four cards of your library. You may put a permanent card from among them
+ *    into your hand. Put the rest into your graveyard. Create a 0/1 colorless Eldrazi Spawn
+ *    creature token with 'Sacrifice this token: Add {C}.'"
+ */
+class MalevolentRumbleScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Malevolent Rumble") {
+            test("puts the chosen permanent into hand, the rest into the graveyard, and creates a token") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Malevolent Rumble")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Grizzly Bears") // top — the only permanent
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.state.getZone(game.player1Id, Zone.LIBRARY)
+                    .first { game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears" }
+
+                val cast = game.castSpell(1, "Malevolent Rumble")
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+
+                game.resolveStack()
+                game.selectCards(listOf(bears))
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be put into hand") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("The three non-permanent cards should be in the graveyard") {
+                    game.isInGraveyard(1, "Mountain") shouldBe true
+                    game.isInGraveyard(1, "Island") shouldBe true
+                    game.isInGraveyard(1, "Swamp") shouldBe true
+                }
+                withClue("An Eldrazi Spawn token should be created") {
+                    game.findPermanents("Eldrazi Spawn") shouldHaveSize 1
+                }
+            }
+
+            test("declining the optional pick puts all four cards into the graveyard, still creates a token") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Malevolent Rumble")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Malevolent Rumble")
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+
+                game.resolveStack()
+                game.skipSelection()
+                game.resolveStack()
+
+                withClue("Nothing was put into hand") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe false
+                }
+                withClue("All four revealed cards plus Malevolent Rumble itself are in the graveyard") {
+                    game.graveyardSize(1) shouldBe 5
+                }
+                withClue("An Eldrazi Spawn token should still be created") {
+                    game.findPermanents("Eldrazi Spawn") shouldHaveSize 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/UginsLabyrinthScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/UginsLabyrinthScenarioTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mh3.cards.UginsLabyrinth
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ugin's Labyrinth (MH3 #233) — Land.
+ *
+ *   "Imprint — When this land enters, you may exile a colorless card with mana value 7 or
+ *    greater from your hand.
+ *    {T}: Add {C}. If a card is exiled with this land, add {C}{C} instead.
+ *    {T}: Return the exiled card to its owner's hand."
+ *
+ * Three pieces of behaviour to pin down:
+ *  - The ETB offers the choice only for eligible (colorless, mana value >= 7) hand cards, and
+ *    links the exiled card to this land.
+ *  - The mana ability reads the link: {C} normally, {C}{C} once something is imprinted.
+ *  - The third ability returns the linked card to its owner's hand.
+ */
+class UginsLabyrinthScenarioTest : FunSpec({
+
+    // A colorless {7} artifact — eligible for the imprint ability. Not a real printed card;
+    // just a minimal fixture so the test doesn't depend on another set's corpus.
+    val ColorlessRelic = CardDefinition(
+        name = "Colorless Relic",
+        manaCost = ManaCost.parse("{7}"),
+        typeLine = TypeLine.artifact()
+    )
+
+    val manaAbilityId = UginsLabyrinth.activatedAbilities[0].id
+    val returnAbilityId = UginsLabyrinth.activatedAbilities[1].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(UginsLabyrinth)
+        driver.registerCard(ColorlessRelic)
+        return driver
+    }
+
+    test("playing the land offers to exile an eligible card, linking it to the land") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val land = driver.putCardInHand(me, "Ugin's Labyrinth")
+        val relic = driver.putCardInHand(me, "Colorless Relic")
+
+        driver.playLand(me, land).error shouldBe null
+        // The ETB trigger needs a priority round to resolve off the stack.
+        driver.bothPass()
+
+        driver.submitCardSelection(me, listOf(relic)).error shouldBe null
+
+        driver.getExile(me).contains(relic) shouldBe true
+        val linked = driver.state.getEntity(land)?.get<LinkedExileComponent>()
+        linked?.exiledIds shouldBe listOf(relic)
+    }
+
+    test("declining the imprint choice leaves the hand untouched") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val land = driver.putCardInHand(me, "Ugin's Labyrinth")
+        val relic = driver.putCardInHand(me, "Colorless Relic")
+
+        driver.playLand(me, land).error shouldBe null
+        driver.bothPass()
+
+        driver.submitCardSelection(me, emptyList()).error shouldBe null
+
+        driver.getExile(me).contains(relic) shouldBe false
+        driver.getHand(me).contains(relic) shouldBe true
+        driver.state.getEntity(land)?.get<LinkedExileComponent>() shouldBe null
+    }
+
+    test("mana ability adds {C} with nothing imprinted, {C}{C} once a card is linked") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val plainLand = driver.putPermanentOnBattlefield(me, "Ugin's Labyrinth")
+
+        driver.submit(ActivateAbility(playerId = me, sourceId = plainLand, abilityId = manaAbilityId))
+            .isSuccess shouldBe true
+        driver.state.getEntity(me)?.get<ManaPoolComponent>()?.colorless shouldBe 1
+
+        val linkedLand = driver.putPermanentOnBattlefield(me, "Ugin's Labyrinth")
+        val exiledRelic = driver.putCardInExile(me, "Colorless Relic")
+        driver.replaceState(
+            driver.state.updateEntity(linkedLand) { c ->
+                c.with(LinkedExileComponent(listOf(exiledRelic)))
+            }
+        )
+
+        driver.submit(ActivateAbility(playerId = me, sourceId = linkedLand, abilityId = manaAbilityId))
+            .isSuccess shouldBe true
+        driver.state.getEntity(me)?.get<ManaPoolComponent>()?.colorless shouldBe (1 + 2)
+    }
+
+    test("third ability returns the linked card to its owner's hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val land = driver.putPermanentOnBattlefield(me, "Ugin's Labyrinth")
+        val exiledRelic = driver.putCardInExile(me, "Colorless Relic")
+        driver.replaceState(
+            driver.state.updateEntity(land) { c ->
+                c.with(LinkedExileComponent(listOf(exiledRelic)))
+            }
+        )
+
+        driver.submit(ActivateAbility(playerId = me, sourceId = land, abilityId = returnAbilityId))
+            .isSuccess shouldBe true
+
+        // Unlike the mana ability, this one isn't a mana ability — it goes on the stack and needs
+        // resolving before the card actually moves.
+        driver.bothPass()
+
+        driver.getHand(me).contains(exiledRelic) shouldBe true
+        driver.getExile(me).contains(exiledRelic) shouldBe false
+    }
+})

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -44,6 +44,28 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
 object PredefinedTokens {
 
     /**
+     * Eldrazi Spawn token — a 0/1 colorless Eldrazi creature with:
+     * "Sacrifice this creature: Add {C}."
+     * Created by Kozilek's Command, Malevolent Rumble, Drowner of Truth, and others.
+     */
+    val EldraziSpawn = card("Eldrazi Spawn") {
+        typeLine = "Creature — Eldrazi Spawn"
+        power = 0
+        toughness = 1
+
+        activatedAbility {
+            cost = Costs.SacrificeSelf
+            effect = Effects.AddColorlessMana(1)
+            manaAbility = true
+        }
+
+        metadata {
+            imageUri = "https://cards.scryfall.io/normal/front/e/0/e0e3826c-3c85-4910-bd6c-04894ea328d0.jpg?1783941948"
+            artist = "Aleksi Briclot"
+        }
+    }
+
+    /**
      * Treasure token — an artifact with:
      * "{T}, Sacrifice this artifact: Add one mana of any color."
      */
@@ -885,6 +907,7 @@ object PredefinedTokens {
      * Register these in the CardRegistry so token abilities are resolved.
      */
     val allTokens: List<CardDefinition> = listOf(
+        EldraziSpawn,
         Treasure,
         Meteorite,
         Food,

--- a/mtg-sets/src/test/resources/snapshots/cards/BFZ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BFZ.json
@@ -867,6 +867,99 @@
     ]
 }
 
+// Ulamog, the Ceaseless Hunger
+{
+    "name": "Ulamog, the Ceaseless Hunger",
+    "manaCost": "{10}",
+    "typeLine": "Legendary Creature — Eldrazi",
+    "oracleText": "When you cast this spell, exile two target permanents.\nIndestructible\nWhenever Ulamog attacks, defending player exiles the top twenty cards of their library.",
+    "creatureStats": {
+        "power": 10,
+        "toughness": 10
+    },
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Exile"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "target permanents"
+                },
+                "descriptionOverride": "When you cast this spell, exile two target permanents."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 20
+                                },
+                                "player": "DefendingPlayer"
+                            },
+                            "storeAs": "exiled_top"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiled_top",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile",
+                                "player": "DefendingPlayer"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever Ulamog attacks, defending player exiles the top twenty cards of their library."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "MYTHIC",
+        "artist": "Michael Komarck",
+        "flavorText": "A force as voracious as time itself.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/1192f7a9-102e-4b3a-b154-18c8eb332217.jpg?1783938222",
+        "rulings": [
+            {
+                "date": "2015-08-25",
+                "text": "Ulamog's first ability resolves independently of Ulamog once they've both been put on the stack. If Ulamog is countered, that triggered ability will still resolve. That triggered ability will always resolve before Ulamog does."
+            },
+            {
+                "date": "2015-08-25",
+                "text": "If the player has less than twenty cards in their library, exile all of them. That player won't lose the game until they have to draw a card from an empty library."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Valakut Invoker
 {
     "name": "Valakut Invoker",

--- a/mtg-sets/src/test/resources/snapshots/cards/FUT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FUT.json
@@ -36,6 +36,60 @@
     ]
 }
 
+// Dryad Arbor
+{
+    "name": "Dryad Arbor",
+    "manaCost": "",
+    "typeLine": "Land Creature — Forest Dryad",
+    "oracleText": "(This land isn't a spell, it's affected by summoning sickness, and it has \"{T}: Add {G}.\")",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {G}."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Fortune",
+        "flavorText": "\"Touch no tree, break no branch, and speak only the question you wish answered.\"\n—Von Yomm, elder druid, to her initiates",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8cee476d-42e1-4997-87af-73e18f542167.jpg?1783943089",
+        "rulings": [
+            {
+                "date": "2021-03-19",
+                "text": "Due to its color indicator (appearing to the left of its type line), Dryad Arbor is green. Color indicators apply in all zones, not just the battlefield."
+            },
+            {
+                "date": "2021-03-19",
+                "text": "If Dryad Arbor is changed into another basic land type, it continues to be a green Dryad creature."
+            },
+            {
+                "date": "2021-03-19",
+                "text": "Dryad Arbor is played as a land. It doesn't use the stack, it's not a spell, it can't be responded to, it has no mana cost, and it counts as your land play for the turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ],
+    "colorIndicator": [
+        "GREEN"
+    ]
+}
+
 // Fomori Nomad
 {
     "name": "Fomori Nomad",

--- a/mtg-sets/src/test/resources/snapshots/cards/M21.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M21.json
@@ -98,6 +98,118 @@
     ]
 }
 
+// Elder Gargaroth
+{
+    "name": "Elder Gargaroth",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Reach, vigilance, trample\nWhenever this creature attacks or blocks, choose one —\n• Create a 3/3 green Beast creature token.\n• You gain 3 life.\n• Draw a card.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "REACH",
+        "VIGILANCE",
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "CreateToken",
+                                "power": 3,
+                                "toughness": 3,
+                                "colors": [
+                                    "GREEN"
+                                ],
+                                "creatureTypes": [
+                                    "Beast"
+                                ],
+                                "imageUri": "https://cards.scryfall.io/normal/front/8/8/882247ba-99d2-46db-8314-f800f3366b7f.jpg?1783930590"
+                            }
+                        },
+                        {
+                            "effect": {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            }
+                        },
+                        {
+                            "effect": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "CreateToken",
+                                "power": 3,
+                                "toughness": 3,
+                                "colors": [
+                                    "GREEN"
+                                ],
+                                "creatureTypes": [
+                                    "Beast"
+                                ],
+                                "imageUri": "https://cards.scryfall.io/normal/front/8/8/882247ba-99d2-46db-8314-f800f3366b7f.jpg?1783930590"
+                            }
+                        },
+                        {
+                            "effect": {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            }
+                        },
+                        {
+                            "effect": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "rarity": "MYTHIC",
+        "artist": "Nicholas Gregory",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d51269cf-a333-4a64-94cd-245798d840d2.jpg?1783930678"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Garruk's Gorehorn
 {
     "name": "Garruk's Gorehorn",

--- a/mtg-sets/src/test/resources/snapshots/cards/MH1.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MH1.json
@@ -105,6 +105,64 @@
     ]
 }
 
+// Force of Vigor
+{
+    "name": "Force of Vigor",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Instant",
+    "oracleText": "If it's not your turn, you may exile a green card from your hand rather than pay this spell's mana cost.\nDestroy up to two target artifacts and/or enchantments.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                },
+                "destination": "Graveyard",
+                "byDestruction": true
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "targets"
+            }
+        ],
+        "selfAlternativeCost": {
+            "manaCost": "{0}",
+            "additionalCosts": [
+                {
+                    "type": "AdditionalAtom",
+                    "atom": {
+                        "type": "AtomExileFrom",
+                        "zone": "Hand",
+                        "filter": "green"
+                    }
+                }
+            ],
+            "condition": "IsNotYourTurn"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "rarity": "RARE",
+        "artist": "Randy Vargas",
+        "flavorText": "The vines overgrew the construct, snapping gears and soaking up aether.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/017c415b-d635-43c6-92b8-8c95d1c4ff8d.jpg?1783933099"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Goblin Oriflamme
 {
     "name": "Goblin Oriflamme",

--- a/mtg-sets/src/test/resources/snapshots/cards/MH3.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MH3.json
@@ -485,6 +485,79 @@
     ]
 }
 
+// Malevolent Rumble
+{
+    "name": "Malevolent Rumble",
+    "manaCost": "{1}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Reveal the top four cards of your library. You may put a permanent card from among them into your hand. Put the rest into your graveyard. Create a 0/1 colorless Eldrazi Spawn creature token with \"Sacrifice this token: Add {C}.\"",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    },
+                    "storeAs": "revealed",
+                    "revealed": true
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "revealed",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "permanent",
+                    "storeSelected": "toHand",
+                    "storeRemainder": "toGraveyard",
+                    "prompt": "You may put a permanent card into your hand",
+                    "selectedLabel": "Put into hand",
+                    "remainderLabel": "Put into graveyard",
+                    "showAllCards": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toHand",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toGraveyard",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    }
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Eldrazi Spawn"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "161",
+        "artist": "Néstor Ossandón Leal",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a178cfe8-f9fa-4255-88d0-54a0bed079f5.jpg?1783911259"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Nightshade Dryad
 {
     "name": "Nightshade Dryad",
@@ -953,6 +1026,137 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// Ugin's Labyrinth
+{
+    "name": "Ugin's Labyrinth",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "Imprint — When this land enters, you may exile a colorless card with mana value 7 or greater from your hand.\n{T}: Add {C}. If a card is exiled with this land, add {C}{C} instead.\n{T}: Return the exiled card to its owner's hand.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsColorless",
+                                        {
+                                            "type": "ManaValueAtLeast",
+                                            "min": 7
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "labyrinthEligible"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "labyrinthEligible",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "labyrinthPicked",
+                            "prompt": "Exile a colorless card with mana value 7 or greater?",
+                            "selectedLabel": "Exile"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "labyrinthPicked",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true
+                        }
+                    ]
+                },
+                "descriptionOverride": "Imprint — When this land enters, you may exile a colorless card with mana value 7 or greater from your hand."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Add",
+                        "left": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "right": {
+                            "type": "Min",
+                            "left": {
+                                "type": "ContextProperty",
+                                "key": "LINKED_EXILE_CARD_COUNT"
+                            },
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {C}. If a card is exiled with this land, add {C}{C} instead."
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return_hand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return_hand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "{T}: Return the exiled card to its owner's hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "233",
+        "rarity": "MYTHIC",
+        "artist": "Mark Poole",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/020e1348-1a35-4cc8-bad6-9fbddfa79277.jpg?1783911233",
+        "rulings": [
+            {
+                "date": "2024-06-07",
+                "text": "In the rare case where more than one card is exiled with Ugin's Labyrinth's imprint ability (likely because the triggered ability was copied or the ability triggered a second time), its last ability will return all such cards to their owners' hands."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Warren Soultrader

--- a/mtg-sets/src/test/resources/snapshots/cards/NPH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/NPH.json
@@ -1,3 +1,53 @@
+// Dismember
+{
+    "name": "Dismember",
+    "manaCost": "{1}{B/P}{B/P}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -5/-5 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": -5
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "rarity": "UNCOMMON",
+        "artist": "Terese Nielsen",
+        "flavorText": "\"You serve Phyrexia. Your pieces would better serve Phyrexia elsewhere.\"\n—Azax-Azog, the Demon Thane",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/064dfdeb-485f-473e-9fa0-8fdb7638cdc6.jpg?1783941314",
+        "rulings": [
+            {
+                "date": "2024-06-07",
+                "text": "A Phyrexian mana symbol contributes 1 toward the mana value of a card, even if life is paid for it. Specifically, Dismember's mana value is always 3."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Flameborn Viron
 {
     "name": "Flameborn Viron",

--- a/mtg-sets/src/test/resources/snapshots/cards/OGW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OGW.json
@@ -323,6 +323,114 @@
     ]
 }
 
+// Thought-Knot Seer
+{
+    "name": "Thought-Knot Seer",
+    "manaCost": "{3}{C}",
+    "typeLine": "Creature — Eldrazi",
+    "oracleText": "When this creature enters, target opponent reveals their hand. You choose a nonland card from it and exile that card.\nWhen this creature leaves the battlefield, target opponent draws a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "RevealHand",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "filter": "nonland"
+                            },
+                            "storeAs": "chosenCardCandidates"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "chosenCardCandidates",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "chosenCard",
+                            "prompt": "Choose a nonland card to exile"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "chosenCard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When this creature enters, target opponent reveals their hand. You choose a nonland card from it and exile that card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When this creature leaves the battlefield, target opponent draws a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "RARE",
+        "artist": "Svetlin Velinov",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bffc360e-db41-48f3-9365-680d55046e04.jpg?1783937929"
+    },
+    "colorIdentityOverride": []
+}
+
 // Untamed Hunger
 {
     "name": "Untamed Hunger",

--- a/mtg-sets/src/test/resources/snapshots/cards/SNC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SNC.json
@@ -1561,11 +1561,7 @@
                                             "storeAs": "fightRiggingLinked"
                                         },
                                         {
-                                            "type": "GrantMayPlayFromExile",
-                                            "from": "fightRiggingLinked"
-                                        },
-                                        {
-                                            "type": "GrantPlayWithoutPayingCost",
+                                            "type": "PlayFromCollectionWithoutPayingCost",
                                             "from": "fightRiggingLinked"
                                         }
                                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/SNC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SNC.json
@@ -1435,6 +1435,182 @@
     ]
 }
 
+// Fight Rigging
+{
+    "name": "Fight Rigging",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Hideaway 5 (When this enchantment enters, look at the top five cards of your library, exile one face down, then put the rest on the bottom in a random order.)\nAt the beginning of combat on your turn, put a +1/+1 counter on target creature you control. Then if you control a creature with power 7 or greater, you may play the exiled card without paying its mana cost.",
+    "keywords": [
+        "HIDEAWAY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "HIDEAWAY",
+            "n": 5
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                }
+                            },
+                            "storeAs": "fightRiggingTop"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "fightRiggingTop",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "fightRiggingPicked",
+                            "storeRemainder": "fightRiggingRest",
+                            "prompt": "Choose a card to exile face down",
+                            "selectedLabel": "Exile face down",
+                            "remainderLabel": "Put on bottom of library"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "fightRiggingPicked",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true,
+                            "faceDown": "HIDDEN"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "fightRiggingRest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "creature pow>=7"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "Gated",
+                                "gate": "Gate.MayDecide",
+                                "then": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": "FromLinkedExile",
+                                            "storeAs": "fightRiggingLinked"
+                                        },
+                                        {
+                                            "type": "GrantMayPlayFromExile",
+                                            "from": "fightRiggingLinked"
+                                        },
+                                        {
+                                            "type": "GrantPlayWithoutPayingCost",
+                                            "from": "fightRiggingLinked"
+                                        }
+                                    ]
+                                },
+                                "descriptionOverride": "Play the exiled card without paying its mana cost"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control. Then if you control a creature with power 7 or greater, you may play the exiled card without paying its mana cost."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "rarity": "RARE",
+        "artist": "Daarken",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/86fd3454-efe7-4feb-a6ad-069ae2fdbd18.jpg?1783923103",
+        "rulings": [
+            {
+                "date": "2022-04-29",
+                "text": "\"Hideaway N\" means \"When this permanent enters the battlefield, look at the top N cards of your library. Exile one of them face down and put the rest on the bottom of your library in a random order. The exiled card gains 'The player who controls the permanent that exiled this card may look at this card in the exile zone.'\""
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Any player who has controlled a permanent with a hideaway ability since a card was exiled with it may look at that card."
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Hideaway now causes you to put the rest of the cards on the bottom of your library in a random order instead of any order."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Fleetfoot Dancer
 {
     "name": "Fleetfoot Dancer",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
@@ -339,7 +339,11 @@ sealed interface PaymentStrategy {
      */
     @Serializable
     @SerialName("Explicit")
-    data class Explicit(val manaAbilitiesToActivate: List<EntityId>) : PaymentStrategy
+    data class Explicit(
+        val manaAbilitiesToActivate: List<EntityId>,
+        /** Multiset of Phyrexian pip colors paid with 2 life each instead of mana. */
+        val phyrexianLifePayments: List<com.wingedsheep.sdk.core.Color> = emptyList()
+    ) : PaymentStrategy
 }
 
 // =============================================================================

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -442,8 +442,12 @@ class ActivateAbilityHandler(
         // Check summoning sickness for tap/untap abilities. CR 302.6 restricts a *creature's*
         // activated ability whose cost includes the tap symbol **or the untap symbol** — read
         // creature-ness and haste from projected state so a Vehicle or animated permanent that
-        // became a creature this turn is gated correctly. The `!typeLine.isLand` carve-out is
-        // preserved (basic-land mana abilities are not restricted by summoning sickness).
+        // became a creature this turn is gated correctly. Gating on `isCreature` alone (no
+        // `!typeLine.isLand` carve-out) is already correct for plain lands — a land that isn't
+        // also a creature never satisfies `isCreature`, so this is a no-op for every ordinary
+        // land's mana ability — and it's the only way to catch a land that *is* also a creature
+        // (Dryad Arbor: "This land ... is affected by summoning sickness"), which the old
+        // land-wide carve-out silently exempted.
         //
         // `ActivatedAbilityEnumerator` mirrors this for `AbilityCost.Untap` both bare and inside a
         // `Composite`, so the two agree on `{Q}` in either shape and the enumerator never offers an
@@ -452,7 +456,7 @@ class ActivateAbilityHandler(
         if (costTouchesTapSymbol(effectiveCost) ||
             (effectiveCost is AbilityCost.Composite && effectiveCost.costs.any(costTouchesTapSymbol))
         ) {
-            if (!cardComponent.typeLine.isLand && state.projectedState.isCreature(action.sourceId) &&
+            if (state.projectedState.isCreature(action.sourceId) &&
                 SummoningSicknessRules.blocksTapOrUntapCost(action.sourceId, container, state.projectedState)
             ) {
                 return "This creature has summoning sickness"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.EnteredThisTurnComponent
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
@@ -199,6 +200,14 @@ class PlayLandHandler(
         // GameObjectFilter.enteredThisTurn() check keyed on a land would never see it as true,
         // even on the very turn it was played.
         newState = newState.updateEntity(action.cardId) { c -> c.with(EnteredThisTurnComponent) }
+
+        // Same bypass, same consequence for CR 302.6/508.1a: ZoneTransitionService stamps
+        // SummoningSicknessComponent on every permanent it puts onto the battlefield (a no-op for
+        // an ordinary land, since only a {T}/{Q} cost or an attack check ever reads it, gated on
+        // isCreature). A land played from hand skips that stamp entirely, which was invisible
+        // until a land that's also a creature existed (Dryad Arbor) — its "{T}: Add {G}" must be
+        // blocked the turn it's played, and without this it never was.
+        newState = newState.updateEntity(action.cardId) { c -> c.with(SummoningSicknessComponent) }
 
         // Same bypass, same consequence for Rule 712 face tracking: a double-faced *land* played
         // from hand (Balamb Garden, SeeD Academy — "{5}{G}{U}, {T}: Transform this land") never went

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -61,15 +61,18 @@ class PlayLandHandler(
 
     private val predicateEvaluator = com.wingedsheep.engine.handlers.PredicateEvaluator()
 
-    override fun validate(state: GameState, action: PlayLand): String? {
+    override fun validate(state: GameState, action: PlayLand): String? =
+        validate(state, action, duringResolution = false)
+
+    private fun validate(state: GameState, action: PlayLand, duringResolution: Boolean): String? {
         if (!state.isActiveTurnFor(action.playerId)) {
             // CR 805.4c — each player on the active team may play a land on the team's turn.
             return "You can only play lands on your turn"
         }
-        if (!state.step.isMainPhase) {
+        if (!duringResolution && !state.step.isMainPhase) {
             return "You can only play lands during a main phase"
         }
-        if (state.stack.isNotEmpty()) {
+        if (!duringResolution && state.stack.isNotEmpty()) {
             return "You can only play lands when the stack is empty"
         }
 
@@ -116,6 +119,13 @@ class PlayLandHandler(
         }
 
         return null
+    }
+
+    /** Play a land when a resolving effect explicitly instructs the player to do so. */
+    fun executeDuringResolution(state: GameState, action: PlayLand): ExecutionResult {
+        val validationError = validate(state, action, duringResolution = true)
+        return if (validationError != null) ExecutionResult.error(state, validationError)
+        else execute(state, action)
     }
 
     override fun execute(state: GameState, action: PlayLand): ExecutionResult {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastPaymentProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastPaymentProcessor.kt
@@ -9,7 +9,6 @@ import com.wingedsheep.engine.mechanics.mana.ManaAbilitySideEffectExecutor
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
-import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.model.EntityId
@@ -131,7 +130,7 @@ class CastPaymentProcessor(
     ): PaymentResult {
         val lifePayments = (action.paymentStrategy as? PaymentStrategy.Explicit)?.phyrexianLifePayments.orEmpty()
         val lifeToPay = lifePayments.size * 2
-        val currentLife = state.getEntity(action.playerId)?.get<LifeTotalComponent>()?.life ?: 0
+        val currentLife = state.lifeTotal(action.playerId)
         if (lifeToPay > currentLife) {
             return PaymentResult(state, emptyList(), "Insufficient life for Phyrexian mana payment")
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastPaymentProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastPaymentProcessor.kt
@@ -4,10 +4,12 @@ import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.ManaSpentEvent
 import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.handlers.CostHandler
+import com.wingedsheep.engine.handlers.effects.life.LifePaymentService
 import com.wingedsheep.engine.mechanics.mana.ManaAbilitySideEffectExecutor
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.model.EntityId
@@ -127,20 +129,35 @@ class CastPaymentProcessor(
         spellContext: SpellPaymentContext? = null,
         xManaRestriction: Set<Color> = emptySet()
     ): PaymentResult {
-        return when (action.paymentStrategy) {
-            is PaymentStrategy.FromPool -> payFromPool(state, action.playerId, effectiveCost, cardName, xValue, spellContext, xManaRestriction)
-            is PaymentStrategy.AutoPay -> autoPay(state, action.playerId, effectiveCost, cardName, xValue, spellContext, xManaRestriction = xManaRestriction)
+        val lifePayments = (action.paymentStrategy as? PaymentStrategy.Explicit)?.phyrexianLifePayments.orEmpty()
+        val lifeToPay = lifePayments.size * 2
+        val currentLife = state.getEntity(action.playerId)?.get<LifeTotalComponent>()?.life ?: 0
+        if (lifeToPay > currentLife) {
+            return PaymentResult(state, emptyList(), "Insufficient life for Phyrexian mana payment")
+        }
+        val manaCost = effectiveCost.withPhyrexianPaidByLife(lifePayments)
+            ?: return PaymentResult(state, emptyList(), "Invalid Phyrexian mana payment")
+        val manaResult = when (action.paymentStrategy) {
+            is PaymentStrategy.FromPool -> payFromPool(state, action.playerId, manaCost, cardName, xValue, spellContext, xManaRestriction)
+            is PaymentStrategy.AutoPay -> autoPay(state, action.playerId, manaCost, cardName, xValue, spellContext, xManaRestriction = xManaRestriction)
             is PaymentStrategy.Explicit -> explicitPay(
                 state,
                 action.playerId,
                 action.paymentStrategy,
-                effectiveCost,
+                manaCost,
                 cardName,
                 xValue,
                 spellContext,
                 xManaRestriction
             )
         }
+        if (manaResult.error != null || lifePayments.isEmpty()) return manaResult
+        val lifePayment = LifePaymentService.pay(manaResult.state, action.playerId, lifeToPay)
+            ?: return PaymentResult(state, emptyList(), "Unable to pay life for Phyrexian mana")
+        return manaResult.copy(
+            state = lifePayment.first,
+            events = manaResult.events + lifePayment.second
+        )
     }
 
     private fun payFromPool(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1242,9 +1242,15 @@ class CastSpellHandler(
         val xManaRestriction = (action.faceIndex?.let { cardDef?.cardFaces?.getOrNull(it)?.script }
             ?: cardDef?.script)?.xManaRestriction ?: emptySet()
 
+        val validationCost = when (val strategy = action.paymentStrategy) {
+            is PaymentStrategy.Explicit -> effectiveCost.withPhyrexianPaidByLife(strategy.phyrexianLifePayments)
+                ?: return "Invalid Phyrexian mana payment"
+            else -> effectiveCost
+        }
+
         return when (action.paymentStrategy) {
             is PaymentStrategy.AutoPay -> {
-                if (!manaSolver.canPay(state, action.playerId, effectiveCost, xValue, spellContext = spellCtx, xManaRestriction = xManaRestriction)) {
+                if (!manaSolver.canPay(state, action.playerId, validationCost, xValue, spellContext = spellCtx, xManaRestriction = xManaRestriction)) {
                     "Not enough mana to cast this spell"
                 } else null
             }
@@ -1260,7 +1266,7 @@ class CastSpellHandler(
                     colorless = poolComponent.colorless,
                     restrictedMana = poolComponent.restrictedMana
                 )
-                if (!pool.canPay(effectiveCost, spellCtx)) {
+                if (!pool.canPay(validationCost, spellCtx)) {
                     "Insufficient mana in pool to cast this spell"
                 } else null
             }
@@ -1289,12 +1295,12 @@ class CastSpellHandler(
                     colorless = poolComponent.colorless,
                     restrictedMana = poolComponent.restrictedMana
                 )
-                val partial = pool.payPartial(effectiveCost, spellCtx)
+                val partial = pool.payPartial(validationCost, spellCtx)
                 val remainingCost = partial.remainingCost
                 // Floating mana also covers the {X} portion (execution — explicitPay → autoPay —
                 // spends it before tapping anything), so only ask the chosen sources for the X
                 // the pool can't pay. Eligible restricted mana counts via ManaPool.xCoverage.
-                val xSymbolCount = effectiveCost.xCount.coerceAtLeast(1)
+                val xSymbolCount = validationCost.xCount.coerceAtLeast(1)
                 val totalXMana = xValue * xSymbolCount
                 val xRemaining = totalXMana -
                     partial.newPool.xCoverage(totalXMana, xManaRestriction, spellCtx)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.handlers.actions.spell.CastSpellHandler
+import com.wingedsheep.engine.handlers.actions.land.PlayLandHandler
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.ExecutorModule
 import com.wingedsheep.engine.registry.CardRegistry
@@ -27,6 +28,7 @@ class LibraryExecutors(
 ) : ExecutorModule {
 
     private val castSpellHandlerRef = AtomicReference<CastSpellHandler?>(null)
+    private val playLandHandlerRef = AtomicReference<PlayLandHandler?>(null)
 
     /**
      * The registry's recursive effect executor, used by the scry/surveil macro executors to run
@@ -49,6 +51,7 @@ class LibraryExecutors(
     /** Late-bind the cast machinery once [EngineServices] is fully constructed. */
     fun initialize(services: EngineServices) {
         castSpellHandlerRef.set(CastSpellHandler.create(services))
+        playLandHandlerRef.set(PlayLandHandler.create(services))
     }
 
     /** Late-bind the registry's recursive executor so the scry/surveil macros can delegate. */
@@ -75,6 +78,18 @@ class LibraryExecutors(
         CastFromCollectionWithoutPayingCostExecutor(
             castSpellHandlerProvider = {
                 castSpellHandlerRef.get()
+                    ?: error("LibraryExecutors.initialize(services) was not called before the executor ran")
+            },
+            cardRegistry = cardRegistry,
+            targetFinder = targetFinder ?: TargetFinder(),
+        ),
+        PlayFromCollectionWithoutPayingCostExecutor(
+            castSpellHandlerProvider = {
+                castSpellHandlerRef.get()
+                    ?: error("LibraryExecutors.initialize(services) was not called before the executor ran")
+            },
+            playLandHandlerProvider = {
+                playLandHandlerRef.get()
                     ?: error("LibraryExecutors.initialize(services) was not called before the executor ran")
             },
             cardRegistry = cardRegistry,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/PlayFromCollectionWithoutPayingCostExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/PlayFromCollectionWithoutPayingCostExecutor.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.engine.handlers.effects.library
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.TargetFinder
+import com.wingedsheep.engine.handlers.actions.land.PlayLandHandler
+import com.wingedsheep.engine.handlers.actions.spell.CastSpellHandler
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.PlayFromCollectionWithoutPayingCostEffect
+import kotlin.reflect.KClass
+
+class PlayFromCollectionWithoutPayingCostExecutor(
+    castSpellHandlerProvider: () -> CastSpellHandler,
+    private val playLandHandlerProvider: () -> PlayLandHandler,
+    cardRegistry: CardRegistry,
+    targetFinder: TargetFinder,
+) : EffectExecutor<PlayFromCollectionWithoutPayingCostEffect> {
+    override val effectType: KClass<PlayFromCollectionWithoutPayingCostEffect> =
+        PlayFromCollectionWithoutPayingCostEffect::class
+    private val castExecutor = CastFromCollectionWithoutPayingCostExecutor(
+        castSpellHandlerProvider, cardRegistry, targetFinder
+    )
+
+    override fun execute(
+        state: GameState,
+        effect: PlayFromCollectionWithoutPayingCostEffect,
+        context: EffectContext,
+    ): EffectResult {
+        val cardId = context.pipeline.storedCollections[effect.from]?.firstOrNull()
+            ?: return EffectResult.success(state)
+        val card = state.getEntity(cardId)?.get<CardComponent>() ?: return EffectResult.success(state)
+        if (!card.typeLine.isLand) {
+            return castExecutor.execute(state, CastFromCollectionWithoutPayingCostEffect(effect.from), context)
+        }
+        val (permissionId, grantedState) = CastFromCollectionWithoutPayingCostExecutor.grantFreeCast(
+            state, cardId, context.controllerId, context.sourceId, withoutPayingCost = false
+        )
+        val result = playLandHandlerProvider().executeDuringResolution(
+            grantedState.copy(priorityPlayerId = context.controllerId), PlayLand(context.controllerId, cardId)
+        )
+        return if (result.error == null) EffectResult.from(result) else EffectResult.success(
+            CastFromCollectionWithoutPayingCostExecutor.revokeFreeCast(state, cardId, permissionId)
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -215,7 +215,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 when (effectiveCost) {
                     is AbilityCost.Tap -> {
                         if (container.has<TappedComponent>()) continue
-                        if (!cardComponent.typeLine.isLand && projected.isCreature(entityId) &&
+                        if (projected.isCreature(entityId) &&
                             SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
                         ) continue
                     }
@@ -224,7 +224,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                     // enumerator and `ActivateAbilityHandler`'s authoritative re-check agree.
                     is AbilityCost.Untap -> {
                         if (!container.has<TappedComponent>()) continue
-                        if (!cardComponent.typeLine.isLand && projected.isCreature(entityId) &&
+                        if (projected.isCreature(entityId) &&
                             SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
                         ) continue
                     }
@@ -402,7 +402,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                         costCanBePaid = false
                                         break
                                     }
-                                    if (!cardComponent.typeLine.isLand && projected.isCreature(entityId) &&
+                                    if (projected.isCreature(entityId) &&
                                         SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
                                     ) {
                                         costCanBePaid = false
@@ -419,7 +419,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                         costCanBePaid = false
                                         break
                                     }
-                                    if (!cardComponent.typeLine.isLand && projected.isCreature(entityId) &&
+                                    if (projected.isCreature(entityId) &&
                                         SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
                                     ) {
                                         costCanBePaid = false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -577,12 +577,11 @@ class CastSpellEnumerator : ActionEnumerator {
                 val selfAltEffective = context.costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, selfAltMana, playerId)
                 val canPayMana = context.manaSolver.canPay(state, playerId, selfAltEffective, precomputedSources = cachedSources)
                 val canPayAdditional = selfAltCost.additionalCosts.all { cost ->
-                    when (val atom = (cost as? AdditionalCost.Atom)?.atom) {
-                        is CostAtom.TapPermanents -> {
-                            context.costUtils.findAbilityTapTargets(state, playerId, atom.filter).size >= atom.count
-                        }
-                        else -> true
-                    }
+                    val candidates = SelectionCostPresentation.candidates(
+                        state, playerId, cardId, cost, context.costUtils, context.predicateEvaluator
+                    )
+                    val selectionCount = SelectionCostPresentation.selectionCount(cost)
+                    selectionCount == 0 || candidates.size >= selectionCount
                 }
                 canPayMana && canPayAdditional
             } else false
@@ -787,16 +786,12 @@ class CastSpellEnumerator : ActionEnumerator {
                     context.manaSolver.solve(state, playerId, selfAltEffective, precomputedSources = cachedSources)
                         ?.sources?.map { it.entityId }
                 }
-                val tapCost = selfAltCost.additionalCosts.firstNotNullOfOrNull { (it as? AdditionalCost.Atom)?.atom as? CostAtom.TapPermanents }
-                val tapTargets = if (tapCost != null) context.costUtils.findAbilityTapTargets(state, playerId, tapCost.filter) else null
-                val addlCostInfo = if (tapTargets != null && tapCost != null) {
-                    AdditionalCostData(
-                        description = tapCost.description,
-                        costType = "TapPermanents",
-                        validTapTargets = tapTargets,
-                        tapCount = tapCost.count
+                val addlCostInfo = selfAltCost.additionalCosts.firstNotNullOfOrNull { cost ->
+                    val candidates = SelectionCostPresentation.candidates(
+                        state, playerId, cardId, cost, context.costUtils, context.predicateEvaluator
                     )
-                } else null
+                    SelectionCostPresentation.costData(cost, candidates)?.second
+                }
                 SelfAltCostResult(
                     manaCostString = selfAltEffective.toString(),
                     autoTapPreview = selfAltPreview,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
@@ -206,7 +206,7 @@ class ManaAbilityEnumerator : ActionEnumerator {
                                     if (container.has<TappedComponent>()) {
                                         affordable = false; break
                                     }
-                                    if (!cardComponent.typeLine.isLand && projected.isCreature(entityId) &&
+                                    if (projected.isCreature(entityId) &&
                                         SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
                                     ) {
                                         affordable = false; break

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CostEnumerationUtils.kt
@@ -507,11 +507,13 @@ class CostEnumerationUtils(
     fun canPayTapCost(state: GameState, entityId: EntityId): Boolean {
         val container = state.getEntity(entityId) ?: return false
         if (container.has<TappedComponent>()) return false
-        val cardComponent = container.get<CardComponent>() ?: return false
         // Read creature-ness / haste from projected state so a Vehicle or animated permanent
-        // that is currently a creature is gated. Lands keep the carve-out (basic-land mana
-        // abilities are not restricted by summoning sickness).
-        if (!cardComponent.typeLine.isLand && state.projectedState.isCreature(entityId) &&
+        // that is currently a creature is gated. Gating on `isCreature` alone (no `isLand`
+        // carve-out) is already correct for plain lands — a land that isn't also a creature
+        // never satisfies `isCreature` — and it's the only way to catch a land that *is* also a
+        // creature (Dryad Arbor: "This land ... is affected by summoning sickness"), which a
+        // land-wide carve-out would silently exempt.
+        if (state.projectedState.isCreature(entityId) &&
             SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, state.projectedState)
         ) return false
         return true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/SelectionCostPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/SelectionCostPresentation.kt
@@ -82,8 +82,8 @@ object SelectionCostPresentation {
      * client cost data for paying [cost] from [candidates], or null when [cost] carries no
      * selection a picker could drive.
      *
-     * `"ExileFromGraveyard"` pins the client's picker to the graveyard, so a non-graveyard exile
-     * cost is declined rather than shown against the wrong zone.
+     * Exile costs identify their source zone so the client opens the matching picker instead of
+     * assuming every exile payment comes from the graveyard.
      */
     fun costData(
         cost: AdditionalCost,
@@ -110,10 +110,15 @@ object SelectionCostPresentation {
                     validDiscardTargets = candidates,
                     discardCount = atom.count,
                 )
-                is CostAtom.ExileFrom -> if (atom.zone != Zone.GRAVEYARD) null else {
-                    "Exile from graveyard" to AdditionalCostData(
+                is CostAtom.ExileFrom -> {
+                    val (label, costType) = when (atom.zone) {
+                        Zone.GRAVEYARD -> "Exile from graveyard" to "ExileFromGraveyard"
+                        Zone.HAND -> "Exile from hand" to "ExileFromHand"
+                        else -> return null
+                    }
+                    label to AdditionalCostData(
                         description = description,
-                        costType = "ExileFromGraveyard",
+                        costType = costType,
                         validExileTargets = candidates,
                         exileMinCount = atom.count,
                         exileMaxCount = atom.count,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -56,6 +56,7 @@ import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
@@ -2006,8 +2007,26 @@ class ManaSolver(
         spellContext: SpellPaymentContext? = null,
         precomputedSources: List<ManaSource>? = null,
         /** Colors that may pay the `{X}` portion ("spend only [colors] on X"); empty = any. */
-        xManaRestriction: Set<Color> = emptySet()
+        xManaRestriction: Set<Color> = emptySet(),
+        /** Internal recursion tally for Phyrexian pips tentatively paid with life. */
+        phyrexianLifePipsCommitted: Int = 0
     ): Boolean {
+        // A Phyrexian pip may be paid with 2 life instead of its color. Try each distinct pip
+        // choice before the mana-only solver below; recursive calls see a strictly smaller cost.
+        // Paying down to exactly 0 is legal, though state-based actions will make the player lose.
+        val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+        if ((phyrexianLifePipsCommitted + 1) * 2 <= life) {
+            val triedColors = mutableSetOf<Color>()
+            for (pip in cost.phyrexianSymbols) {
+                if (!triedColors.add(pip.color)) continue
+                val reduced = cost.withPhyrexianPaidByLife(listOf(pip.color)) ?: continue
+                if (canPay(
+                        state, playerId, reduced, xValue, excludeSources, spellContext,
+                        precomputedSources, xManaRestriction, phyrexianLifePipsCommitted + 1
+                    )) return true
+            }
+        }
+
         // Get the player's floating mana pool
         val poolComponent = state.getEntity(playerId)?.get<ManaPoolComponent>()
         val pool = if (poolComponent != null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -1203,7 +1203,7 @@ class ManaSolver(
                 }
 
                 // Check summoning sickness for creatures (non-lands)
-                if (!card.typeLine.isLand && isCreature && tapBlockedBySickness) {
+                if (isCreature && tapBlockedBySickness) {
                     continue // Can't use this ability due to summoning sickness
                 }
 
@@ -2411,10 +2411,11 @@ class ManaSolver(
     private fun canTapForCost(state: GameState, entityId: EntityId): Boolean {
         val container = state.getEntity(entityId) ?: return false
         if (container.has<TappedComponent>()) return false
-        val card = container.get<CardComponent>() ?: return false
         val projected = state.projectedState
-        // Summoning sickness only bites non-land creatures (CR 302.6).
-        if (!card.typeLine.isLand && projected.isCreature(entityId)) {
+        // Summoning sickness bites any creature (CR 302.6) — including a land that is also a
+        // creature (Dryad Arbor). A land that isn't also a creature never satisfies isCreature,
+        // so this is a no-op for every ordinary land's mana ability.
+        if (projected.isCreature(entityId)) {
             if (SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)) return false
         }
         return true
@@ -2472,7 +2473,7 @@ class ManaSolver(
             // Summoning sickness applies to non-land creatures (CR 302.6) — they can't tap unless
             // they have haste or an "activate as though hasty" grant.
             val isCreature = projected.isCreature(entityId)
-            if (!card.typeLine.isLand && isCreature &&
+            if (isCreature &&
                 SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
             ) continue
 
@@ -2589,7 +2590,7 @@ class ManaSolver(
             if (projected.hasLostAllAbilities(entityId)) continue
 
             val isCreature = projected.isCreature(entityId)
-            if (!card.typeLine.isLand && isCreature &&
+            if (isCreature &&
                 SummoningSicknessRules.blocksTapOrUntapCost(entityId, container, projected)
             ) continue
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -56,7 +56,6 @@ import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
@@ -2014,7 +2013,7 @@ class ManaSolver(
         // A Phyrexian pip may be paid with 2 life instead of its color. Try each distinct pip
         // choice before the mana-only solver below; recursive calls see a strictly smaller cost.
         // Paying down to exactly 0 is legal, though state-based actions will make the player lose.
-        val life = state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+        val life = state.lifeTotal(playerId)
         if ((phyrexianLifePipsCommitted + 1) * 2 <= life) {
             val triedColors = mutableSetOf<Color>()
             for (pip in cost.phyrexianSymbols) {

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -242,6 +242,10 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
       advancePipeline({
         type: 'manaSource',
         selectedSources: [...manaSelectionState.selectedSources],
+        phyrexianLifePayments: manaSelectionState.phyrexianLifePipIndices.map((pipIndex) => {
+          const pip = manaSelectionState.manaCost.match(/\{([^}]+)\}/g)?.[pipIndex]?.slice(1, -1).split('/')[0]
+          return pip === 'B' ? 'BLACK' : pip === 'W' ? 'WHITE' : pip === 'U' ? 'BLUE' : pip === 'R' ? 'RED' : 'GREEN'
+        }),
       })
       return
     }
@@ -250,6 +254,13 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
     const paymentStrategy = {
       type: 'Explicit' as const,
       manaAbilitiesToActivate: [...manaSelectionState.selectedSources],
+      phyrexianLifePayments: manaSelectionState.phyrexianLifePipIndices.map((pipIndex) => {
+        const symbol = manaSelectionState.manaCost.match(/\{([^}]+)\}/g)?.[pipIndex] ?? ''
+        return symbol.slice(1, -1).split('/')[0] === 'B' ? 'BLACK'
+          : symbol.slice(1, -1).split('/')[0] === 'W' ? 'WHITE'
+          : symbol.slice(1, -1).split('/')[0] === 'U' ? 'BLUE'
+          : symbol.slice(1, -1).split('/')[0] === 'R' ? 'RED' : 'GREEN'
+      }),
     }
     // Cast to add paymentStrategy - only actions with mana costs reach here
     const modifiedAction = { ...manaSelectionState.action, paymentStrategy } as import('../../types').GameAction
@@ -444,8 +455,14 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
     // Build list of unfulfilled requirements: colored pips + generic pips
     const coloredReqs: string[] = []
     let genericCount = 0
-    for (const match of symbols) {
+    for (const [pipIndex, match] of symbols.entries()) {
       const inner = match.slice(1, -1)
+      if (inner.endsWith('/P')) {
+        if (!manaSelectionState.phyrexianLifePipIndices.includes(pipIndex)) {
+          coloredReqs.push(inner.split('/')[0]!)
+        }
+        continue
+      }
       const num = parseInt(inner, 10)
       if (!isNaN(num)) {
         genericCount += num
@@ -2008,6 +2025,42 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           alignItems: 'flex-end',
           zIndex: 100,
         }}>
+          {manaSelectionState.manaCost.match(/\{([^}]+)\}/g)?.some((symbol) => symbol.includes('/P')) && (
+            <div style={{
+              backgroundColor: 'rgba(0, 0, 0, 0.9)',
+              border: '1px solid rgba(239, 68, 68, 0.45)',
+              borderRadius: 8,
+              padding: '10px 12px',
+              display: 'flex',
+              gap: 8,
+              alignItems: 'center',
+            }}>
+              <span style={{ color: '#ddd', fontSize: responsive.fontSize.small }}>Pay with life:</span>
+              {manaSelectionState.manaCost.match(/\{([^}]+)\}/g)!.map((symbol, pipIndex) => {
+                if (!symbol.includes('/P')) return null
+                const selected = manaSelectionState.phyrexianLifePipIndices.includes(pipIndex)
+                const canSelect = selected || ((manaSelectionState.phyrexianLifePipIndices.length + 1) * 2 <= (viewingPlayer?.life ?? 0))
+                return (
+                  <button
+                    key={pipIndex}
+                    type="button"
+                    disabled={!canSelect}
+                    onClick={() => useGameStore.getState().togglePhyrexianLifePayment(pipIndex)}
+                    style={{
+                      padding: '5px 8px',
+                      borderRadius: 6,
+                      border: `1px solid ${selected ? '#ef4444' : '#666'}`,
+                      background: selected ? 'rgba(127, 29, 29, 0.9)' : 'rgba(40, 40, 40, 0.9)',
+                      color: selected ? '#fecaca' : '#ddd',
+                      cursor: canSelect ? 'pointer' : 'not-allowed',
+                    }}
+                  >
+                    <ManaSymbol symbol={symbol.slice(1, -1)} size={18} /> {selected ? '2 life' : 'mana'}
+                  </button>
+                )
+              })}
+            </div>
+          )}
           {/* Mana progress indicator */}
           {manaProgress && (
             <div style={{

--- a/web-client/src/components/game/board/StackZone.tsx
+++ b/web-client/src/components/game/board/StackZone.tsx
@@ -10,7 +10,7 @@ import { ActiveEffectBadges } from '../card/CardOverlays'
 import { AbilityText, ManaCost } from '../../ui/ManaSymbols'
 import { useResponsiveContext, handleImageError } from './shared'
 import { styles } from './styles'
-import { groupStackCards, type StackGroup } from './stackGrouping'
+import { chosenModeGroupsForStack, groupStackCards, type StackGroup } from './stackGrouping'
 import { YieldContextMenu } from './YieldContextMenu'
 
 /**
@@ -581,10 +581,11 @@ export function StackDisplay() {
       if (!topCard) return null
       const isAbility = topCard.typeLine === 'Ability' || topCard.typeLine === 'Triggered Ability'
 
-      // Modal spells with cast-time mode choices (700.2) render per-mode descriptions with their
-      // chosen targets below, so opponents can see exactly what's been committed before responding.
-      const perModeGroups = topCard.perModeTargets ?? []
-      if (!isAbility && perModeGroups.length > 0) {
+      // Modal spells and triggered abilities render their chosen modes (and any targets) below,
+      // so opponents can see exactly what's been committed before responding. Triggered modes are
+      // chosen as the ability is put on the stack, just like a modal spell's cast-time choice.
+      const perModeGroups = chosenModeGroupsForStack(topCard)
+      if (perModeGroups.length > 0) {
         return (
           <div style={{
             padding: responsive.isMobile ? '4px 6px' : '6px 10px',

--- a/web-client/src/components/game/board/stackGrouping.test.ts
+++ b/web-client/src/components/game/board/stackGrouping.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { groupStackCards, stackGroupKey } from './stackGrouping'
+import { chosenModeGroupsForStack, groupStackCards, stackGroupKey } from './stackGrouping'
 import type { ClientCard } from '@/types/gameState'
 
 /** Minimal ClientCard factory — only the fields stackGroupKey reads matter here. */
@@ -80,5 +80,23 @@ describe('groupStackCards', () => {
 
   it('handles an empty stack', () => {
     expect(groupStackCards([])).toEqual([])
+  })
+})
+
+describe('chosenModeGroupsForStack', () => {
+  it('exposes the chosen mode for a triggered ability such as Elder Gargaroth', () => {
+    const chosenMode = {
+      modeDescription: 'You gain 3 life',
+      targets: [],
+      targetNames: [],
+    }
+    const trigger = card({
+      id: 'gargaroth-trigger',
+      name: 'Elder Gargaroth trigger',
+      typeLine: 'Triggered Ability',
+      perModeTargets: [chosenMode],
+    })
+
+    expect(chosenModeGroupsForStack(trigger)).toEqual([chosenMode])
   })
 })

--- a/web-client/src/components/game/board/stackGrouping.ts
+++ b/web-client/src/components/game/board/stackGrouping.ts
@@ -50,6 +50,14 @@ export interface StackGroup {
 }
 
 /**
+ * Chosen modal details shown beneath a stack object. This deliberately applies to triggered
+ * abilities as well as spells: a modal trigger's choice is committed before opponents respond.
+ */
+export function chosenModeGroupsForStack(card: ClientCard) {
+  return card.perModeTargets ?? []
+}
+
+/**
  * Fold a stack-ordered card list into contiguous identity groups, preserving order.
  * A run of length 1 is just a single-member group.
  */

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -282,6 +282,8 @@ export interface ManaSelectionState {
   sourceColors: Readonly<Record<EntityId, readonly string[]>>
   /** Mana amount per source: entityId -> amount (e.g., 3 for Gilded Lotus) */
   sourceManaAmounts: Readonly<Record<EntityId, number>>
+  /** Indices of Phyrexian pips selected to be paid with life. */
+  phyrexianLifePipIndices: readonly number[]
 }
 
 /**
@@ -837,7 +839,7 @@ export type PhaseResult =
   | { type: 'convoke'; convokedCreatures: Record<string, { color: string | null }> }
   | { type: 'tapForGeneric'; tapForGenericPermanents: EntityId[] }
   | { type: 'harmonize'; harmonizeCreature: EntityId | null; reduction: number }
-  | { type: 'manaSource'; selectedSources: EntityId[] }
+  | { type: 'manaSource'; selectedSources: EntityId[]; phyrexianLifePayments?: string[] }
   | { type: 'costPayment'; costType: string; selectedTargets: EntityId[] }
   | { type: 'blightVariable'; blightAmount: number }
   | { type: 'payXLife'; payXLifeAmount: number }
@@ -1220,6 +1222,7 @@ export type GameStore = {
   confirmCounterDistribution: () => void
   startManaSelection: (actionInfo: LegalActionInfo) => void
   toggleManaSource: (entityId: EntityId) => void
+  togglePhyrexianLifePayment: (pipIndex: number) => void
   cancelManaSelection: () => void
   confirmManaSelection: () => void
   showRevealedHand: (cardIds: readonly EntityId[]) => void

--- a/web-client/src/store/slices/ui/pipelinePhases.test.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.test.ts
@@ -140,6 +140,26 @@ describe('computePhases — tap-for-generic (improvise / waterbend)', () => {
   })
 })
 
+describe('computePhases — Phyrexian mana', () => {
+  it('opens manual payment even when auto-tap is enabled so life is selectable', () => {
+    const info = castAction({
+      manaCostString: '{1}{B/P}{B/P}',
+      availableManaSources: [{ entityId: 'swamp', producesColors: ['B'] }],
+    })
+
+    expect(computePhases(info, { autoTapEnabled: true })).toEqual([{ type: 'manaSource' }])
+  })
+
+  it('opens manual payment for a Phyrexian-only cost with no mana sources', () => {
+    const info = castAction({
+      manaCostString: '{B/P}',
+      availableManaSources: [],
+    })
+
+    expect(computePhases(info, { autoTapEnabled: true })).toEqual([{ type: 'manaSource' }])
+  })
+})
+
 describe('enterPhase — sum-gated graveyard exile costs', () => {
   /**
    * Collect evidence N (CR 701.59a) and Baron Helmut Zemo's pip total are the same picker: any

--- a/web-client/src/store/slices/ui/pipelinePhases.test.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computePhases, enterPhase } from './pipelinePhases'
+import { computePhases, enterPhase, mergeResult } from './pipelinePhases'
 import type { LegalActionInfo } from '@/types/messages'
 
 /**
@@ -157,6 +157,56 @@ describe('computePhases — Phyrexian mana', () => {
     })
 
     expect(computePhases(info, { autoTapEnabled: true })).toEqual([{ type: 'manaSource' }])
+  })
+})
+
+describe('Force of Vigor hand-exile payment', () => {
+  const info = castAction({
+    actionType: 'CastWithAlternativeCost',
+    description: 'Cast Force of Vigor ({0})',
+    action: {
+      type: 'CastSpell',
+      playerId: 'p1',
+      cardId: 'force',
+      useAlternativeCost: true,
+      alternativeCostType: 'SELF_ALTERNATIVE',
+    },
+    additionalCostInfo: {
+      costType: 'ExileFromHand',
+      description: 'Exile a green card from your hand',
+      validExileTargets: ['green-card'],
+      exileMinCount: 1,
+      exileMaxCount: 1,
+    },
+  })
+
+  it('opens a hand selection phase and exposes the eligible green card', () => {
+    expect(computePhases(info, { autoTapEnabled: true })).toEqual([{ type: 'costPayment' }])
+
+    let captured: Record<string, unknown> | null = null
+    const store = {
+      startTargeting: (arg: Record<string, unknown>) => { captured = arg },
+    } as unknown as Parameters<typeof enterPhase>[3]
+    enterPhase({ type: 'costPayment' }, info, info.action, store)
+
+    expect(captured).toMatchObject({
+      validTargets: ['green-card'],
+      minTargets: 1,
+      maxTargets: 1,
+      targetZone: 'Hand',
+    })
+  })
+
+  it('submits the chosen card through additionalCostPayment.exiledCards', () => {
+    const action = mergeResult(
+      info.action,
+      info,
+      { type: 'costPayment', costType: 'ExileFromHand', selectedTargets: ['green-card' as never] },
+      {} as never,
+    )
+    expect(action).toMatchObject({
+      additionalCostPayment: { exiledCards: ['green-card'] },
+    })
   })
 })
 

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -213,6 +213,7 @@ export function computePhases(actionInfo: LegalActionInfo, options?: ComputePhas
       'BouncePermanent',
       'DiscardCard',
       'ExileFromGraveyard',
+      'ExileFromHand',
       'CollectEvidence',
       'ExileForTotal',
       'ExileFromZone',
@@ -456,7 +457,8 @@ export function mergeResult(
               ? { discardedCards: selectedTargets }
               : costType === 'BouncePermanent'
                 ? { bouncedPermanents: selectedTargets }
-                : costType === 'ExileFromGraveyard' || costType === 'CollectEvidence' ||
+                : costType === 'ExileFromGraveyard' || costType === 'ExileFromHand' ||
+                    costType === 'CollectEvidence' ||
                     costType === 'ExileForTotal'
                   ? { exiledCards: selectedTargets }
                   : costType === 'Behold' || costType === 'ChooseEntity'
@@ -493,7 +495,8 @@ export function mergeResult(
               ? { discardedCards: selectedTargets }
               : costType === 'BouncePermanent'
                 ? { bouncedPermanents: selectedTargets }
-                : costType === 'ExileFromGraveyard' || costType === 'Craft' ||
+                : costType === 'ExileFromGraveyard' || costType === 'ExileFromHand' ||
+                    costType === 'Craft' ||
                     costType === 'CollectEvidence' || costType === 'ExileForTotal'
                   ? { exiledCards: selectedTargets }
                   : costType === 'Blight'
@@ -916,6 +919,14 @@ export function enterPhase(
           flags.sourceCardName = actionInfo.description
             .replace(/^Cast /, '')
             .replace(/^Activate /, '')
+          break
+        case 'ExileFromHand':
+          validTargets = [...(costInfo.validExileTargets ?? [])]
+          minTargets = costInfo.exileMinCount ?? 1
+          maxTargets = costInfo.exileMaxCount ?? costInfo.validExileTargets?.length ?? 1
+          flags.isSacrificeSelection = true
+          flags.targetZone = 'Hand'
+          flags.targetDescription = costInfo.description
           break
         // The sum-gated graveyard exiles: collect evidence N (CR 701.59a) and "exile any number of
         // <filter> cards from your graveyard with N or more <measure>" (Baron Helmut Zemo). Any

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -194,9 +194,10 @@ export function computePhases(actionInfo: LegalActionInfo, options?: ComputePhas
   const hasAlternativePaymentPhase = phases.some(
     (p) => p.type === 'delve' || p.type === 'convoke',
   )
+  const hasPhyrexianMana = (actionInfo.manaCostString ?? '').includes('/P}')
   if (
-    actionInfo.availableManaSources && actionInfo.availableManaSources.length > 0 &&
-    (hasAlternativePaymentPhase || !options?.autoTapEnabled)
+    ((actionInfo.availableManaSources?.length ?? 0) > 0 || hasPhyrexianMana) &&
+    (hasAlternativePaymentPhase || hasPhyrexianMana || !options?.autoTapEnabled)
   ) {
     phases.push({ type: 'manaSource' })
   }
@@ -393,6 +394,7 @@ export function mergeResult(
           paymentStrategy: {
             type: 'Explicit' as const,
             manaAbilitiesToActivate: result.selectedSources,
+            phyrexianLifePayments: result.phyrexianLifePayments ?? [],
           },
         }
       }

--- a/web-client/src/store/slices/ui/selectionSlice.ts
+++ b/web-client/src/store/slices/ui/selectionSlice.ts
@@ -93,6 +93,7 @@ export interface SelectionSliceActions {
   confirmDecisionSelection: () => void
   startManaSelection: (actionInfo: LegalActionInfo) => void
   toggleManaSource: (entityId: EntityId) => void
+  togglePhyrexianLifePayment: (pipIndex: number) => void
   cancelManaSelection: () => void
   confirmManaSelection: () => void
 }
@@ -565,8 +566,8 @@ export const createSelectionSlice: SliceCreator<SelectionSlice> = (set, get) => 
 
   // Mana source selection actions (pre-cast)
   startManaSelection: (actionInfo) => {
-    const sources = actionInfo.availableManaSources
-    if (!sources || sources.length === 0) return
+    const sources = actionInfo.availableManaSources ?? []
+    if (sources.length === 0 && !(actionInfo.manaCostString ?? '').includes('/P}')) return
     const sourceColors: Record<string, readonly string[]> = {}
     const sourceManaAmounts: Record<string, number> = {}
     for (const source of sources) {
@@ -622,6 +623,7 @@ export const createSelectionSlice: SliceCreator<SelectionSlice> = (set, get) => 
           harmonizeReduction,
           sourceColors,
           sourceManaAmounts,
+          phyrexianLifePipIndices: [],
         },
       })
       return
@@ -672,6 +674,7 @@ export const createSelectionSlice: SliceCreator<SelectionSlice> = (set, get) => 
         harmonizeReduction: 0,
         sourceColors,
         sourceManaAmounts,
+        phyrexianLifePipIndices: [],
       },
     })
   },
@@ -687,6 +690,21 @@ export const createSelectionSlice: SliceCreator<SelectionSlice> = (set, get) => 
           selectedSources: isSelected
             ? selectedSources.filter(id => id !== entityId)
             : [...selectedSources, entityId],
+        },
+      }
+    })
+  },
+
+  togglePhyrexianLifePayment: (pipIndex) => {
+    set((state) => {
+      if (!state.manaSelectionState) return state
+      const selected = state.manaSelectionState.phyrexianLifePipIndices
+      return {
+        manaSelectionState: {
+          ...state.manaSelectionState,
+          phyrexianLifePipIndices: selected.includes(pipIndex)
+            ? selected.filter((index) => index !== pipIndex)
+            : [...selected, pipIndex],
         },
       }
     })

--- a/web-client/src/types/actions.ts
+++ b/web-client/src/types/actions.ts
@@ -174,7 +174,12 @@ export interface CastSpellAction {
 export type PaymentStrategy =
   | { readonly type: 'AutoPay' }
   | { readonly type: 'FromPool' }
-  | { readonly type: 'Explicit'; readonly manaAbilitiesToActivate: readonly EntityId[] }
+  | {
+      readonly type: 'Explicit'
+      readonly manaAbilitiesToActivate: readonly EntityId[]
+      /** Multiset of Phyrexian pip colors paid with 2 life each. */
+      readonly phyrexianLifePayments?: readonly string[]
+    }
 
 // =============================================================================
 // Ability Actions


### PR DESCRIPTION
# Add nine Eldrazi Trudge decklist cards

Decklist: https://magic.wizards.com/en/news/announcements/banned-and-restricted-august-10-2026#eldrazi-trudge

## Summary

Nine cards from a user-supplied Modern "Eldrazi Trudge" decklist, implemented as pure composition
of existing `mtg-sdk` primitives — plus one small reusable addition (the Eldrazi Spawn token) they
share. One card definition, one scenario test each.

- **Ulamog, the Ceaseless Hunger** (BFZ) — {10} Legendary Creature Eldrazi 10/10, Indestructible.
  Cast trigger exiles two target permanents; attack trigger exiles the defending player's top 20.
- **Dryad Arbor** (FUT) — Land Creature Forest Dryad 1/1, "{T}: Add {G}." Also fixes a latent
  engine bug: several call sites blanket-exempted every land from CR 302.6 summoning sickness on
  tap abilities, which was only safe before a land was ever also a creature.
- **Thought-Knot Seer** (OGW, not BFZ as commonly assumed — it was never printed there) — {3}{C}
  Creature Eldrazi 4/4. ETB: reveal opponent's hand, exile a chosen nonland card. LTB: that
  opponent draws a card.
- **Dismember** (NPH) — {1}{B/P}{B/P} Instant, target creature gets -5/-5 until end of turn.
- **Elder Gargaroth** (M21) — {3}{G}{G} Creature Beast 6/6, modal attack/block trigger.
- **Force of Vigor** (MH1) — {2}{G}{G} Instant, Force-cycle alternative cost, destroy up to two
  artifacts/enchantments.
- **Fight Rigging** (SNC, not MH2 as guessed) — {2}{G} Enchantment, Hideaway 5 + combat-trigger
  counter and conditional free-cast (Mosswort Bridge's shape).
- **Malevolent Rumble** (MH3) — {1}{G} Sorcery, reveal-4/pick-a-permanent/rest-to-graveyard, plus
  an Eldrazi Spawn token.
- **Ugin's Labyrinth** (MH3, not TDM as guessed) — Land, Imprint ETB exile + linked mana bonus +
  return-to-hand ability.
- **Add reusable Eldrazi Spawn predefined token** — 0/1 colorless Eldrazi Spawn ("Sacrifice this
  creature: Add {C}.") registered in `PredefinedTokens`, with a `CreateEldraziSpawn` facade
  mirroring `CreateTreasure`/`CreateFood`.

## Dropped from this batch (need real engine work, not just composition)

Verification during implementation caught several genuine primitive gaps my initial triage missed:

- **Kozilek's Command** — a modal spell where the "scry X, then draw" mode needs two sequential
  in-resolution decisions (which cards go to the bottom, then reorder the ones staying on top).
  When that mode is followed by another chosen mode, the second mode never runs — the
  `ModalPreChosenContinuation` tail appears to get dropped somewhere in that decision chain. Real
  engine bug in `ModalEffectExecutor`/`processPreTargetedEffectQueue`, reproducible with the
  simplest legal mode combination a player would actually pick.
- **Green Sun's Zenith** — no primitive for "shuffle this spell into its owner's library instead
  of the graveyard as it resolves."
- **Fanatic of Rhonas** — the `Eternalize` keyword (CR 702.126-ish, Amonkhet block) doesn't exist
  in the SDK at all (its siblings Embalm/Renew do).
- **Endurance** — `Evoke`'s cost is hardcoded to a mana-only alternative cost; Endurance's evoke
  cost ("exile a green card from your hand") has no mana component.
- **Eldrazi Temple** — its mana restriction needs a color+subtype AND condition
  ("colorless Eldrazi spells/abilities"); `SpellPaymentContext` carries no color information today.
- **Gemstone Caverns** — the existing "begin the game on the battlefield" (Leyline) mechanism is
  unconditional yes/no; this card needs it gated to non-starting players, with a mandatory
  follow-up cost (exile a card) and a luck-counter marker distinguishing this entry path from an
  ordinary later land drop.
- **Disciple of Freyalise // Garden of Freyalise** — the engine's two MDFC shapes both assume the
  back face is *cast* (with its own mana cost); a land back face is *played*, and nothing offers or
  executes "play this card's land-typed secondary face."
- **Boseiju, Who Endures** — "costs {1} less per legendary creature you control" can't reach a
  Channel ability activated from hand: the cost-reduction scan only looks at permanents on the
  battlefield, and Boseiju's own copy of the reduction is on the card being discarded as the cost.
- **Sowing Mycospawn**, **Drowner of Truth // Drowned Jungle** — both print `Devoid`, which doesn't
  exist as a keyword/static ability anywhere in the SDK (`CardDefinition.colors` has no override
  hook). Drowner of Truth also needs "if {C} was spent to cast it" exposed as a `Conditions.*` —
  the underlying tracking (`CastRecordComponent.colorlessSpent`) already exists but nothing reads it.
- **Trinisphere** — needs a genuinely new cost-modification shape: "each spell that would cost
  less than N costs N instead" (a floor on total cost across every player's spells), which is a
  different direction from every existing `CostModification` variant (all flat increases/reductions).

None of the above got any files — clean drops, no partial/lossy implementations.

## Test plan

- [x] `:mtg-sdk:test :rules-engine:test :mtg-sets:scenarioTest` green for all 9 cards' scenario
      tests plus the full existing suite, run three times to separate real failures from machine
      contention (this box runs other concurrent sessions — several *other* pre-existing tests
      intermittently hit `TimeoutCancellationException` under load; none of them are in this diff,
      and they weren't touched).
- [x] `Dryad Arbor`'s summoning-sickness fix verified not to regress the Restless manland cycle
      (those tests use a helper that never attaches `SummoningSicknessComponent` in the first
      place, so the fix is a no-op for them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNFerXJgbnuNJLwdnEbfLc
