### PR TITLE
Make card interaction work on touch devices

### DIFF
--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -1979,7 +1979,10 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           that size anyway. */}
       {!spectatorMode && !responsive.isMobile && <GameLog />}
       {!spectatorMode && <ActiveYieldsPanel />}
-      {!spectatorMode && <AiInsightPanel />}
+      {/* Hidden on phones for the same reason as the log: its toggle sits in the
+          bottom-left corner, directly on top of the hand, and the expanded panel
+          is a 520px table that a phone can't show. */}
+      {!spectatorMode && !responsive.isMobile && <AiInsightPanel />}
 
       {/* Draw animations */}
       <DrawAnimations />

--- a/web-client/src/components/game/board/StackZone.tsx
+++ b/web-client/src/components/game/board/StackZone.tsx
@@ -8,6 +8,7 @@ import type { ClientAbilityIdentity, ClientCard } from '@/types/gameState'
 import { getCardImageUrl } from '@/utils/cardImages.ts'
 import { ActiveEffectBadges } from '../card/CardOverlays'
 import { AbilityText, ManaCost } from '../../ui/ManaSymbols'
+import { useOpenCardMenuOnTap } from '@/hooks/useOpenCardMenuOnTap.ts'
 import { useResponsiveContext, handleImageError } from './shared'
 import { styles } from './styles'
 import { groupStackCards, type StackGroup } from './stackGrouping'
@@ -26,6 +27,7 @@ export function StackDisplay() {
   const stackCards = useStackCards()
   const responsive = useResponsiveContext()
   const hoverCard = useGameStore((state) => state.hoverCard)
+  const openCardMenuOnTap = useOpenCardMenuOnTap()
   const targetingState = useGameStore((state) => state.targetingState)
   const addTarget = useGameStore((state) => state.addTarget)
   const removeTarget = useGameStore((state) => state.removeTarget)
@@ -99,6 +101,20 @@ export function StackDisplay() {
     } else if (isValidTarget) {
       addTarget(cardId)
     }
+  }
+
+  /**
+   * A tap/click on a stack item. Targeting and decision selection own it whenever either is
+   * running; otherwise the gesture only ever means "let me read this", which without hover has to
+   * go through the action menu's "View card" row — the same route as any other card the player
+   * can't do anything with.
+   */
+  const handleStackItemTap = (cardId: EntityId) => {
+    if (targetingState || decisionSelectionState) {
+      handleStackItemClick(cardId)
+      return
+    }
+    openCardMenuOnTap?.(cardId)
   }
 
   // A card the player can currently target/select — such a card must never be hidden inside a
@@ -187,10 +203,13 @@ export function StackDisplay() {
           ...seatBorderFor(card.controllerId),
           ...highlight,
         }}
-        onClick={opts.onClick ?? (() => handleStackItemClick(card.id))}
+        onClick={opts.onClick ?? (() => handleStackItemTap(card.id))}
         onContextMenu={(e) => openYieldMenu(card, e)}
