### PR TITLE
Add two Murders at Karlov Manor cards

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/hidden/Determinizer.kt
@@ -163,6 +163,7 @@ class Determinizer(
                 it is CantBeCounteredComponent ||
                 it is CantBeCopiedComponent ||
                 it is HasMorphAbilityComponent ||
+                it is com.wingedsheep.engine.state.components.identity.HasDisguiseAbilityComponent ||
                 it is ProtectionComponent ||
                 it is SelfZoneRedirectComponent ||
                 it is HexproofFromComponent ||

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5157,6 +5157,25 @@ Triggers.youCastSpell(
   emitted from a completed resolution (not the paused may-cast batch), so watchers fire reliably; it
   fires even when the library was empty or no matching card was found.
 
+### Cases (CR 719)
+
+- `WheneverYouSolveACase` — fires as one of your Cases becomes solved (CR 719.3a), i.e. when its
+  "To solve" trigger resolves and `BecomeSolvedExecutor` stamps the designation. Case File Auditor's
+  printed ruling words it as "whenever a 'to solve' ability you control resolves". Backed by
+  `EventPattern.CaseSolvedEvent(player)` + the engine `CaseSolvedEvent`; the binding is
+  `TriggerBinding.ANY`, because the event subject is the **Case**, not the permanent carrying the
+  payoff.
+  - The **solving player rides the event** (`CaseSolvedEvent.controllerId`, the Case's projected
+    controller at the moment it was solved) rather than being read back off the permanent: a Case
+    whose "Solved —" ability sacrifices it is already gone by the time a payoff is matched. That is
+    also what makes `Player.You` mean "the player who solved it", so an opponent's Case solving
+    never fires your Auditor.
+  - Fires **at most once per Case object**: the designation is sticky and one-way (CR 719.3b), and
+    `BecomeSolvedExecutor` emits nothing for an already-solved permanent. A Case that leaves and
+    returns is a new object and can be solved again.
+  - Solved-ness itself is read with `Conditions.SourceIsSolved` / `.solved()`; this is the *moment
+    it flips*, not the standing state.
+
 ### Explore (CR 701.44)
 
 - `Triggers.creatureExplores(filter, revealedType)` — "Whenever a permanent matching `filter`
@@ -11034,6 +11053,9 @@ Card authors rarely reference these directly; they are created/updated by the ma
     nor a copiable value. `Effects.BecomeSolved` stamps it, `Conditions.SourceIsSolved` / `.solved()` /
     `StatePredicate.IsSolved` read it, `ClientCard.isSolved` surfaces it as a card badge, and
     `ZoneMovementUtils.stripBattlefieldComponents` drops it when the Case leaves the battlefield.
+  - The **moment** it flips is `Triggers.WheneverYouSolveACase` (§ Cases (CR 719) under triggers) —
+    "when this creature enters **and whenever you solve a Case**" (Case File Auditor). That is the
+    event, not the standing state; `SourceIsSolved` is the state.
   - An **unsolved** Case shows how close its criterion is as a `current/required` badge — Case of the
     Burning Masks counts 0/3 up to 3/3 as sources deal damage — and drops it once solved. That falls
     out of the generic intervening-if badge (§ Triggered abilities) reading inside the

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3859,6 +3859,18 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
 - `.nontoken()` / `.token()` — token vs printed.
 - `.monocolored()` — restrict to monocolored objects (exactly one color, CR 105.2); colorless objects don't match. ("for each color among monocolored permanents you control" — Tarnation Vista.)
 - `.faceDown()` — face-down state.
+- `.withMorph()` — has a morph *procedure*: the printed keyword (`HasMorphAbilityComponent`, any
+  zone) **or** a turn-up procedure whose mechanic is morph. "Creature with a morph ability"
+  (Backslide) — a manifested/cloaked/disguised permanent carries turn-up data too, so the runtime
+  half checks the mechanic rather than the component's presence.
+- `.withDisguise()` — has a printed **disguise** ability (CR 702.168), read off the card definition
+  via `HasDisguiseAbilityComponent`, so it answers the same in every zone and regardless of whether
+  the object is currently face down. Deliberately *not* a `withMorph()` variant: that asks "can this
+  be turned face up", which is also true of a cloaked permanent that has no disguise, and is only
+  answerable while the permanent is face **down**. Expose the Culprit's "any number of face-up
+  creatures you control **with disguise**" asks the printed-ability question about a face-**up**
+  permanent, which is why the component rides the card rather than the turn-up data:
+  `GameObjectFilter.Creature.youControl().faceUp().withDisguise()`.
 - `.card(filter)` — defer to a card-shape filter for off-battlefield checks.
 
 **Explicit constructor**:

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -2451,6 +2451,20 @@ object Triggers {
     )
 
     /**
+     * Whenever you solve a Case (CR 719.3a). Fires as the Case's own "To solve" trigger resolves and
+     * stamps the designation — Case File Auditor's ruling words it as "whenever a 'to solve' ability
+     * you control resolves". Binding is [TriggerBinding.ANY]: the event subject is the *Case*, not
+     * the permanent bearing this trigger, and "you" is the solving player.
+     *
+     * Fires once per Case, ever: the designation is sticky and one-way (CR 719.3b), so a Case can't
+     * be re-solved. This includes the Case that carries the payoff, if it is itself a Case.
+     */
+    val WheneverYouSolveACase: TriggerSpec = TriggerSpec(
+        event = CaseSolvedEvent(Player.You),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
      * Whenever a permanent matching [filter] explores (CR 701.44), optionally gated by the reveal
      * outcome ([revealedType]). Binding is [TriggerBinding.ANY] — the observer watches every
      * matching permanent, so `filter.youControl()` resolves "you" to the observer's controller.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -542,6 +542,26 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     /**
+     * Whenever [player] solves a Case (CR 719.3a) — fires as that Case's "To solve" trigger
+     * resolves and the designation is stamped, which is exactly what the printed ruling for Case
+     * File Auditor says ("triggers whenever a 'to solve' ability you control resolves").
+     *
+     * The solving player is the Case's controller, carried on the engine event rather than looked
+     * up afterwards: a Case whose Solved ability sacrifices it is already gone by the time this
+     * payoff is matched.
+     *
+     * The designation is sticky and one-way (CR 719.3b), so this can only fire once per Case
+     * object — a Case that leaves and returns is a new object and can be solved again.
+     */
+    @SerialName("CaseSolvedEvent")
+    @Serializable
+    data class CaseSolvedEvent(
+        val player: Player = Player.You
+    ) : EventPattern {
+        override val description: String = "${player.description} solves a Case"
+    }
+
+    /**
      * Whenever a permanent matching [filter] explores (CR 701.44), optionally gated by whether the
      * revealed card was a land ([revealedType]). The exploring permanent is the event subject, so
      * "a creature you control explores" is `filter = GameObjectFilter.Creature.youControl()` with a

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -1070,6 +1070,14 @@ data class GameObjectFilter(
         statePredicates = statePredicates + StatePredicate.HasMorphAbility
     )
 
+    /**
+     * Must have a printed disguise ability (CR 702.168) — see [StatePredicate.HasDisguiseAbility].
+     * Zone-independent, and independent of whether the object is currently face down.
+     */
+    fun withDisguise() = copy(
+        statePredicates = statePredicates + StatePredicate.HasDisguiseAbility
+    )
+
     /** Must have a counter of the specified type */
     fun withCounter(counterType: String) = copy(
         statePredicates = statePredicates + StatePredicate.HasCounter(counterType)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -497,6 +497,24 @@ sealed interface StatePredicate {
         override val description: String = "with a morph ability"
     }
 
+    /**
+     * Has a **disguise** ability (CR 702.168) — the printed keyword, read off the card definition,
+     * so it answers the same in every zone.
+     *
+     * Deliberately *not* folded into [HasMorphAbility], which asks "can this be turned face up by a
+     * morph-family procedure" and therefore also answers true for a permanent that is face down for
+     * some other reason. Disguise is a printed ability of a card, and Expose the Culprit's "any
+     * number of face-up creatures you control **with disguise**" asks about the card's abilities
+     * while it is face **up** — a moment at which no turn-up procedure exists to inspect. A cloaked
+     * permanent is face down without having disguise; a card with disguise sitting in hand has it
+     * without being face down. This predicate is the printed-ability half only.
+     */
+    @SerialName("HasDisguiseAbility")
+    @Serializable
+    data object HasDisguiseAbility : Entity {
+        override val description: String = "with disguise"
+    }
+
     // =============================================================================
     // Counters (Entity)
     // =============================================================================

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CaseFileAuditor.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CaseFileAuditor.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.SpendAnyManaTypeForSpells
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Case File Auditor — Murders at Karlov Manor #7
+ * {2}{W} · Creature — Human Detective · 1/4 · Uncommon
+ *
+ * When this creature enters and whenever you solve a Case, look at the top six cards of your
+ * library. You may reveal an enchantment card from among them and put it into your hand. Put the
+ * rest on the bottom of your library in a random order.
+ * You may spend mana as though it were mana of any color to cast Case spells.
+ *
+ * **Two triggered abilities, not one.** The printed sentence joins them, but CR 603.1 makes "when
+ * this creature enters" and "whenever you solve a Case" separate abilities with separate
+ * conditions — the repo's Up the Beanstalk idiom, one `triggeredAbility` block each. They also
+ * differ in binding: the enters trigger watches this creature, while the solve trigger watches
+ * every Case its controller has, so it can't be folded into a single `Triggers.or`.
+ *
+ * `Triggers.WheneverYouSolveACase` fires when a Case's "To solve" trigger resolves and stamps the
+ * designation, which is exactly what the printed ruling says. The solved-ness is sticky and one-way
+ * (CR 719.3b), so each Case feeds this at most once — and a Case whose Solved ability sacrifices it
+ * still counts, because the solving player rides the event rather than being read back off a
+ * permanent that may already be gone.
+ *
+ * **The look is "up to one", not "one".** "You *may* reveal an enchantment card" is a declinable
+ * choice, so it is `chooseUpToSplit(1, …)` filtered to enchantments — never `chooseExactly`, which
+ * would force the pick whenever an enchantment happened to be there. Declining (or looking at six
+ * non-enchantments) leaves the kept slot empty, and the reveal and hand move are no-ops over it.
+ * All six are shown (`showAllCards`) because the card says *look at* the top six — the player sees
+ * the lands and creatures they are burying, even though only an enchantment may be taken.
+ *
+ * The bottoming is `CardOrder.Random`, not the usual controller-chooses: "in a random order" means
+ * the player does not get to stack their own library.
+ *
+ * The mana ability is [SpendAnyManaTypeForSpells] over the Case subtype — zone-agnostic and mana-
+ * only, so a Case cast from anywhere gets its colored pips relaxed while any additional cost is
+ * untouched. Note this is a *fixing* effect for the whole Case cycle (five colors of Case in this
+ * set), not a discount.
+ */
+val CaseFileAuditor = card("Case File Auditor") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Detective"
+    power = 1
+    toughness = 4
+    oracleText = "When this creature enters and whenever you solve a Case, look at the top six " +
+        "cards of your library. You may reveal an enchantment card from among them and put it " +
+        "into your hand. Put the rest on the bottom of your library in a random order.\n" +
+        "You may spend mana as though it were mana of any color to cast Case spells."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = lookAtSixForAnEnchantment()
+        description = "When this creature enters, look at the top six cards of your library. You " +
+            "may reveal an enchantment card from among them and put it into your hand. Put the " +
+            "rest on the bottom of your library in a random order."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.WheneverYouSolveACase
+        effect = lookAtSixForAnEnchantment()
+        description = "Whenever you solve a Case, look at the top six cards of your library. You " +
+            "may reveal an enchantment card from among them and put it into your hand. Put the " +
+            "rest on the bottom of your library in a random order."
+    }
+
+    staticAbility {
+        ability = SpendAnyManaTypeForSpells(GameObjectFilter.Any.withSubtype(Subtype.CASE))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "7"
+        artist = "Ryan Valle"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70a52038-9d1c-4be1-8dbe-6f0ee916ba94.jpg?1783912929"
+
+        ruling(
+            "2024-02-02",
+            "Case File Auditor's first ability triggers whenever a \"to solve\" ability you " +
+                "control resolves."
+        )
+    }
+}
+
+/**
+ * The shared payoff of both triggers, built fresh per call so the two abilities are independent
+ * effect trees rather than one shared instance.
+ */
+private fun lookAtSixForAnEnchantment() = Effects.Pipeline {
+    val looked = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(6)))
+    val (kept, rest) = chooseUpToSplit(
+        count = 1,
+        from = looked,
+        filter = GameObjectFilter.Enchantment,
+        prompt = "You may reveal an enchantment card and put it into your hand",
+        selectedLabel = "To hand",
+        remainderLabel = "Bottom of library",
+        showAllCards = true
+    )
+    reveal(kept)
+    toHand(kept)
+    toLibraryBottom(rest, order = CardOrder.Random)
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ExposeTheCulprit.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ExposeTheCulprit.kt
@@ -1,0 +1,144 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.TurnFaceUpEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Expose the Culprit — Murders at Karlov Manor #124
+ * {1}{R} · Instant · Uncommon
+ *
+ * Choose one or both —
+ * • Turn target face-down creature face up.
+ * • Exile any number of face-up creatures you control with disguise in a face-down pile, shuffle
+ *   that pile, then cloak them.
+ *
+ * **"Choose one or both" is the count, not a third mode** — `chooseCount = 2` with
+ * `minChooseCount = 1` (CR 700.2), the same shape as Winterflame. Spelling "both" as an extra mode
+ * would misreport `SpellCastEvent.chosenModesCount` and give a mode-changing copy effect three
+ * modes to pick from instead of two.
+ *
+ * **Mode 1** is Break Open without the "an opponent controls" clause: any face-down creature is a
+ * legal target, including your own. Turning it face up is *not* the special action — no cost is
+ * paid and no reveal-a-creature-card requirement applies (CR 701.58c is about the special action,
+ * not about effects that turn a permanent face up). The printed ruling for a face-down *instant or
+ * sorcery* card is that it is revealed and stays face down, with no turned-face-up trigger;
+ * `TurnFaceUpExecutor` already owns that branch, which is why this mode is one effect and not a
+ * conditional.
+ *
+ * **Mode 2 is not a targeted mode.** "Exile any number of face-up creatures you control" prints no
+ * "target", so it is a resolution-time choice — a gather → choose → exile → return pipeline, not a
+ * `TargetPermanent(unlimited = true)`. That distinction is load-bearing: shroud, protection and
+ * "can't be the target of spells" on your own creature do not stop this, and a creature that
+ * becomes an illegal target between cast and resolution is still eligible.
+ *
+ * The `withDisguise()` filter is the **printed** disguise ability (CR 702.168), read off the card
+ * in any zone — deliberately not `withMorph()`, which asks the "can this be turned face up"
+ * question and would also answer true for a cloaked or manifested permanent. Combined with
+ * `faceUp()` it is exactly the card's wording: a disguise creature you already turned face up (or
+ * simply hard-cast) can be hidden away again, which is the card's whole trick.
+ *
+ * **The shuffle is informational.** In paper the pile is shuffled so opponents can't track which
+ * cloaked permanent is which (the printed ruling adds "after you cloak the creatures, you may look
+ * at them" — the controller keeps the information). This engine hides a face-down permanent's card
+ * from everyone but its controller regardless of order, so the shuffle changes no game state; it is
+ * expressed as `CardOrder.Random` on the return move so the intent survives in the script rather
+ * than being silently dropped.
+ *
+ * Cloaking is `FaceDownMode.CLOAK` on the move that puts the cards onto the battlefield (CR 701.58)
+ * — the 2/2 body and the ward {2} are data on the mode, not abilities this card grants. The cards
+ * genuinely pass through exile, so each returns as a **new object**: Auras fall off, counters are
+ * gone, and summoning sickness applies afresh.
+ */
+val ExposeTheCulprit = card("Expose the Culprit") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Choose one or both —\n" +
+        "• Turn target face-down creature face up.\n" +
+        "• Exile any number of face-up creatures you control with disguise in a face-down pile, " +
+        "shuffle that pile, then cloak them. (To cloak a card, put it onto the battlefield face " +
+        "down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's " +
+        "a creature card.)"
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Turn target face-down creature face up") {
+                val faceDownCreature = target(
+                    "face-down creature",
+                    TargetPermanent(filter = TargetFilter(GameObjectFilter.Creature.faceDown()))
+                )
+                effect = TurnFaceUpEffect(faceDownCreature)
+            }
+            mode("Exile any number of face-up creatures you control with disguise, then cloak them") {
+                effect = Effects.Pipeline {
+                    val candidates = gather(
+                        GameObjectFilter.Creature.youControl().faceUp().withDisguise()
+                    )
+                    // Selecting permanents already in play — the battlefield UI, not an overlay,
+                    // so the player can see counters, Auras and which duplicate is which.
+                    val chosen = chooseAnyNumber(
+                        from = candidates,
+                        prompt = "Exile any number of face-up creatures you control with disguise",
+                        useTargetingUI = true
+                    )
+                    val piled = moveTracked(chosen, CardDestination.ToZone(Zone.EXILE))
+                    move(
+                        piled,
+                        CardDestination.ToZone(Zone.BATTLEFIELD),
+                        order = CardOrder.Random,
+                        faceDown = FaceDownMode.CLOAK
+                    )
+                }
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "124"
+        artist = "Ryan Valle"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31aadd3d-5ce1-44ba-ac6d-b192a9ea491b.jpg?1783912881"
+
+        ruling(
+            "2024-02-02",
+            "The pile is shuffled to disguise from your opponents which cloaked creature is which. " +
+                "After you cloak the creatures, you may look at them."
+        )
+        ruling(
+            "2024-02-02",
+            "To cloak a card, put it onto the battlefield face down. It becomes a 2/2 face-down " +
+                "creature card with ward {2} and no name, mana cost, or creature types. It's " +
+                "colorless and has a mana value of 0. Other effects that apply to the permanent " +
+                "can still grant it any characteristics it doesn't have or change the " +
+                "characteristics it does have."
+        )
+        ruling(
+            "2024-02-02",
+            "If a cloaked creature would have disguise (or morph) if it were face up, you may also " +
+                "turn it face up by paying its disguise (or morph) cost."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+        ruling(
+            "2024-02-02",
+            "If something tries to turn a face-down instant or sorcery card on the battlefield " +
+                "face up, reveal that card to show all players it's an instant or sorcery card. " +
+                "The permanent remains on the battlefield face down. Abilities that trigger when a " +
+                "permanent turns face up won't trigger, because even though you revealed the card, " +
+                "it never turned face up."
+        )
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CaseFileAuditorScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CaseFileAuditorScenarioTest.kt
@@ -1,0 +1,172 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.SolvedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.CaseFileAuditor
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.CaseOfTheGatewayExpress
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Case File Auditor — "When this creature enters **and whenever you solve a Case**, look at the top
+ * six cards of your library. You may reveal an enchantment card from among them and put it into
+ * your hand. Put the rest on the bottom of your library in a random order."
+ *
+ * The new vocabulary is `Triggers.WheneverYouSolveACase`, so the load-bearing assertions are:
+ *
+ *  1. solving a Case fires it — and fires it for the *solving* player, which is what the event's
+ *     carried controller is for;
+ *  2. it does **not** fire on the Case merely entering, nor on an opponent's Case being solved;
+ *  3. the two printed conditions are two abilities, so an Auditor that entered earlier still sees a
+ *     later solve.
+ *
+ * The look itself is the "up to one" shape: the pick is filtered to enchantments and declinable, so
+ * a library of six non-enchantments must resolve with no prompt-forced pick and an unchanged hand.
+ */
+class CaseFileAuditorScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(CaseFileAuditor)
+        driver.registerCard(CaseOfTheGatewayExpress)
+        driver.initMirrorMatch(Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Stack [names] so that `names.first()` ends up on top of [player]'s library. */
+    fun GameTestDriver.stackTop(player: EntityId, names: List<String>) {
+        names.reversed().forEach { putCardOnTopOfLibrary(player, it) }
+    }
+
+    fun GameTestDriver.isSolved(id: EntityId): Boolean =
+        state.getEntity(id)?.has<SolvedComponent>() == true
+
+    test("the enters trigger looks at six and takes the enchantment") {
+        val driver = newDriver()
+        driver.stackTop(
+            driver.player1,
+            listOf("Plains", "Plains", "Case of the Gateway Express", "Plains", "Plains", "Plains")
+        )
+        val handBefore = driver.getHand(driver.player1).size
+
+        val card = driver.putCardInHand(driver.player1, "Case File Auditor")
+        driver.giveMana(driver.player1, Color.WHITE, 3)
+        driver.castSpell(driver.player1, card).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature; the enters trigger goes on the stack
+        driver.bothPass() // resolve the trigger
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        withClue("declinable — 'you may reveal'") { decision.minSelections shouldBe 0 }
+        withClue("only the enchantment among the six is selectable") {
+            decision.options.size shouldBe 1
+            decision.maxSelections shouldBe 1
+        }
+        withClue("but all six are shown — the card says 'look at the top six'") {
+            decision.options.size + decision.nonSelectableOptions.size shouldBe 6
+        }
+        val enchantment = decision.options.single()
+        driver.submitCardSelection(driver.player1, listOf(enchantment))
+
+        withClue("the Case goes to hand; the Auditor itself left the hand when cast") {
+            driver.getHand(driver.player1).contains(enchantment) shouldBe true
+            driver.getHand(driver.player1).size shouldBe handBefore + 1
+        }
+        withClue("the other five are bottomed, not exiled or milled") {
+            driver.state.getZone(driver.player1, Zone.LIBRARY).size shouldBe
+                driver.state.getZone(driver.player1, Zone.LIBRARY).distinct().size
+            driver.state.getZone(driver.player1, Zone.GRAVEYARD).isEmpty() shouldBe true
+        }
+    }
+
+    test("declining takes nothing and bottoms all six") {
+        val driver = newDriver()
+        driver.stackTop(
+            driver.player1,
+            listOf("Plains", "Plains", "Case of the Gateway Express", "Plains", "Plains", "Plains")
+        )
+        val librarySize = driver.state.getZone(driver.player1, Zone.LIBRARY).size
+        val handBefore = driver.getHand(driver.player1).size
+
+        val card = driver.putCardInHand(driver.player1, "Case File Auditor")
+        driver.giveMana(driver.player1, Color.WHITE, 3)
+        driver.castSpell(driver.player1, card).isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass()
+
+        driver.submitCardSelection(driver.player1, emptyList())
+
+        driver.getHand(driver.player1).size shouldBe handBefore
+        withClue("nothing left the library") {
+            driver.state.getZone(driver.player1, Zone.LIBRARY).size shouldBe librarySize
+        }
+    }
+
+    test("solving a Case fires the second ability on an Auditor already in play") {
+        val driver = newDriver()
+        val auditor = driver.putCreatureOnBattlefield(driver.player1, "Case File Auditor")
+        val case = driver.putPermanentOnBattlefield(driver.player1, "Case of the Gateway Express")
+        val a = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        val b = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        val c = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        listOf(a, b, c).forEach { driver.removeSummoningSickness(it) }
+        driver.stackTop(
+            driver.player1,
+            listOf("Plains", "Plains", "Case of the Gateway Express", "Plains", "Plains", "Plains")
+        )
+
+        withClue("putting the Case into play does not solve it, so nothing has fired yet") {
+            driver.isSolved(case) shouldBe false
+            (driver.pendingDecision is SelectCardsDecision) shouldBe false
+        }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(driver.player1, listOf(a, b, c), driver.player2)
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass() // the "To solve" trigger resolves and stamps the designation
+        driver.isSolved(case) shouldBe true
+
+        driver.bothPass() // the Auditor's solve trigger resolves
+
+        val decision = driver.pendingDecision
+        withClue("the Auditor was already on the battlefield and still sees the solve") {
+            decision.shouldBeInstanceOf<SelectCardsDecision>()
+            decision.playerId shouldBe driver.player1
+        }
+        driver.state.getBattlefield().contains(auditor) shouldBe true
+    }
+
+    test("an opponent solving their own Case does not fire your Auditor") {
+        val driver = newDriver()
+        driver.putCreatureOnBattlefield(driver.player1, "Case File Auditor")
+        val theirCase = driver.putPermanentOnBattlefield(driver.player2, "Case of the Gateway Express")
+        val a = driver.putCreatureOnBattlefield(driver.player2, "Grizzly Bears")
+        val b = driver.putCreatureOnBattlefield(driver.player2, "Grizzly Bears")
+        val c = driver.putCreatureOnBattlefield(driver.player2, "Grizzly Bears")
+        listOf(a, b, c).forEach { driver.removeSummoningSickness(it) }
+
+        // Hand the turn to player 2 so their creatures can attack and their Case can solve.
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(driver.player2, listOf(a, b, c), driver.player1)
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        driver.isSolved(theirCase) shouldBe true
+        withClue("\"whenever YOU solve a Case\" — the solving player is the Case's controller") {
+            (driver.pendingDecision is SelectCardsDecision) shouldBe false
+        }
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ExposeTheCulpritScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ExposeTheCulpritScenarioTest.kt
@@ -1,0 +1,165 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.BasilicaStalker
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.ExposeTheCulprit
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Expose the Culprit — "Choose one or both — • Turn target face-down creature face up. • Exile any
+ * number of face-up creatures you control with disguise in a face-down pile, shuffle that pile,
+ * then cloak them."
+ *
+ * The card's own logic is two existing primitives, so what actually needs proving here is the new
+ * `withDisguise()` filter and the two shapes it has to get right:
+ *
+ *  1. it selects on the **printed** disguise ability, so a vanilla creature is never offered even
+ *     though it is just as face-up and just as yours — a filter that fell through to "any creature
+ *     you control" would still pass a happy-path test;
+ *  2. it reads the card, not the turn-up procedure, so it holds for a creature that is *face up*
+ *     right now — which is the only state the mode can ever see.
+ *
+ * Plus the mode-2 outcome itself: the chosen creature really leaves via exile and comes back
+ * cloaked (face down, `FaceDownMode.CLOAK`), which is what makes it a new object rather than a
+ * turned-over one.
+ */
+class ExposeTheCulpritScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ExposeTheCulprit)
+        driver.registerCard(BasilicaStalker)
+        driver.initMirrorMatch(Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Put [cardName] onto [playerId]'s battlefield face down under [mode], the way a real entry does. */
+    fun GameTestDriver.putFaceDown(playerId: EntityId, cardName: String, mode: FaceDownMode): EntityId {
+        val id = putPermanentOnBattlefield(playerId, cardName)
+        val cardDef = cardRegistry.requireCard(cardName)
+        replaceState(
+            state.updateEntity(id) { container ->
+                var c = container.with(FaceDownComponent).with(FaceDownModeComponent(mode))
+                FaceDownTurnUp.dataFor(cardDef, cardName, mode)?.let { c = c.with(it) }
+                c
+            }
+        )
+        return id
+    }
+
+    fun GameTestDriver.isFaceDown(id: EntityId): Boolean =
+        state.getEntity(id)?.has<FaceDownComponent>() == true
+
+    /** Cast the spell with exactly [modes] chosen, each carrying the targets in [targetsPerMode]. */
+    fun GameTestDriver.castExpose(modes: List<Int>, targetsPerMode: List<List<ChosenTarget>>) {
+        val spell = putCardInHand(player1, "Expose the Culprit")
+        giveMana(player1, Color.RED, 4)
+        submit(
+            CastSpell(
+                playerId = player1,
+                cardId = spell,
+                targets = targetsPerMode.flatten(),
+                chosenModes = modes,
+                modeTargetsOrdered = targetsPerMode
+            )
+        ).error shouldBe null
+        bothPass()
+    }
+
+    test("mode 1 turns a face-down creature face up") {
+        val driver = newDriver()
+        val hidden = driver.putFaceDown(driver.player1, "Basilica Stalker", FaceDownMode.DISGUISE)
+        driver.isFaceDown(hidden) shouldBe true
+
+        driver.castExpose(listOf(0), listOf(listOf(ChosenTarget.Permanent(hidden))))
+
+        withClue("no cost is paid — the effect turns it face up outright") {
+            driver.isFaceDown(hidden) shouldBe false
+        }
+        val projected = StateProjector().project(driver.state)
+        projected.getPower(hidden) shouldBe 3
+        projected.getToughness(hidden) shouldBe 4
+    }
+
+    test("mode 2 offers only face-up creatures you control with disguise") {
+        val driver = newDriver()
+        val stalker = driver.putCreatureOnBattlefield(driver.player1, "Basilica Stalker")
+        val bears = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        val theirStalker = driver.putCreatureOnBattlefield(driver.player2, "Basilica Stalker")
+        val hidden = driver.putFaceDown(driver.player1, "Basilica Stalker", FaceDownMode.DISGUISE)
+
+        driver.castExpose(listOf(1), listOf(emptyList()))
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        val offered = decision.options.toSet()
+        withClue("a face-up disguise creature you control is the only legal pick") {
+            offered shouldBe setOf(stalker)
+        }
+        withClue("no disguise on the card") { offered.contains(bears) shouldBe false }
+        withClue("not yours") { offered.contains(theirStalker) shouldBe false }
+        withClue("already face down, so not face-up") { offered.contains(hidden) shouldBe false }
+    }
+
+    test("mode 2 exiles the chosen creature and returns it cloaked") {
+        val driver = newDriver()
+        val stalker = driver.putCreatureOnBattlefield(driver.player1, "Basilica Stalker")
+
+        driver.castExpose(listOf(1), listOf(emptyList()))
+        driver.submitCardSelection(driver.player1, listOf(stalker))
+
+        withClue("it is back on the battlefield, not left in exile") {
+            driver.state.getZone(driver.player1, Zone.BATTLEFIELD).contains(stalker) shouldBe true
+        }
+        driver.isFaceDown(stalker) shouldBe true
+        driver.state.getEntity(stalker)?.get<FaceDownModeComponent>()?.mode shouldBe FaceDownMode.CLOAK
+
+        val projected = StateProjector().project(driver.state)
+        withClue("a cloaked permanent is a 2/2 (CR 701.58a), not the 3/4 it was") {
+            projected.getPower(stalker) shouldBe 2
+            projected.getToughness(stalker) shouldBe 2
+        }
+    }
+
+    test("mode 2 selecting nothing is legal and changes nothing") {
+        val driver = newDriver()
+        val stalker = driver.putCreatureOnBattlefield(driver.player1, "Basilica Stalker")
+
+        driver.castExpose(listOf(1), listOf(emptyList()))
+        driver.submitCardSelection(driver.player1, emptyList())
+
+        driver.isFaceDown(stalker) shouldBe false
+        StateProjector().project(driver.state).getPower(stalker) shouldBe 3
+    }
+
+    test("both modes — one creature flips up while another is cloaked") {
+        val driver = newDriver()
+        val hidden = driver.putFaceDown(driver.player1, "Basilica Stalker", FaceDownMode.DISGUISE)
+        val stalker = driver.putCreatureOnBattlefield(driver.player1, "Basilica Stalker")
+
+        driver.castExpose(listOf(0, 1), listOf(listOf(ChosenTarget.Permanent(hidden)), emptyList()))
+        driver.submitCardSelection(driver.player1, listOf(stalker))
+
+        driver.isFaceDown(hidden) shouldBe false
+        driver.isFaceDown(stalker) shouldBe true
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -2707,6 +2707,169 @@
     ]
 }
 
+// Case File Auditor
+{
+    "name": "Case File Auditor",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Detective",
+    "oracleText": "When this creature enters and whenever you solve a Case, look at the top six cards of your library. You may reveal an enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nYou may spend mana as though it were mana of any color to cast Case spells.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 6
+                                }
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered0",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "enchantment",
+                            "storeSelected": "selected1",
+                            "storeRemainder": "remainder1",
+                            "prompt": "You may reveal an enchantment card and put it into your hand",
+                            "selectedLabel": "To hand",
+                            "remainderLabel": "Bottom of library",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "selected1"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "remainder1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, look at the top six cards of your library. You may reveal an enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "CaseSolvedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 6
+                                }
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered0",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "enchantment",
+                            "storeSelected": "selected1",
+                            "storeRemainder": "remainder1",
+                            "prompt": "You may reveal an enchantment card and put it into your hand",
+                            "selectedLabel": "To hand",
+                            "remainderLabel": "Bottom of library",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "selected1"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "remainder1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever you solve a Case, look at the top six cards of your library. You may reveal an enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "SpendAnyManaTypeForSpells",
+                "filter": "Case"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "rarity": "UNCOMMON",
+        "artist": "Ryan Valle",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/70a52038-9d1c-4be1-8dbe-6f0ee916ba94.jpg?1783912929",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Case File Auditor's first ability triggers whenever a \"to solve\" ability you control resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Case of the Burning Masks
 {
     "name": "Case of the Burning Masks",

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -7582,6 +7582,125 @@
     ]
 }
 
+// Expose the Culprit
+{
+    "name": "Expose the Culprit",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one or both —\n• Turn target face-down creature face up.\n• Exile any number of face-up creatures you control with disguise in a face-down pile, shuffle that pile, then cloak them. (To cloak a card, put it onto the battlefield face down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "TurnFaceUp",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "face-down creature"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature facedown"
+                            },
+                            "id": "face-down creature"
+                        }
+                    ],
+                    "description": "Turn target face-down creature face up"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "BattlefieldMatching",
+                                    "filter": {
+                                        "cardPredicates": [
+                                            "IsCreature"
+                                        ],
+                                        "statePredicates": [
+                                            "IsFaceUp",
+                                            "HasDisguiseAbility"
+                                        ],
+                                        "controllerPredicate": "ControlledByYou"
+                                    }
+                                },
+                                "storeAs": "gathered0"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "gathered0",
+                                "selection": "ChooseAnyNumber",
+                                "storeSelected": "selected1",
+                                "prompt": "Exile any number of face-up creatures you control with disguise",
+                                "useTargetingUI": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "selected1",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                },
+                                "storeMovedAs": "moved2"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "moved2",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                },
+                                "order": "Random",
+                                "faceDown": "CLOAK"
+                            }
+                        ]
+                    },
+                    "description": "Exile any number of face-up creatures you control with disguise, then cloak them"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "rarity": "UNCOMMON",
+        "artist": "Ryan Valle",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/31aadd3d-5ce1-44ba-ac6d-b192a9ea491b.jpg?1783912881",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "The pile is shuffled to disguise from your opponents which cloaked creature is which. After you cloak the creatures, you may look at them."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "To cloak a card, put it onto the battlefield face down. It becomes a 2/2 face-down creature card with ward {2} and no name, mana cost, or creature types. It's colorless and has a mana value of 0. Other effects that apply to the permanent can still grant it any characteristics it doesn't have or change the characteristics it does have."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a cloaked creature would have disguise (or morph) if it were face up, you may also turn it face up by paying its disguise (or morph) cost."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Extract a Confession
 {
     "name": "Extract a Confession",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -546,6 +546,7 @@ class BeginningPhaseManager(
         StatePredicate.IsFaceDown,
         StatePredicate.IsFaceUp,
         StatePredicate.HasMorphAbility,
+        StatePredicate.HasDisguiseAbility,
         StatePredicate.IsRingBearer,
         StatePredicate.HasAnyCounter,
         StatePredicate.HasGreatestPower,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardEntityFactory.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardEntityFactory.kt
@@ -121,6 +121,15 @@ object CardEntityFactory {
             result = result.with(HasMorphAbilityComponent)
         }
 
+        // Disguise (CR 702.168) rides the card entity in every zone for the same reason morph does:
+        // "creatures you control with disguise" is asked of a face-**up** permanent, where the
+        // runtime MorphDataComponent that describes a turn-up procedure does not exist.
+        if (cardDef.keywordAbilities.any { it is KeywordAbility.Disguise }) {
+            result = result.with(
+                com.wingedsheep.engine.state.components.identity.HasDisguiseAbilityComponent
+            )
+        }
+
         // Madness (CR 702.35a). The static half functions while the card is in a player's *hand*,
         // so the cost has to ride the card entity in every zone rather than be looked up from the
         // battlefield — see [MadnessComponent].

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -1119,7 +1119,14 @@ data class BecameSaddledEvent(
 @SerialName("CaseSolvedEvent")
 data class CaseSolvedEvent(
     val entityId: EntityId,
-    val entityName: String
+    val entityName: String,
+    /**
+     * The player who solved it — the Case's controller at the moment the "To solve" trigger
+     * resolved. Carried on the event rather than looked up from the Case, because a "whenever you
+     * solve a Case" payoff (Case File Auditor) is matched after the fact, when the Case may already
+     * have been sacrificed by its own Solved ability.
+     */
+    val controllerId: EntityId
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -413,6 +413,7 @@ val engineSerializersModule = SerializersModule {
         subclass(VanguardAvatarComponent::class)
         subclass(ExileAfterResolveComponent::class)
         subclass(HasMorphAbilityComponent::class)
+        subclass(com.wingedsheep.engine.state.components.identity.HasDisguiseAbilityComponent::class)
         subclass(PlayWithAdditionalCostComponent::class)
         subclass(PlayWithCostIncreaseComponent::class)
         subclass(PlayWithFixedAlternativeManaCostComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -295,6 +295,12 @@ data class TriggerContext(
                 is com.wingedsheep.engine.core.EvidenceCollectedEvent -> TriggerContext(
                     triggeringPlayerId = event.playerId
                 )
+                // Solve a Case (CR 719.3a): the solving player is the triggering player, and the
+                // solved Case itself is the triggering entity — so a payoff can name either.
+                is com.wingedsheep.engine.core.CaseSolvedEvent -> TriggerContext(
+                    triggeringEntityId = event.entityId,
+                    triggeringPlayerId = event.controllerId
+                )
                 // Manifest dread (CR 701.60): the cards put into the graveyard this way are
                 // carried as capturedEntityIds, seeded into the resolving trigger's pipeline under
                 // TRIGGER_CAPTURED_COLLECTION so "a card you put into your graveyard this way"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -81,6 +81,7 @@ enum class TriggerCategory {
     SURVEILED,
     DISCOVERED,
     EVIDENCE_COLLECTED,
+    CASE_SOLVED,
     EXPLORED,
     CONNIVED,
     EXPLOITED,
@@ -287,6 +288,7 @@ class TriggerIndex(
                 is SdkGameEvent.ScriedOrSurveiledEvent -> SCRIED_OR_SURVEILED_LIST
                 is SdkGameEvent.DiscoveredEvent -> DISCOVERED_LIST
                 is SdkGameEvent.EvidenceCollectedEvent -> EVIDENCE_COLLECTED_LIST
+                is SdkGameEvent.CaseSolvedEvent -> CASE_SOLVED_LIST
                 is SdkGameEvent.ExploredEvent -> EXPLORED_LIST
                 is SdkGameEvent.ConnivedEvent -> CONNIVED_LIST
                 is SdkGameEvent.ExploitedEvent -> EXPLOITED_LIST
@@ -342,6 +344,7 @@ class TriggerIndex(
             is com.wingedsheep.engine.core.SurveiledEvent -> SURVEILED_LIST
             is com.wingedsheep.engine.core.DiscoveredEvent -> DISCOVERED_LIST
             is com.wingedsheep.engine.core.EvidenceCollectedEvent -> EVIDENCE_COLLECTED_LIST
+            is com.wingedsheep.engine.core.CaseSolvedEvent -> CASE_SOLVED_LIST
             is com.wingedsheep.engine.core.PermanentExploredEvent -> EXPLORED_LIST
             is com.wingedsheep.engine.core.PermanentConnivedEvent -> CONNIVED_LIST
             is com.wingedsheep.engine.core.ExploitedEvent -> EXPLOITED_LIST
@@ -388,6 +391,7 @@ class TriggerIndex(
         private val SURVEILED_LIST = listOf(TriggerCategory.SURVEILED)
         private val DISCOVERED_LIST = listOf(TriggerCategory.DISCOVERED)
         private val EVIDENCE_COLLECTED_LIST = listOf(TriggerCategory.EVIDENCE_COLLECTED)
+        private val CASE_SOLVED_LIST = listOf(TriggerCategory.CASE_SOLVED)
         private val SCRIED_OR_SURVEILED_LIST = listOf(TriggerCategory.SCRIED, TriggerCategory.SURVEILED)
         private val EXPLORED_LIST = listOf(TriggerCategory.EXPLORED)
         private val CONNIVED_LIST = listOf(TriggerCategory.CONNIVED)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -582,6 +582,13 @@ class TriggerMatcher(
                 event is com.wingedsheep.engine.core.EvidenceCollectedEvent &&
                     matchesPlayer(trigger.player, event.playerId, controllerId)
             }
+            is EventPattern.CaseSolvedEvent -> {
+                // The solving player rides the event (the Case's controller when its "To solve"
+                // trigger resolved), so a Case sacrificed by its own Solved ability still credits
+                // the right player here.
+                event is com.wingedsheep.engine.core.CaseSolvedEvent &&
+                    matchesPlayer(trigger.player, event.controllerId, controllerId)
+            }
             is EventPattern.ExploredEvent -> {
                 if (event !is com.wingedsheep.engine.core.PermanentExploredEvent) return false
                 // Reveal-type gate (CR 701.44a): ANY always matches; LAND/NONLAND require the
@@ -2161,6 +2168,7 @@ class TriggerMatcher(
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.BlockedOrWasBlockedByLegendaryThisTurn,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsFaceUp,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasMorphAbility,
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasDisguiseAbility,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsRingBearer,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasGreatestPower,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasLeastPowerAmongAllCreatures,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1449,6 +1449,12 @@ class PredicateEvaluator {
                 container.has<HasMorphAbilityComponent>() ||
                 container.get<MorphDataComponent>()?.hasMorphProcedure == true
 
+            // Disguise ability (CR 702.168) — the printed keyword only, read off the card in any
+            // zone. No MorphDataComponent fallback: the turn-up data exists only while the
+            // permanent is face down, and "creatures with disguise" asks about face-up ones.
+            StatePredicate.HasDisguiseAbility ->
+                container.has<com.wingedsheep.engine.state.components.identity.HasDisguiseAbilityComponent>()
+
             // Ring-bearer designation (CR 701.54e): only while it has the component AND is controlled
             // by the player who designated it.
             StatePredicate.IsRingBearer -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/BecomeSolvedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/BecomeSolvedExecutor.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.SolvedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.sdk.scripting.effects.BecomeSolvedEffect
 import kotlin.reflect.KClass
 
@@ -47,8 +48,13 @@ class BecomeSolvedExecutor : EffectExecutor<BecomeSolvedEffect> {
         }
 
         val name = container.get<CardComponent>()?.name ?: "Unknown"
+        // The solving player is the Case's controller (CR 719.3a — its own "To solve" trigger), read
+        // from the projection so a Case under someone else's control credits that player.
+        val solver = state.projectedState.getController(targetId)
+            ?: container.get<ControllerComponent>()?.playerId
+            ?: context.controllerId
         val newState = state.updateEntity(targetId) { it.with(SolvedComponent) }
 
-        return EffectResult.success(newState, listOf(CaseSolvedEvent(targetId, name)))
+        return EffectResult.success(newState, listOf(CaseSolvedEvent(targetId, name, solver)))
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -516,6 +516,10 @@ internal class AffectsFilterResolver {
         StatePredicate.HasMorphAbility ->
             container.has<HasMorphAbilityComponent>() ||
                 container.get<MorphDataComponent>()?.hasMorphProcedure == true
+        // Disguise (CR 702.168) is the printed keyword, read off the card in any zone — see
+        // StatePredicate.HasDisguiseAbility for why there is no turn-up-data fallback here.
+        StatePredicate.HasDisguiseAbility ->
+            container.has<com.wingedsheep.engine.state.components.identity.HasDisguiseAbilityComponent>()
         StatePredicate.IsRingBearer -> {
             val bearer = container.get<com.wingedsheep.engine.state.components.identity.RingBearerComponent>()
             bearer != null && projectedController(state, entityId, projectedValues) == bearer.ownerId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/FaceDownComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/FaceDownComponents.kt
@@ -86,6 +86,18 @@ data class MorphDataComponent(
 data object HasMorphAbilityComponent : Component
 
 /**
+ * Marks a card as having a disguise keyword ability (CR 702.168).
+ *
+ * The disguise sibling of [HasMorphAbilityComponent], and stamped from the card definition for the
+ * same reason: the printed ability has to be readable while the card is face **up** (and in any
+ * zone), which is exactly when [MorphDataComponent] — the runtime turn-up data — is absent. Backs
+ * `StatePredicate.HasDisguiseAbility` / `GameObjectFilter.withDisguise()`, i.e. Expose the
+ * Culprit's "face-up creatures you control with disguise".
+ */
+@Serializable
+data object HasDisguiseAbilityComponent : Component
+
+/**
  * Which face-down mechanic put this permanent onto the battlefield face down (CR 708.6: which
  * ability or rule made a permanent face down is public information, and paper Magic represents
  * morph, manifest and disguise/cloak with visually distinct helper cards).


### PR DESCRIPTION
Two of Murders at Karlov Manor's remaining cards. The set was at 257/276; the nineteen left are the tail, and every one of them wants engine vocabulary that does not exist yet — so this is deliberately a small batch of two rather than the usual five, with one narrowly-scoped primitive each.

## Cards

- **Expose the Culprit** ({1}{R} instant, #124) — "Choose one or both — • Turn target face-down creature face up. • Exile any number of face-up creatures you control with disguise in a face-down pile, shuffle that pile, then cloak them." Mode 1 is Break Open's `TurnFaceUpEffect`. Mode 2 prints no "target", so it composes as a `gather → chooseAnyNumber → exile → return-as-CLOAK` inline pipeline rather than an unlimited target requirement — shroud on your own creature does not stop it, and nothing fizzles between cast and resolution. The shuffle is expressed as `CardOrder.Random`; it changes no game state here, since face-down identity is already hidden from opponents and the printed ruling lets the controller keep looking.
- **Case File Auditor** ({2}{W} 1/4 Human Detective, #7) — "When this creature enters and whenever you solve a Case, look at the top six cards of your library. You may reveal an enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order. You may spend mana as though it were mana of any color to cast Case spells." Two `triggeredAbility` blocks (CR 603.1, and the bindings differ), `chooseUpToSplit(1)` filtered to enchantments so the "may" stays declinable, and the existing `SpendAnyManaTypeForSpells` over the Case subtype.

## New SDK vocabulary

Both additions are additive — no existing card's behaviour or golden entry changed.

- **`GameObjectFilter.withDisguise()`** / `StatePredicate.HasDisguiseAbility`, backed by a definition-derived `HasDisguiseAbilityComponent` stamped in `CardEntityFactory`. The existing `withMorph()` cannot serve: it asks "can this be turned face up", which is also true of a cloaked permanent that has no disguise, and it is only answerable while the permanent is face **down** — whereas the card asks a printed-ability question about a face-**up** one.
- **`Triggers.WheneverYouSolveACase`** / `EventPattern.CaseSolvedEvent`, with matcher, `TriggerIndex` (both directions) and `TriggerContext` branches. The engine already emitted `CaseSolvedEvent` and its KDoc anticipated this payoff; only the pattern half was missing. `CaseSolvedEvent` now also carries the solving player, because a Case whose "Solved —" ability sacrifices it is gone by the time a payoff is matched.

## Cards deliberately not in this batch

Three that looked batchable and were not, so the reasoning is not re-derived later:

- **Airtight Alibi** needs "can't become suspected". `Effects.Suspect` is a three-part `CompositeEffect`, so gating only `SetSuspectedExecutor` would still leave the creature with menace and can't-block. Doing it right means making suspect atomic, which moves 16 existing cards in the golden — `add-feature` work, not a card PR.
- **Officious Interrogation** needs "costs {W}{U} more for each target beyond the first". The existing `PayLifePerTarget` sidesteps mana affordability; a mana version has to reach the cost calculator before targets are chosen.
- **Coveted Falcon**'s turned-face-up ability needs a `ForEach` over one target requirement while still naming a target from another; `IterationSpace.Targets` iterates all of them and wipes the context to one.

## Verification

- `just build`, `just test`, `just check` — all green.
- `just test-class ExposeTheCulpritScenarioTest` (5 tests), `just test-class CaseFileAuditorScenarioTest` (4 tests) — green. The filter and trigger tests assert the over-firing cases directly: a vanilla creature and an opponent's disguise creature must be unselectable; a Case merely entering, and an opponent solving their own Case, must not fire the Auditor.
- `just check-card-printing` clean for both — MKM is the earliest real printing of each.
- Card golden re-blessed; only the two new cards moved.
- `docs/card-sdk-language-reference.md` updated for both additions.
- MKM has no `backlog/sets/` entry, so there was nothing to tick. `just card-status --set MKM` now reads 259/276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)