### PR TITLE
Add two Mirrodin cards

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/IsochronScepter.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/IsochronScepter.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Isochron Scepter
+ * {2}
+ * Artifact
+ *
+ * Imprint — When this artifact enters, you may exile an instant card with mana value 2 or less
+ * from your hand.
+ * {2}, {T}: You may copy the exiled card. If you do, you may cast the copy without paying its
+ * mana cost.
+ *
+ * The imprint is the Chrome Mox shape: a linked exile (`linkToSource = true`) from your own hand,
+ * with no reveal — only the exiled card becomes public. Because the pile is linked to the Scepter,
+ * the activated ability re-reads it live: if the imprinted card leaves exile the gather comes back
+ * empty and nothing is copied, matching the ruling that the copy can't be made once the card has
+ * left the exile zone.
+ *
+ * The printed text carries two "may"s — copy, then cast. They collapse into the single prompt here
+ * because declining the second one is indistinguishable from declining the first: a copy that is
+ * never cast is a card-shaped object in exile that the next state-based-action check removes, and
+ * nothing in the rules triggers on a card in exile being copied. The prompt therefore covers the
+ * whole copy-and-cast, which is the only branch with an observable outcome.
+ */
+val IsochronScepter = card("Isochron Scepter") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Imprint — When this artifact enters, you may exile an instant card with mana " +
+        "value 2 or less from your hand.\n" +
+        "{2}, {T}: You may copy the exiled card. If you do, you may cast the copy without paying " +
+        "its mana cost."
+
+    // Imprint — When this artifact enters, you may exile an instant card with mana value 2 or
+    // less from your hand.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            Patterns.Hand.revealHandAndExileChosen(
+                target = EffectTarget.Controller,
+                filter = GameObjectFilter.Instant.manaValueAtMost(2),
+                prompt = "Choose an instant card with mana value 2 or less to exile",
+                storeChosenAs = "scepterImprint",
+                revealHand = false,
+                linkToSource = true
+            ),
+            descriptionOverride = "You may exile an instant card with mana value 2 or less from your hand."
+        )
+    }
+
+    // {2}, {T}: You may copy the exiled card. If you do, you may cast the copy without paying its
+    // mana cost.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        effect = MayEffect(
+            Effects.Composite(
+                GatherCardsEffect(
+                    source = CardSource.FromLinkedExile(),
+                    storeAs = "scepterImprinted"
+                ),
+                Effects.CopyCollectionIntoCollection(
+                    from = "scepterImprinted",
+                    storeAs = "scepterCopy"
+                ),
+                Effects.CastFromCollectionWithoutPayingCost("scepterCopy")
+            ),
+            descriptionOverride = "You may copy the exiled card and cast the copy without paying its mana cost."
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "188"
+        artist = "Mark Harrison"
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/878b0159-6917-45d3-b9ea-562ac49f0b8f.jpg?1783944517"
+
+        ruling(
+            "2020-08-07",
+            "If Isochron Scepter leaves the battlefield while the activated ability is on the " +
+                "stack, the ability can still make a copy. On the other hand, if the imprinted " +
+                "card leaves the exile zone while the activated ability is on the stack, the copy " +
+                "can't be made."
+        )
+        ruling(
+            "2020-08-07",
+            "You cast the copy while the ability is resolving and still on the stack. You can't " +
+                "wait to cast it later in the turn."
+        )
+        ruling(
+            "2020-08-07",
+            "If you don't want to cast the copy, you can choose not to; the copy ceases to exist " +
+                "the next time state-based actions are checked."
+        )
+        ruling(
+            "2020-08-07",
+            "If you cast a spell \"without paying its mana cost,\" you can't choose to cast it for " +
+                "any alternative costs. You can, however, pay additional costs. If the card has any " +
+                "mandatory additional costs, those must be paid to cast the spell."
+        )
+        ruling(
+            "2020-08-07",
+            "If a spell has {X} in its mana cost, you must choose 0 as the value of X when casting " +
+                "it without paying its mana cost."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ProteusStaff.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ProteusStaff.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Proteus Staff
+ * {3}
+ * Artifact
+ *
+ * {2}{U}, {T}: Put target creature on the bottom of its owner's library. That creature's
+ * controller reveals cards from the top of their library until they reveal a creature card. The
+ * player puts that card onto the battlefield and the rest on the bottom of their library in any
+ * order. Activate only as a sorcery.
+ *
+ * Every clause after the bottoming acts on *that creature's controller*, not on the Staff's, so
+ * the whole reveal runs inside a one-player [Effects.ForEachPlayer] over [Player.ControllerOf].
+ * That rebinds the resolution context's controller, which is what makes `Player.You` mean the
+ * target's controller for the library being revealed *and* routes the "in any order" prompt to
+ * them rather than to the Staff's controller. The reference itself stays correct even though the
+ * creature has already left the battlefield: the engine falls back to the entity's
+ * last-known-permanent snapshot.
+ *
+ * Inside that scope the reveal is the `revealUntilMatchToHand` shape with a different landing
+ * zone: gather until the first creature card, reveal the whole pile, then split it — the single
+ * match onto the battlefield, everything revealed before it to the bottom of the library, under
+ * the target itself since it was bottomed first. That ordering is also why a library holding no
+ * *other* creature card finds the bottomed target and puts it straight back.
+ */
+val ProteusStaff = card("Proteus Staff") {
+    manaCost = "{3}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "{2}{U}, {T}: Put target creature on the bottom of its owner's library. That " +
+        "creature's controller reveals cards from the top of their library until they reveal a " +
+        "creature card. The player puts that card onto the battlefield and the rest on the bottom " +
+        "of their library in any order. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{U}"), Costs.Tap)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.PutOnBottomOfLibrary(creature),
+            Effects.ForEachPlayer(
+                Player.ControllerOf("that creature"),
+                listOf(
+                    GatherUntilMatchEffect(
+                        player = Player.You,
+                        filter = GameObjectFilter.Creature,
+                        storeMatch = "proteusIgnored",
+                        storeRevealed = "proteusRevealed"
+                    ),
+                    RevealCollectionEffect(from = "proteusRevealed"),
+                    FilterCollectionEffect(
+                        from = "proteusRevealed",
+                        filter = CollectionFilter.MatchesFilter(GameObjectFilter.Creature),
+                        storeMatching = "proteusCreature",
+                        storeNonMatching = "proteusRest"
+                    ),
+                    MoveCollectionEffect(
+                        from = "proteusCreature",
+                        destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You)
+                    ),
+                    MoveCollectionEffect(
+                        from = "proteusRest",
+                        destination = CardDestination.ToZone(
+                            Zone.LIBRARY,
+                            Player.You,
+                            ZonePlacement.Bottom
+                        ),
+                        order = CardOrder.ControllerChooses
+                    )
+                )
+            )
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "230"
+        artist = "Trevor Hairsine"
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55e5c69c-43d0-4f5b-8720-40074eb122bb.jpg?1783944506"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/IsochronScepterScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/IsochronScepterScenarioTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.IsochronScepter
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Isochron Scepter (MRD #188) — "Imprint — When this artifact enters, you may exile an instant card
+ * with mana value 2 or less from your hand. {2}, {T}: You may copy the exiled card. If you do, you
+ * may cast the copy without paying its mana cost."
+ *
+ * The point of the card is that the imprinted card *stays* exiled: the ability copies it rather
+ * than casting it, so the same Lightning Bolt is available again next turn. These tests pin that,
+ * plus the two ways the linked-exile pile can be empty — a declined imprint, and a hand with
+ * nothing legal in it.
+ */
+class IsochronScepterScenarioTest : FunSpec({
+
+    val scepterAbility = IsochronScepter.activatedAbilities.single().id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + IsochronScepter)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** Cast the Scepter from hand so the imprint trigger actually fires, and return it. */
+    fun GameTestDriver.castScepter(): EntityId {
+        val inHand = putCardInHand(player1, "Isochron Scepter")
+        giveColorlessMana(player1, 2)
+        castSpell(player1, inHand).error shouldBe null
+        // One pass resolves the artifact, the next resolves the imprint trigger it put on the stack.
+        repeat(4) { if (state.pendingDecision == null) bothPass() }
+        return findPermanent(player1, "Isochron Scepter")!!
+    }
+
+    test("imprints a Lightning Bolt and casts a free copy without spending the exiled card") {
+        val d = driver()
+        val bolt = d.putCardInHand(d.player1, "Lightning Bolt")
+        // Counterspell ({U}{U}, mana value 2) is also legal, so the imprint is a real choice.
+        d.putCardInHand(d.player1, "Counterspell")
+        val scepter = d.castScepter()
+
+        withClue("the imprint is a 'may', so it asks first") {
+            d.submitYesNo(d.player1, true).error shouldBe null
+        }
+        d.submitCardSelection(d.player1, listOf(bolt)).error shouldBe null
+        d.getExileCardNames(d.player1) shouldBe listOf("Lightning Bolt")
+
+        d.giveColorlessMana(d.player1, 2)
+        d.submit(ActivateAbility(d.player1, scepter, scepterAbility)).error shouldBe null
+        d.bothPass()
+        d.submitYesNo(d.player1, true).error shouldBe null
+        d.submitTargetSelection(d.player1, listOf(d.player2)).error shouldBe null
+        d.bothPass()
+
+        withClue("the copy resolved for free") {
+            d.getLifeTotal(d.player2) shouldBe 17
+        }
+        withClue("the imprinted card is still exiled — the Scepter copies, it doesn't spend") {
+            d.getExileCardNames(d.player1) shouldBe listOf("Lightning Bolt")
+        }
+        withClue("only the copy was cast, so the real Bolt never hit the graveyard") {
+            d.getGraveyardCardNames(d.player1).contains("Lightning Bolt") shouldBe false
+        }
+    }
+
+    test("declining the imprint leaves the Scepter with nothing to copy") {
+        val d = driver()
+        d.putCardInHand(d.player1, "Lightning Bolt")
+        val scepter = d.castScepter()
+
+        d.submitYesNo(d.player1, false).error shouldBe null
+        d.getExileCardNames(d.player1) shouldBe emptyList()
+
+        d.giveColorlessMana(d.player1, 2)
+        d.submit(ActivateAbility(d.player1, scepter, scepterAbility)).error shouldBe null
+        d.bothPass()
+        d.submitYesNo(d.player1, true).error shouldBe null
+
+        withClue("an empty linked-exile pile copies nothing and casts nothing") {
+            d.state.pendingDecision shouldBe null
+            d.getLifeTotal(d.player2) shouldBe 20
+        }
+    }
+
+    test("a hand with no instant of mana value 2 or less imprints nothing") {
+        val d = driver()
+        // A creature card, not an instant — every other card in hand is a basic land.
+        val bears = d.putCardInHand(d.player1, "Grizzly Bears")
+        d.castScepter()
+
+        d.submitYesNo(d.player1, true).error shouldBe null
+
+        withClue("there were no legal candidates, so nothing was exiled") {
+            d.getExileCardNames(d.player1) shouldBe emptyList()
+            d.findCardInHand(d.player1, "Grizzly Bears") shouldBe bears
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ProteusStaffScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ProteusStaffScenarioTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.ProteusStaff
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Proteus Staff (MRD #230) — "{2}{U}, {T}: Put target creature on the bottom of its owner's
+ * library. That creature's controller reveals cards from the top of their library until they
+ * reveal a creature card. The player puts that card onto the battlefield and the rest on the
+ * bottom of their library in any order."
+ *
+ * Everything after the bottoming is scoped to the *target's* controller, not the Staff's, and the
+ * target has already left the battlefield by the time that scope is resolved — so these tests
+ * exercise the reveal against an opponent's library too, not just the easy same-player case.
+ */
+class ProteusStaffScenarioTest : FunSpec({
+
+    val staffAbility = ProteusStaff.activatedAbilities.single().id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + ProteusStaff)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** {2}{U} in the pool, ready to pay for one activation. */
+    fun GameTestDriver.fundActivation(player: EntityId) {
+        giveMana(player, Color.BLUE, 1)
+        giveColorlessMana(player, 2)
+    }
+
+    fun GameTestDriver.library(player: EntityId): List<EntityId> =
+        state.getZone(ZoneKey(player, Zone.LIBRARY))
+
+    fun GameTestDriver.setLibrary(player: EntityId, cards: List<EntityId>) {
+        replaceState(state.copy(zones = state.zones + (ZoneKey(player, Zone.LIBRARY) to cards)))
+    }
+
+    test("bottoms the target and puts the first creature revealed onto the battlefield") {
+        val d = driver()
+        val staff = d.putPermanentOnBattlefield(d.player1, "Proteus Staff")
+        val victim = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        d.fundActivation(d.player1)
+
+        // Top of library: one Swamp, then a Centaur Courser to be revealed under it.
+        val courser = d.putCardOnTopOfLibrary(d.player1, "Centaur Courser")
+        val swamp = d.putCardOnTopOfLibrary(d.player1, "Swamp")
+
+        d.submitSuccess(
+            ActivateAbility(
+                d.player1,
+                staff,
+                staffAbility,
+                targets = listOf(ChosenTarget.Permanent(victim))
+            )
+        )
+        d.bothPass()
+
+        withClue("the revealed creature replaces the bottomed one") {
+            d.getCreatures(d.player1) shouldBe listOf(courser)
+        }
+        val library = d.library(d.player1)
+        withClue("the target is bottomed first, then the reveals land under it") {
+            library.takeLast(2) shouldBe listOf(victim, swamp)
+        }
+        withClue("the creature that entered is no longer in the library") {
+            library.contains(courser) shouldBe false
+        }
+    }
+
+    test("the target's controller reveals from their own library and orders their own leftovers") {
+        val d = driver()
+        val staff = d.putPermanentOnBattlefield(d.player1, "Proteus Staff")
+        val victim = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        d.fundActivation(d.player1)
+
+        val courser = d.putCardOnTopOfLibrary(d.player2, "Centaur Courser")
+        val second = d.putCardOnTopOfLibrary(d.player2, "Swamp")
+        val first = d.putCardOnTopOfLibrary(d.player2, "Swamp")
+
+        d.submitSuccess(
+            ActivateAbility(
+                d.player1,
+                staff,
+                staffAbility,
+                targets = listOf(ChosenTarget.Permanent(victim))
+            )
+        )
+        d.bothPass()
+
+        withClue("two non-creature cards were revealed, so their owner orders them") {
+            val decision = d.state.pendingDecision
+            (decision as? ReorderLibraryDecision)?.playerId shouldBe d.player2
+            d.submitOrderedResponse(d.player2, listOf(second, first)).isSuccess shouldBe true
+        }
+
+        withClue("the revealed creature enters under the target's controller, not the Staff's") {
+            d.getCreatures(d.player2) shouldBe listOf(courser)
+            d.getCreatures(d.player1) shouldBe emptyList()
+        }
+        d.library(d.player2).takeLast(3) shouldBe listOf(victim, second, first)
+    }
+
+    test("with no other creature in the library the target is revealed and comes straight back") {
+        val d = driver()
+        val staff = d.putPermanentOnBattlefield(d.player1, "Proteus Staff")
+        val victim = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        d.fundActivation(d.player1)
+
+        // A two-card, creature-free library. The target is bottomed *first*, so it is the only
+        // creature card the reveal can find — and the reveal walks the whole library to find it.
+        val top = d.putCardOnTopOfLibrary(d.player1, "Swamp")
+        val next = d.putCardOnTopOfLibrary(d.player1, "Swamp")
+        d.setLibrary(d.player1, listOf(top, next))
+
+        d.submitSuccess(
+            ActivateAbility(
+                d.player1,
+                staff,
+                staffAbility,
+                targets = listOf(ChosenTarget.Permanent(victim))
+            )
+        )
+        d.bothPass()
+        (d.state.pendingDecision as? ReorderLibraryDecision)?.playerId shouldBe d.player1
+        d.submitOrderedResponse(d.player1, listOf(top, next)).isSuccess shouldBe true
+
+        withClue("the bottomed target is the creature the reveal finds, so it returns") {
+            d.getCreatures(d.player1).map { d.getCardName(it) } shouldBe listOf("Grizzly Bears")
+        }
+        withClue("only the two revealed non-creature cards are left in the library") {
+            d.library(d.player1) shouldBe listOf(top, next)
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -4808,6 +4808,137 @@
     ]
 }
 
+// Isochron Scepter
+{
+    "name": "Isochron Scepter",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "Imprint — When this artifact enters, you may exile an instant card with mana value 2 or less from your hand.\n{2}, {T}: You may copy the exiled card. If you do, you may cast the copy without paying its mana cost.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "filter": "instant mv<=2"
+                                },
+                                "storeAs": "scepterImprintCandidates"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "scepterImprintCandidates",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "scepterImprint",
+                                "prompt": "Choose an instant card with mana value 2 or less to exile"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "scepterImprint",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                },
+                                "linkToSource": true
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "You may exile an instant card with mana value 2 or less from your hand."
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": "FromLinkedExile",
+                                "storeAs": "scepterImprinted"
+                            },
+                            {
+                                "type": "CopyCollectionIntoCollection",
+                                "from": "scepterImprinted",
+                                "storeAs": "scepterCopy"
+                            },
+                            {
+                                "type": "CastFromCollectionWithoutPayingCost",
+                                "from": "scepterCopy"
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "You may copy the exiled card and cast the copy without paying its mana cost."
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "188",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Harrison",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/878b0159-6917-45d3-b9ea-562ac49f0b8f.jpg?1783944517",
+        "rulings": [
+            {
+                "date": "2020-08-07",
+                "text": "If Isochron Scepter leaves the battlefield while the activated ability is on the stack, the ability can still make a copy. On the other hand, if the imprinted card leaves the exile zone while the activated ability is on the stack, the copy can't be made."
+            },
+            {
+                "date": "2020-08-07",
+                "text": "You cast the copy while the ability is resolving and still on the stack. You can't wait to cast it later in the turn."
+            },
+            {
+                "date": "2020-08-07",
+                "text": "If you don't want to cast the copy, you can choose not to; the copy ceases to exist the next time state-based actions are checked."
+            },
+            {
+                "date": "2020-08-07",
+                "text": "If you cast a spell \"without paying its mana cost,\" you can't choose to cast it for any alternative costs. You can, however, pay additional costs. If the card has any mandatory additional costs, those must be paid to cast the spell."
+            },
+            {
+                "date": "2020-08-07",
+                "text": "If a spell has {X} in its mana cost, you must choose 0 as the value of X when casting it without paying its mana cost."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Jinxed Choker
 {
     "name": "Jinxed Choker",

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -9087,6 +9087,120 @@
     ]
 }
 
+// Proteus Staff
+{
+    "name": "Proteus Staff",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}{U}, {T}: Put target creature on the bottom of its owner's library. That creature's controller reveals cards from the top of their library until they reveal a creature card. The player puts that card onto the battlefield and the rest on the bottom of their library in any order. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            },
+                            "destination": "Library",
+                            "placement": "Bottom"
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": {
+                                    "type": "ControllerOf",
+                                    "targetDescription": "that creature"
+                                }
+                            },
+                            "body": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherUntilMatch",
+                                        "filter": "creature",
+                                        "storeMatch": "proteusIgnored",
+                                        "storeRevealed": "proteusRevealed"
+                                    },
+                                    {
+                                        "type": "RevealCollection",
+                                        "from": "proteusRevealed"
+                                    },
+                                    {
+                                        "type": "FilterCollection",
+                                        "from": "proteusRevealed",
+                                        "filter": {
+                                            "type": "MatchesFilter",
+                                            "filter": "creature"
+                                        },
+                                        "storeMatching": "proteusCreature",
+                                        "storeNonMatching": "proteusRest"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "proteusCreature",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Battlefield"
+                                        }
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "proteusRest",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Library",
+                                            "placement": "Bottom"
+                                        },
+                                        "order": "ControllerChooses"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "230",
+        "rarity": "RARE",
+        "artist": "Trevor Hairsine",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/55e5c69c-43d0-4f5b-8720-40074eb122bb.jpg?1783944506"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Psychic Membrane
 {
     "name": "Psychic Membrane",


### PR DESCRIPTION
Two more Mirrodin cards, both built purely from existing `Effects.*` / `Patterns.*` primitives — no new SDK vocabulary.

- **Isochron Scepter** (#188) — imprints an instant of mana value 2 or less from hand into the Scepter's linked exile (`Patterns.Hand.revealHandAndExileChosen(linkToSource = true)`, the Chrome Mox shape), then `GatherCards(FromLinkedExile)` → `CopyCollectionIntoCollection` → `CastFromCollectionWithoutPayingCost` to copy and free-cast it on each activation. The pile is read live, so the copy can't be made once the imprinted card has left exile.
- **Proteus Staff** (#230) — `PutOnBottomOfLibrary` on the target, then the `revealUntilMatchToHand` pipeline with a different landing zone (gather-until-creature → reveal → split → battlefield / bottom-of-library). The whole tail runs inside a one-player `Effects.ForEachPlayer` over `Player.ControllerOf`, which is what scopes the library, the battlefield placement and the "in any order" prompt to the *target's* controller rather than the Staff's.

### Why only two

Every other unimplemented Mirrodin card needs new engine vocabulary, so per AGENTS.md each of them belongs in its own PR. I probed all 24 remaining cards; the blockers are: imprint characteristic/protection copying (Duplicant, Mirror Golem, Soul Foundry, Thought Prison, Spellweaver Helix), coin-flip replacement and repetition (Krark's Thumb, Fiery Gambit), a library-shuffled trigger (Psychogenic Probe), hand-size-at-turn-start tracking (Mindstorm Crown), a lowest-life `PlayerRankMetric` (Loxodon Peacekeeper), a same-name-as-linked-exile filter (Extraplanar Lens), step/phase skipping (Fatespinner), a chosen-source-sharing-a-color prevention filter (Mourner's Shield), a shares-a-card-type target filter (Confusion in the Ranks), a guess decision (Liar's Pendulum), plus Quicksilver Elemental / Quicksilver Fountain / Scythe of the Wretched / Shared Fate / Grim Reminder / Timesifter.

### Notes

- Isochron Scepter's printed text carries two "may"s (copy, then cast). They collapse into one prompt: a copy that is never cast is swept by state-based actions, so declining the second is indistinguishable from declining the first, and nothing triggers on copying a card in exile. Documented on the card.
- Proteus Staff bottoms the target *before* the reveal, so a library with no other creature card finds the target itself and puts it straight back. Covered by a test.

### Verification

- `just build` — green.
- `IsochronScepterScenarioTest` (3 tests) and `ProteusStaffScenarioTest` (3 tests) — green.
- `just check-card-printing` — ok for both; MRD is the earliest real printing of each.
- `just rebless-cards` — only the two new cards moved in `snapshots/cards/MRD.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)