-        onMouseEnter={(e) => hoverCard(card.id, { x: e.clientX, y: e.clientY })}
-        onMouseLeave={() => hoverCard(null)}
+        /* Pointer events with a touch guard, as on GameCard: a tap synthesizes mouseenter and
+           never the matching mouseleave, which used to open the preview on top of whatever the
+           same tap opened and leave it stranded there. */
+        onPointerEnter={(e) => { if (e.pointerType !== 'touch') hoverCard(card.id, { x: e.clientX, y: e.clientY }) }}
+        onPointerLeave={(e) => { if (e.pointerType !== 'touch') hoverCard(null) }}
       >
         {(() => {
           // A sideways-printed card (split layout, Room, battle) reads landscape only once rotated
@@ -531,8 +550,10 @@ export function StackDisplay() {
           {/* Source card image */}
           {sourceCard && (
             <div
-              onMouseEnter={(e) => sourceCard && hoverCard(pendingDecision.context.sourceId!, { x: e.clientX, y: e.clientY })}
-              onMouseLeave={() => hoverCard(null)}
+              onPointerEnter={(e) => { if (e.pointerType !== 'touch' && sourceCard) hoverCard(pendingDecision.context.sourceId!, { x: e.clientX, y: e.clientY }) }}
+              onPointerLeave={(e) => { if (e.pointerType !== 'touch') hoverCard(null) }}
+              onClick={() => handleStackItemTap(pendingDecision.context.sourceId!)}
+              style={{ cursor: openCardMenuOnTap ? 'pointer' : 'default' }}
             >
               <img
                 src={getCardImageUrl(sourceCard.name, sourceCard.imageUri, 'small')}

--- a/web-client/src/components/game/card/CardPreview.tsx
+++ b/web-client/src/components/game/card/CardPreview.tsx
@@ -8,6 +8,7 @@ import { useResponsiveContext, handleImageError, getCounterStatModifier, hasStat
 import { styles } from '../board/styles'
 import { counterManaClass } from '@/assets/icons/keywords'
 import { HoverCardPreview } from '../../ui/HoverCardPreview'
+import { useHasHover } from '@/hooks/useHasHover.ts'
 import { ManaCost, AbilityText } from '../../ui/ManaSymbols'
 import { buildActionOptions, playCostRange, playLadderOptions } from '@/utils/actionOptions.ts'
 import { parseManaCost, totalManaNeeded } from '@/utils/manaCost.ts'
@@ -22,6 +23,7 @@ export function CardPreview() {
   const gameState = useGameStore(selectGameState)
   const playerId = useGameStore(selectViewingPlayerId)
   const responsive = useResponsiveContext()
+  const hasHover = useHasHover()
 
   // All hooks must be called before any early return
   const cardActions = useCardLegalActions(hoveredCardId)
@@ -94,9 +96,15 @@ export function CardPreview() {
 
   if (!card) return null
 
-  // On mobile, show the fullscreen overlay (game-specific behaviour)
-  if (responsive.isMobile) {
-    return <MobileCardPreview card={card} />
+  // On mobile, show the fullscreen overlay (game-specific behaviour). Any device that can't hover
+  // gets it too, whatever its width: the cursor-following variant has nowhere to anchor without a
+  // cursor, and a landscape tablet would otherwise get a 280px card pinned to the top-left corner.
+  //
+  // `dismissible` is exactly "can't hover", not "is a phone": with a mouse the preview is dismissed
+  // by moving off the card, and a tap-catching backdrop over a hovered card would both swallow the
+  // board's clicks and prevent the mouseleave that clears it.
+  if (responsive.isMobile || !hasHover) {
+    return <MobileCardPreview card={card} dismissible={!hasHover} />
   }
 
   const isRevealedFaceDown = card.isFaceDown && !!card.revealedName
@@ -433,31 +441,39 @@ export function CardPreview() {
 /**
  * Mobile fullscreen card preview overlay (game-specific).
  */
-function MobileCardPreview({ card }: { card: import('@/types').ClientCard }) {
+function MobileCardPreview({ card, dismissible = false }: { card: import('@/types').ClientCard; dismissible?: boolean }) {
+  const hoverCard = useGameStore((state) => state.hoverCard)
   const isRevealedFaceDown = card.isFaceDown && !!card.revealedName
   const cardImageUrl = isRevealedFaceDown
     ? getCardImageUrl(card.revealedName!, card.revealedImageUri ?? undefined, 'large')
     : getCardImageUrl(card.name, card.imageUri, 'large')
 
-  const previewWidth = 200
-  const previewHeight = Math.round(previewWidth * 1.4)
+  // As wide as the desktop preview wherever the viewport allows, shrinking to fit narrow or short
+  // screens — the point of opening it is to read the rules text, which 200px can't carry.
+  const previewWidth = 'min(280px, 78vw, calc((100vh - 140px) / 1.4))'
 
   // Portalled to <body> for the same reason HoverCardPreview is: the spectator/replay shells
   // wrap the board in their own stacking context, and the zone browsers (graveyard/exile/deck)
   // portal to <body> — an in-tree preview lands underneath them.
   return createPortal(
-    <div style={{
-      ...styles.cardPreviewOverlay,
-      top: 0, left: 0, right: 0, bottom: 0,
-      display: 'flex', alignItems: 'center', justifyContent: 'center',
-      backgroundColor: 'rgba(0, 0, 0, 0.6)',
-    }}>
-      <div style={{ ...styles.cardPreviewContainer, width: previewWidth }}>
+    <div
+      style={{
+        ...styles.cardPreviewOverlay,
+        top: 0, left: 0, right: 0, bottom: 0,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        backgroundColor: 'rgba(0, 0, 0, 0.6)',
+        // A long-press preview clears itself on touchend; one opened from the action menu's
+        // "View card" has no such gesture behind it, so the backdrop takes the next tap.
+        ...(dismissible ? { pointerEvents: 'auto' as const, cursor: 'pointer' } : null),
+      }}
+      onClick={dismissible ? () => hoverCard(null) : undefined}
+    >
+      <div style={{ ...styles.cardPreviewContainer, width: previewWidth, alignItems: 'center' }}>
         <div style={{
           ...styles.cardPreviewCard,
           position: 'relative',
           width: previewWidth,
-          height: previewHeight,
+          aspectRatio: '63 / 88',
         }}>
           {card.isToken && card.imageUri?.includes('/art_crop/') ? (
             <div style={{
@@ -512,6 +528,16 @@ function MobileCardPreview({ card }: { card: import('@/types').ClientCard }) {
             </div>
           )}
         </div>
+        {dismissible && (
+          <div style={{
+            color: '#aaa',
+            fontSize: 12,
+            textAlign: 'center',
+            textShadow: '0 1px 3px rgba(0, 0, 0, 0.9)',
+          }}>
+            Tap anywhere to close
+          </div>
+        )}
       </div>
     </div>,
     document.body,

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -5,6 +5,8 @@ import type { ClientCard, EntityId, LegalActionInfo } from '@/types'
 import { Color, ColorSymbols, Keyword } from '@/types/enums'
 import { getCardImageUrl, getScryfallFallbackUrl, faceDownImageUrl } from '@/utils/cardImages.ts'
 import { useInteraction } from '@/hooks/useInteraction.ts'
+import { useOpenCardMenuOnTap } from '@/hooks/useOpenCardMenuOnTap.ts'
+import { isGhostMouseEvent, noteTouchInteraction } from '@/utils/ghostMouse.ts'
 import { ManaCost, ManaSymbol } from '@/components/ui/ManaSymbols.tsx'
 import { HoverCardPreview } from '@/components/ui/HoverCardPreview.tsx'
 import {
@@ -289,24 +291,35 @@ function GameCardImpl({
   const submitYesNoDecision = useGameStore((state) => state.submitYesNoDecision)
   const isBeheldPulsing = useGameStore((state) => state.beholdPulses.some((p) => p.cardId === card.id))
   const responsive = useResponsiveContext()
+  const openCardMenuOnTap = useOpenCardMenuOnTap()
   const { handleCardClick, handleDoubleClick, executeAction } = useInteraction()
   const dragStartPos = useRef<{ x: number; y: number } | null>(null)
   const handledByDrag = useRef(false)
   /** Whether the attacker was already selected when drag started (to know if short press = select or deselect) */
   const attackerWasSelected = useRef(false)
 
-  // Hover handlers for card preview — track position via onMouseMove like the deckbuilder
+  // Hover handlers for card preview — track position via the move handler like the deckbuilder.
+  //
+  // Pointer events, not mouse events, and only for a device that can actually hover: a tap fires a
+  // synthesized mouseenter/mousemove pair before its click, so on a phone the preview opened on top
+  // of the action menu that same tap had just opened — and since no mouseleave follows a tap, it
+  // stayed there. Touch reaches the preview through the long-press below instead.
   const updateHoverPosition = useGameStore((s) => s.updateHoverPosition)
 
-  const handleMouseEnter = useCallback((e: React.MouseEvent) => {
+  const handleHoverEnter = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === 'touch') return
     hoverCard(card.id, { x: e.clientX, y: e.clientY })
   }, [card.id, hoverCard])
 
-  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+  const handleHoverMove = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === 'touch') return
     updateHoverPosition({ x: e.clientX, y: e.clientY })
   }, [updateHoverPosition])
 
-  const handleMouseLeave = useCallback(() => {
+  // Guarded on touch too: without it a finger straying off the card during a long-press would clear
+  // the preview that long-press just opened.
+  const handleHoverLeave = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === 'touch') return
     hoverCard(null)
   }, [hoverCard])
 
@@ -328,6 +341,10 @@ function GameCardImpl({
     }, 400)
   }, [card.id, hoverCard, stopDraggingCard, stopDraggingBlocker])
 
+  // Also wired to touchcancel, not just touchend: a long press is exactly the gesture that makes a
+  // mobile browser take the touch away from us (native text selection / callout), and it delivers
+  // touchcancel instead of touchend when it does. Only listening for touchend left the preview
+  // stuck on screen with no way to dismiss it.
   const handleTouchEndPreview = useCallback(() => {
     if (longPressTimer.current) {
       clearTimeout(longPressTimer.current)
@@ -730,7 +747,12 @@ function GameCardImpl({
       stopDraggingCard()
     }
 
-    const handleMouseUp = (e: MouseEvent) => handleGlobalPointerUp(e.clientX, e.clientY)
+    // The mouseup half must ignore a tap's compatibility sequence, or the touchend above and the
+    // ghost mouseup behind it both resolve the same drag.
+    const handleMouseUp = (e: MouseEvent) => {
+      if (isGhostMouseEvent()) return
+      handleGlobalPointerUp(e.clientX, e.clientY)
+    }
     const handleTouchEnd = (e: TouchEvent) => {
       const touch = e.changedTouches[0]
       if (touch) handleGlobalPointerUp(touch.clientX, touch.clientY)
@@ -750,6 +772,7 @@ function GameCardImpl({
     if (!draggingBlockerId) return
 
     const handleGlobalMouseUp = () => {
+      if (isGhostMouseEvent()) return
       stopDraggingBlocker()
     }
 
@@ -886,7 +909,10 @@ function GameCardImpl({
       stopDraggingAttacker()
     }
 
-    const handleMouseUp = (e: MouseEvent) => handleGlobalPointerUp(e.clientX, e.clientY)
+    const handleMouseUp = (e: MouseEvent) => {
+      if (isGhostMouseEvent()) return
+      handleGlobalPointerUp(e.clientX, e.clientY)
+    }
     const handleTouchEnd = (e: TouchEvent) => {
       const touch = e.changedTouches[0]
       if (touch) {
@@ -1077,6 +1103,15 @@ function GameCardImpl({
       } else {
         handleCardClick(card.id)
       }
+      return
+    }
+
+    // Without hover there is no other way to read a card, so on touch every card the player can
+    // actually see opens the menu — an opponent's permanent is `interactive={false}` and would
+    // otherwise swallow the tap, leaving its rules text unreachable. The menu it gets holds only
+    // "View card"; a face-down card is skipped because there is nothing to reveal.
+    if (openCardMenuOnTap && !faceDown && !isInTargetingMode && !isInCombatMode) {
+      openCardMenuOnTap(card.id)
     }
   }
 
@@ -1324,14 +1359,17 @@ function GameCardImpl({
       {...(isGhost ? { 'data-ghost': 'true' } : {})}
       onClick={handleClick}
       onDoubleClick={handleDoubleClickEvent}
-      onMouseDown={handlePointerDown}
-      onMouseUp={handlePointerUp}
-      onTouchStart={(e) => { handleTouchStartPreview(e); handlePointerDown(e) }}
-      onTouchEnd={() => { handleTouchEndPreview(); handlePointerUp() }}
-      onTouchMove={handleTouchMovePreview}
-      onMouseEnter={handleMouseEnter}
-      onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
+      /* Mouse and touch both drive the drag handlers, so every mouse one has to ignore the
+         compatibility sequence a tap fires after touchend — see utils/ghostMouse. */
+      onMouseDown={(e) => { if (!isGhostMouseEvent()) handlePointerDown(e) }}
+      onMouseUp={() => { if (!isGhostMouseEvent()) handlePointerUp() }}
+      onTouchStart={(e) => { noteTouchInteraction(); handleTouchStartPreview(e); handlePointerDown(e) }}
+      onTouchEnd={() => { noteTouchInteraction(); handleTouchEndPreview(); handlePointerUp() }}
+      onTouchCancel={() => { noteTouchInteraction(); handleTouchEndPreview(); handlePointerUp() }}
+      onTouchMove={() => { noteTouchInteraction(); handleTouchMovePreview() }}
+      onPointerEnter={handleHoverEnter}
+      onPointerMove={handleHoverMove}
+      onPointerLeave={handleHoverLeave}
       style={{
         ...styles.card,
         width,

--- a/web-client/src/components/ui/ActionMenu.module.css
+++ b/web-client/src/components/ui/ActionMenu.module.css
@@ -236,6 +236,31 @@
 }
 
 /* =========================================================================
+ * View Card Button
+ * -------------------------------------------------------------------------
+ * Touch-only row (see ActionMenu.showViewCard): opens the full-screen zoomed
+ * card that a mouse gets by hovering. Deliberately neutral rather than one of
+ * the action gradients — it changes nothing about the game state.
+ * ========================================================================= */
+.viewCardButton {
+  width: 100%;
+  min-height: 44px;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background-color: var(--bg-surface-3);
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.viewCardButton:hover {
+  filter: brightness(1.15);
+}
+
+/* =========================================================================
  * Cancel Button
  * ========================================================================= */
 .cancelButton {

--- a/web-client/src/components/ui/ActionMenu.tsx
+++ b/web-client/src/components/ui/ActionMenu.tsx
@@ -2,6 +2,7 @@ import { useEffect, useCallback, useMemo, useState } from 'react'
 import { useGameStore } from '@/store/gameStore.ts'
 import { useCardActions } from '@/hooks/useLegalActions.ts'
 import { useInteraction } from '@/hooks/useInteraction.ts'
+import { useHasHover } from '@/hooks/useHasHover.ts'
 import type { LegalActionInfo } from '@/types'
 import { ManaCost, AbilityText } from './ManaSymbols'
 import { ManaCostProgress } from './ManaCostProgress'
@@ -19,6 +20,8 @@ export function ActionMenu() {
   const selectedCardId = useGameStore((state) => state.selectedCardId)
   const gameState = useGameStore((state) => state.gameState)
   const cardActions = useCardActions(selectedCardId)
+  const hoverCard = useGameStore((state) => state.hoverCard)
+  const hasHover = useHasHover()
   const { executeAction, cancelAction } = useInteraction()
 
   // Get card info for modal display
@@ -36,8 +39,13 @@ export function ActionMenu() {
   const hasMultiplePotentialOptions = actionOptions.length > 1
   const hasSingleAction = actionOptions.length === 1
   const hasAnyLegalAction = cardActions.length > 0
+  // A device that can't hover has no other way to read a card, so the menu doubles as the route to
+  // the zoomed preview: it carries a "View card" row, and it opens for cards with nothing to do at
+  // all (an opponent's creature, a land already played this turn). The 120px thumbnail in this
+  // panel is not that view — it's too small on a phone to read rules text off.
+  const showViewCard = !hasHover
   // Show the nice modal for any actionable card click
-  const shouldShowModal = hasMultiplePotentialOptions || hasSingleAction
+  const shouldShowModal = hasMultiplePotentialOptions || hasSingleAction || showViewCard
 
   // Debug logging - always log when card is selected
   if (import.meta.env.DEV && selectedCardId) {
@@ -67,8 +75,16 @@ export function ActionMenu() {
     }
   }, [selectedCardId, shouldShowModal, handleKeyDown])
 
-  // Don't show if no card selected or no potential options
-  if (!selectedCardId || !hasAnyLegalAction) {
+  // A spell resolving off the stack — or a permanent dying — takes the menu's subject with it.
+  // The menu used to close on its own because it required a legal action, and the vanished card
+  // has none; now that "View card" alone can hold it open, the selection has to be dropped
+  // explicitly or the player is left with a menu for a card that no longer exists.
+  useEffect(() => {
+    if (selectedCardId && gameState && !cardInfo) cancelAction()
+  }, [selectedCardId, gameState, cardInfo, cancelAction])
+
+  // Don't show if no card selected, the card is gone, or there is nothing to offer for it
+  if (!selectedCardId || !cardInfo || (!hasAnyLegalAction && !showViewCard)) {
     return null
   }
 
@@ -104,6 +120,19 @@ export function ActionMenu() {
                 }}
               />
             ))}
+
+            {/* The touch stand-in for desktop hover. The menu deliberately stays open underneath
+                the preview (which sits on the tooltip layer, above it): dismissing the zoomed card
+                drops the player back on the same list of actions rather than making them re-tap
+                the card to play what they just read. */}
+            {showViewCard && (
+              <button
+                className={styles.viewCardButton}
+                onClick={() => hoverCard(selectedCardId)}
+              >
+                View card
+              </button>
+            )}
           </div>
 
           {/* Cancel button */}

--- a/web-client/src/hooks/useHasHover.ts
+++ b/web-client/src/hooks/useHasHover.ts
@@ -10,32 +10,29 @@ import { useSyncExternalStore } from 'react'
  * that follows the cursor — or only because it doesn't — the "View card" row in the action menu,
  * tap-to-dismiss on the preview — keys off this.
  *
- * Every card on the board calls this, so the MediaQueryList is a module-level singleton and the
- * snapshot is cached: `useSyncExternalStore` calls `getSnapshot` on every render, and re-running
- * `matchMedia()` there would allocate ~50 query objects per board repaint.
+ * Every card on the board calls this, so the MediaQueryList is a module-level singleton —
+ * `useSyncExternalStore` calls `getSnapshot` on every render, and re-running `matchMedia()` there
+ * would allocate a query object per card per repaint. Reading `.matches` off the one instance is
+ * free and always current, which a cached copy would not be: a change that lands while nothing is
+ * subscribed has no listener to record it.
+ *
+ * Assume hover wherever the query can't be answered (SSR, jsdom). The desktop behaviour is the safe
+ * default — it costs a phone nothing it didn't already have, while the reverse would strip hover
+ * previews from a real mouse.
  */
 const HOVER_QUERY = '(hover: hover)'
 
 const mediaQuery: MediaQueryList | null =
   typeof window !== 'undefined' && window.matchMedia ? window.matchMedia(HOVER_QUERY) : null
 
-// Assume hover wherever the query can't be answered (SSR, jsdom): the desktop behaviour is the
-// safe default — it costs a phone nothing it didn't already have, while the reverse would strip
-// hover previews from a real mouse.
-let snapshot = mediaQuery?.matches ?? true
-
 function subscribe(onChange: () => void): () => void {
   if (!mediaQuery) return () => {}
-  const listener = () => {
-    snapshot = mediaQuery.matches
-    onChange()
-  }
-  mediaQuery.addEventListener('change', listener)
-  return () => mediaQuery.removeEventListener('change', listener)
+  mediaQuery.addEventListener('change', onChange)
+  return () => mediaQuery.removeEventListener('change', onChange)
 }
 
 function getSnapshot(): boolean {
-  return snapshot
+  return mediaQuery ? mediaQuery.matches : true
 }
 
 function getServerSnapshot(): boolean {

--- a/web-client/src/hooks/useHasHover.ts
+++ b/web-client/src/hooks/useHasHover.ts
@@ -1,0 +1,47 @@
+import { useSyncExternalStore } from 'react'
+
+/**
+ * Whether the primary pointer can hover — false on phones and tablets, true with a mouse or
+ * trackpad (including a hybrid laptop whose screen also takes touch).
+ *
+ * This is a *capability* question, not a size question, so it is deliberately not
+ * `useResponsive().isMobile` (viewport width): a narrow desktop window still hovers, and a
+ * landscape tablet still can't. Anything that exists only because hover exists — the card preview
+ * that follows the cursor — or only because it doesn't — the "View card" row in the action menu,
+ * tap-to-dismiss on the preview — keys off this.
+ *
+ * Every card on the board calls this, so the MediaQueryList is a module-level singleton and the
+ * snapshot is cached: `useSyncExternalStore` calls `getSnapshot` on every render, and re-running
+ * `matchMedia()` there would allocate ~50 query objects per board repaint.
+ */
+const HOVER_QUERY = '(hover: hover)'
+
+const mediaQuery: MediaQueryList | null =
+  typeof window !== 'undefined' && window.matchMedia ? window.matchMedia(HOVER_QUERY) : null
+
+// Assume hover wherever the query can't be answered (SSR, jsdom): the desktop behaviour is the
+// safe default — it costs a phone nothing it didn't already have, while the reverse would strip
+// hover previews from a real mouse.
+let snapshot = mediaQuery?.matches ?? true
+
+function subscribe(onChange: () => void): () => void {
+  if (!mediaQuery) return () => {}
+  const listener = () => {
+    snapshot = mediaQuery.matches
+    onChange()
+  }
+  mediaQuery.addEventListener('change', listener)
+  return () => mediaQuery.removeEventListener('change', listener)
+}
+
+function getSnapshot(): boolean {
+  return snapshot
+}
+
+function getServerSnapshot(): boolean {
+  return true
+}
+
+export function useHasHover(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}

--- a/web-client/src/hooks/useInteraction.ts
+++ b/web-client/src/hooks/useInteraction.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react'
 import { useGameStore } from '@/store/gameStore'
 import type { EntityId, GameAction, LegalActionInfo } from '@/types'
 import { resolveAction, needsInteraction } from './interaction/actionResolvers'
+import { useOpenCardMenuOnTap } from './useOpenCardMenuOnTap'
 import type { ActionContext } from './interaction/actionResolvers'
 
 /**
@@ -31,9 +32,12 @@ export type CardClickResult =
  * couple of cards care about — and each card already tracks its own selection and playability
  * with a narrow per-card selector. Both are only ever needed *inside* the handlers below, so they
  * are read lazily from the store at call time (the same lazy-read pattern as `useLobbyCommands`),
- * leaving this hook with no subscriptions at all.
+ * leaving this hook with no store subscriptions of consequence. (`useOpenCardMenuOnTap` adds two
+ * that effectively never fire: a media query for hover capability, and whether this session is
+ * spectating.)
  */
 export function useInteraction() {
+  const openCardMenuOnTap = useOpenCardMenuOnTap()
   const submitAction = useGameStore((state) => state.submitAction)
   const selectCard = useGameStore((state) => state.selectCard)
   const startTapForPowerSelection = useGameStore((state) => state.startTapForPowerSelection)
@@ -128,8 +132,11 @@ export function useInteraction() {
 
       switch (result.type) {
         case 'noAction':
-          // Clicking a card with no actions deselects
-          selectCard(null)
+          // Clicking a card with no actions deselects — except on a device that can't hover,
+          // where the menu is the only route to the zoomed card, so it opens anyway and shows
+          // just "View card".
+          if (openCardMenuOnTap) openCardMenuOnTap(cardId)
+          else selectCard(null)
           break
 
         case 'singleAction':
@@ -141,7 +148,7 @@ export function useInteraction() {
           break
       }
     },
-    [processCardClick, getCardActions, selectCard]
+    [processCardClick, getCardActions, selectCard, openCardMenuOnTap]
   )
 
   /**

--- a/web-client/src/hooks/useOpenCardMenuOnTap.ts
+++ b/web-client/src/hooks/useOpenCardMenuOnTap.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react'
+import { useGameStore } from '@/store/gameStore'
+import type { EntityId } from '@/types'
+import { useHasHover } from './useHasHover'
+
+/**
+ * Opens the action menu for a card that a tap would otherwise do nothing with — an opponent's
+ * permanent, a land already played this turn, a spell on the stack.
+ *
+ * Without hover there is no other way to read a card, and the menu is where "View card" lives
+ * (see `ActionMenu.showViewCard`), so on those devices every visible card has to be able to open
+ * it. Returns `null` — meaning "leave the tap alone" — when a mouse is present, or while
+ * spectating/replaying, where `GameBoard` doesn't mount the menu at all and selecting a card would
+ * just light it up with nothing to follow.
+ *
+ * Tapping the same card again closes the menu, so the gesture is its own undo.
+ */
+export function useOpenCardMenuOnTap(): ((cardId: EntityId) => void) | null {
+  const selectCard = useGameStore((state) => state.selectCard)
+  const isSpectating = useGameStore((state) => state.spectatingState !== null)
+  const hasHover = useHasHover()
+
+  const open = useCallback(
+    (cardId: EntityId) => {
+      const alreadyOpen = useGameStore.getState().selectedCardId === cardId
+      selectCard(alreadyOpen ? null : cardId)
+    },
+    [selectCard],
+  )
+
+  return hasHover || isSpectating ? null : open
+}

--- a/web-client/src/utils/ghostMouse.ts
+++ b/web-client/src/utils/ghostMouse.ts
@@ -1,0 +1,30 @@
+/**
+ * Tap-generated ("ghost") mouse events.
+ *
+ * A tap fires a compatibility mouse sequence — mouseover/mouseenter, mousemove, mousedown, mouseup,
+ * click — after touchend. A page can normally suppress it by calling `preventDefault()` on
+ * touchstart, but React attaches touchstart, touchmove and wheel as *passive* listeners on its root
+ * container, so a component's `e.preventDefault()` inside `onTouchStart` is a no-op. Anything wired
+ * to both touch and mouse therefore runs twice per tap.
+ *
+ * That is what made tapping a selected attacker blink and stay selected: the touch path deselected
+ * it, and the phantom mousedown immediately after re-ran the same "start dragging an attacker"
+ * handler, which selects an unselected attacker so its arrow can be dragged.
+ *
+ * Touch handlers call {@link noteTouchInteraction}; mouse handlers bail out on
+ * {@link isGhostMouseEvent}. Deliberately time-based rather than keyed off `useHasHover()`: an
+ * actual mouse plugged into a touchscreen device keeps working, it just has to move more than
+ * `GHOST_MOUSE_WINDOW_MS` after the last touch. The state is module-level rather than per-card
+ * because the ghost sequence is not guaranteed to land on the element the touch started on.
+ */
+const GHOST_MOUSE_WINDOW_MS = 700
+
+let lastTouchAt = 0
+
+export function noteTouchInteraction(): void {
+  lastTouchAt = Date.now()
+}
+
+export function isGhostMouseEvent(): boolean {
+  return Date.now() - lastTouchAt < GHOST_MOUSE_WINDOW_MS
+}


### PR DESCRIPTION
# Make card interaction work on touch devices

Playing a game on a phone surfaced four faults. They look unrelated, but all four come from
one thing: the board is wired for a mouse, and a browser fakes mouse input from a tap.

A tap fires a compatibility mouse sequence — `mouseenter`, `mousemove`, `mousedown`, `mouseup`,
`click` — after `touchend`, and never the matching `mouseleave`. A page can normally suppress that
by calling `preventDefault()` on `touchstart`, which `GameCard.handlePointerDown` already does, but
it can't take effect: React registers `touchstart`, `touchmove` and `wheel` as **passive** listeners
on its root container (`react-dom-client.development.js:19251`), so `preventDefault()` inside
`onTouchStart` is a no-op. Anything wired to both touch and mouse therefore runs twice per tap.

## What that broke

- **Tapping a card in hand opened two things.** The phantom `mouseenter` opened the hover preview
  (`--z-tooltip`, 10000) on top of the action menu the same tap opened (`--z-modal`, 1000). No
  `mouseleave` follows a tap, so it stayed there.
- **Tapping a selected attacker blinked and re-selected it.** `touchend` deselected it; the phantom
  `mousedown` immediately after re-ran the attacker-drag handler, which selects an unselected
  attacker so its arrow can be dragged, and recorded `attackerWasSelected = false` so the following
  `mouseup` had nothing to undo.
- **The preview couldn't be dismissed.** Only `touchend` cleared a long-press preview, and a long
  press is exactly the gesture a mobile browser takes the touch away for (native text selection /
  callout) — it delivers `touchcancel` instead. The full-screen overlay was also
  `pointer-events: none`, so there was nothing to tap.
- **Nothing could be read.** Without hover there is no way to see a card's rules text, and the
  action menu's own thumbnail is 120×168 on a phone.

## The fixes

**Suppressing the echo.** Hover is now driven by pointer events gated on `pointerType !== 'touch'`
(`GameCard.tsx:301`, `StackZone.tsx:206`), so touch never opens the preview by accident. A shared
guard, `utils/ghostMouse.ts`, makes every mouse-bound *drag* handler ignore a tap's echo: touch
handlers stamp a timestamp, mouse handlers bail within 700ms of it. That is deliberately time-based
rather than keyed to the hover capability, so a real mouse plugged into a touchscreen device keeps
working. `touchcancel` is now handled alongside `touchend`.

**`useHasHover()`** reports the pointer's capability (`matchMedia('(hover: hover)')`) rather than the
viewport's width. This is not `useResponsive().isMobile`: a narrow desktop window still hovers, and a
landscape tablet still doesn't. Everything below keys off it, so desktop behaviour is untouched at
every width.

**"View card".** On a device that can't hover, the action menu carries a `View card` row, and opens
for cards with nothing to do at all — an opponent's permanent (rendered `interactive={false}`, so it
used to swallow the tap), a land already played this turn, a spell on the stack. The menu stays open
*beneath* the zoomed card, so dismissing it drops the player back on the same list of actions rather
than making them re-tap the card to play what they just read. `useOpenCardMenuOnTap()` holds that
rule once for its three callers, and returns `null` — leave the tap alone — with a mouse present, or
while spectating/replaying, where `GameBoard` doesn't mount the menu at all.

**The preview itself** is now the full-screen variant on any device that can't hover, not only at
phone widths (the cursor-following one has nowhere to anchor without a cursor), takes pointer events
so a tap anywhere dismisses it, and is sized to be read — `min(280px, 78vw, (100vh - 140px) / 1.4)`
rather than a fixed 200px. It stays `pointer-events: none` where hover exists: a tap-catching
backdrop over a hovered card would swallow the board's clicks and block the `mouseleave` that clears
it.

**Stack items** get the same tap and the same touch-guarded hover. Targeting and decision selection
still own the tap whenever either is running, so counterspell targeting is unaffected; a collapsed
pile still expands on tap, and its members are readable once expanded.

**AI Insight** is hidden on phones, matching the game log it sits beside — both are bottom-left
fixed buttons that land on top of the hand, and the log already carried a comment saying exactly
that.

## Also in here

The action menu now drops a selection whose card has vanished (`ActionMenu.tsx:78`). It used to
close on its own by requiring a legal action, which a resolved spell no longer has; now that
`View card` alone can hold it open, a spell resolving off the stack would leave the menu behind.

## Deliberately not done

- The zone browsers (`ZonePiles.tsx`, `DeckBrowser.tsx`) still open the preview from raw
  `onMouseEnter`, so a tap there opens it as a side effect. That is no longer a dead end — the
  preview is dismissible now — but the handlers should get the same `pointerType` guard. Left out to
  keep this diff to the reported flows.
- Blocker/attacker mode still doesn't open the view menu on tap, to stay clear of the drag-based
  block assignment. Long-press still works there.
- No test covers any of this; see below.

## Verification

`npm run typecheck`, `npm test` (41 files, 579 tests) and `npm run build` — all green, run from
`web-client/`.

**What that does not cover: the behaviour this PR is about.** The vitest suite here is pure logic —
there are no `.test.tsx` files and no testing-library in the project, so nothing renders a card or
dispatches a touch sequence. Every claim above about what a tap now does is reasoned from the event
model and read off the code, not observed in a test, and not yet confirmed on a device by me — the
faults were all reported from a phone, and the fixes want the same phone to sign them off. Adding
component-level tests would mean introducing a rendering harness to `web-client`, which felt out of
scope for a bug fix; happy to do it as a follow-up if wanted.

Worth checking by hand: tap a land in hand (menu, no preview), tap "View card" then anywhere (back
to the menu), tap an attacker twice (selects, then deselects and stays deselected), drag an attacker
to a planeswalker (target still assigns), tap a spell on the stack, and cast a counterspell at one
(targeting still wins the tap).

No Kotlin gate was run and none applies — the diff is ten files, all under `web-client/src`.
