### PR TITLE
Give Mirrodin its own basic lands

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/MirrodinSet.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/MirrodinSet.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.mrd
 
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.model.CardDefinition
@@ -24,11 +23,15 @@ object MirrodinSet : MtgSet {
     override val displayName = "Mirrodin"
     override val releaseDate = "2003-10-02"
     override val block = "Mirrodin"
-    override val basicLandsFallback = PortalSet
     override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    /** Mirrodin's own basics: four arts each of the five types, collector numbers 287-306. */
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {


### PR DESCRIPTION
## What

Mirrodin now uses its own basic lands instead of borrowing Portal's.

`MirrodinBasicLands.kt` has held all 20 of the set's art variants since it was added — collector numbers 287–306, four arts each of Plains/Island/Swamp/Mountain/Forest (Mark Tedin, Rob Alexander, Martina Pilcerova, John Avon) — but `MirrodinSet` never overrode `basicLands`. The definitions were dead weight: the set still declared `basicLandsFallback = PortalSet`, so booster/sealed deck building and the game-server card registry handed out Portal lands for an MRD pool.

This wires the package through `CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)` — the single place basics get their set stamp, and the one that applies `BasicLandArt.standardFirst` ordering — and drops the fallback plus its now-unused `PortalSet` import.

One file changed; the land definitions themselves were already correct and are untouched. I re-checked all 20 against Scryfall (`set:mrd t:basic`, `unique=prints`): collector numbers, artists, and image URIs all match, all four arts of each type are `booster: true`, and none are full-art — so ascending collector number correctly leaves 287/291/295/299/303 as the standard art that limited deck building hands out.

## Verification

- `just test-class BasicLandArtOrderTest` — passes (MRD's per-type art order is standard-first).
- `:mtg-sets:test` — full module green, including `CardDefinitionSnapshotTest`, `CardImageUriTest`, `MtgSetCatalogTest`, and `CardDiscoveryEquivalenceTest` ("`CardDiscovery.findBasicLandsIn` agrees with every `MtgSet.basicLands` list"). No snapshot re-bless was needed: `cards` is unchanged, only `basicLands`.
- `:rules-engine:test --tests "com.wingedsheep.engine.limited.*"` — green, covering the booster/basic-land-art path.
- `just build` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)