### PR TITLE
Add the 101 Assay-ready Jumpstart cards

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CinderElemental.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CinderElemental.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Cinder Elemental
+ * {3}{R}
+ * Creature — Elemental
+ * 2/2
+ *
+ * {X}{R}, {T}, Sacrifice this creature: It deals X damage to any target.
+ */
+val CinderElemental = card("Cinder Elemental") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    oracleText = "{X}{R}, {T}, Sacrifice this creature: It deals X damage to any target."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{X}{R}"), Costs.Tap, Costs.SacrificeSelf)
+        target = Targets.Any
+        effect = Effects.DealDamage(DynamicAmount.XValue, EffectTarget.ContextTarget(0))
+        description = "{X}{R}, {T}, Sacrifice this creature: It deals X damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "183"
+        artist = "Greg Staples"
+        flavorText = "Their rage can grow to such proportions that they explode in a cloud of fire."
+        imageUri = "https://cards.scryfall.io/normal/front/8/0/80b39056-2ee8-4cfd-acbd-ba99f74e788d.jpg?1783945942"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RishadanAirship.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RishadanAirship.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CanOnlyBlockCreaturesWith
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Rishadan Airship
+ * {2}{U}
+ * Creature — Human Pirate
+ * 3/1
+ *
+ * Flying
+ * This creature can block only creatures with flying.
+ */
+val RishadanAirship = card("Rishadan Airship") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Pirate"
+    oracleText = "Flying\nThis creature can block only creatures with flying."
+    power = 3
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = CanOnlyBlockCreaturesWith(GameObjectFilter.Creature.withKeyword(Keyword.FLYING))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "91"
+        artist = "Kev Walker"
+        flavorText = "The view is truly spectacular—as long as you don't look at Rishada itself."
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d8e596b-f5ef-405a-8910-c5d0b5c8c0fc.jpg?1783945964"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/GoblinCommando.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/GoblinCommando.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Goblin Commando
+ * {4}{R}
+ * Creature — Goblin
+ * 2/2
+ *
+ * When this creature enters, it deals 2 damage to target creature.
+ */
+val GoblinCommando = card("Goblin Commando") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin"
+    oracleText = "When this creature enters, it deals 2 damage to target creature."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(2, creature)
+        description = "When this creature enters, it deals 2 damage to target creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "100"
+        artist = "Todd Lockwood"
+        flavorText = "With a commando around, somebody's gonna get hurt."
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/da90043b-0e67-4a68-b6fb-0ca53ca7defc.jpg?1783946030"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sth/cards/WallOfBlossoms.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sth/cards/WallOfBlossoms.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.sth.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+
+/**
+ * Wall of Blossoms
+ * {1}{G}
+ * Creature — Plant Wall
+ * 0/4
+ *
+ * Defender
+ * When this creature enters, draw a card.
+ */
+val WallOfBlossoms = card("Wall of Blossoms") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Wall"
+    oracleText = "Defender\nWhen this creature enters, draw a card."
+    power = 0
+    toughness = 4
+
+    keywords(Keyword.DEFENDER)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = DrawCardsEffect(1)
+        description = "When this creature enters, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "125"
+        artist = "Heather Hudson"
+        flavorText = "Each flower identical, every leaf and petal disturbingly exact."
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7eb4a1a3-efcf-4c9a-ad1f-0a3f8f2b456f.jpg?1783946546"
+    }
+}

--- a/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ody/cards/ZombieInfestation.kt
+++ b/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ody/cards/ZombieInfestation.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ody.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zombie Infestation
+ * {1}{B}
+ * Enchantment
+ *
+ * Discard two cards: Create a 2/2 black Zombie creature token.
+ */
+val ZombieInfestation = card("Zombie Infestation") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Discard two cards: Create a 2/2 black Zombie creature token."
+
+    activatedAbility {
+        cost = Costs.Discard(count = 2)
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Zombie"),
+        )
+        description = "Discard two cards: Create a 2/2 black Zombie creature token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "170"
+        artist = "Thomas M. Baxa"
+        flavorText = "The nomads' funeral pyres are more practical than ceremonial."
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/ccd5f98a-7ab5-44b3-850c-b50963dace66.jpg?1783945237"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/RonomUnicorn.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/RonomUnicorn.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.csp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ronom Unicorn
+ * {1}{W}
+ * Creature — Unicorn
+ * 2/2
+ *
+ * Sacrifice this creature: Destroy target enchantment.
+ */
+val RonomUnicorn = card("Ronom Unicorn") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Unicorn"
+    oracleText = "Sacrifice this creature: Destroy target enchantment."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        target = Targets.Enchantment
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+        description = "Sacrifice this creature: Destroy target enchantment."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "16"
+        artist = "Carl Critchlow"
+        flavorText = "The aberrant magic of the Rimewind drew the unicorns back from the northern wastes to do battle once again."
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae4764e1-e47c-4934-86a5-9b432c29a158.jpg?1783943367"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dst/cards/MirrodinsCore.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dst/cards/MirrodinsCore.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.dst.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mirrodin's Core
+ * Land
+ *
+ * {T}: Add {C}.
+ * {T}: Put a charge counter on this land.
+ * {T}, Remove a charge counter from this land: Add one mana of any color.
+ */
+val MirrodinsCore = card("Mirrodin's Core") {
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n{T}: Put a charge counter on this land.\n{T}, Remove a charge counter from this land: Add one mana of any color."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddCounters(Counters.CHARGE, 1, EffectTarget.Self)
+        description = "{T}: Put a charge counter on this land."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.RemoveCounterFromSelf(Counters.CHARGE))
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "165"
+        artist = "Greg Staples"
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cf0e60c9-1548-4981-ada1-6656804a772e.jpg?1783944413"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/PlaguedRusalka.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/PlaguedRusalka.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Plagued Rusalka
+ * {B}
+ * Creature — Spirit
+ * 1/1
+ *
+ * {B}, Sacrifice a creature: Target creature gets -1/-1 until end of turn.
+ */
+val PlaguedRusalka = card("Plagued Rusalka") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit"
+    oracleText = "{B}, Sacrifice a creature: Target creature gets -1/-1 until end of turn."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}"), Costs.Sacrifice(GameObjectFilter.Creature))
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-1, -1, creature)
+        description = "{B}, Sacrifice a creature: Target creature gets -1/-1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "56"
+        artist = "Alex Horley-Orlandelli"
+        flavorText = "\"Look at her, once filled with innocence. Death has a way of wringing away such . . . deficiencies.\"\n—Savra"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd84bbb3-8b99-4e6d-b514-b094ec93eaa0.jpg?1783943506"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/LeafGilder.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/LeafGilder.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Leaf Gilder
+ * {1}{G}
+ * Creature — Elf Druid
+ * 2/1
+ *
+ * {T}: Add {G}.
+ */
+val LeafGilder = card("Leaf Gilder") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid"
+    oracleText = "{T}: Add {G}."
+    power = 2
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "227"
+        artist = "Quinton Hoover"
+        flavorText = "Eidren, perfect of Lys Alana, ordered hundreds of trees uprooted and rearranged into a pattern he deemed beautiful. Thus the Gilt-Leaf Wood was born."
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3aaff934-cc79-4a01-a4be-3c4936605e4e.jpg?1783942859"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/NightshadeStinger.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/NightshadeStinger.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+
+/**
+ * Nightshade Stinger
+ * {B}
+ * Creature — Faerie Rogue
+ * 1/1
+ *
+ * Flying
+ * This creature can't block.
+ */
+val NightshadeStinger = card("Nightshade Stinger") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Faerie Rogue"
+    oracleText = "Flying\nThis creature can't block."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "132"
+        artist = "Mark Poole"
+        flavorText = "\"Most faeries are harmless pranksters. Every now and again, though, you get one that crosses over from mischievous to malicious.\"\n—Gaddock Teeg"
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aa341824-bf3a-49ce-a8a0-ee53f537d626.jpg?1783942886"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/PrimordialSage.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/PrimordialSage.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+
+/**
+ * Primordial Sage
+ * {4}{G}{G}
+ * Creature — Spirit
+ * 4/5
+ *
+ * Whenever you cast a creature spell, you may draw a card.
+ */
+val PrimordialSage = card("Primordial Sage") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spirit"
+    oracleText = "Whenever you cast a creature spell, you may draw a card."
+    power = 4
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.YouCastCreature
+        optional = true
+        effect = DrawCardsEffect(1)
+        description = "Whenever you cast a creature spell, you may draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "177"
+        artist = "Justin Sweet"
+        flavorText = "For each creature that arrives in its audience, the sage imparts another piece of ancient wisdom for all to hear."
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e11e6d8-d375-4278-8cb0-94deeecaeeca.jpg?1783943634"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Fortify.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Fortify.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fortify
+ * {2}{W}
+ * Instant
+ *
+ * Choose one —
+ * • Creatures you control get +2/+0 until end of turn.
+ * • Creatures you control get +0/+2 until end of turn.
+ */
+val Fortify = card("Fortify") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n• Creatures you control get +2/+0 until end of turn.\n• Creatures you control get +0/+2 until end of turn."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Creatures you control get +2/+0 until end of turn") {
+                effect = Effects.ForEachInGroup(
+                    GroupFilter(GameObjectFilter.Creature.youControl()),
+                    ModifyStatsEffect(2, 0, EffectTarget.Self),
+                )
+            }
+            mode("Creatures you control get +0/+2 until end of turn") {
+                effect = Effects.ForEachInGroup(
+                    GroupFilter(GameObjectFilter.Creature.youControl()),
+                    ModifyStatsEffect(0, 2, EffectTarget.Self),
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Christopher Moeller"
+        flavorText = "\"Where metal is tainted and wood is scarce, we are best armed by faith.\"\n—Tavalus, acolyte of Korlis"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd063dc7-a35c-44c9-9f8d-b7bb2dc95bec.jpg?1783943254"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/LeafGilderArcReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/LeafGilderArcReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Leaf Gilder reprint in Archenemy. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val LeafGilderArcReprint = Printing(
+    oracleId = "61324e37-4b79-4325-bf46-621b4270afe2",
+    name = "Leaf Gilder",
+    setCode = "ARC",
+    collectorNumber = "63",
+    scryfallId = "2381eb3b-e45b-4fbb-a84a-0858b356a008",
+    artist = "Quinton Hoover",
+    imageUri = "https://cards.scryfall.io/normal/front/2/3/2381eb3b-e45b-4fbb-a84a-0858b356a008.jpg?1783941903",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/VolcanicFalloutArcReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/VolcanicFalloutArcReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Volcanic Fallout reprint in Archenemy. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val VolcanicFalloutArcReprint = Printing(
+    oracleId = "bd6ce147-c991-40ac-b276-65b630fad8b6",
+    name = "Volcanic Fallout",
+    setCode = "ARC",
+    collectorNumber = "51",
+    scryfallId = "9e2c51bc-ebc9-4264-9426-122e7f568bd1",
+    artist = "Zoltan Boros & Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/9/e/9e2c51bc-ebc9-4264-9426-122e7f568bd1.jpg?1783941905",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/ZombieInfestationArcReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/ZombieInfestationArcReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zombie Infestation reprint in Archenemy. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val ZombieInfestationArcReprint = Printing(
+    oracleId = "bdce1af0-3643-4e77-88f9-320206a191d4",
+    name = "Zombie Infestation",
+    setCode = "ARC",
+    collectorNumber = "28",
+    scryfallId = "e1078bef-8caf-4dc5-a055-e64314501b23",
+    artist = "Thomas M. Baxa",
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e1078bef-8caf-4dc5-a055-e64314501b23.jpg?1783941911",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ScrollOfAvacyn.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ScrollOfAvacyn.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Scroll of Avacyn
+ * {1}
+ * Artifact
+ *
+ * {1}, Sacrifice this artifact: Draw a card. If you control an Angel, you gain 5 life.
+ */
+val ScrollOfAvacyn = card("Scroll of Avacyn") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{1}, Sacrifice this artifact: Draw a card. If you control an Angel, you gain 5 life."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1).then(
+            ConditionalEffect(
+                condition = Conditions.ControlPermanentOfType(Subtype.ANGEL),
+                effect = Effects.GainLife(5),
+            )
+        )
+        description = "{1}, Sacrifice this artifact: Draw a card. If you control an Angel, you gain 5 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "220"
+        artist = "Cliff Childs"
+        flavorText = "Words to bless the eye that reads them, telling of a future beyond the reach of fear."
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/871e6e2a-7e45-446b-b964-94377eb6ca92.jpg?1783940650"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/SoulOfTheHarvest.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/SoulOfTheHarvest.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+
+/**
+ * Soul of the Harvest
+ * {4}{G}{G}
+ * Creature — Elemental
+ * 6/6
+ *
+ * Trample
+ * Whenever another nontoken creature you control enters, you may draw a card.
+ */
+val SoulOfTheHarvest = card("Soul of the Harvest") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental"
+    oracleText = "Trample\nWhenever another nontoken creature you control enters, you may draw a card."
+    power = 6
+    toughness = 6
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl().nontoken(),
+            binding = TriggerBinding.OTHER,
+        )
+        optional = true
+        effect = DrawCardsEffect(1)
+        description = "Whenever another nontoken creature you control enters, you may draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "195"
+        artist = "Eytan Zana"
+        flavorText = "It's there when a seed sprouts, when gourds ripen on the vines, and when the reapers cut the grains under the Harvest Moon."
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/078f5e79-18dd-44e5-a930-8dc288f0b535.jpg?1783940661"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/BeetlebackChiefC14Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/BeetlebackChiefC14Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Beetleback Chief reprint in Commander 2014. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val BeetlebackChiefC14Reprint = Printing(
+    oracleId = "f5c5f64c-6911-430c-a825-b32b96d39c7d",
+    name = "Beetleback Chief",
+    setCode = "C14",
+    collectorNumber = "171",
+    scryfallId = "274897aa-fe1a-454a-be66-7c50761c252e",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/274897aa-fe1a-454a-be66-7c50761c252e.jpg?1783938837",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/BuriedRuinC14Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/BuriedRuinC14Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Buried Ruin reprint in Commander 2014. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val BuriedRuinC14Reprint = Printing(
+    oracleId = "3644f316-f9a3-46c9-9b1e-747f86cf4ead",
+    name = "Buried Ruin",
+    setCode = "C14",
+    collectorNumber = "286",
+    scryfallId = "fb89f53a-b74a-4b04-b100-81dbb73ebeba",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/f/b/fb89f53a-b74a-4b04-b100-81dbb73ebeba.jpg?1783938811",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/PrimordialSageC14Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/PrimordialSageC14Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Primordial Sage reprint in Commander 2014. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val PrimordialSageC14Reprint = Printing(
+    oracleId = "499f1e1e-d96e-481f-a5d9-eb38da927cd7",
+    name = "Primordial Sage",
+    setCode = "C14",
+    collectorNumber = "211",
+    scryfallId = "b08b7324-15a6-426e-bd8b-e4fa1965bf82",
+    artist = "Justin Sweet",
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b08b7324-15a6-426e-bd8b-e4fa1965bf82.jpg?1783938828",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SeaGateOracleC14Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SeaGateOracleC14Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sea Gate Oracle reprint in Commander 2014. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val SeaGateOracleC14Reprint = Printing(
+    oracleId = "b333c194-d285-4dfb-984c-57b7e88393af",
+    name = "Sea Gate Oracle",
+    setCode = "C14",
+    collectorNumber = "124",
+    scryfallId = "84290bc3-a157-41ba-911a-a480a760632c",
+    artist = "Daniel Ljunggren",
+    imageUri = "https://cards.scryfall.io/normal/front/8/4/84290bc3-a157-41ba-911a-a480a760632c.jpg?1783938847",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SoulOfTheHarvestC14Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SoulOfTheHarvestC14Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soul of the Harvest reprint in Commander 2014. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val SoulOfTheHarvestC14Reprint = Printing(
+    oracleId = "6b9194dd-2296-4879-ac5e-f89b18431df6",
+    name = "Soul of the Harvest",
+    setCode = "C14",
+    collectorNumber = "215",
+    scryfallId = "0fb9e961-7c1c-41ce-b058-11ef33198057",
+    artist = "Eytan Zana",
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0fb9e961-7c1c-41ce-b058-11ef33198057.jpg?1783938828",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SylvanRangerC14Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SylvanRangerC14Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sylvan Ranger reprint in Commander 2014. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val SylvanRangerC14Reprint = Printing(
+    oracleId = "29a90fda-541e-4923-b3ed-e2b35d02c74b",
+    name = "Sylvan Ranger",
+    setCode = "C14",
+    collectorNumber = "216",
+    scryfallId = "0dbe0c40-4c62-4d95-b8ff-86cd190f829a",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/0/d/0dbe0c40-4c62-4d95-b8ff-86cd190f829a.jpg?1783938827",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/UnstableObelisk.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/UnstableObelisk.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Unstable Obelisk
+ * {3}
+ * Artifact
+ *
+ * {T}: Add {C}.
+ * {7}, {T}, Sacrifice this artifact: Destroy target permanent.
+ */
+val UnstableObelisk = card("Unstable Obelisk") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {C}.\n{7}, {T}, Sacrifice this artifact: Destroy target permanent."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{7}"), Costs.Tap, Costs.SacrificeSelf)
+        target = Targets.Permanent
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+        description = "{7}, {T}, Sacrifice this artifact: Destroy target permanent."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "58"
+        artist = "William Wu"
+        flavorText = "Its collapse is like the lashing out of a long-dead civilization that resents being forgotten."
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b331b231-f31f-479f-80a9-f32c64d35096.jpg?1783938864"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/TalrandSkySummonerC15Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/TalrandSkySummonerC15Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Talrand, Sky Summoner reprint in Commander 2015. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val TalrandSkySummonerC15Reprint = Printing(
+    oracleId = "ea1eb902-a23c-44ff-9169-19baf71de238",
+    name = "Talrand, Sky Summoner",
+    setCode = "C15",
+    collectorNumber = "109",
+    scryfallId = "85c0d00b-7faf-4a1a-b439-49704f6f1349",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/8/5/85c0d00b-7faf-4a1a-b439-49704f6f1349.jpg?1783938090",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/WallOfBlossomsC15Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/WallOfBlossomsC15Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Blossoms reprint in Commander 2015. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val WallOfBlossomsC15Reprint = Printing(
+    oracleId = "ef4d5fb3-70a3-433d-a9d3-18b2beb8d79f",
+    name = "Wall of Blossoms",
+    setCode = "C15",
+    collectorNumber = "211",
+    scryfallId = "bb6e4fe1-29a3-494c-9b45-f5f9fd15927c",
+    artist = "Heather Hudson",
+    imageUri = "https://cards.scryfall.io/normal/front/b/b/bb6e4fe1-29a3-494c-9b45-f5f9fd15927c.jpg?1783938062",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/BuriedRuinC16Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/BuriedRuinC16Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Buried Ruin reprint in Commander 2016. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val BuriedRuinC16Reprint = Printing(
+    oracleId = "3644f316-f9a3-46c9-9b1e-747f86cf4ead",
+    name = "Buried Ruin",
+    setCode = "C16",
+    collectorNumber = "284",
+    scryfallId = "9405ceb1-112b-4cef-8c3f-2a22c7eb6692",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/9405ceb1-112b-4cef-8c3f-2a22c7eb6692.jpg?1783937031",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/LanguishC16Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/LanguishC16Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Languish reprint in Commander 2016. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val LanguishC16Reprint = Printing(
+    oracleId = "ef1a83f2-6707-41a2-b5ed-861c8e45ae07",
+    name = "Languish",
+    setCode = "C16",
+    collectorNumber = "114",
+    scryfallId = "7cf7bf85-851c-4bd3-92b7-e1f1601d4a51",
+    artist = "Jeff Simpson",
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7cf7bf85-851c-4bd3-92b7-e1f1601d4a51.jpg?1783937068",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/WallOfBlossomsC16Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/WallOfBlossomsC16Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Blossoms reprint in Commander 2016. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val WallOfBlossomsC16Reprint = Printing(
+    oracleId = "ef4d5fb3-70a3-433d-a9d3-18b2beb8d79f",
+    name = "Wall of Blossoms",
+    setCode = "C16",
+    collectorNumber = "175",
+    scryfallId = "6cece7ed-0e64-4833-8944-784d94ac67ba",
+    artist = "Heather Hudson",
+    imageUri = "https://cards.scryfall.io/normal/front/6/c/6cece7ed-0e64-4833-8944-784d94ac67ba.jpg?1783937054",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/VolcanicFallout.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/VolcanicFallout.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Volcanic Fallout
+ * {1}{R}{R}
+ * Instant
+ *
+ * This spell can't be countered.
+ * Volcanic Fallout deals 2 damage to each creature and each player.
+ */
+val VolcanicFallout = card("Volcanic Fallout") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "This spell can't be countered.\nVolcanic Fallout deals 2 damage to each creature and each player."
+
+    cantBeCountered = true
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreatures,
+            DealDamageEffect(2, EffectTarget.Self),
+        ).then(
+            Effects.ForEachPlayer(
+                Player.Each,
+                listOf(DealDamageEffect(2, EffectTarget.Controller)),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "74"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "\"How can we outrun the sky?\"\n—Hadran, sunseeder of Naya"
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/65536d12-e75c-42b5-b592-a3ad4f550a71.jpg?1783942477"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dgm/cards/MurmuringPhantasm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dgm/cards/MurmuringPhantasm.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.dgm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Murmuring Phantasm
+ * {1}{U}
+ * Creature — Spirit
+ * 0/5
+ *
+ * Defender
+ */
+val MurmuringPhantasm = card("Murmuring Phantasm") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    oracleText = "Defender"
+    power = 0
+    toughness = 5
+
+    keywords(Keyword.DEFENDER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "15"
+        artist = "Peter Mohrbacher"
+        flavorText = "\"The most insidious thing in the world is nonsense that sounds just plausible enough to listen to.\"\n—Lazav"
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/9752644c-7c43-429e-a79c-1239b9a0bc8a.jpg?1783940041"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/TorchFiend.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/TorchFiend.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Torch Fiend
+ * {1}{R}
+ * Creature — Devil
+ * 2/1
+ *
+ * {R}, Sacrifice this creature: Destroy target artifact.
+ */
+val TorchFiend = card("Torch Fiend") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Devil"
+    oracleText = "{R}, Sacrifice this creature: Destroy target artifact."
+    power = 2
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.SacrificeSelf)
+        target = Targets.Artifact
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+        description = "{R}, Sacrifice this creature: Destroy target artifact."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "106"
+        artist = "Winona Nelson"
+        flavorText = "Devils redecorate every room with fire."
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d596feee-6ccc-4648-884b-ed2eeb1cffc0.jpg?1783940810"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DragonloftIdol.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/DragonloftIdol.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Dragonloft Idol
+ * {4}
+ * Artifact Creature — Gargoyle
+ * 3/3
+ *
+ * As long as you control a Dragon, this creature gets +1/+1 and has flying and trample.
+ */
+val DragonloftIdol = card("Dragonloft Idol") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Gargoyle"
+    oracleText = "As long as you control a Dragon, this creature gets +1/+1 and has flying and trample."
+    power = 3
+    toughness = 3
+
+    val youControlADragon = Conditions.ControlPermanentOfType(Subtype.DRAGON)
+
+    staticAbility {
+        ability = ModifyStats(1, 1, Filters.Self)
+        condition = youControlADragon
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING, GroupFilter.source())
+        condition = youControlADragon
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE, GroupFilter.source())
+        condition = youControlADragon
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "237"
+        artist = "Jung Park"
+        flavorText = "The idols were forged during the time of the Khanfall, when the dragons came to rule Tarkir and its people aligned themselves with the five dragonlords."
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c7463c18-5bef-42a0-a37e-6112809ebc78.jpg?1783938569"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ShamblingGoblin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/ShamblingGoblin.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shambling Goblin
+ * {B}
+ * Creature — Zombie Goblin
+ * 1/1
+ *
+ * When this creature dies, target creature an opponent controls gets -1/-1 until end of turn.
+ */
+val ShamblingGoblin = card("Shambling Goblin") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Goblin"
+    oracleText = "When this creature dies, target creature an opponent controls gets -1/-1 until end of turn."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val creature = target("target creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.ModifyStats(-1, -1, creature)
+        description = "When this creature dies, target creature an opponent controls gets -1/-1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Yeong-Hao Han"
+        flavorText = "\"The Kolaghan send them at us. We kill and raise them. They fight the next wave the Kolaghan send. It's a neat little cycle.\"\n—Asmala, Silumgar sorcerer"
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/9404c7d5-3450-4425-94e5-aa7d4e571d4e.jpg?1783938594"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/WeaverOfLightning.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/WeaverOfLightning.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Weaver of Lightning
+ * {2}{R}
+ * Creature — Human Shaman
+ * 1/4
+ *
+ * Reach (This creature can block creatures with flying.)
+ * Whenever you cast an instant or sorcery spell, this creature deals 1 damage to target creature an opponent controls.
+ */
+val WeaverOfLightning = card("Weaver of Lightning") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Shaman"
+    oracleText = "Reach (This creature can block creatures with flying.)\nWhenever you cast an instant or sorcery spell, this creature deals 1 damage to target creature an opponent controls."
+    power = 1
+    toughness = 4
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        val creature = target("target creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.DealDamage(1, creature)
+        description = "Whenever you cast an instant or sorcery spell, this creature deals 1 damage to " +
+            "target creature an opponent controls."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "149"
+        artist = "John Stanko"
+        flavorText = "\"Lightning in a bottle? That's not where I need it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba1e6885-dca0-4a4b-abb8-0f32680f618d.jpg?1783937450"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eve/cards/Scarecrone.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eve/cards/Scarecrone.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.eve.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Scarecrone
+ * {3}
+ * Artifact Creature — Scarecrow
+ * 1/2
+ *
+ * {1}, Sacrifice a Scarecrow: Draw a card.
+ * {4}, {T}: Return target artifact creature card from your graveyard to the battlefield.
+ */
+val Scarecrone = card("Scarecrone") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Scarecrow"
+    oracleText = "{1}, Sacrifice a Scarecrow: Draw a card.\n{4}, {T}: Return target artifact creature card from your graveyard to the battlefield."
+    power = 1
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.Sacrifice(GameObjectFilter.Permanent.withSubtype(Subtype.SCARECROW)),
+        )
+        effect = Effects.DrawCards(1)
+        description = "{1}, Sacrifice a Scarecrow: Draw a card."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap)
+        val card = target(
+            "target artifact creature card in your graveyard",
+            TargetObject(
+                filter = TargetFilter(GameObjectFilter.ArtifactCreature.ownedByYou(), zone = Zone.GRAVEYARD)
+            ),
+        )
+        effect = Effects.PutOntoBattlefieldFromGraveyard(card)
+        description = "{4}, {T}: Return target artifact creature card from your graveyard to the battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "172"
+        artist = "Jesper Ejsing"
+        flavorText = "Her poppets bring joy to the truly depraved."
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/1978400d-a8f1-4df7-8caf-b9ca81334bce.jpg?1783942656"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/BatheInDragonfire.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/BatheInDragonfire.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.frf.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Bathe in Dragonfire
+ * {2}{R}
+ * Sorcery
+ *
+ * Bathe in Dragonfire deals 4 damage to target creature.
+ */
+val BatheInDragonfire = card("Bathe in Dragonfire") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Bathe in Dragonfire deals 4 damage to target creature."
+
+    spell {
+        target = Targets.Creature
+        effect = Effects.DealDamage(4, EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "92"
+        artist = "Chris Rallis"
+        flavorText = "The scent of cooked flesh lingers in the charred landscape of Tarkir."
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b8cc6931-2005-4d0a-a42a-ce8bc279372e.jpg?1783938691"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/CollateralDamage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/CollateralDamage.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.frf.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Collateral Damage
+ * {R}
+ * Instant
+ *
+ * As an additional cost to cast this spell, sacrifice a creature.
+ * Collateral Damage deals 3 damage to any target.
+ */
+val CollateralDamage = card("Collateral Damage") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature.\nCollateral Damage deals 3 damage to any target."
+
+    additionalCost(Costs.additional.SacrificePermanent(GameObjectFilter.Creature))
+
+    spell {
+        target = Targets.Any
+        effect = Effects.DealDamage(3, EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "Ryan Barger"
+        flavorText = "It is much easier to create fire than to contain it."
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb738362-b0b4-4811-9fbf-5f45c852c822.jpg?1783938691"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/CinderElementalGtcReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/CinderElementalGtcReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.gtc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cinder Elemental reprint in Gatecrash. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val CinderElementalGtcReprint = Printing(
+    oracleId = "01805d0d-3a72-4d26-9475-3e68c278b7fe",
+    name = "Cinder Elemental",
+    setCode = "GTC",
+    collectorNumber = "87",
+    scryfallId = "8bbf10ce-69e0-4984-91a3-f65df919830d",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8bbf10ce-69e0-4984-91a3-f65df919830d.jpg?1783940125",
+    releaseDate = "2013-02-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/FlurryOfHorns.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/FlurryOfHorns.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.jou.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flurry of Horns
+ * {4}{R}
+ * Sorcery
+ *
+ * Create two 2/3 red Minotaur creature tokens with haste.
+ */
+val FlurryOfHorns = card("Flurry of Horns") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Create two 2/3 red Minotaur creature tokens with haste."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 3,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Minotaur"),
+            keywords = setOf(Keyword.HASTE),
+            count = 2,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "96"
+        artist = "Phill Simmer"
+        flavorText = "A minotaur does not distinguish between human, satyr, and triton. They are all meat."
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/333ff270-4bc7-48ee-9738-f8c70b8a7e40.jpg?1783939424"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/LightningDiadem.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/LightningDiadem.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.jou.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Lightning Diadem
+ * {5}{R}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, it deals 2 damage to any target.
+ * Enchanted creature gets +2/+2.
+ */
+val LightningDiadem = card("Lightning Diadem") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nWhen this Aura enters, it deals 2 damage to any target.\nEnchanted creature gets +2/+2."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val victim = target("any target", Targets.Any)
+        effect = Effects.DealDamage(2, victim)
+        description = "When this Aura enters, it deals 2 damage to any target."
+    }
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Ryan Alexander Lee"
+        flavorText = "\"I fight for Keranos and for mortals. I see no contradiction.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4ce3f1c6-2e6f-4087-8619-a01fdcc6d4a3.jpg?1783939422"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/SigiledStarfish.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/SigiledStarfish.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.jou.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sigiled Starfish
+ * {1}{U}
+ * Creature — Starfish
+ * 0/3
+ *
+ * {T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ */
+val SigiledStarfish = card("Sigiled Starfish") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Starfish"
+    oracleText = "{T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+    power = 0
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.Scry(1)
+        description = "{T}: Scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Nils Hamm"
+        flavorText = "Kruphix hid the most dire prophecies about humankind where humans would never find them and tritons wouldn't care to read them."
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85a61f99-44f8-4a2b-b7f2-7899a694552d.jpg?1783939442"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/LawlessBroker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/LawlessBroker.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lawless Broker
+ * {2}{B}
+ * Creature — Aetherborn Rogue
+ * 3/2
+ *
+ * When this creature dies, put a +1/+1 counter on target creature you control.
+ */
+val LawlessBroker = card("Lawless Broker") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Aetherborn Rogue"
+    oracleText = "When this creature dies, put a +1/+1 counter on target creature you control."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+        description = "When this creature dies, put a +1/+1 counter on target creature you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86"
+        artist = "Darek Zabrocki"
+        flavorText = "Kaladesh's illicit marketplaces are known as \"night markets,\" but if you know who to ask, you can find what you're looking for at any time of the day."
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b5bfff7-aa23-42ef-af1b-bc3304bd3a17.jpg?1783937205"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/ChildOfNight.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/ChildOfNight.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Child of Night
+ * {1}{B}
+ * Creature — Vampire
+ * 2/1
+ *
+ * Lifelink
+ */
+val ChildOfNight = card("Child of Night") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire"
+    oracleText = "Lifelink"
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "88"
+        artist = "Ash Wood"
+        flavorText = "A vampire enacts vengeance on the entire world, claiming her debt two tiny pinpricks at a time."
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e1f7a9a7-3679-4a18-a52a-e3a8ab16ad32.jpg?1783942385"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/ChildOfNightM11Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/ChildOfNightM11Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Child of Night reprint in Magic 2011. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val ChildOfNightM11Reprint = Printing(
+    oracleId = "c650a7bc-e350-44a0-a698-d4a233d66156",
+    name = "Child of Night",
+    setCode = "M11",
+    collectorNumber = "88",
+    scryfallId = "ef351dcb-64c0-413a-81d3-38e7cd4a8f78",
+    artist = "Ash Wood",
+    imageUri = "https://cards.scryfall.io/normal/front/e/f/ef351dcb-64c0-413a-81d3-38e7cd4a8f78.jpg?1783941818",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/SylvanRanger.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/SylvanRanger.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Sylvan Ranger
+ * {1}{G}
+ * Creature — Elf Scout Ranger
+ * 1/1
+ *
+ * When this creature enters, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.
+ */
+val SylvanRanger = card("Sylvan Ranger") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Scout Ranger"
+    oracleText = "When this creature enters, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        effect = Patterns.Library.searchLibrary(
+            filter = Filters.BasicLand,
+            destination = SearchDestination.HAND,
+            reveal = true,
+        )
+        description = "When this creature enters, you may search your library for a basic land card, " +
+            "reveal it, put it into your hand, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "198"
+        artist = "Christopher Moeller"
+        flavorText = "\"Not all paths are found on the forest floor.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f73ea30-c6d2-4224-ae54-f6b89e006cf4.jpg?1783941792"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/WallOfVines.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/WallOfVines.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Vines
+ * {G}
+ * Creature — Plant Wall
+ * 0/3
+ *
+ * Defender (This creature can't attack.)
+ * Reach (This creature can block creatures with flying.)
+ */
+val WallOfVines = card("Wall of Vines") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Wall"
+    oracleText = "Defender (This creature can't attack.)\nReach (This creature can block creatures with flying.)"
+    power = 0
+    toughness = 3
+
+    keywords(Keyword.DEFENDER, Keyword.REACH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "199"
+        artist = "John Stanko"
+        flavorText = "Like all jungle plants, the vines must fight and claw for sunlight. Once their place is secured, they grow strong, sharp, and impenetrable."
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/2050a168-870e-4c47-bc74-bc1c90dd7b3b.jpg?1783941792"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/AlabasterMage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/AlabasterMage.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alabaster Mage
+ * {1}{W}
+ * Creature — Human Wizard
+ * 2/1
+ *
+ * {1}{W}: Target creature you control gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)
+ */
+val AlabasterMage = card("Alabaster Mage") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "{1}{W}: Target creature you control gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)"
+    power = 2
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}")
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.GrantKeyword(Keyword.LIFELINK, creature)
+        description = "{1}{W}: Target creature you control gains lifelink until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "2"
+        artist = "Izzy"
+        flavorText = "\"We hold sacred the powers of light and life. Truth and honor are our greatest weapons.\"\n—Alabaster creed"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f82e6a81-6a45-45f9-829d-332859a32257.jpg?1783941106"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/BuriedRuin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/BuriedRuin.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Buried Ruin
+ * Land
+ *
+ * {T}: Add {C}.
+ * {2}, {T}, Sacrifice this land: Return target artifact card from your graveyard to your hand.
+ */
+val BuriedRuin = card("Buried Ruin") {
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n{2}, {T}, Sacrifice this land: Return target artifact card from your graveyard to your hand."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.SacrificeSelf)
+        val card = target(
+            "target artifact card in your graveyard",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Artifact.ownedByYou(), zone = Zone.GRAVEYARD)),
+        )
+        effect = Effects.ReturnToHand(card)
+        description = "{2}, {T}, Sacrifice this land: Return target artifact card from your graveyard " +
+            "to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "224"
+        artist = "Franz Vohwinkel"
+        flavorText = "History has buried its treasures deep."
+        imageUri = "https://cards.scryfall.io/normal/front/e/9/e910cf59-f7aa-44b1-bb8a-c2211179137c.jpg?1783941046"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/ChildOfNightM12Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/ChildOfNightM12Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Child of Night reprint in Magic 2012. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val ChildOfNightM12Reprint = Printing(
+    oracleId = "c650a7bc-e350-44a0-a698-d4a233d66156",
+    name = "Child of Night",
+    setCode = "M12",
+    collectorNumber = "87",
+    scryfallId = "c4780079-7f4c-4a43-883f-4722423c4fec",
+    artist = "Ash Wood",
+    imageUri = "https://cards.scryfall.io/normal/front/c/4/c4780079-7f4c-4a43-883f-4722423c4fec.jpg?1783941084",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/ZombieInfestationM12Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/ZombieInfestationM12Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zombie Infestation reprint in Magic 2012. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val ZombieInfestationM12Reprint = Printing(
+    oracleId = "bdce1af0-3643-4e77-88f9-320206a191d4",
+    name = "Zombie Infestation",
+    setCode = "M12",
+    collectorNumber = "120",
+    scryfallId = "c84a3e27-841a-4eb5-afcd-ddb87d4280f7",
+    artist = "Thomas M. Baxa",
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c84a3e27-841a-4eb5-afcd-ddb87d4280f7.jpg?1783941075",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/BloodhunterBat.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/BloodhunterBat.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Bloodhunter Bat
+ * {3}{B}
+ * Creature — Bat
+ * 2/2
+ *
+ * Flying
+ * When this creature enters, target player loses 2 life and you gain 2 life.
+ */
+val BloodhunterBat = card("Bloodhunter Bat") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Bat"
+    oracleText = "Flying\nWhen this creature enters, target player loses 2 life and you gain 2 life."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val player = target("target player", Targets.Player)
+        effect = Effects.DrainLife(2, from = player, to = EffectTarget.Controller)
+        description = "When this creature enters, target player loses 2 life and you gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "82"
+        artist = "Tomasz Jedruszek"
+        flavorText = "It returns eager to share the feast of blood and gore with its ghoulish master."
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/99c10705-6e0e-46f6-a64c-0095b2796aaf.jpg?1783940499"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/DragonHatchling.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/DragonHatchling.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dragon Hatchling
+ * {1}{R}
+ * Creature — Dragon
+ * 0/1
+ *
+ * Flying
+ * {R}: This creature gets +1/+0 until end of turn.
+ */
+val DragonHatchling = card("Dragon Hatchling") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    oracleText = "Flying\n{R}: This creature gets +1/+0 until end of turn."
+    power = 0
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "{R}: This creature gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "128"
+        artist = "David Palumbo"
+        flavorText = "\"Those dragons grow fast. For a while they feed on squirrels and goblins and then suddenly you're missing a mammoth.\"\n—Hurdek, Mazar mammoth trainer"
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/ed599d52-f2d9-4913-ad88-70f8aa4af7b9.jpg?1783940484"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/MarkOfTheVampire.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/MarkOfTheVampire.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Mark of the Vampire
+ * {3}{B}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets +2/+2 and has lifelink.
+ */
+val MarkOfTheVampire = card("Mark of the Vampire") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nEnchanted creature gets +2/+2 and has lifelink."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.LIFELINK)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "99"
+        artist = "Winona Nelson"
+        flavorText = "\"My 'condition' is a trial. The weak are consumed by it. The strong transcend it.\"\n—Sorin Markov"
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/90484815-2529-4a81-9f1b-f0f7382e4b66.jpg?1783940493"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/TalrandSkySummoner.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/TalrandSkySummoner.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Talrand, Sky Summoner
+ * {2}{U}{U}
+ * Legendary Creature — Merfolk Wizard
+ * 2/2
+ *
+ * Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.
+ */
+val TalrandSkySummoner = card("Talrand, Sky Summoner") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Merfolk Wizard"
+    oracleText = "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Drake"),
+            keywords = setOf(Keyword.FLYING),
+        )
+        description = "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature " +
+            "token with flying."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "72"
+        artist = "Svetlin Velinov"
+        flavorText = "\"The seas are vast, but the skies are even more so. Why be content with one kingdom when I can rule them both?\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc1a6867-921d-4912-afae-c3c445ad81e7.jpg?1783940501"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/TorchFiendM13Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/TorchFiendM13Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Torch Fiend reprint in Magic 2013. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val TorchFiendM13Reprint = Printing(
+    oracleId = "15f8049c-f21d-4cd0-aa81-1a533936cf77",
+    name = "Torch Fiend",
+    setCode = "M13",
+    collectorNumber = "151",
+    scryfallId = "cbd53740-43bb-4ea2-aa01-937a5786ccda",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cbd53740-43bb-4ea2-aa01-937a5786ccda.jpg?1783940479",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/BarrageOfExpendables.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/BarrageOfExpendables.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Barrage of Expendables
+ * {R}
+ * Enchantment
+ *
+ * {R}, Sacrifice a creature: This enchantment deals 1 damage to any target.
+ */
+val BarrageOfExpendables = card("Barrage of Expendables") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "{R}, Sacrifice a creature: This enchantment deals 1 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Sacrifice(GameObjectFilter.Creature))
+        target = Targets.Any
+        effect = Effects.DealDamage(1, EffectTarget.ContextTarget(0))
+        description = "{R}, Sacrifice a creature: This enchantment deals 1 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "127"
+        artist = "Trevor Claxton"
+        flavorText = "Goblin generals don't distinguish between troops and ammunition."
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9e0912d-b4b9-497c-bce7-ed80b79bab32.jpg?1783939918"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ChildOfNightM14Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ChildOfNightM14Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Child of Night reprint in Magic 2014. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val ChildOfNightM14Reprint = Printing(
+    oracleId = "c650a7bc-e350-44a0-a698-d4a233d66156",
+    name = "Child of Night",
+    setCode = "M14",
+    collectorNumber = "89",
+    scryfallId = "c21b5476-5f5f-46b5-b627-398e9fcd04aa",
+    artist = "Ash Wood",
+    imageUri = "https://cards.scryfall.io/normal/front/c/2/c21b5476-5f5f-46b5-b627-398e9fcd04aa.jpg?1783939926",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/DragonHatchlingM14Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/DragonHatchlingM14Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragon Hatchling reprint in Magic 2014. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val DragonHatchlingM14Reprint = Printing(
+    oracleId = "3f48f6a7-906d-4287-8440-06bfabc93b89",
+    name = "Dragon Hatchling",
+    setCode = "M14",
+    collectorNumber = "138",
+    scryfallId = "98f2e830-a8ef-4c91-978d-23b5f851edae",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/9/8/98f2e830-a8ef-4c91-978d-23b5f851edae.jpg?1783939914",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/FortifyM14Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/FortifyM14Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fortify reprint in Magic 2014. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val FortifyM14Reprint = Printing(
+    oracleId = "52ea24d4-d33d-40fc-8ffc-09ae625b908f",
+    name = "Fortify",
+    setCode = "M14",
+    collectorNumber = "19",
+    scryfallId = "1eff4028-d4f9-4822-81d6-9f5e5e6f3011",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1eff4028-d4f9-4822-81d6-9f5e5e6f3011.jpg?1783939943",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/MarkOfTheVampireM14Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/MarkOfTheVampireM14Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mark of the Vampire reprint in Magic 2014. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val MarkOfTheVampireM14Reprint = Printing(
+    oracleId = "af942d30-a191-4306-846d-6c26755ca3e6",
+    name = "Mark of the Vampire",
+    setCode = "M14",
+    collectorNumber = "105",
+    scryfallId = "71c2f0fb-3291-489c-92cf-8d326f2e6735",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/7/1/71c2f0fb-3291-489c-92cf-8d326f2e6735.jpg?1783939922",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/BloodHost.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/BloodHost.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blood Host
+ * {3}{B}{B}
+ * Creature — Vampire
+ * 3/3
+ *
+ * {1}{B}, Sacrifice another creature: Put a +1/+1 counter on this creature and you gain 2 life.
+ */
+val BloodHost = card("Blood Host") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire"
+    oracleText = "{1}{B}, Sacrifice another creature: Put a +1/+1 counter on this creature and you gain 2 life."
+    power = 3
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{B}"), Costs.SacrificeAnother(GameObjectFilter.Creature))
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            .then(Effects.GainLife(2))
+        description = "{1}{B}, Sacrifice another creature: Put a +1/+1 counter on this creature and " +
+            "you gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "87"
+        artist = "Cynthia Sheppard"
+        flavorText = "It would be ill-mannered to decline his invitation. It would be ill-advised to accept it."
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/1454a83d-f018-446c-89fb-21460924e589.jpg?1783939186"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/ChildOfNightM15Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/ChildOfNightM15Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Child of Night reprint in Magic 2015. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val ChildOfNightM15Reprint = Printing(
+    oracleId = "c650a7bc-e350-44a0-a698-d4a233d66156",
+    name = "Child of Night",
+    setCode = "M15",
+    collectorNumber = "90",
+    scryfallId = "bff5d53c-5698-4d09-b557-89d10ce4fbbf",
+    artist = "Ash Wood",
+    imageUri = "https://cards.scryfall.io/normal/front/b/f/bff5d53c-5698-4d09-b557-89d10ce4fbbf.jpg?1783939186",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/TorchFiendM15Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/TorchFiendM15Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Torch Fiend reprint in Magic 2015. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val TorchFiendM15Reprint = Printing(
+    oracleId = "15f8049c-f21d-4cd0-aa81-1a533936cf77",
+    name = "Torch Fiend",
+    setCode = "M15",
+    collectorNumber = "166",
+    scryfallId = "3ea18c3f-0ca3-44ba-b8f5-87ce1797c58f",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/3/e/3ea18c3f-0ca3-44ba-b8f5-87ce1797c58f.jpg?1783939170",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/AlloyMyr.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/AlloyMyr.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.nph.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alloy Myr
+ * {3}
+ * Artifact Creature — Myr
+ * 2/2
+ *
+ * {T}: Add one mana of any color.
+ */
+val AlloyMyr = card("Alloy Myr") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Myr"
+    oracleText = "{T}: Add one mana of any color."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "129"
+        artist = "Matt Cavotta"
+        flavorText = "With or without witnesses, the suns continued their prismatic dance."
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abd3350b-89fb-40b4-a942-28e0c8c274aa.jpg?1783941297"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BoggartBrute.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BoggartBrute.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Boggart Brute
+ * {2}{R}
+ * Creature — Goblin Warrior
+ * 3/2
+ *
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ */
+val BoggartBrute = card("Boggart Brute") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Warrior"
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)"
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.MENACE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "133"
+        artist = "Igor Kieryluk"
+        flavorText = "He has the biggest bashing stick, so it's a safe bet he's the leader."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d735ebf-61a4-4507-9399-6d32c8903ded.jpg?1783938333"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/KnightlyValorOriReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/KnightlyValorOriReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Knightly Valor reprint in Magic Origins. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val KnightlyValorOriReprint = Printing(
+    oracleId = "9ba6cec6-97bf-4a83-9ffa-77e187d0945b",
+    name = "Knightly Valor",
+    setCode = "ORI",
+    collectorNumber = "22",
+    scryfallId = "20930fab-eb4f-4179-94a7-84dc7055710a",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/2/0/20930fab-eb4f-4179-94a7-84dc7055710a.jpg?1783938359",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/Languish.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/Languish.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Languish
+ * {2}{B}{B}
+ * Sorcery
+ *
+ * All creatures get -4/-4 until end of turn.
+ */
+val Languish = card("Languish") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "All creatures get -4/-4 until end of turn."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreatures,
+            ModifyStatsEffect(-4, -4, EffectTarget.Self),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "105"
+        artist = "Jeff Simpson"
+        flavorText = "Life is such a fragile thing."
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d3593efa-0a05-4061-9f6e-edd0a5ca9a1f.jpg?1783938340"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/LeafGilderOriReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/LeafGilderOriReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Leaf Gilder reprint in Magic Origins. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val LeafGilderOriReprint = Printing(
+    oracleId = "61324e37-4b79-4325-bf46-621b4270afe2",
+    name = "Leaf Gilder",
+    setCode = "ORI",
+    collectorNumber = "184",
+    scryfallId = "99f0c9b4-9b79-4e61-8386-a36b26d9963c",
+    artist = "Quinton Hoover",
+    imageUri = "https://cards.scryfall.io/normal/front/9/9/99f0c9b4-9b79-4e61-8386-a36b26d9963c.jpg?1783938321",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SigiledStarfishOriReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SigiledStarfishOriReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sigiled Starfish reprint in Magic Origins. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val SigiledStarfishOriReprint = Printing(
+    oracleId = "94a4f70a-8aac-412a-99f0-933e3ff87fe0",
+    name = "Sigiled Starfish",
+    setCode = "ORI",
+    collectorNumber = "73",
+    scryfallId = "d5849fa3-6296-4ca9-b2ac-519cf90f6b62",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/d/5/d5849fa3-6296-4ca9-b2ac-519cf90f6b62.jpg?1783938348",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/BeetlebackChief.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/BeetlebackChief.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Beetleback Chief
+ * {2}{R}{R}
+ * Creature — Goblin Warrior
+ * 2/2
+ *
+ * When this creature enters, create two 1/1 red Goblin creature tokens.
+ */
+val BeetlebackChief = card("Beetleback Chief") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Warrior"
+    oracleText = "When this creature enters, create two 1/1 red Goblin creature tokens."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Goblin"),
+            count = 2,
+        )
+        description = "When this creature enters, create two 1/1 red Goblin creature tokens."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "40"
+        artist = "Wayne England"
+        flavorText = "Whether trained, ridden, or eaten, few goblin military innovations have rivaled the bug."
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1e3ccf3d-583c-46b4-b51e-ae1b0628d506.jpg?1783940621"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/BrindleShoat.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/BrindleShoat.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brindle Shoat
+ * {1}{G}
+ * Creature — Boar
+ * 1/1
+ *
+ * When this creature dies, create a 3/3 green Boar creature token.
+ */
+val BrindleShoat = card("Brindle Shoat") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Boar"
+    oracleText = "When this creature dies, create a 3/3 green Boar creature token."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 3,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Boar"),
+        )
+        description = "When this creature dies, create a 3/3 green Boar creature token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "60"
+        artist = "Steven Belledin"
+        flavorText = "Hunters lure the stripling boar into the open, hoping to trap greater prey."
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e40569c-640b-4a1a-a586-bde37de5591f.jpg?1783940614"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/CadaverImpPc2Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/CadaverImpPc2Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cadaver Imp reprint in Planechase 2012. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val CadaverImpPc2Reprint = Printing(
+    oracleId = "7265d768-b79f-44eb-9873-d834e55f6463",
+    name = "Cadaver Imp",
+    setCode = "PC2",
+    collectorNumber = "31",
+    scryfallId = "1e20385c-a093-43a4-8573-68746b2d8d1e",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1e20385c-a093-43a4-8573-68746b2d8d1e.jpg?1783940625",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/WallOfBlossomsPc2Reprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/WallOfBlossomsPc2Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Blossoms reprint in Planechase 2012. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val WallOfBlossomsPc2Reprint = Printing(
+    oracleId = "ef4d5fb3-70a3-433d-a9d3-18b2beb8d79f",
+    name = "Wall of Blossoms",
+    setCode = "PC2",
+    collectorNumber = "81",
+    scryfallId = "a9d98a42-fa8d-44bb-a926-3380ccdf85e7",
+    artist = "Heather Hudson",
+    imageUri = "https://cards.scryfall.io/normal/front/a/9/a9d98a42-fa8d-44bb-a926-3380ccdf85e7.jpg?1783940604",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/AffaGuardHound.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/AffaGuardHound.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Affa Guard Hound
+ * {2}{W}
+ * Creature — Dog
+ * 2/2
+ *
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * When this creature enters, target creature gets +0/+3 until end of turn.
+ */
+val AffaGuardHound = card("Affa Guard Hound") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dog"
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, target creature gets +0/+3 until end of turn."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(0, 3, creature)
+        description = "When this creature enters, target creature gets +0/+3 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "14"
+        artist = "Ryan Pancoast"
+        flavorText = "Once a welcoming hub for explorers, Affa became a place of guarded tongues and quick defenses."
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85623f54-1c18-4b1e-a8da-df66de3832a6.jpg?1783942011"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/CadaverImp.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/CadaverImp.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cadaver Imp
+ * {1}{B}{B}
+ * Creature — Imp
+ * 1/1
+ *
+ * Flying
+ * When this creature enters, you may return target creature card from your graveyard to your hand.
+ */
+val CadaverImp = card("Cadaver Imp") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Imp"
+    oracleText = "Flying\nWhen this creature enters, you may return target creature card from your graveyard to your hand."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val card = target("target creature card in your graveyard", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.ReturnToHand(card)
+        description = "When this creature enters, you may return target creature card from your " +
+            "graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "99"
+        artist = "Dave Kendall"
+        flavorText = "The mouth must be pried open before rigor mortis sets in. Otherwise the returning soul can find no ingress."
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b2f83d5-9269-4297-b507-558c2bdec32b.jpg?1783941988"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/KilnFiend.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/KilnFiend.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kiln Fiend
+ * {1}{R}
+ * Creature — Elemental Beast
+ * 1/2
+ *
+ * Whenever you cast an instant or sorcery spell, this creature gets +3/+0 until end of turn.
+ */
+val KilnFiend = card("Kiln Fiend") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental Beast"
+    oracleText = "Whenever you cast an instant or sorcery spell, this creature gets +3/+0 until end of turn."
+    power = 1
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.ModifyStats(3, 0, EffectTarget.Self)
+        description = "Whenever you cast an instant or sorcery spell, this creature gets +3/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "153"
+        artist = "Adi Granov"
+        flavorText = "It traps an explosion within its stony skin."
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c584268-67c3-411b-a26c-aee3adf23872.jpg?1783941974"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SeaGateOracle.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/SeaGateOracle.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+
+/**
+ * Sea Gate Oracle
+ * {2}{U}
+ * Creature — Human Wizard
+ * 1/3
+ *
+ * When this creature enters, look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.
+ */
+val SeaGateOracle = card("Sea Gate Oracle") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "When this creature enters, look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library."
+    power = 1
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.lookAtTopAndKeep(
+            count = 2,
+            keepCount = 1,
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+        )
+        description = "When this creature enters, look at the top two cards of your library. Put one " +
+            "of them into your hand and the other on the bottom of your library."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "85"
+        artist = "Daniel Ljunggren"
+        flavorText = "\"The secret entrance should be near.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd056c91-5026-41ea-bc9e-68078d78ca82.jpg?1783941992"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/AugerSpree.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/AugerSpree.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Auger Spree
+ * {1}{B}{R}
+ * Instant
+ *
+ * Target creature gets +4/-4 until end of turn.
+ */
+val AugerSpree = card("Auger Spree") {
+    manaCost = "{1}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +4/-4 until end of turn."
+
+    spell {
+        target = Targets.Creature
+        effect = Effects.ModifyStats(4, -4, EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "144"
+        artist = "Raymond Swanland"
+        flavorText = "\"Finally, a weapon the Boros can't confiscate!\"\n—Juri, proprietor of the Juri Revue"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/9580a40b-b413-4f0d-9b38-13903a9d367d.jpg?1783940345"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Brushstrider.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Brushstrider.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brushstrider
+ * {1}{G}
+ * Creature — Beast
+ * 3/1
+ *
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ */
+val Brushstrider = card("Brushstrider") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)"
+    power = 3
+    toughness = 1
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "117"
+        artist = "Raoul Vitale"
+        flavorText = "Magistrate Ludy agreed to designate land for the brushstriders only after several broken windows and dozens of missing blini-cakes."
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/59bd1534-52d1-4946-b430-d26f039a9067.jpg?1783940350"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/DrainpipeVermin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/DrainpipeVermin.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Drainpipe Vermin
+ * {B}
+ * Creature — Rat
+ * 1/1
+ *
+ * When this creature dies, you may pay {B}. If you do, target player discards a card.
+ */
+val DrainpipeVermin = card("Drainpipe Vermin") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Rat"
+    oracleText = "When this creature dies, you may pay {B}. If you do, target player discards a card."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val player = target("target player", Targets.Player)
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{B}"),
+            effect = Effects.Discard(1, player),
+        )
+        description = "When this creature dies, you may pay {B}. If you do, target player discards a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Trevor Claxton"
+        flavorText = "When times are tough, the poor eat the rats. When times are tougher, the rats eat the poor."
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4d7251f3-df66-4611-a84c-1897f74431f7.jpg?1783940362"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/KnightlyValor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/KnightlyValor.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Knightly Valor
+ * {4}{W}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, create a 2/2 white Knight creature token with vigilance. (Attacking doesn't cause it to tap.)
+ * Enchanted creature gets +2/+2 and has vigilance.
+ */
+val KnightlyValor = card("Knightly Valor") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nWhen this Aura enters, create a 2/2 white Knight creature token with vigilance. (Attacking doesn't cause it to tap.)\nEnchanted creature gets +2/+2 and has vigilance."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Knight"),
+            keywords = setOf(Keyword.VIGILANCE),
+        )
+        description = "When this Aura enters, create a 2/2 white Knight creature token with vigilance."
+    }
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "13"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/122d821f-c8dd-4a3c-a6d7-b42fe5491f02.jpg?1783940374"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/CatharsCompanion.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/CatharsCompanion.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cathar's Companion
+ * {2}{W}
+ * Creature — Dog
+ * 3/1
+ *
+ * Whenever you cast a noncreature spell, this creature gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.)
+ */
+val CatharsCompanion = card("Cathar's Companion") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dog"
+    oracleText = "Whenever you cast a noncreature spell, this creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)"
+    power = 3
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self)
+        description = "Whenever you cast a noncreature spell, this creature gains indestructible until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "9"
+        artist = "Svetlin Velinov"
+        flavorText = "\"Unwavering and loyal, they represent stability in uncertain times.\"\n—Rem Karolus, Slayer of Angels"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f4b9943-0fe6-4383-90a0-4a719dcf9499.jpg?1783937824"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/PerilousMyr.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/PerilousMyr.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Perilous Myr
+ * {2}
+ * Artifact Creature — Phyrexian Myr
+ * 1/1
+ *
+ * When this creature dies, it deals 2 damage to any target.
+ */
+val PerilousMyr = card("Perilous Myr") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Phyrexian Myr"
+    oracleText = "When this creature dies, it deals 2 damage to any target."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val victim = target("any target", Targets.Any)
+        effect = Effects.DealDamage(2, victim)
+        description = "When this creature dies, it deals 2 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "192"
+        artist = "Jason Felix"
+        flavorText = "To Mirrodin, an explosive. To Phyrexia, a missionary."
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b942605-eb4a-452d-9b07-a4f912f96958.jpg?1783941699"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/FeralInvocation.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/FeralInvocation.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Feral Invocation
+ * {2}{G}
+ * Enchantment — Aura
+ *
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * Enchant creature
+ * Enchanted creature gets +2/+2.
+ */
+val FeralInvocation = card("Feral Invocation") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +2/+2."
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "158"
+        artist = "Mathias Kollros"
+        flavorText = "Nylea's sacred lynx guards those who honor the Nessian Wood and hunts those who don't."
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5c1f15a2-0058-4188-9696-385fa6974bd4.jpg?1783939745"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/MinotaurSkullcleaver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/MinotaurSkullcleaver.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Minotaur Skullcleaver
+ * {2}{R}
+ * Creature — Minotaur Berserker
+ * 2/2
+ *
+ * Haste
+ * When this creature enters, it gets +2/+0 until end of turn.
+ */
+val MinotaurSkullcleaver = card("Minotaur Skullcleaver") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Berserker"
+    oracleText = "Haste\nWhen this creature enters, it gets +2/+0 until end of turn."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+        description = "When this creature enters, it gets +2/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Phill Simmer"
+        flavorText = "\"Their only dreams are of full stomachs.\"\n—Kleon the Iron-Booted"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/6854c913-d4bd-42f7-901c-f3c25be5c4b2.jpg?1783939759"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/PrescientChimera.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/PrescientChimera.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prescient Chimera
+ * {3}{U}{U}
+ * Creature — Chimera
+ * 3/4
+ *
+ * Flying
+ * Whenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ */
+val PrescientChimera = card("Prescient Chimera") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Chimera"
+    oracleText = "Flying\nWhenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.Scry(1)
+        description = "Whenever you cast an instant or sorcery spell, scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "Daarken"
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f9342aba-e3aa-4210-ad72-e609c7c027b8.jpg?1783939794"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/VoyagesEnd.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/VoyagesEnd.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Voyage's End
+ * {1}{U}
+ * Instant
+ *
+ * Return target creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ */
+val VoyagesEnd = card("Voyage's End") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        target = Targets.Creature
+        effect = Effects.ReturnToHand(EffectTarget.ContextTarget(0))
+            .then(Effects.Scry(1))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "73"
+        artist = "Chris Rahn"
+        flavorText = "Philosophers say those lost at sea ascended to a more perfect realm. Sailors say they drowned."
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/3992ae67-ad0b-40be-a97d-d7fb36754918.jpg?1783939787"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/MoltenRavager.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/MoltenRavager.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Molten Ravager
+ * {2}{R}
+ * Creature — Elemental
+ * 0/4
+ *
+ * {R}: This creature gets +1/+0 until end of turn.
+ */
+val MoltenRavager = card("Molten Ravager") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    oracleText = "{R}: This creature gets +1/+0 until end of turn."
+    power = 0
+    toughness = 4
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "{R}: This creature gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "138"
+        artist = "Dave Kendall"
+        flavorText = "\"Only the foolhardy would venture into the Akoum Mountains without a lullmage to tame the raging rocks and living fires.\"\n—Sachir, Akoum Expeditionary House"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9ebc7622-e7a7-419c-abb4-d9d339e6cdb0.jpg?1783942142"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/GiftedAetherborn.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/GiftedAetherborn.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.aer.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gifted Aetherborn
+ * {B}{B}
+ * Creature — Aetherborn Vampire
+ * 2/3
+ *
+ * Deathtouch, lifelink
+ */
+val GiftedAetherborn = card("Gifted Aetherborn") {
+    manaCost = "{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Aetherborn Vampire"
+    oracleText = "Deathtouch, lifelink"
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.DEATHTOUCH, Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "61"
+        artist = "Ryan Yee"
+        flavorText = "A few aetherborn have discovered a way to sustain their own existences at the cost of an insatiable hunger for the life essence of other beings."
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abceb4fd-e3c5-400d-af7a-6dd17108a4b4.jpg?1783936763"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/BlightedBat.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/BlightedBat.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blighted Bat
+ * {2}{B}
+ * Creature — Zombie Bat
+ * 2/1
+ *
+ * Flying
+ * {1}: This creature gains haste until end of turn.
+ */
+val BlightedBat = card("Blighted Bat") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Bat"
+    oracleText = "Flying\n{1}: This creature gains haste until end of turn."
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        effect = Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self)
+        description = "{1}: This creature gains haste until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "80"
+        artist = "Nils Hamm"
+        flavorText = "Amonkhet's dual suns don't allow for the darkness of night, so bats are most active under the gloom of the frequent sandstorms."
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8da308e9-1862-46c1-a62a-90720b484d91.jpg?1783936512"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/BloodrageBrawler.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/BloodrageBrawler.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bloodrage Brawler
+ * {1}{R}
+ * Creature — Minotaur Warrior
+ * 4/3
+ *
+ * When this creature enters, discard a card.
+ */
+val BloodrageBrawler = card("Bloodrage Brawler") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Warrior"
+    oracleText = "When this creature enters, discard a card."
+    power = 4
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Discard(1)
+        description = "When this creature enters, discard a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "121"
+        artist = "Lars Grant-West"
+        flavorText = "To Hazoret, those who fight for her are her beloved children."
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e6080f9e-2415-4e05-97a1-0fe4ad4fdf3b.jpg?1783936492"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/InitiatesCompanion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/InitiatesCompanion.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Initiate's Companion
+ * {1}{G}
+ * Creature — Cat
+ * 3/1
+ *
+ * Whenever this creature deals combat damage to a player, untap target creature or land.
+ */
+val InitiatesCompanion = card("Initiate's Companion") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat"
+    oracleText = "Whenever this creature deals combat damage to a player, untap target creature or land."
+    power = 3
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        val permanent = target(
+            "target creature or land",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrLand)),
+        )
+        effect = Effects.Untap(permanent)
+        description = "Whenever this creature deals combat damage to a player, untap target creature or land."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "174"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"I'd like to say that it's our pet, but the reverse may be closer to the truth.\"\n—Ixor, initiate of Rhet crop"
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/0046b802-bc71-44af-8925-666684d5fc87.jpg?1783936472"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/MinotaurSureshot.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/MinotaurSureshot.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Minotaur Sureshot
+ * {2}{R}
+ * Creature — Minotaur Archer
+ * 2/3
+ *
+ * Reach (This creature can block creatures with flying.)
+ * {1}{R}: This creature gets +1/+0 until end of turn.
+ */
+val MinotaurSureshot = card("Minotaur Sureshot") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Archer"
+    oracleText = "Reach (This creature can block creatures with flying.)\n{1}{R}: This creature gets +1/+0 until end of turn."
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.REACH)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "{1}{R}: This creature gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "143"
+        artist = "Joseph Meehan"
+        flavorText = "\"Those wings are no advantage. I will pin them to the ceiling of the Hekma.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/777b98c3-d0b8-4ee3-9d89-e86344269ff1.jpg?1783936484"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/PouncingCheetah.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/PouncingCheetah.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pouncing Cheetah
+ * {2}{G}
+ * Creature — Cat
+ * 3/2
+ *
+ * Flash
+ */
+val PouncingCheetah = card("Pouncing Cheetah") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat"
+    oracleText = "Flash"
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.FLASH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "179"
+        artist = "Matt Stewart"
+        flavorText = "Rhonas's monument is home to a wider variety of creatures than anywhere else in the city of Naktamun—a feature most initiates fail to appreciate."
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fca8a590-75c1-4e85-b8b7-8c0c0f18b96e.jpg?1783936471"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/MoltenRavagerAnbReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/MoltenRavagerAnbReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Molten Ravager reprint in Arena Beginner Set. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val MoltenRavagerAnbReprint = Printing(
+    oracleId = "697c851d-8475-479e-8783-cebdbe9a892d",
+    name = "Molten Ravager",
+    setCode = "ANB",
+    collectorNumber = "78",
+    scryfallId = "50cd434c-a04c-4ac8-9b1a-a79903d84060",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/50cd434c-a04c-4ac8-9b1a-a79903d84060.jpg?1783929804",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/WingedWordsAnbReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/WingedWordsAnbReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Winged Words reprint in Arena Beginner Set. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val WingedWordsAnbReprint = Printing(
+    oracleId = "c623aeb1-e6d4-48fe-bd2a-a7a6729aa4df",
+    name = "Winged Words",
+    setCode = "ANB",
+    collectorNumber = "43",
+    scryfallId = "3449f98f-92d2-4be4-a596-fefa8843b6fd",
+    artist = "Chris Seaman",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/3449f98f-92d2-4be4-a596-fefa8843b6fd.jpg?1783929825",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/SeaGateOracleC17Reprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/SeaGateOracleC17Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sea Gate Oracle reprint in Commander 2017. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val SeaGateOracleC17Reprint = Printing(
+    oracleId = "b333c194-d285-4dfb-984c-57b7e88393af",
+    name = "Sea Gate Oracle",
+    setCode = "C17",
+    collectorNumber = "92",
+    scryfallId = "60b7ea54-1bb5-40e6-bdaf-5ef6916d8f6f",
+    artist = "Daniel Ljunggren",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/60b7ea54-1bb5-40e6-bdaf-5ef6916d8f6f.jpg?1783935914",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/UnstableObeliskC17Reprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/UnstableObeliskC17Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Unstable Obelisk reprint in Commander 2017. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val UnstableObeliskC17Reprint = Printing(
+    oracleId = "060ae1bb-956a-4264-b405-a33151f31493",
+    name = "Unstable Obelisk",
+    setCode = "C17",
+    collectorNumber = "229",
+    scryfallId = "7e28fef0-432b-4554-b2cd-9ef8ce6b09b4",
+    artist = "William Wu",
+    imageUri = "https://cards.scryfall.io/normal/front/7/e/7e28fef0-432b-4554-b2cd-9ef8ce6b09b4.jpg?1783935862",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/PerilousMyrCmrReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/PerilousMyrCmrReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Perilous Myr reprint in Commander Legends. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val PerilousMyrCmrReprint = Printing(
+    oracleId = "f1e8f746-1837-4ea8-9a07-e57946883353",
+    name = "Perilous Myr",
+    setCode = "CMR",
+    collectorNumber = "330",
+    scryfallId = "5a15c8ef-04ad-4aab-a7f1-c7a90c10eb50",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/5/a/5a15c8ef-04ad-4aab-a7f1-c7a90c10eb50.jpg?1783928750",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/VolcanicFalloutCmrReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/VolcanicFalloutCmrReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Volcanic Fallout reprint in Commander Legends. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val VolcanicFalloutCmrReprint = Printing(
+    oracleId = "bd6ce147-c991-40ac-b276-65b630fad8b6",
+    name = "Volcanic Fallout",
+    setCode = "CMR",
+    collectorNumber = "418",
+    scryfallId = "6109c345-ce73-44b6-9228-5c4882764fab",
+    artist = "Zoltan Boros & Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/6/1/6109c345-ce73-44b6-9228-5c4882764fab.jpg?1783928713",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/JoustingDummy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/JoustingDummy.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Jousting Dummy
+ * {2}
+ * Artifact Creature — Scarecrow Knight
+ * 2/1
+ *
+ * {3}: This creature gets +1/+0 until end of turn.
+ */
+val JoustingDummy = card("Jousting Dummy") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Scarecrow Knight"
+    oracleText = "{3}: This creature gets +1/+0 until end of turn."
+    power = 2
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Mana("{3}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "{3}: This creature gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "224"
+        artist = "Milivoj Ćeran"
+        flavorText = "\"Don't let it fool you. Many of us got our first scars from Syr Nobody.\"\n—Syr Layne, knight of Embereth"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6601056-af08-4239-97d5-5e11597fce18.jpg?1783932584"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/KeeperOfFables.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/KeeperOfFables.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Keeper of Fables
+ * {3}{G}{G}
+ * Creature — Cat
+ * 4/5
+ *
+ * Whenever one or more non-Human creatures you control deal combat damage to a player, draw a card.
+ */
+val KeeperOfFables = card("Keeper of Fables") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat"
+    oracleText = "Whenever one or more non-Human creatures you control deal combat damage to a player, draw a card."
+    power = 4
+    toughness = 5
+
+    triggeredAbility {
+        // CR 603.2c batch trigger: one draw no matter how many of them connect at once.
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            sourceFilter = GameObjectFilter.Creature.youControl().notSubtype(Subtype.HUMAN),
+            binding = TriggerBinding.ANY,
+            batch = true,
+        )
+        effect = DrawCardsEffect(1)
+        description = "Whenever one or more non-Human creatures you control deal combat damage to a " +
+            "player, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "163"
+        artist = "Alex Konstad"
+        flavorText = "\"Only the lion knows more stories than I do.\"\n—Chulane, Teller of Tales"
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/6754d6cf-3506-48b5-a0ef-8a90b8dd2701.jpg?1783932608"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/SignpostScarecrow.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/SignpostScarecrow.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Signpost Scarecrow
+ * {4}
+ * Artifact Creature — Scarecrow
+ * 2/4
+ *
+ * Vigilance
+ * {2}: Add one mana of any color.
+ */
+val SignpostScarecrow = card("Signpost Scarecrow") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Scarecrow"
+    oracleText = "Vigilance\n{2}: Add one mana of any color."
+    power = 2
+    toughness = 4
+
+    keywords(Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "231"
+        artist = "Jung Park"
+        flavorText = "\"Accursed scarecrow! Sending folk in every direction is the same as sending them nowhere at all.\"\n—Corliss the Wanderer"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2c5f336-c100-4bec-89d5-548f60064d7f.jpg?1783932583"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/ChildOfNightGrnReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/ChildOfNightGrnReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Child of Night reprint in Guilds of Ravnica. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val ChildOfNightGrnReprint = Printing(
+    oracleId = "c650a7bc-e350-44a0-a698-d4a233d66156",
+    name = "Child of Night",
+    setCode = "GRN",
+    collectorNumber = "65",
+    scryfallId = "afebf1a5-eb9a-48c6-a26a-55b75408992b",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/a/f/afebf1a5-eb9a-48c6-a26a-55b75408992b.jpg?1783934180",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/InspiringUnicorn.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/InspiringUnicorn.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Inspiring Unicorn
+ * {2}{W}{W}
+ * Creature — Unicorn
+ * 2/2
+ *
+ * Whenever this creature attacks, creatures you control get +1/+1 until end of turn.
+ */
+val InspiringUnicorn = card("Inspiring Unicorn") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Unicorn"
+    oracleText = "Whenever this creature attacks, creatures you control get +1/+1 until end of turn."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.ModifyStats(1, 1, EffectTarget.Self),
+        )
+        description = "Whenever this creature attacks, creatures you control get +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "16"
+        artist = "Even Amundsen"
+        flavorText = "There are two lives: the life you live before you see a unicorn, and the life you live after."
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ce8b745e-1e62-4c54-9e73-e2d0a40568a0.jpg?1783934199"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/FeralProwler.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/FeralProwler.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.hou.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+
+/**
+ * Feral Prowler
+ * {1}{G}
+ * Creature — Cat
+ * 1/3
+ *
+ * When this creature dies, draw a card.
+ */
+val FeralProwler = card("Feral Prowler") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat"
+    oracleText = "When this creature dies, draw a card."
+    power = 1
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = DrawCardsEffect(1)
+        description = "When this creature dies, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "Ben Wootten"
+        flavorText = "Once favored companions, many cats were left to fend for themselves."
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba0431ad-185a-4917-b994-e58dd9850f5e.jpg?1783936020"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/JumpstartSet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/JumpstartSet.kt
@@ -23,6 +23,10 @@ object JumpstartSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AegisOfTheHeavensJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AegisOfTheHeavensJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aegis of the Heavens reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Core Set 2019's `cards/` package; this file contributes only presentation data.
+ */
+val AegisOfTheHeavensJmpReprint = Printing(
+    oracleId = "f8e1b38a-2a77-4cf1-8bef-31acb61ede10",
+    name = "Aegis of the Heavens",
+    setCode = "JMP",
+    collectorNumber = "79",
+    scryfallId = "a94f356d-4714-4500-8fb0-1ac68ec5c1cf",
+    artist = "Anthony Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/a/9/a94f356d-4714-4500-8fb0-1ac68ec5c1cf.jpg?1783930483",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AffaGuardHoundJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AffaGuardHoundJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Affa Guard Hound reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Rise of the Eldrazi's `cards/` package; this file contributes only presentation data.
+ */
+val AffaGuardHoundJmpReprint = Printing(
+    oracleId = "3819daab-fe35-4f99-9282-47bd05c7fcd6",
+    name = "Affa Guard Hound",
+    setCode = "JMP",
+    collectorNumber = "81",
+    scryfallId = "f762546c-f5eb-420d-a8f7-c3566cd8f506",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/f/7/f762546c-f5eb-420d-a8f7-c3566cd8f506.jpg?1783930483",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AgonizingSyphonJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AgonizingSyphonJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Agonizing Syphon reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Core Set 2020's `cards/` package; this file contributes only presentation data.
+ */
+val AgonizingSyphonJmpReprint = Printing(
+    oracleId = "11669fe5-9298-4e1a-a4f7-6a4598dbc8dd",
+    name = "Agonizing Syphon",
+    setCode = "JMP",
+    collectorNumber = "199",
+    scryfallId = "3532a279-b8e1-4124-bcd7-d7f4c71673eb",
+    artist = "Seb McKinnon",
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/3532a279-b8e1-4124-bcd7-d7f4c71673eb.jpg?1783930436",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AlabasterMageJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AlabasterMageJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alabaster Mage reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic 2012's `cards/` package; this file contributes only presentation data.
+ */
+val AlabasterMageJmpReprint = Printing(
+    oracleId = "ea7a8acb-f01f-4a69-9b3c-954d8f0d3155",
+    name = "Alabaster Mage",
+    setCode = "JMP",
+    collectorNumber = "83",
+    scryfallId = "b7026ffb-98de-4da7-84a8-1198639873f4",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/b/7/b7026ffb-98de-4da7-84a8-1198639873f4.jpg?1783930482",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AlloyMyrJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AlloyMyrJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alloy Myr reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * New Phyrexia's `cards/` package; this file contributes only presentation data.
+ */
+val AlloyMyrJmpReprint = Printing(
+    oracleId = "efb0394c-2a45-4dd8-bca3-08704056fa31",
+    name = "Alloy Myr",
+    setCode = "JMP",
+    collectorNumber = "457",
+    scryfallId = "e8d2180b-f54c-47a9-9458-28e7a19e35ee",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/e/8/e8d2180b-f54c-47a9-9458-28e7a19e35ee.jpg?1783930344",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/Archaeomender.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/Archaeomender.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Archaeomender
+ * {2}{U}
+ * Creature — Human Wizard
+ * 2/3
+ *
+ * When this creature enters, return target artifact card from your graveyard to your hand.
+ */
+val Archaeomender = card("Archaeomender") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "When this creature enters, return target artifact card from your graveyard to your hand."
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val card = target(
+            "target artifact card in your graveyard",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Artifact.ownedByYou(), zone = Zone.GRAVEYARD)),
+        )
+        effect = Effects.ReturnToHand(card)
+        description = "When this creature enters, return target artifact card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "9"
+        artist = "Miranda Meeks"
+        flavorText = "\"Just as a broken relic can be mended, a shattered history can be made whole.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/22bb8779-ac19-43d6-b818-86eb8ee2f87d.jpg?1783930507"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AugerSpreeJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AugerSpreeJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Auger Spree reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Return to Ravnica's `cards/` package; this file contributes only presentation data.
+ */
+val AugerSpreeJmpReprint = Printing(
+    oracleId = "c0c96c7a-02d8-40cb-a08b-4a2a3b631eef",
+    name = "Auger Spree",
+    setCode = "JMP",
+    collectorNumber = "449",
+    scryfallId = "05f0092a-b642-41be-a907-4c8931962ef9",
+    artist = "Raymond Swanland",
+    imageUri = "https://cards.scryfall.io/normal/front/0/5/05f0092a-b642-41be-a907-4c8931962ef9.jpg?1783930346",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BarrageOfExpendablesJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BarrageOfExpendablesJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barrage of Expendables reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic 2014's `cards/` package; this file contributes only presentation data.
+ */
+val BarrageOfExpendablesJmpReprint = Printing(
+    oracleId = "da7600f6-5d4c-46bf-936a-9e0f0d508e19",
+    name = "Barrage of Expendables",
+    setCode = "JMP",
+    collectorNumber = "292",
+    scryfallId = "8b94ff00-0821-4743-b693-2ba310466306",
+    artist = "Trevor Claxton",
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8b94ff00-0821-4743-b693-2ba310466306.jpg?1783930404",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BatheInDragonfireJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BatheInDragonfireJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bathe in Dragonfire reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Fate Reforged's `cards/` package; this file contributes only presentation data.
+ */
+val BatheInDragonfireJmpReprint = Printing(
+    oracleId = "72d793e8-1d19-4ca1-894c-8851a2ebecde",
+    name = "Bathe in Dragonfire",
+    setCode = "JMP",
+    collectorNumber = "293",
+    scryfallId = "102740d0-ca74-460d-af30-c71bddad87c4",
+    artist = "Chris Rallis",
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/102740d0-ca74-460d-af30-c71bddad87c4.jpg?1783930402",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BeetlebackChiefJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BeetlebackChiefJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Beetleback Chief reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Planechase 2012's `cards/` package; this file contributes only presentation data.
+ */
+val BeetlebackChiefJmpReprint = Printing(
+    oracleId = "f5c5f64c-6911-430c-a825-b32b96d39c7d",
+    name = "Beetleback Chief",
+    setCode = "JMP",
+    collectorNumber = "294",
+    scryfallId = "a4a514b9-8a67-47aa-8218-8d6fe8040128",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/a/4/a4a514b9-8a67-47aa-8218-8d6fe8040128.jpg?1783930402",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BlightedBatJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BlightedBatJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blighted Bat reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Amonkhet's `cards/` package; this file contributes only presentation data.
+ */
+val BlightedBatJmpReprint = Printing(
+    oracleId = "542887e9-1032-4396-9cbb-aa3c11ee43a0",
+    name = "Blighted Bat",
+    setCode = "JMP",
+    collectorNumber = "205",
+    scryfallId = "6c0cc3d9-85f1-49ed-bf8a-81fc6c60bd2a",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/6/c/6c0cc3d9-85f1-49ed-bf8a-81fc6c60bd2a.jpg?1783930436",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BloodDivinationJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BloodDivinationJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blood Divination reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Core Set 2019's `cards/` package; this file contributes only presentation data.
+ */
+val BloodDivinationJmpReprint = Printing(
+    oracleId = "c1cf9d74-e700-456a-9e5a-1c4df22db268",
+    name = "Blood Divination",
+    setCode = "JMP",
+    collectorNumber = "207",
+    scryfallId = "51278b56-5056-4a37-a1e8-daca45d8e360",
+    artist = "Filip Burburan",
+    imageUri = "https://cards.scryfall.io/normal/front/5/1/51278b56-5056-4a37-a1e8-daca45d8e360.jpg?1783930434",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BloodHostJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BloodHostJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blood Host reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic 2015's `cards/` package; this file contributes only presentation data.
+ */
+val BloodHostJmpReprint = Printing(
+    oracleId = "ac193909-7e81-4082-ad02-2a60d142a0ab",
+    name = "Blood Host",
+    setCode = "JMP",
+    collectorNumber = "208",
+    scryfallId = "59d0839b-a021-4227-aa0f-1fa2ff806892",
+    artist = "Cynthia Sheppard",
+    imageUri = "https://cards.scryfall.io/normal/front/5/9/59d0839b-a021-4227-aa0f-1fa2ff806892.jpg?1783930434",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BloodhunterBatJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BloodhunterBatJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bloodhunter Bat reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic 2013's `cards/` package; this file contributes only presentation data.
+ */
+val BloodhunterBatJmpReprint = Printing(
+    oracleId = "7e3e09a2-b45c-4897-ba10-02628cca3f4c",
+    name = "Bloodhunter Bat",
+    setCode = "JMP",
+    collectorNumber = "210",
+    scryfallId = "99a14228-3716-4448-a8c3-93928b9b85d6",
+    artist = "Tomasz Jedruszek",
+    imageUri = "https://cards.scryfall.io/normal/front/9/9/99a14228-3716-4448-a8c3-93928b9b85d6.jpg?1783930433",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BloodrageBrawlerJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BloodrageBrawlerJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bloodrage Brawler reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Amonkhet's `cards/` package; this file contributes only presentation data.
+ */
+val BloodrageBrawlerJmpReprint = Printing(
+    oracleId = "8603e2d4-93f3-491a-91e7-a187fc6db599",
+    name = "Bloodrage Brawler",
+    setCode = "JMP",
+    collectorNumber = "296",
+    scryfallId = "c3b633bf-a77e-4b78-b729-a83896abf17c",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/c/3/c3b633bf-a77e-4b78-b729-a83896abf17c.jpg?1783930401",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BoggartBruteJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BoggartBruteJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Boggart Brute reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic Origins's `cards/` package; this file contributes only presentation data.
+ */
+val BoggartBruteJmpReprint = Printing(
+    oracleId = "880793a2-84b0-4ae1-9bb8-6e942e3dc723",
+    name = "Boggart Brute",
+    setCode = "JMP",
+    collectorNumber = "299",
+    scryfallId = "3d6de3a7-30a7-49d7-8e39-494355c6edae",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3d6de3a7-30a7-49d7-8e39-494355c6edae.jpg?1783930402",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BrindleShoatJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BrindleShoatJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brindle Shoat reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Planechase 2012's `cards/` package; this file contributes only presentation data.
+ */
+val BrindleShoatJmpReprint = Printing(
+    oracleId = "d385c2e1-a62e-43ad-80ef-a6178deac82c",
+    name = "Brindle Shoat",
+    setCode = "JMP",
+    collectorNumber = "380",
+    scryfallId = "318a41e3-1c5a-467e-9ffb-e6a5f817f8fe",
+    artist = "Steven Belledin",
+    imageUri = "https://cards.scryfall.io/normal/front/3/1/318a41e3-1c5a-467e-9ffb-e6a5f817f8fe.jpg?1783930371",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BrushstriderJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BrushstriderJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brushstrider reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Return to Ravnica's `cards/` package; this file contributes only presentation data.
+ */
+val BrushstriderJmpReprint = Printing(
+    oracleId = "6dfcc4bb-7cd5-4b3e-ad79-3c246a3af2a8",
+    name = "Brushstrider",
+    setCode = "JMP",
+    collectorNumber = "381",
+    scryfallId = "6649d5e9-22fb-4134-a4d9-ee05e6668f94",
+    artist = "Raoul Vitale",
+    imageUri = "https://cards.scryfall.io/normal/front/6/6/6649d5e9-22fb-4134-a4d9-ee05e6668f94.jpg?1783930370",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BulwarkGiantJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BulwarkGiantJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bulwark Giant reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * War of the Spark's `cards/` package; this file contributes only presentation data.
+ */
+val BulwarkGiantJmpReprint = Printing(
+    oracleId = "f606bd15-b380-447f-b147-72f811266593",
+    name = "Bulwark Giant",
+    setCode = "JMP",
+    collectorNumber = "93",
+    scryfallId = "5104d4fe-4c20-4106-b405-a2b35140c942",
+    artist = "Victor Adame Minguez",
+    imageUri = "https://cards.scryfall.io/normal/front/5/1/5104d4fe-4c20-4106-b405-a2b35140c942.jpg?1783930477",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BuriedRuinJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BuriedRuinJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Buried Ruin reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic 2012's `cards/` package; this file contributes only presentation data.
+ */
+val BuriedRuinJmpReprint = Printing(
+    oracleId = "3644f316-f9a3-46c9-9b1e-747f86cf4ead",
+    name = "Buried Ruin",
+    setCode = "JMP",
+    collectorNumber = "491",
+    scryfallId = "011bc5b7-c4d5-4c4c-af0d-aa0853d63f3a",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/0/1/011bc5b7-c4d5-4c4c-af0d-aa0853d63f3a.jpg?1783930328",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CadaverImpJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CadaverImpJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cadaver Imp reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Rise of the Eldrazi's `cards/` package; this file contributes only presentation data.
+ */
+val CadaverImpJmpReprint = Printing(
+    oracleId = "7265d768-b79f-44eb-9873-d834e55f6463",
+    name = "Cadaver Imp",
+    setCode = "JMP",
+    collectorNumber = "215",
+    scryfallId = "4fefd7f9-57ff-41bb-aef6-b1d568a7588b",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/4/f/4fefd7f9-57ff-41bb-aef6-b1d568a7588b.jpg?1783930431",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CatharsCompanionJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CatharsCompanionJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cathar's Companion reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Shadows over Innistrad's `cards/` package; this file contributes only presentation data.
+ */
+val CatharsCompanionJmpReprint = Printing(
+    oracleId = "668f646b-94f0-4f1a-badd-2d69b559d8a2",
+    name = "Cathar's Companion",
+    setCode = "JMP",
+    collectorNumber = "94",
+    scryfallId = "0291a964-1117-4fbd-9193-9719b273c348",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/0/2/0291a964-1117-4fbd-9193-9719b273c348.jpg?1783930476",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ChainedBrute.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ChainedBrute.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Chained Brute
+ * {1}{R}
+ * Creature — Devil
+ * 4/3
+ *
+ * This creature doesn't untap during your untap step.
+ * {1}, Sacrifice another creature: Untap this creature. Activate only during your turn.
+ */
+val ChainedBrute = card("Chained Brute") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Devil"
+    oracleText = "This creature doesn't untap during your untap step.\n{1}, Sacrifice another creature: Untap this creature. Activate only during your turn."
+    power = 4
+    toughness = 3
+
+    flags(AbilityFlag.DOESNT_UNTAP)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeAnother(GameObjectFilter.Creature))
+        effect = Effects.Untap(EffectTarget.Self)
+        restrictions = listOf(ActivationRestriction.OnlyDuringYourTurn)
+        description = "{1}, Sacrifice another creature: Untap this creature. Activate only during your turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "19"
+        artist = "Dan Murayama Scott"
+        flavorText = "A momentary lapse is all it needs to break free."
+        imageUri = "https://cards.scryfall.io/normal/front/1/d/1d4e5c23-3a7f-4a6b-99c4-6a1487a9b097.jpg?1783930504"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ChildOfNightJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ChildOfNightJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Child of Night reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic 2010's `cards/` package; this file contributes only presentation data.
+ */
+val ChildOfNightJmpReprint = Printing(
+    oracleId = "c650a7bc-e350-44a0-a698-d4a233d66156",
+    name = "Child of Night",
+    setCode = "JMP",
+    collectorNumber = "218",
+    scryfallId = "3887af00-a87d-4396-b82b-38b88c084e8e",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/3/8/3887af00-a87d-4396-b82b-38b88c084e8e.jpg?1783930429",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CinderElementalJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CinderElementalJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cinder Elemental reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Mercadian Masques's `cards/` package; this file contributes only presentation data.
+ */
+val CinderElementalJmpReprint = Printing(
+    oracleId = "01805d0d-3a72-4d26-9475-3e68c278b7fe",
+    name = "Cinder Elemental",
+    setCode = "JMP",
+    collectorNumber = "304",
+    scryfallId = "78c3c616-1f95-41b1-a624-79d6362d4f16",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/7/8/78c3c616-1f95-41b1-a624-79d6362d4f16.jpg?1783930398",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CollateralDamageJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CollateralDamageJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Collateral Damage reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Fate Reforged's `cards/` package; this file contributes only presentation data.
+ */
+val CollateralDamageJmpReprint = Printing(
+    oracleId = "b89dd47e-0f65-41f0-ad23-cefc61e68978",
+    name = "Collateral Damage",
+    setCode = "JMP",
+    collectorNumber = "305",
+    scryfallId = "81232b04-a4a0-48d8-b8af-a6e3d50173e5",
+    artist = "Ryan Barger",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/81232b04-a4a0-48d8-b8af-a6e3d50173e5.jpg?1783930399",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DragonHatchlingJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DragonHatchlingJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragon Hatchling reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic 2013's `cards/` package; this file contributes only presentation data.
+ */
+val DragonHatchlingJmpReprint = Printing(
+    oracleId = "3f48f6a7-906d-4287-8440-06bfabc93b89",
+    name = "Dragon Hatchling",
+    setCode = "JMP",
+    collectorNumber = "310",
+    scryfallId = "c5d3a18c-d030-494d-b7b1-4d1d1e27fbbf",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c5d3a18c-d030-494d-b7b1-4d1d1e27fbbf.jpg?1783930396",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DragonloftIdolJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DragonloftIdolJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonloft Idol reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Dragons of Tarkir's `cards/` package; this file contributes only presentation data.
+ */
+val DragonloftIdolJmpReprint = Printing(
+    oracleId = "736ce43b-28cd-4b8b-9936-3e3975a56b6a",
+    name = "Dragonloft Idol",
+    setCode = "JMP",
+    collectorNumber = "463",
+    scryfallId = "2e9fa21a-a92e-4bcd-84fe-a7aa159fd0eb",
+    artist = "Jung Park",
+    imageUri = "https://cards.scryfall.io/normal/front/2/e/2e9fa21a-a92e-4bcd-84fe-a7aa159fd0eb.jpg?1783930340",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DrainpipeVerminJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DrainpipeVerminJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Drainpipe Vermin reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Return to Ravnica's `cards/` package; this file contributes only presentation data.
+ */
+val DrainpipeVerminJmpReprint = Printing(
+    oracleId = "b6d39905-e074-4517-b806-d081d1069f74",
+    name = "Drainpipe Vermin",
+    setCode = "JMP",
+    collectorNumber = "224",
+    scryfallId = "761f2f66-a43b-422e-94b7-3c068314b7ec",
+    artist = "Trevor Claxton",
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/761f2f66-a43b-422e-94b7-3c068314b7ec.jpg?1783930428",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DroverOfTheMightyJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DroverOfTheMightyJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Drover of the Mighty reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Ixalan's `cards/` package; this file contributes only presentation data.
+ */
+val DroverOfTheMightyJmpReprint = Printing(
+    oracleId = "6deba6e8-077b-4602-86af-64db766fbbd9",
+    name = "Drover of the Mighty",
+    setCode = "JMP",
+    collectorNumber = "388",
+    scryfallId = "68f1d2e6-ffa4-4c4e-8179-671deb9f5a7f",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/6/8/68f1d2e6-ffa4-4c4e-8179-671deb9f5a7f.jpg?1783930368",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ErraticVisionaryJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ErraticVisionaryJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Erratic Visionary reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * War of the Spark's `cards/` package; this file contributes only presentation data.
+ */
+val ErraticVisionaryJmpReprint = Printing(
+    oracleId = "334c0913-0ce0-4934-979d-64dbc1ec4aa2",
+    name = "Erratic Visionary",
+    setCode = "JMP",
+    collectorNumber = "150",
+    scryfallId = "40dfe354-d527-4f56-8457-b95884700a40",
+    artist = "Randy Vargas",
+    imageUri = "https://cards.scryfall.io/normal/front/4/0/40dfe354-d527-4f56-8457-b95884700a40.jpg?1783930457",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/EternalTaskmasterJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/EternalTaskmasterJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eternal Taskmaster reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * War of the Spark's `cards/` package; this file contributes only presentation data.
+ */
+val EternalTaskmasterJmpReprint = Printing(
+    oracleId = "a7c000a8-1864-4bb2-80fa-a61d74dbd966",
+    name = "Eternal Taskmaster",
+    setCode = "JMP",
+    collectorNumber = "228",
+    scryfallId = "94a6644a-52e6-454e-a479-44b086240974",
+    artist = "Tomasz Jedruszek",
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/94a6644a-52e6-454e-a479-44b086240974.jpg?1783930428",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FeralInvocationJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FeralInvocationJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Feral Invocation reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Theros's `cards/` package; this file contributes only presentation data.
+ */
+val FeralInvocationJmpReprint = Printing(
+    oracleId = "5b3c069b-5bed-4b70-b04c-b7143a4a6e96",
+    name = "Feral Invocation",
+    setCode = "JMP",
+    collectorNumber = "396",
+    scryfallId = "190ad379-1a0f-4598-b5b1-453955846597",
+    artist = "Mathias Kollros",
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/190ad379-1a0f-4598-b5b1-453955846597.jpg?1783930365",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FeralProwlerJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FeralProwlerJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Feral Prowler reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Hour of Devastation's `cards/` package; this file contributes only presentation data.
+ */
+val FeralProwlerJmpReprint = Printing(
+    oracleId = "5bebba2d-867f-4ed1-a308-904fac32c8b6",
+    name = "Feral Prowler",
+    setCode = "JMP",
+    collectorNumber = "397",
+    scryfallId = "a59d92b0-5ad1-42a7-9c06-1cb31a63bd64",
+    artist = "Ben Wootten",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a59d92b0-5ad1-42a7-9c06-1cb31a63bd64.jpg?1783930365",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FlurryOfHornsJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FlurryOfHornsJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flurry of Horns reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Journey into Nyx's `cards/` package; this file contributes only presentation data.
+ */
+val FlurryOfHornsJmpReprint = Printing(
+    oracleId = "0c8ab7bf-7b6a-4a34-b988-9f3f4d84a9ea",
+    name = "Flurry of Horns",
+    setCode = "JMP",
+    collectorNumber = "321",
+    scryfallId = "be522ae8-9cf4-4c63-9a1c-0010d482c00a",
+    artist = "Phill Simmer",
+    imageUri = "https://cards.scryfall.io/normal/front/b/e/be522ae8-9cf4-4c63-9a1c-0010d482c00a.jpg?1783930392",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FortifyJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FortifyJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fortify reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Time Spiral's `cards/` package; this file contributes only presentation data.
+ */
+val FortifyJmpReprint = Printing(
+    oracleId = "52ea24d4-d33d-40fc-8ffc-09ae625b908f",
+    name = "Fortify",
+    setCode = "JMP",
+    collectorNumber = "105",
+    scryfallId = "b9d4b138-5edc-4c12-b526-5c258bc1555c",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/b/9/b9d4b138-5edc-4c12-b526-5c258bc1555c.jpg?1783930472",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GiftedAetherbornJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GiftedAetherbornJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gifted Aetherborn reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Aether Revolt's `cards/` package; this file contributes only presentation data.
+ */
+val GiftedAetherbornJmpReprint = Printing(
+    oracleId = "0c6a6587-2b3f-40d1-a5f2-06128da0d52e",
+    name = "Gifted Aetherborn",
+    setCode = "JMP",
+    collectorNumber = "239",
+    scryfallId = "8644d4d1-8499-40a8-a01f-68172c82bf58",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/8/6/8644d4d1-8499-40a8-a01f-68172c82bf58.jpg?1783930423",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GoblinCommandoJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GoblinCommandoJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Commando reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Starter 1999's `cards/` package; this file contributes only presentation data.
+ */
+val GoblinCommandoJmpReprint = Printing(
+    oracleId = "76c02534-35e3-4950-b4b3-90c679cdf6a7",
+    name = "Goblin Commando",
+    setCode = "JMP",
+    collectorNumber = "325",
+    scryfallId = "c742d940-1a8d-487a-a787-2ad96a96ef1f",
+    artist = "Todd Lockwood",
+    imageUri = "https://cards.scryfall.io/normal/front/c/7/c742d940-1a8d-487a-a787-2ad96a96ef1f.jpg?1783930389",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GoblinInstigatorJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GoblinInstigatorJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Instigator reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Core Set 2019's `cards/` package; this file contributes only presentation data.
+ */
+val GoblinInstigatorJmpReprint = Printing(
+    oracleId = "8b022754-6d16-470e-b754-4df6e4f4709e",
+    name = "Goblin Instigator",
+    setCode = "JMP",
+    collectorNumber = "327",
+    scryfallId = "f32d7ce5-078b-40ff-8ecb-34309a0e3719",
+    artist = "Filip Burburan",
+    imageUri = "https://cards.scryfall.io/normal/front/f/3/f32d7ce5-078b-40ff-8ecb-34309a0e3719.jpg?1783930389",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/HeartfireJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/HeartfireJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Heartfire reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * War of the Spark's `cards/` package; this file contributes only presentation data.
+ */
+val HeartfireJmpReprint = Printing(
+    oracleId = "2f6f5054-4a48-458e-969e-3a0f0e507354",
+    name = "Heartfire",
+    setCode = "JMP",
+    collectorNumber = "333",
+    scryfallId = "af482a14-a144-4e60-bd04-a548a3c89f5a",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/a/f/af482a14-a144-4e60-bd04-a548a3c89f5a.jpg?1783930390",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/InitiatesCompanionJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/InitiatesCompanionJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Initiate's Companion reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Amonkhet's `cards/` package; this file contributes only presentation data.
+ */
+val InitiatesCompanionJmpReprint = Printing(
+    oracleId = "f3264224-43a4-4c6b-b363-2d147687dfc1",
+    name = "Initiate's Companion",
+    setCode = "JMP",
+    collectorNumber = "403",
+    scryfallId = "380e83c1-e5e3-49b2-bbf3-fad8cc7d020a",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/3/8/380e83c1-e5e3-49b2-bbf3-fad8cc7d020a.jpg?1783930362",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/InspiringUnicornJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/InspiringUnicornJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inspiring Unicorn reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Guilds of Ravnica's `cards/` package; this file contributes only presentation data.
+ */
+val InspiringUnicornJmpReprint = Printing(
+    oracleId = "1f9797e2-7ebb-41f9-9199-e9ee575eefd3",
+    name = "Inspiring Unicorn",
+    setCode = "JMP",
+    collectorNumber = "112",
+    scryfallId = "3320865c-ef02-4f18-82b0-47a6d845de0f",
+    artist = "Even Amundsen",
+    imageUri = "https://cards.scryfall.io/normal/front/3/3/3320865c-ef02-4f18-82b0-47a6d845de0f.jpg?1783930471",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/IronrootWarlordJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/IronrootWarlordJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ironroot Warlord reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Core Set 2020's `cards/` package; this file contributes only presentation data.
+ */
+val IronrootWarlordJmpReprint = Printing(
+    oracleId = "abc49dc3-03b3-48a4-afe1-5fc435b65d0f",
+    name = "Ironroot Warlord",
+    setCode = "JMP",
+    collectorNumber = "452",
+    scryfallId = "b78765aa-f952-47f5-b6fc-8aca93fc4104",
+    artist = "Filip Burburan",
+    imageUri = "https://cards.scryfall.io/normal/front/b/7/b78765aa-f952-47f5-b6fc-8aca93fc4104.jpg?1783930344",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/JoustingDummyJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/JoustingDummyJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jousting Dummy reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Throne of Eldraine's `cards/` package; this file contributes only presentation data.
+ */
+val JoustingDummyJmpReprint = Printing(
+    oracleId = "96eea161-8af0-452f-b992-576efdf58d88",
+    name = "Jousting Dummy",
+    setCode = "JMP",
+    collectorNumber = "470",
+    scryfallId = "3d0c95b0-7b63-40e8-92ad-5ae5ffd3c4c1",
+    artist = "Milivoj Ćeran",
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3d0c95b0-7b63-40e8-92ad-5ae5ffd3c4c1.jpg?1783930338",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/JumpstartBasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/JumpstartBasicLands.kt
@@ -1,0 +1,253 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Jumpstart Basic Lands
+ *
+ * Jumpstart printed forty basic land arts — eight Plains and Islands, eight Swamps and Mountains,
+ * eight Forests. One `basicLand(...)` per art variant; `CardDiscovery.findBasicLandsIn` picks these
+ * up from the set object and stamps them with the JMP set code. Limited deck building hands out the
+ * lowest-numbered variant of each type (`BasicLandArt.standardFirst`).
+ */
+
+
+val JumpstartPlains38 = basicLand("Plains") {
+    collectorNumber = "38"
+    artist = "Jedd Chevrier"
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/27d283ba-9d88-45d2-80d3-7e4fffea6d22.jpg?1783930496"
+}
+
+val JumpstartPlains39 = basicLand("Plains") {
+    collectorNumber = "39"
+    artist = "Sung Choi"
+    imageUri = "https://cards.scryfall.io/normal/front/2/b/2bcd008d-446e-41ba-a92e-871b9296fead.jpg?1783930495"
+}
+
+val JumpstartPlains40 = basicLand("Plains") {
+    collectorNumber = "40"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/7/5/75c3424f-0500-48ce-9779-b77e7763e253.jpg?1783930495"
+}
+
+val JumpstartPlains41 = basicLand("Plains") {
+    collectorNumber = "41"
+    artist = "Donato Giancola"
+    imageUri = "https://cards.scryfall.io/normal/front/c/0/c0690e60-e11e-4903-b1e0-e36854213b65.jpg?1783930496"
+}
+
+val JumpstartPlains42 = basicLand("Plains") {
+    collectorNumber = "42"
+    artist = "Yeong-Hao Han"
+    imageUri = "https://cards.scryfall.io/normal/front/9/9/999d82f8-6c64-4b6a-a8ac-fbc48dd1750c.jpg?1783930495"
+}
+
+val JumpstartPlains43 = basicLand("Plains") {
+    collectorNumber = "43"
+    artist = "Lius Lasahido"
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a334360b-2943-4442-8557-e0a5efd272b7.jpg?1783930494"
+}
+
+val JumpstartPlains44 = basicLand("Plains") {
+    collectorNumber = "44"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/2/5/25d96d9e-c6c2-4c51-ac57-b63dee0cf27a.jpg?1783930494"
+}
+
+val JumpstartPlains45 = basicLand("Plains") {
+    collectorNumber = "45"
+    artist = "Johannes Voss"
+    imageUri = "https://cards.scryfall.io/normal/front/e/f/efe75b38-c145-420e-9446-f2ac443ab3a5.jpg?1783930494"
+}
+
+val JumpstartIsland46 = basicLand("Island") {
+    collectorNumber = "46"
+    artist = "Mauricio Calle"
+    imageUri = "https://cards.scryfall.io/normal/front/c/4/c4a837f2-dbb0-435f-adf9-7632b97f94ab.jpg?1783930493"
+}
+
+val JumpstartIsland47 = basicLand("Island") {
+    collectorNumber = "47"
+    artist = "Sung Choi"
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/76b4a655-0051-47c6-a683-c4c3f56e45fc.jpg?1783930493"
+}
+
+val JumpstartIsland48 = basicLand("Island") {
+    collectorNumber = "48"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/6/a/6a3c7c06-76e4-487d-a63f-4aed3bbb4638.jpg?1783930493"
+}
+
+val JumpstartIsland49 = basicLand("Island") {
+    collectorNumber = "49"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/5/c/5c7f7338-8edc-4579-b92f-86b02527682c.jpg?1783930493"
+}
+
+val JumpstartIsland50 = basicLand("Island") {
+    collectorNumber = "50"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/ed351e4f-7ee7-4e84-a69d-02b59cebd180.jpg?1783930493"
+}
+
+val JumpstartIsland51 = basicLand("Island") {
+    collectorNumber = "51"
+    artist = "Yeong-Hao Han"
+    imageUri = "https://cards.scryfall.io/normal/front/e/6/e6cd2ccc-3148-4507-856d-55140c54d09d.jpg?1783930492"
+}
+
+val JumpstartIsland52 = basicLand("Island") {
+    collectorNumber = "52"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c8c61b0c-408a-4ba5-9a1c-5208b5f7f8d0.jpg?1783930492"
+}
+
+val JumpstartIsland53 = basicLand("Island") {
+    collectorNumber = "53"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b5a4dfac-2a47-48be-8611-d7f69e261c60.jpg?1783930491"
+}
+
+val JumpstartSwamp54 = basicLand("Swamp") {
+    collectorNumber = "54"
+    artist = "Jedd Chevrier"
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/06e0edda-1943-47a3-9ad3-673b38f42c86.jpg?1783930490"
+}
+
+val JumpstartSwamp55 = basicLand("Swamp") {
+    collectorNumber = "55"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/9/a/9a189653-dc0b-4b04-9544-5314cebf23fd.jpg?1783930489"
+}
+
+val JumpstartSwamp56 = basicLand("Swamp") {
+    collectorNumber = "56"
+    artist = "Lucas Graciano"
+    imageUri = "https://cards.scryfall.io/normal/front/3/8/3810ec60-3f93-46c0-af39-7628b77bacec.jpg?1783930489"
+}
+
+val JumpstartSwamp57 = basicLand("Swamp") {
+    collectorNumber = "57"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c8ea7816-e501-4384-9176-61819a1784f6.jpg?1783930489"
+}
+
+val JumpstartSwamp58 = basicLand("Swamp") {
+    collectorNumber = "58"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/7/5/7577198f-8b2d-4cee-b400-ebab8fb0df8c.jpg?1783930489"
+}
+
+val JumpstartSwamp59 = basicLand("Swamp") {
+    collectorNumber = "59"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/0/0/00030770-5e99-4943-819d-8d807c24cc14.jpg?1783930489"
+}
+
+val JumpstartSwamp60 = basicLand("Swamp") {
+    collectorNumber = "60"
+    artist = "Ravenna Tran"
+    imageUri = "https://cards.scryfall.io/normal/front/5/9/59e597d5-37e7-4add-b454-c3399b4e3704.jpg?1783930488"
+}
+
+val JumpstartSwamp61 = basicLand("Swamp") {
+    collectorNumber = "61"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/8/5/85f7b339-cce2-421e-83b8-1764c53dee47.jpg?1783930488"
+}
+
+val JumpstartMountain62 = basicLand("Mountain") {
+    collectorNumber = "62"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1b8d1535-68e7-4ca0-aa71-fc7fc63090fc.jpg?1783930488"
+}
+
+val JumpstartMountain63 = basicLand("Mountain") {
+    collectorNumber = "63"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/a/9/a92c5c74-d5b5-40bf-be86-39ac5e4c4f1a.jpg?1783930488"
+}
+
+val JumpstartMountain64 = basicLand("Mountain") {
+    collectorNumber = "64"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cb524a84-34a4-43bf-9872-b4a053a141b5.jpg?1783930488"
+}
+
+val JumpstartMountain65 = basicLand("Mountain") {
+    collectorNumber = "65"
+    artist = "Ralph Horsley"
+    imageUri = "https://cards.scryfall.io/normal/front/3/7/37d0d802-2bd2-444f-81e0-4cc2f8ece38f.jpg?1783930487"
+}
+
+val JumpstartMountain66 = basicLand("Mountain") {
+    collectorNumber = "66"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c55498ad-f474-4805-b9e9-592ec1c8a8e5.jpg?1783930488"
+}
+
+val JumpstartMountain67 = basicLand("Mountain") {
+    collectorNumber = "67"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4e6bce91-f1e6-40d4-9ecc-cafa8d2586b6.jpg?1783930487"
+}
+
+val JumpstartMountain68 = basicLand("Mountain") {
+    collectorNumber = "68"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/7/3/73c6382b-ceff-4092-9ec3-328cefab440e.jpg?1783930487"
+}
+
+val JumpstartMountain69 = basicLand("Mountain") {
+    collectorNumber = "69"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/9/9/99c3decf-4a32-45ff-b7f6-ea2d52387c89.jpg?1783930486"
+}
+
+val JumpstartForest70 = basicLand("Forest") {
+    collectorNumber = "70"
+    artist = "Cliff Childs"
+    imageUri = "https://cards.scryfall.io/normal/front/a/6/a6712361-976a-4ef9-bae9-48505344904e.jpg?1783930484"
+}
+
+val JumpstartForest71 = basicLand("Forest") {
+    collectorNumber = "71"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/88adbda4-7818-4888-a908-de6073bd0152.jpg?1783930485"
+}
+
+val JumpstartForest72 = basicLand("Forest") {
+    collectorNumber = "72"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/0/1/01838859-51ef-474a-9653-23dd37eed1d6.jpg?1783930483"
+}
+
+val JumpstartForest73 = basicLand("Forest") {
+    collectorNumber = "73"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/c/2/c2b534b1-2d78-4de3-afc8-8bdd6ee6da82.jpg?1783930483"
+}
+
+val JumpstartForest74 = basicLand("Forest") {
+    collectorNumber = "74"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/e/a/ea556a69-c487-45ca-8f60-7e89407ec7b7.jpg?1783930483"
+}
+
+val JumpstartForest75 = basicLand("Forest") {
+    collectorNumber = "75"
+    artist = "Tomasz Jedruszek"
+    imageUri = "https://cards.scryfall.io/normal/front/3/0/30a4d3de-e004-4a15-9f45-4d50813de533.jpg?1783930483"
+}
+
+val JumpstartForest76 = basicLand("Forest") {
+    collectorNumber = "76"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b5b4e14a-ab24-4740-b727-165ee9d22e99.jpg?1783930482"
+}
+
+val JumpstartForest77 = basicLand("Forest") {
+    collectorNumber = "77"
+    artist = "Johannes Voss"
+    imageUri = "https://cards.scryfall.io/normal/front/9/c/9c301150-16a8-4ce3-818c-16d6fb0df1b7.jpg?1783930482"
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/KeeperOfFablesJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/KeeperOfFablesJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Keeper of Fables reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Throne of Eldraine's `cards/` package; this file contributes only presentation data.
+ */
+val KeeperOfFablesJmpReprint = Printing(
+    oracleId = "c8ca3116-e0f0-4e27-aa0f-99ed85927040",
+    name = "Keeper of Fables",
+    setCode = "JMP",
+    collectorNumber = "407",
+    scryfallId = "3c21c795-e455-4ecf-a7a2-8f204c114c81",
+    artist = "Alex Konstad",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3c21c795-e455-4ecf-a7a2-8f204c114c81.jpg?1783930362",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/KilnFiendJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/KilnFiendJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kiln Fiend reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Rise of the Eldrazi's `cards/` package; this file contributes only presentation data.
+ */
+val KilnFiendJmpReprint = Printing(
+    oracleId = "eac8c196-8477-4b79-9875-21afa1e61708",
+    name = "Kiln Fiend",
+    setCode = "JMP",
+    collectorNumber = "338",
+    scryfallId = "6c957c94-3d2d-4b98-8990-cd8909462081",
+    artist = "Adi Granov",
+    imageUri = "https://cards.scryfall.io/normal/front/6/c/6c957c94-3d2d-4b98-8990-cd8909462081.jpg?1783930386",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/KnightOfTheTuskJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/KnightOfTheTuskJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Knight of the Tusk reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Core Set 2019's `cards/` package; this file contributes only presentation data.
+ */
+val KnightOfTheTuskJmpReprint = Printing(
+    oracleId = "524d81fb-33f5-4e77-ae41-477b91e67be4",
+    name = "Knight of the Tusk",
+    setCode = "JMP",
+    collectorNumber = "114",
+    scryfallId = "2f81d2a0-5301-4cae-ac83-ad51647146e3",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/2/f/2f81d2a0-5301-4cae-ac83-ad51647146e3.jpg?1783930470",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/KnightlyValorJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/KnightlyValorJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Knightly Valor reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Return to Ravnica's `cards/` package; this file contributes only presentation data.
+ */
+val KnightlyValorJmpReprint = Printing(
+    oracleId = "9ba6cec6-97bf-4a83-9ffa-77e187d0945b",
+    name = "Knightly Valor",
+    setCode = "JMP",
+    collectorNumber = "115",
+    scryfallId = "c6f463b5-188f-4ecc-8cbf-0f200515bb09",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/c/6/c6f463b5-188f-4ecc-8cbf-0f200515bb09.jpg?1783930469",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LanguishJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LanguishJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Languish reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic Origins's `cards/` package; this file contributes only presentation data.
+ */
+val LanguishJmpReprint = Printing(
+    oracleId = "ef1a83f2-6707-41a2-b5ed-861c8e45ae07",
+    name = "Languish",
+    setCode = "JMP",
+    collectorNumber = "246",
+    scryfallId = "9b53ce1b-9353-42ad-89a0-36e907ba576a",
+    artist = "Jeff Simpson",
+    imageUri = "https://cards.scryfall.io/normal/front/9/b/9b53ce1b-9353-42ad-89a0-36e907ba576a.jpg?1783930420",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LawlessBrokerJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LawlessBrokerJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lawless Broker reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Kaladesh's `cards/` package; this file contributes only presentation data.
+ */
+val LawlessBrokerJmpReprint = Printing(
+    oracleId = "d17d085f-aeda-4b23-ab80-729d070ae813",
+    name = "Lawless Broker",
+    setCode = "JMP",
+    collectorNumber = "249",
+    scryfallId = "381b4e3b-85d7-4f61-b395-f278f212bda7",
+    artist = "Darek Zabrocki",
+    imageUri = "https://cards.scryfall.io/normal/front/3/8/381b4e3b-85d7-4f61-b395-f278f212bda7.jpg?1783930418",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LeafGilderJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LeafGilderJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Leaf Gilder reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Lorwyn's `cards/` package; this file contributes only presentation data.
+ */
+val LeafGilderJmpReprint = Printing(
+    oracleId = "61324e37-4b79-4325-bf46-621b4270afe2",
+    name = "Leaf Gilder",
+    setCode = "JMP",
+    collectorNumber = "408",
+    scryfallId = "58b3bd44-3b01-4507-b9be-ab94601ea736",
+    artist = "Quinton Hoover",
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/58b3bd44-3b01-4507-b9be-ab94601ea736.jpg?1783930361",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LightningCoreExcavator.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LightningCoreExcavator.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lightning-Core Excavator
+ * {1}
+ * Artifact Creature — Golem
+ * 0/3
+ *
+ * {5}, {T}, Sacrifice this creature: It deals 3 damage to any target.
+ */
+val LightningCoreExcavator = card("Lightning-Core Excavator") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    oracleText = "{5}, {T}, Sacrifice this creature: It deals 3 damage to any target."
+    power = 0
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap, Costs.SacrificeSelf)
+        target = Targets.Any
+        effect = Effects.DealDamage(3, EffectTarget.ContextTarget(0))
+        description = "{5}, {T}, Sacrifice this creature: It deals 3 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32"
+        artist = "Cristi Balanescu"
+        flavorText = "\"That's the third time this month it's exploded on site. Maybe we should switch to something a little less defective.\"\n—Kerrin, archaeologist"
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b1b959af-bb23-42e7-8848-7405ed597c8d.jpg?1783930499"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LightningDiademJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LightningDiademJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Diadem reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Journey into Nyx's `cards/` package; this file contributes only presentation data.
+ */
+val LightningDiademJmpReprint = Printing(
+    oracleId = "1e4de77b-27cb-4afd-8d4b-1cc89f2a6986",
+    name = "Lightning Diadem",
+    setCode = "JMP",
+    collectorNumber = "343",
+    scryfallId = "9223ac16-e6fc-4ba6-91d9-7ff27cc17271",
+    artist = "Ryan Alexander Lee",
+    imageUri = "https://cards.scryfall.io/normal/front/9/2/9223ac16-e6fc-4ba6-91d9-7ff27cc17271.jpg?1783930383",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LightningVisionary.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LightningVisionary.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Visionary
+ * {1}{R}
+ * Creature — Minotaur Shaman
+ * 2/1
+ *
+ * Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)
+ */
+val LightningVisionary = card("Lightning Visionary") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Shaman"
+    oracleText = "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)"
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.PROWESS)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "22"
+        artist = "Bryan Sola"
+        flavorText = "\"The gods don't speak to mortals with gentle entreaties. They speak with thunder and fury.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/af648aaf-a8e0-4291-acf9-5f8533728f92.jpg?1783930502"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ManaGeodeJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ManaGeodeJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mana Geode reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * War of the Spark's `cards/` package; this file contributes only presentation data.
+ */
+val ManaGeodeJmpReprint = Printing(
+    oracleId = "0844f4e6-2b98-4d09-a5c5-92f0a3b6a517",
+    name = "Mana Geode",
+    setCode = "JMP",
+    collectorNumber = "472",
+    scryfallId = "f8c54d41-683e-42fd-8aa4-371dddf3bcb3",
+    artist = "Raoul Vitale",
+    imageUri = "https://cards.scryfall.io/normal/front/f/8/f8c54d41-683e-42fd-8aa4-371dddf3bcb3.jpg?1783930338",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MaraudersAxeJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MaraudersAxeJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Marauder's Axe reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Core Set 2019's `cards/` package; this file contributes only presentation data.
+ */
+val MaraudersAxeJmpReprint = Printing(
+    oracleId = "5d0e49fa-5dfb-48c2-af97-fdfb788d5f40",
+    name = "Marauder's Axe",
+    setCode = "JMP",
+    collectorNumber = "473",
+    scryfallId = "49d8aa8a-3e87-42ac-9c79-2baec771c1ef",
+    artist = "Mitchell Malloy",
+    imageUri = "https://cards.scryfall.io/normal/front/4/9/49d8aa8a-3e87-42ac-9c79-2baec771c1ef.jpg?1783930337",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MarkOfTheVampireJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MarkOfTheVampireJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mark of the Vampire reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic 2013's `cards/` package; this file contributes only presentation data.
+ */
+val MarkOfTheVampireJmpReprint = Printing(
+    oracleId = "af942d30-a191-4306-846d-6c26755ca3e6",
+    name = "Mark of the Vampire",
+    setCode = "JMP",
+    collectorNumber = "254",
+    scryfallId = "d908bf00-86ba-4911-b15b-1af2a79dff85",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/d/9/d908bf00-86ba-4911-b15b-1af2a79dff85.jpg?1783930418",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MinotaurSkullcleaverJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MinotaurSkullcleaverJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Minotaur Skullcleaver reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Theros's `cards/` package; this file contributes only presentation data.
+ */
+val MinotaurSkullcleaverJmpReprint = Printing(
+    oracleId = "dd36aea8-9f1c-4daf-86f6-ab9307279ce7",
+    name = "Minotaur Skullcleaver",
+    setCode = "JMP",
+    collectorNumber = "349",
+    scryfallId = "b6fef9f8-ff3e-4a3f-a3ff-4534ff0c3946",
+    artist = "Phill Simmer",
+    imageUri = "https://cards.scryfall.io/normal/front/b/6/b6fef9f8-ff3e-4a3f-a3ff-4534ff0c3946.jpg?1783930382",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MinotaurSureshotJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MinotaurSureshotJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Minotaur Sureshot reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Amonkhet's `cards/` package; this file contributes only presentation data.
+ */
+val MinotaurSureshotJmpReprint = Printing(
+    oracleId = "cbb6c481-bcf1-459d-a6fb-bb46cc521368",
+    name = "Minotaur Sureshot",
+    setCode = "JMP",
+    collectorNumber = "350",
+    scryfallId = "cbd65150-a698-4f23-836c-5cd0fb153eb3",
+    artist = "Joseph Meehan",
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cbd65150-a698-4f23-836c-5cd0fb153eb3.jpg?1783930383",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MirrodinsCoreJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MirrodinsCoreJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mirrodin's Core reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Darksteel's `cards/` package; this file contributes only presentation data.
+ */
+val MirrodinsCoreJmpReprint = Printing(
+    oracleId = "ea53adbe-3f9a-4847-87c7-723ac2789918",
+    name = "Mirrodin's Core",
+    setCode = "JMP",
+    collectorNumber = "492",
+    scryfallId = "c0a9fbb3-9fe4-4ec6-82f0-3bb101524e1e",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/c/0/c0a9fbb3-9fe4-4ec6-82f0-3bb101524e1e.jpg?1783930329",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MoltenRavagerJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MoltenRavagerJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Molten Ravager reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Zendikar's `cards/` package; this file contributes only presentation data.
+ */
+val MoltenRavagerJmpReprint = Printing(
+    oracleId = "697c851d-8475-479e-8783-cebdbe9a892d",
+    name = "Molten Ravager",
+    setCode = "JMP",
+    collectorNumber = "351",
+    scryfallId = "a5664b7d-b553-4e0a-93ec-3d70e8e4f63b",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a5664b7d-b553-4e0a-93ec-3d70e8e4f63b.jpg?1783930383",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MurmuringPhantasmJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MurmuringPhantasmJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Murmuring Phantasm reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Dragon's Maze's `cards/` package; this file contributes only presentation data.
+ */
+val MurmuringPhantasmJmpReprint = Printing(
+    oracleId = "35e684fd-69e3-4137-bf15-94f705191f5e",
+    name = "Murmuring Phantasm",
+    setCode = "JMP",
+    collectorNumber = "157",
+    scryfallId = "87c1aaff-ab26-437e-a88a-494683aec831",
+    artist = "Peter Mohrbacher",
+    imageUri = "https://cards.scryfall.io/normal/front/8/7/87c1aaff-ab26-437e-a88a-494683aec831.jpg?1783930453",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/NightshadeStingerJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/NightshadeStingerJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nightshade Stinger reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Lorwyn's `cards/` package; this file contributes only presentation data.
+ */
+val NightshadeStingerJmpReprint = Printing(
+    oracleId = "c57edca9-b71e-4ec1-84d5-4b178969ccb7",
+    name = "Nightshade Stinger",
+    setCode = "JMP",
+    collectorNumber = "258",
+    scryfallId = "c894372f-7d28-4035-b45a-384c5bf8fd1f",
+    artist = "Mark Poole",
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c894372f-7d28-4035-b45a-384c5bf8fd1f.jpg?1783930415",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PerilousMyrJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PerilousMyrJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Perilous Myr reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Scars of Mirrodin's `cards/` package; this file contributes only presentation data.
+ */
+val PerilousMyrJmpReprint = Printing(
+    oracleId = "f1e8f746-1837-4ea8-9a07-e57946883353",
+    name = "Perilous Myr",
+    setCode = "JMP",
+    collectorNumber = "476",
+    scryfallId = "d0aa3726-038f-4522-a7bd-1877a4fef350",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/d/0/d0aa3726-038f-4522-a7bd-1877a4fef350.jpg?1783930336",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PlaguedRusalkaJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PlaguedRusalkaJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plagued Rusalka reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Guildpact's `cards/` package; this file contributes only presentation data.
+ */
+val PlaguedRusalkaJmpReprint = Printing(
+    oracleId = "d6912f52-e478-4cc6-a34c-67e372abc4fa",
+    name = "Plagued Rusalka",
+    setCode = "JMP",
+    collectorNumber = "268",
+    scryfallId = "72bcfb24-1649-4c8f-ba76-346914d11572",
+    artist = "Alex Horley-Orlandelli",
+    imageUri = "https://cards.scryfall.io/normal/front/7/2/72bcfb24-1649-4c8f-ba76-346914d11572.jpg?1783930411",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PouncingCheetahJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PouncingCheetahJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pouncing Cheetah reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Amonkhet's `cards/` package; this file contributes only presentation data.
+ */
+val PouncingCheetahJmpReprint = Printing(
+    oracleId = "1d5e32b1-1a2d-4b3d-80f2-f8c688b90587",
+    name = "Pouncing Cheetah",
+    setCode = "JMP",
+    collectorNumber = "419",
+    scryfallId = "73f5156b-b200-41f7-8b93-557c4cdc2bf7",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/7/3/73f5156b-b200-41f7-8b93-557c4cdc2bf7.jpg?1783930357",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PrescientChimeraJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PrescientChimeraJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prescient Chimera reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Theros's `cards/` package; this file contributes only presentation data.
+ */
+val PrescientChimeraJmpReprint = Printing(
+    oracleId = "af199b80-d5d8-417a-97d5-459a5bd48b22",
+    name = "Prescient Chimera",
+    setCode = "JMP",
+    collectorNumber = "164",
+    scryfallId = "f4bb655d-8d62-4a79-9a9d-7384d1cb2cc0",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/f/4/f4bb655d-8d62-4a79-9a9d-7384d1cb2cc0.jpg?1783930452",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PrimordialSageJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PrimordialSageJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Primordial Sage reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Ravnica: City of Guilds's `cards/` package; this file contributes only presentation data.
+ */
+val PrimordialSageJmpReprint = Printing(
+    oracleId = "499f1e1e-d96e-481f-a5d9-eb38da927cd7",
+    name = "Primordial Sage",
+    setCode = "JMP",
+    collectorNumber = "422",
+    scryfallId = "4b0d8dec-e139-4565-9259-3c24c54c1d45",
+    artist = "Justin Sweet",
+    imageUri = "https://cards.scryfall.io/normal/front/4/b/4b0d8dec-e139-4565-9259-3c24c54c1d45.jpg?1783930356",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PyroclasticElementalJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PyroclasticElementalJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pyroclastic Elemental reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Core Set 2020's `cards/` package; this file contributes only presentation data.
+ */
+val PyroclasticElementalJmpReprint = Printing(
+    oracleId = "1f37e3a6-ce3a-472f-ac45-0d9b23a31a11",
+    name = "Pyroclastic Elemental",
+    setCode = "JMP",
+    collectorNumber = "356",
+    scryfallId = "15148b4e-19e2-4e39-8e6f-1dc94ea03463",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/1/5/15148b4e-19e2-4e39-8e6f-1dc94ea03463.jpg?1783930379",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RagingRegisaurJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RagingRegisaurJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Raging Regisaur reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Rivals of Ixalan's `cards/` package; this file contributes only presentation data.
+ */
+val RagingRegisaurJmpReprint = Printing(
+    oracleId = "3d563149-7d4e-43e5-b701-28e3212051ec",
+    name = "Raging Regisaur",
+    setCode = "JMP",
+    collectorNumber = "455",
+    scryfallId = "0c1632bd-30bc-40a2-963f-44be3b42efb3",
+    artist = "Bayard Wu",
+    imageUri = "https://cards.scryfall.io/normal/front/0/c/0c1632bd-30bc-40a2-963f-44be3b42efb3.jpg?1783930344",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RishadanAirshipJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RishadanAirshipJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rishadan Airship reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Mercadian Masques's `cards/` package; this file contributes only presentation data.
+ */
+val RishadanAirshipJmpReprint = Printing(
+    oracleId = "3c4661da-db2e-4834-9bba-d9a5592465d2",
+    name = "Rishadan Airship",
+    setCode = "JMP",
+    collectorNumber = "170",
+    scryfallId = "b3ea87f1-fbe2-4905-8a97-ceef9d3d0faf",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/b/3/b3ea87f1-fbe2-4905-8a97-ceef9d3d0faf.jpg?1783930447",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RonomUnicornJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RonomUnicornJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ronom Unicorn reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Coldsnap's `cards/` package; this file contributes only presentation data.
+ */
+val RonomUnicornJmpReprint = Printing(
+    oracleId = "3c6913cc-c543-45f8-ad3b-ccd282efa6f7",
+    name = "Ronom Unicorn",
+    setCode = "JMP",
+    collectorNumber = "131",
+    scryfallId = "cb993412-69bc-4000-ac8f-b2f62161fc55",
+    artist = "Carl Critchlow",
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cb993412-69bc-4000-ac8f-b2f62161fc55.jpg?1783930464",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ScarecroneJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ScarecroneJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scarecrone reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Eventide's `cards/` package; this file contributes only presentation data.
+ */
+val ScarecroneJmpReprint = Printing(
+    oracleId = "f45716dc-c613-4b14-865d-419395fb02f6",
+    name = "Scarecrone",
+    setCode = "JMP",
+    collectorNumber = "482",
+    scryfallId = "a8c9d86a-54a3-457c-b9b4-61f914de6e14",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/a/8/a8c9d86a-54a3-457c-b9b4-61f914de6e14.jpg?1783930333",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ScrollOfAvacynJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ScrollOfAvacynJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scroll of Avacyn reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Avacyn Restored's `cards/` package; this file contributes only presentation data.
+ */
+val ScrollOfAvacynJmpReprint = Printing(
+    oracleId = "f728c4f1-178f-421b-a713-21f85892f051",
+    name = "Scroll of Avacyn",
+    setCode = "JMP",
+    collectorNumber = "483",
+    scryfallId = "2a2d0981-0af6-42d6-b926-16f8f2327320",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2a2d0981-0af6-42d6-b926-16f8f2327320.jpg?1783930333",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SeaGateOracleJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SeaGateOracleJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sea Gate Oracle reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Rise of the Eldrazi's `cards/` package; this file contributes only presentation data.
+ */
+val SeaGateOracleJmpReprint = Printing(
+    oracleId = "b333c194-d285-4dfb-984c-57b7e88393af",
+    name = "Sea Gate Oracle",
+    setCode = "JMP",
+    collectorNumber = "173",
+    scryfallId = "3a0b3006-16cb-4752-908e-3c9f37ac249c",
+    artist = "Daniel Ljunggren",
+    imageUri = "https://cards.scryfall.io/normal/front/3/a/3a0b3006-16cb-4752-908e-3c9f37ac249c.jpg?1783930448",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SethronHurloonGeneral.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SethronHurloonGeneral.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sethron, Hurloon General
+ * {3}{R}{R}
+ * Legendary Creature — Minotaur Warrior
+ * 4/4
+ *
+ * Whenever Sethron or another nontoken Minotaur you control enters, create a 2/3 red Minotaur creature token.
+ * {2}{B/R}: Minotaurs you control get +1/+0 and gain menace and haste until end of turn. ({B/R} can be paid with either {B} or {R}.)
+ */
+val SethronHurloonGeneral = card("Sethron, Hurloon General") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Minotaur Warrior"
+    oracleText = "Whenever Sethron or another nontoken Minotaur you control enters, create a 2/3 red Minotaur creature token.\n{2}{B/R}: Minotaurs you control get +1/+0 and gain menace and haste until end of turn. ({B/R} can be paid with either {B} or {R}.)"
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        // "Sethron or another nontoken Minotaur you control" — the corpus spells this as one
+        // ANY-bound trigger over the nontoken filter (Headless Rider's shape).
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.MINOTAUR).youControl().nontoken(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 3,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Minotaur"),
+        )
+        description = "Whenever Sethron or another nontoken Minotaur you control enters, create a 2/3 " +
+            "red Minotaur creature token."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{B/R}")
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.MINOTAUR).youControl()),
+            Effects.ModifyStats(1, 0, EffectTarget.Self)
+                .then(Effects.GrantKeyword(Keyword.MENACE, EffectTarget.Self))
+                .then(Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self)),
+        )
+        description = "{2}{B/R}: Minotaurs you control get +1/+0 and gain menace and haste until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "25"
+        artist = "Jason Rainville"
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/274cdb39-1454-4c9b-acd8-4f762a48e71f.jpg?1783930501"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ShamblingGoblinJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ShamblingGoblinJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shambling Goblin reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Dragons of Tarkir's `cards/` package; this file contributes only presentation data.
+ */
+val ShamblingGoblinJmpReprint = Printing(
+    oracleId = "9d8c39f2-ddb5-4b79-861a-e1e25f447c29",
+    name = "Shambling Goblin",
+    setCode = "JMP",
+    collectorNumber = "277",
+    scryfallId = "d3ab1d6c-09a6-4f6a-9549-94b439a46680",
+    artist = "Yeong-Hao Han",
+    imageUri = "https://cards.scryfall.io/normal/front/d/3/d3ab1d6c-09a6-4f6a-9549-94b439a46680.jpg?1783930408",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SigiledStarfishJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SigiledStarfishJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sigiled Starfish reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Journey into Nyx's `cards/` package; this file contributes only presentation data.
+ */
+val SigiledStarfishJmpReprint = Printing(
+    oracleId = "94a4f70a-8aac-412a-99f0-933e3ff87fe0",
+    name = "Sigiled Starfish",
+    setCode = "JMP",
+    collectorNumber = "177",
+    scryfallId = "7a1a93c3-8561-4c65-bea8-a9c3a898a48c",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7a1a93c3-8561-4c65-bea8-a9c3a898a48c.jpg?1783930445",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SignpostScarecrowJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SignpostScarecrowJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Signpost Scarecrow reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Throne of Eldraine's `cards/` package; this file contributes only presentation data.
+ */
+val SignpostScarecrowJmpReprint = Printing(
+    oracleId = "5b6c6dab-0687-4297-b215-89e699d65681",
+    name = "Signpost Scarecrow",
+    setCode = "JMP",
+    collectorNumber = "485",
+    scryfallId = "e77f544c-1d27-4632-8ca5-7dfb38f42b1c",
+    artist = "Jung Park",
+    imageUri = "https://cards.scryfall.io/normal/front/e/7/e77f544c-1d27-4632-8ca5-7dfb38f42b1c.jpg?1783930332",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SoulOfTheHarvestJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SoulOfTheHarvestJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soul of the Harvest reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Avacyn Restored's `cards/` package; this file contributes only presentation data.
+ */
+val SoulOfTheHarvestJmpReprint = Printing(
+    oracleId = "6b9194dd-2296-4879-ac5e-f89b18431df6",
+    name = "Soul of the Harvest",
+    setCode = "JMP",
+    collectorNumber = "432",
+    scryfallId = "d7ce9104-0ad3-4d3d-bb2c-c456c25030f6",
+    artist = "Eytan Zana",
+    imageUri = "https://cards.scryfall.io/normal/front/d/7/d7ce9104-0ad3-4d3d-bb2c-c456c25030f6.jpg?1783930351",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/StoneHavenPilgrim.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/StoneHavenPilgrim.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stone Haven Pilgrim
+ * {1}{W}
+ * Creature — Kor Cleric
+ * 2/2
+ *
+ * Whenever this creature attacks, if you control an artifact or enchantment, this creature gets +1/+1 and gains lifelink until end of turn.
+ */
+val StoneHavenPilgrim = card("Stone Haven Pilgrim") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kor Cleric"
+    oracleText = "Whenever this creature attacks, if you control an artifact or enchantment, this creature gets +1/+1 and gains lifelink until end of turn."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        interveningIf = Conditions.YouControl(GameObjectFilter.ArtifactOrEnchantment)
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+            .then(Effects.GrantKeyword(Keyword.LIFELINK, EffectTarget.Self))
+        description = "Whenever this creature attacks, if you control an artifact or enchantment, " +
+            "this creature gets +1/+1 and gains lifelink until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "6"
+        artist = "Cristi Balanescu"
+        flavorText = "The persistence to overcome obstacles is the most esteemed of kor virtues."
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5cd3287d-e4d8-4670-a2dd-b683055ae4b9.jpg?1783930508"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SylvanBrushstriderJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SylvanBrushstriderJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sylvan Brushstrider reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Ravnica Allegiance's `cards/` package; this file contributes only presentation data.
+ */
+val SylvanBrushstriderJmpReprint = Printing(
+    oracleId = "67a494dc-deac-43ee-9e47-20fae9788a9f",
+    name = "Sylvan Brushstrider",
+    setCode = "JMP",
+    collectorNumber = "434",
+    scryfallId = "16482e12-7a8d-4999-8438-da227e6d1305",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/1/6/16482e12-7a8d-4999-8438-da227e6d1305.jpg?1783930351",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SylvanRangerJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SylvanRangerJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sylvan Ranger reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic 2011's `cards/` package; this file contributes only presentation data.
+ */
+val SylvanRangerJmpReprint = Printing(
+    oracleId = "29a90fda-541e-4923-b3ed-e2b35d02c74b",
+    name = "Sylvan Ranger",
+    setCode = "JMP",
+    collectorNumber = "435",
+    scryfallId = "e36a5be0-a730-4cb7-9d1e-6ae84b5bc872",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e36a5be0-a730-4cb7-9d1e-6ae84b5bc872.jpg?1783930350",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/TalrandSkySummonerJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/TalrandSkySummonerJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Talrand, Sky Summoner reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic 2013's `cards/` package; this file contributes only presentation data.
+ */
+val TalrandSkySummonerJmpReprint = Printing(
+    oracleId = "ea1eb902-a23c-44ff-9169-19baf71de238",
+    name = "Talrand, Sky Summoner",
+    setCode = "JMP",
+    collectorNumber = "181",
+    scryfallId = "3d89c1a1-1896-4360-b123-52d82a6871d4",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3d89c1a1-1896-4360-b123-52d82a6871d4.jpg?1783930444",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ThunderingSpinebackJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ThunderingSpinebackJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thundering Spineback reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Ixalan's `cards/` package; this file contributes only presentation data.
+ */
+val ThunderingSpinebackJmpReprint = Printing(
+    oracleId = "c9db31d7-00cf-4200-a11f-74cc2d9e843e",
+    name = "Thundering Spineback",
+    setCode = "JMP",
+    collectorNumber = "437",
+    scryfallId = "a2e40ded-6daf-423e-8d74-2c6d448e0853",
+    artist = "Tomasz Jedruszek",
+    imageUri = "https://cards.scryfall.io/normal/front/a/2/a2e40ded-6daf-423e-8d74-2c6d448e0853.jpg?1783930350",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/TibaltsRagerJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/TibaltsRagerJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tibalt's Rager reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * War of the Spark's `cards/` package; this file contributes only presentation data.
+ */
+val TibaltsRagerJmpReprint = Printing(
+    oracleId = "0d7d8f4f-abf3-408b-a289-1dd6a3ebdbf6",
+    name = "Tibalt's Rager",
+    setCode = "JMP",
+    collectorNumber = "366",
+    scryfallId = "2947ad7e-d365-45ff-b107-35819b308f8c",
+    artist = "Yongjae Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/2/9/2947ad7e-d365-45ff-b107-35819b308f8c.jpg?1783930377",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/TorchFiendJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/TorchFiendJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Torch Fiend reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Dark Ascension's `cards/` package; this file contributes only presentation data.
+ */
+val TorchFiendJmpReprint = Printing(
+    oracleId = "15f8049c-f21d-4cd0-aa81-1a533936cf77",
+    name = "Torch Fiend",
+    setCode = "JMP",
+    collectorNumber = "367",
+    scryfallId = "60c3aa66-2436-40a3-a541-185f457bd55a",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/60c3aa66-2436-40a3-a541-185f457bd55a.jpg?1783930376",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/TrustyRetriever.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/TrustyRetriever.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Trusty Retriever
+ * {3}{W}
+ * Creature — Dog
+ * 2/3
+ *
+ * When this creature enters, choose one —
+ * • Put a +1/+1 counter on this creature.
+ * • Return target artifact or enchantment card from your graveyard to your hand.
+ */
+val TrustyRetriever = card("Trusty Retriever") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dog"
+    oracleText = "When this creature enters, choose one —\n• Put a +1/+1 counter on this creature.\n• Return target artifact or enchantment card from your graveyard to your hand."
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+                "Put a +1/+1 counter on this creature",
+            ),
+            Mode.withTarget(
+                Effects.ReturnToHand(EffectTarget.ContextTarget(0)),
+                TargetObject(
+                    filter = TargetFilter(
+                        GameObjectFilter.ArtifactOrEnchantment.ownedByYou(),
+                        zone = Zone.GRAVEYARD,
+                    )
+                ),
+                "Return target artifact or enchantment card from your graveyard to your hand",
+            ),
+        )
+        description = "When this creature enters, choose one — Put a +1/+1 counter on this creature; " +
+            "or return target artifact or enchantment card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "8"
+        artist = "Ralph Horsley"
+        flavorText = "Wipe away the slobber and it's as good as new, give or take a few bite marks."
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab4eb490-acd0-4162-8e8a-7e7ff003d0f3.jpg?1783930507"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/UnstableObeliskJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/UnstableObeliskJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Unstable Obelisk reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Commander 2014's `cards/` package; this file contributes only presentation data.
+ */
+val UnstableObeliskJmpReprint = Printing(
+    oracleId = "060ae1bb-956a-4264-b405-a33151f31493",
+    name = "Unstable Obelisk",
+    setCode = "JMP",
+    collectorNumber = "489",
+    scryfallId = "b7d3681a-78d8-469f-9109-5f8faf04b707",
+    artist = "William Wu",
+    imageUri = "https://cards.scryfall.io/normal/front/b/7/b7d3681a-78d8-469f-9109-5f8faf04b707.jpg?1783930330",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/VolcanicFalloutJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/VolcanicFalloutJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Volcanic Fallout reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Conflux's `cards/` package; this file contributes only presentation data.
+ */
+val VolcanicFalloutJmpReprint = Printing(
+    oracleId = "bd6ce147-c991-40ac-b276-65b630fad8b6",
+    name = "Volcanic Fallout",
+    setCode = "JMP",
+    collectorNumber = "368",
+    scryfallId = "ecba926b-915c-4dd2-84f3-019775e1cc14",
+    artist = "Zoltan Boros & Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/e/c/ecba926b-915c-4dd2-84f3-019775e1cc14.jpg?1783930376",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/VoyagesEndJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/VoyagesEndJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Voyage's End reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Theros's `cards/` package; this file contributes only presentation data.
+ */
+val VoyagesEndJmpReprint = Printing(
+    oracleId = "1c2829b7-f73f-4023-95f3-9cd40b4125d7",
+    name = "Voyage's End",
+    setCode = "JMP",
+    collectorNumber = "189",
+    scryfallId = "c55c60dc-40ed-4a36-9daa-702f79ffe818",
+    artist = "Chris Rahn",
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c55c60dc-40ed-4a36-9daa-702f79ffe818.jpg?1783930441",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WallOfBlossomsJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WallOfBlossomsJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Blossoms reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Stronghold's `cards/` package; this file contributes only presentation data.
+ */
+val WallOfBlossomsJmpReprint = Printing(
+    oracleId = "ef4d5fb3-70a3-433d-a9d3-18b2beb8d79f",
+    name = "Wall of Blossoms",
+    setCode = "JMP",
+    collectorNumber = "442",
+    scryfallId = "f836b155-8829-460b-91f8-4cd00b988196",
+    artist = "Heather Hudson",
+    imageUri = "https://cards.scryfall.io/normal/front/f/8/f836b155-8829-460b-91f8-4cd00b988196.jpg?1783930349",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WallOfVinesJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WallOfVinesJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Vines reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic 2011's `cards/` package; this file contributes only presentation data.
+ */
+val WallOfVinesJmpReprint = Printing(
+    oracleId = "51ce0158-c9a5-4fa5-9704-46ab02f01b86",
+    name = "Wall of Vines",
+    setCode = "JMP",
+    collectorNumber = "443",
+    scryfallId = "9f7b7563-752b-4391-95d1-f5e3960d35c1",
+    artist = "John Stanko",
+    imageUri = "https://cards.scryfall.io/normal/front/9/f/9f7b7563-752b-4391-95d1-f5e3960d35c1.jpg?1783930349",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WeaverOfLightningJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WeaverOfLightningJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Weaver of Lightning reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Eldritch Moon's `cards/` package; this file contributes only presentation data.
+ */
+val WeaverOfLightningJmpReprint = Printing(
+    oracleId = "28274c39-19e2-4b4c-bd53-d31d6063c2ba",
+    name = "Weaver of Lightning",
+    setCode = "JMP",
+    collectorNumber = "371",
+    scryfallId = "302ec5d2-ea36-415c-9aa6-808c88a17932",
+    artist = "John Stanko",
+    imageUri = "https://cards.scryfall.io/normal/front/3/0/302ec5d2-ea36-415c-9aa6-808c88a17932.jpg?1783930375",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WingedWordsJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WingedWordsJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Winged Words reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Core Set 2020's `cards/` package; this file contributes only presentation data.
+ */
+val WingedWordsJmpReprint = Printing(
+    oracleId = "c623aeb1-e6d4-48fe-bd2a-a7a6729aa4df",
+    name = "Winged Words",
+    setCode = "JMP",
+    collectorNumber = "196",
+    scryfallId = "a48ebd79-95d7-4860-9785-45e34a94755d",
+    artist = "Chris Seaman",
+    imageUri = "https://cards.scryfall.io/normal/front/a/4/a48ebd79-95d7-4860-9785-45e34a94755d.jpg?1783930438",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ZombieInfestationJmpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ZombieInfestationJmpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zombie Infestation reprint in Jumpstart. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Odyssey's `cards/` package; this file contributes only presentation data.
+ */
+val ZombieInfestationJmpReprint = Printing(
+    oracleId = "bdce1af0-3643-4e77-88f9-320206a191d4",
+    name = "Zombie Infestation",
+    setCode = "JMP",
+    collectorNumber = "288",
+    scryfallId = "c9ce5007-56ab-4361-8130-df48add1492b",
+    artist = "Thomas M. Baxa",
+    imageUri = "https://cards.scryfall.io/normal/front/c/9/c9ce5007-56ab-4361-8130-df48add1492b.jpg?1783930404",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/SeaGateOracleKhcReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/SeaGateOracleKhcReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sea Gate Oracle reprint in Kaldheim Commander. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val SeaGateOracleKhcReprint = Printing(
+    oracleId = "b333c194-d285-4dfb-984c-57b7e88393af",
+    name = "Sea Gate Oracle",
+    setCode = "KHC",
+    collectorNumber = "43",
+    scryfallId = "498743ce-0ca5-488a-ae5e-d348b274bf3b",
+    artist = "Daniel Ljunggren",
+    imageUri = "https://cards.scryfall.io/normal/front/4/9/498743ce-0ca5-488a-ae5e-d348b274bf3b.jpg?1783928322",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/AegisOfTheHeavens.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/AegisOfTheHeavens.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Aegis of the Heavens
+ * {1}{W}
+ * Instant
+ *
+ * Target creature gets +1/+7 until end of turn.
+ */
+val AegisOfTheHeavens = card("Aegis of the Heavens") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/+7 until end of turn."
+
+    spell {
+        target = Targets.Creature
+        effect = Effects.ModifyStats(1, 7, EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "1"
+        artist = "Anthony Palumbo"
+        flavorText = "Inner strength is never seen until it makes all the difference."
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/0503c55d-74bb-4165-9273-127c01bb2214.jpg?1783934612"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/BloodDivination.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/BloodDivination.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Blood Divination
+ * {3}{B}
+ * Sorcery
+ *
+ * As an additional cost to cast this spell, sacrifice a creature.
+ * Draw three cards.
+ */
+val BloodDivination = card("Blood Divination") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature.\nDraw three cards."
+
+    additionalCost(Costs.additional.SacrificePermanent(GameObjectFilter.Creature))
+
+    spell {
+        effect = Effects.DrawCards(3)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "86"
+        artist = "Filip Burburan"
+        flavorText = "Predicting the future is a messy business."
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6fe72bd9-825e-4451-9314-826882f75c85.jpg?1783934576"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/BoggartBruteM19Reprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/BoggartBruteM19Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Boggart Brute reprint in Core Set 2019. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val BoggartBruteM19Reprint = Printing(
+    oracleId = "880793a2-84b0-4ae1-9bb8-6e942e3dc723",
+    name = "Boggart Brute",
+    setCode = "M19",
+    collectorNumber = "131",
+    scryfallId = "32b7438d-e905-4627-9299-e2224377c8e7",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/3/2/32b7438d-e905-4627-9299-e2224377c8e7.jpg?1783934556",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ChildOfNightM19Reprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ChildOfNightM19Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Child of Night reprint in Core Set 2019. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val ChildOfNightM19Reprint = Printing(
+    oracleId = "c650a7bc-e350-44a0-a698-d4a233d66156",
+    name = "Child of Night",
+    setCode = "M19",
+    collectorNumber = "89",
+    scryfallId = "3867704d-d2ef-4185-b53d-84eba6a6776f",
+    artist = "Ash Wood",
+    imageUri = "https://cards.scryfall.io/normal/front/3/8/3867704d-d2ef-4185-b53d-84eba6a6776f.jpg?1783934576",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GoblinInstigator.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GoblinInstigator.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Instigator
+ * {1}{R}
+ * Creature — Goblin Rogue
+ * 1/1
+ *
+ * When this creature enters, create a 1/1 red Goblin creature token.
+ */
+val GoblinInstigator = card("Goblin Instigator") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Rogue"
+    oracleText = "When this creature enters, create a 1/1 red Goblin creature token."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Goblin"),
+        )
+        description = "When this creature enters, create a 1/1 red Goblin creature token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "Filip Burburan"
+        flavorText = "\"We can take 'em. You go first!\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/90cef94d-d941-4e08-afec-a116626b74fb.jpg?1783934551"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/KnightOfTheTusk.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/KnightOfTheTusk.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Knight of the Tusk
+ * {4}{W}{W}
+ * Creature — Human Knight
+ * 3/7
+ *
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ */
+val KnightOfTheTusk = card("Knight of the Tusk") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)"
+    power = 3
+    toughness = 7
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Jesper Ejsing"
+        flavorText = "\"Horse? Who needs a horse?\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/213b4584-420a-48c2-9709-7b07458e914b.jpg?1783934605"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/KnightlyValorM19Reprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/KnightlyValorM19Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Knightly Valor reprint in Core Set 2019. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val KnightlyValorM19Reprint = Printing(
+    oracleId = "9ba6cec6-97bf-4a83-9ffa-77e187d0945b",
+    name = "Knightly Valor",
+    setCode = "M19",
+    collectorNumber = "20",
+    scryfallId = "366ab022-967d-48ff-a1f9-4bd642dba1ae",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/366ab022-967d-48ff-a1f9-4bd642dba1ae.jpg?1783934604",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/MaraudersAxe.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/MaraudersAxe.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Marauder's Axe
+ * {2}
+ * Artifact — Equipment
+ *
+ * Equipped creature gets +2/+0.
+ * Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)
+ */
+val MaraudersAxe = card("Marauder's Axe") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(2, 0, Filters.EquippedCreature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "240"
+        artist = "Mitchell Malloy"
+        flavorText = "A sharp axe solves most problems."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2ca16ee-e415-4270-a453-47111d07a07f.jpg?1783934509"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/WallOfVinesM19Reprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/WallOfVinesM19Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Vines reprint in Core Set 2019. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val WallOfVinesM19Reprint = Printing(
+    oracleId = "51ce0158-c9a5-4fa5-9704-46ab02f01b86",
+    name = "Wall of Vines",
+    setCode = "M19",
+    collectorNumber = "210",
+    scryfallId = "7327e768-d90d-4677-b4dd-10837ffe8be2",
+    artist = "John Stanko",
+    imageUri = "https://cards.scryfall.io/normal/front/7/3/7327e768-d90d-4677-b4dd-10837ffe8be2.jpg?1783934523",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/AgonizingSyphon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/AgonizingSyphon.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Agonizing Syphon
+ * {3}{B}
+ * Sorcery
+ *
+ * Agonizing Syphon deals 3 damage to any target and you gain 3 life.
+ */
+val AgonizingSyphon = card("Agonizing Syphon") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Agonizing Syphon deals 3 damage to any target and you gain 3 life."
+
+    spell {
+        target = Targets.Any
+        effect = Effects.DealDamage(3, EffectTarget.ContextTarget(0))
+            .then(Effects.GainLife(3))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "83"
+        artist = "Seb McKinnon"
+        flavorText = "\"Your death will take a mere moment, but it will feel like an eternity.\"\n—Vilis, Broker of Blood"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0d8efd95-1c2f-4dd1-b70b-3cfb10ff3a28.jpg?1783933001"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/FeralInvocationM20Reprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/FeralInvocationM20Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Feral Invocation reprint in Core Set 2020. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val FeralInvocationM20Reprint = Printing(
+    oracleId = "5b3c069b-5bed-4b70-b04c-b7143a4a6e96",
+    name = "Feral Invocation",
+    setCode = "M20",
+    collectorNumber = "170",
+    scryfallId = "c2d08b7a-4ed9-4e4c-a52e-9bf2a16420a9",
+    artist = "Mathias Kollros",
+    imageUri = "https://cards.scryfall.io/normal/front/c/2/c2d08b7a-4ed9-4e4c-a52e-9bf2a16420a9.jpg?1783932967",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/IronrootWarlord.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/IronrootWarlord.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ironroot Warlord
+ * {1}{G}{W}
+ * Creature — Treefolk Soldier
+ * &#42;/5
+ *
+ * Ironroot Warlord's power is equal to the number of creatures you control.
+ * {3}{G}{W}: Create a 1/1 white Soldier creature token.
+ */
+val IronrootWarlord = card("Ironroot Warlord") {
+    manaCost = "{1}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Treefolk Soldier"
+    oracleText = "Ironroot Warlord's power is equal to the number of creatures you control.\n{3}{G}{W}: Create a 1/1 white Soldier creature token."
+    toughness = 5
+
+    dynamicPower(DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature))
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{G}{W}")
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Soldier"),
+        )
+        description = "{3}{G}{W}: Create a 1/1 white Soldier creature token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "209"
+        artist = "Filip Burburan"
+        flavorText = "\"Alone, it's a fortification. At the head of its troops, it's a battering ram.\"\n—Skerk Hobnett, wilderness guide"
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/edec85ce-7daa-48c2-b25d-b22941e01e73.jpg?1783932951"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/MaraudersAxeM20Reprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/MaraudersAxeM20Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Marauder's Axe reprint in Core Set 2020. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val MaraudersAxeM20Reprint = Printing(
+    oracleId = "5d0e49fa-5dfb-48c2-af97-fdfb788d5f40",
+    name = "Marauder's Axe",
+    setCode = "M20",
+    collectorNumber = "231",
+    scryfallId = "73ac5204-69ef-491d-9ca8-f522b99f1412",
+    artist = "Mitchell Malloy",
+    imageUri = "https://cards.scryfall.io/normal/front/7/3/73ac5204-69ef-491d-9ca8-f522b99f1412.jpg?1783932943",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/PyroclasticElemental.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/PyroclasticElemental.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pyroclastic Elemental
+ * {3}{R}{R}
+ * Creature — Elemental
+ * 5/4
+ *
+ * {1}{R}{R}: This creature deals 1 damage to target player.
+ */
+val PyroclasticElemental = card("Pyroclastic Elemental") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    oracleText = "{1}{R}{R}: This creature deals 1 damage to target player."
+    power = 5
+    toughness = 4
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}{R}")
+        target = Targets.Player
+        effect = Effects.DealDamage(1, EffectTarget.ContextTarget(0))
+        description = "{1}{R}{R}: This creature deals 1 damage to target player."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "296"
+        artist = "Svetlin Velinov"
+        flavorText = "\"Whoever thought of making mobile volcanoes was a genius.\"\n—Chandra Nalaar"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d57f8b5-fde9-498d-82bf-34bfb2370703.jpg?1783932918"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/WingedWords.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/WingedWords.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Winged Words
+ * {2}{U}
+ * Sorcery
+ *
+ * This spell costs {1} less to cast if you control a creature with flying.
+ * Draw two cards.
+ */
+val WingedWords = card("Winged Words") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "This spell costs {1} less to cast if you control a creature with flying.\nDraw two cards."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfControlFilter(
+                    amount = 1,
+                    filter = GameObjectFilter.Creature.withKeyword(Keyword.FLYING),
+                )
+            ),
+        )
+    }
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "80"
+        artist = "Chris Seaman"
+        flavorText = "Magic written across the sky falls like rain on thirsty ground, bringing forth wisdom in its season."
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff765065-b160-49b6-99ac-cd695bd0d903.jpg?1783933001"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/WallOfBlossomsMh1Reprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/WallOfBlossomsMh1Reprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Blossoms reprint in Modern Horizons. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val WallOfBlossomsMh1Reprint = Printing(
+    oracleId = "ef4d5fb3-70a3-433d-a9d3-18b2beb8d79f",
+    name = "Wall of Blossoms",
+    setCode = "MH1",
+    collectorNumber = "190",
+    scryfallId = "05ef5786-7786-4418-b245-038b58fd7123",
+    artist = "Heather Hudson",
+    imageUri = "https://cards.scryfall.io/normal/front/0/5/05ef5786-7786-4418-b245-038b58fd7123.jpg?1783933087",
+    releaseDate = "2019-06-14",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/RagingRegisaur.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/RagingRegisaur.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Raging Regisaur
+ * {2}{R}{G}
+ * Creature — Dinosaur
+ * 4/4
+ *
+ * Whenever this creature attacks, it deals 1 damage to any target.
+ */
+val RagingRegisaur = card("Raging Regisaur") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Whenever this creature attacks, it deals 1 damage to any target."
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val victim = target("any target", Targets.Any)
+        effect = Effects.DealDamage(1, victim)
+        description = "Whenever this creature attacks, it deals 1 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "168"
+        artist = "Bayard Wu"
+        flavorText = "Its breath is a gale. Its roar is a volcano. Its anger tears soul from flesh."
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad6c43a7-e9c5-4b1c-9a6d-0d8798303045.jpg?1783935270"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SylvanBrushstrider.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SylvanBrushstrider.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sylvan Brushstrider
+ * {2}{G}
+ * Creature — Beast
+ * 3/2
+ *
+ * When this creature enters, you gain 2 life.
+ */
+val SylvanBrushstrider = card("Sylvan Brushstrider") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    oracleText = "When this creature enters, you gain 2 life."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(2)
+        description = "When this creature enters, you gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "144"
+        artist = "Dan Murayama Scott"
+        flavorText = "The mournful lowing of brushstriders warns of changing weather and ill winds."
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8bc288a3-ea56-450a-96fd-c2123121f663.jpg?1783933664"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/UnstableObeliskVocReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/UnstableObeliskVocReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Unstable Obelisk reprint in Crimson Vow Commander. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val UnstableObeliskVocReprint = Printing(
+    oracleId = "060ae1bb-956a-4264-b405-a33151f31493",
+    name = "Unstable Obelisk",
+    setCode = "VOC",
+    collectorNumber = "170",
+    scryfallId = "9b856bf3-6328-435d-ad31-c976245aff8a",
+    artist = "William Wu",
+    imageUri = "https://cards.scryfall.io/normal/front/9/b/9b856bf3-6328-435d-ad31-c976245aff8a.jpg?1783924936",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/BulwarkGiant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/BulwarkGiant.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bulwark Giant
+ * {5}{W}
+ * Creature — Giant Soldier
+ * 3/6
+ *
+ * When this creature enters, you gain 5 life.
+ */
+val BulwarkGiant = card("Bulwark Giant") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Giant Soldier"
+    oracleText = "When this creature enters, you gain 5 life."
+    power = 3
+    toughness = 6
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(5)
+        description = "When this creature enters, you gain 5 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "7"
+        artist = "Victor Adame Minguez"
+        flavorText = "\"Where did she come from? More importantly, are there more like her?\"\n—Gideon Jura"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11510817-edb3-40d4-bd27-6161fedadd11.jpg?1783933488"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/ErraticVisionary.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/ErraticVisionary.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Erratic Visionary
+ * {1}{U}
+ * Creature — Human Wizard
+ * 1/3
+ *
+ * {1}{U}, {T}: Draw a card, then discard a card.
+ */
+val ErraticVisionary = card("Erratic Visionary") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "{1}{U}, {T}: Draw a card, then discard a card."
+    power = 1
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}"), Costs.Tap)
+        effect = Effects.DrawCards(1).then(Effects.Discard(1))
+        description = "{1}{U}, {T}: Draw a card, then discard a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Randy Vargas"
+        flavorText = "An Izzet experiment begins with a \"what if,\" gets approved with a \"why not,\" and concludes with a \"eureka!\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/03188bc3-0ef1-40cd-9c3c-4bb4d806fb92.jpg?1783933466"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/EternalTaskmaster.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/EternalTaskmaster.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Eternal Taskmaster
+ * {1}{B}
+ * Creature — Zombie
+ * 2/3
+ *
+ * This creature enters tapped.
+ * Whenever this creature attacks, you may pay {2}{B}. If you do, return target creature card from your graveyard to your hand.
+ */
+val EternalTaskmaster = card("Eternal Taskmaster") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    oracleText = "This creature enters tapped.\nWhenever this creature attacks, you may pay {2}{B}. If you do, return target creature card from your graveyard to your hand."
+    power = 2
+    toughness = 3
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val card = target("target creature card in your graveyard", Targets.CreatureCardInYourGraveyard)
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{2}{B}"),
+            effect = Effects.ReturnToHand(card),
+        )
+        description = "Whenever this creature attacks, you may pay {2}{B}. If you do, return target " +
+            "creature card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "90"
+        artist = "Tomasz Jedruszek"
+        flavorText = "\"They are called Eternals. They will never stop.\"\n—Jace Beleren"
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/7789188e-5caa-4500-b3e4-bb95f7657903.jpg?1783933446"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/Heartfire.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/Heartfire.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Heartfire
+ * {1}{R}
+ * Instant
+ *
+ * As an additional cost to cast this spell, sacrifice a creature or planeswalker.
+ * Heartfire deals 4 damage to any target.
+ */
+val Heartfire = card("Heartfire") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature or planeswalker.\nHeartfire deals 4 damage to any target."
+
+    additionalCost(Costs.additional.SacrificePermanent(GameObjectFilter.CreatureOrPlaneswalker))
+
+    spell {
+        target = Targets.Any
+        effect = Effects.DealDamage(4, EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "131"
+        artist = "Craig J Spearing"
+        flavorText = "The mage looked within and realized there was still one piece of fuel to burn."
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7db219ea-2ed1-4a86-955c-d61ecedbc019.jpg?1783933427"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/ManaGeode.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/ManaGeode.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mana Geode
+ * {3}
+ * Artifact
+ *
+ * When this artifact enters, scry 1.
+ * {T}: Add one mana of any color.
+ */
+val ManaGeode = card("Mana Geode") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, scry 1.\n{T}: Add one mana of any color."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Scry(1)
+        description = "When this artifact enters, scry 1."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "241"
+        artist = "Raoul Vitale"
+        flavorText = "\"I don't care if it's an all-powerful relic or a street vendor's lucky charm. If it brings you courage, wear it.\"\n—Saheeli Rai"
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/17315a12-a7f8-45ba-ac3b-a62c789e75d0.jpg?1783933371"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/TibaltsRager.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/TibaltsRager.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tibalt's Rager
+ * {1}{R}
+ * Creature — Devil
+ * 1/2
+ *
+ * When this creature dies, it deals 1 damage to any target.
+ * {1}{R}: This creature gets +2/+0 until end of turn.
+ */
+val TibaltsRager = card("Tibalt's Rager") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Devil"
+    oracleText = "When this creature dies, it deals 1 damage to any target.\n{1}{R}: This creature gets +2/+0 until end of turn."
+    power = 1
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val victim = target("any target", Targets.Any)
+        effect = Effects.DealDamage(1, victim)
+        description = "When this creature dies, it deals 1 damage to any target."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+        description = "{1}{R}: This creature gets +2/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "147"
+        artist = "Yongjae Choi"
+        flavorText = "\"Find out whose that is. I like its energy.\"\n—Judith"
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/2985520d-dfce-414e-a4ac-61695be67406.jpg?1783933420"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DroverOfTheMighty.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/DroverOfTheMighty.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Drover of the Mighty
+ * {1}{G}
+ * Creature — Human Druid
+ * 1/1
+ *
+ * This creature gets +2/+2 as long as you control a Dinosaur.
+ * {T}: Add one mana of any color.
+ */
+val DroverOfTheMighty = card("Drover of the Mighty") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Druid"
+    oracleText = "This creature gets +2/+2 as long as you control a Dinosaur.\n{T}: Add one mana of any color."
+    power = 1
+    toughness = 1
+
+    staticAbility {
+        ability = ModifyStats(2, 2, Filters.Self)
+        condition = Conditions.ControlPermanentOfType(Subtype.DINOSAUR)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "187"
+        artist = "Eric Deschamps"
+        flavorText = "\"I do not lead. They do not follow. We walk together.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/51fdf2fc-d948-4c64-a34e-2f90eab83212.jpg?1783935726"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/MarkOfTheVampireXlnReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/MarkOfTheVampireXlnReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mark of the Vampire reprint in Ixalan. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives
+ * in another set's `cards/` package; this file contributes only presentation data.
+ */
+val MarkOfTheVampireXlnReprint = Printing(
+    oracleId = "af942d30-a191-4306-846d-6c26755ca3e6",
+    name = "Mark of the Vampire",
+    setCode = "XLN",
+    collectorNumber = "113",
+    scryfallId = "55fec80c-81d5-4d3b-bc07-6fc6c2513ef8",
+    artist = "Yongjae Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/55fec80c-81d5-4d3b-bc07-6fc6c2513ef8.jpg?1783935760",
+    releaseDate = "2017-09-29",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ThunderingSpineback.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ThunderingSpineback.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Thundering Spineback
+ * {5}{G}{G}
+ * Creature — Dinosaur
+ * 5/5
+ *
+ * Other Dinosaurs you control get +1/+1.
+ * {5}{G}: Create a 3/3 green Dinosaur creature token with trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)
+ */
+val ThunderingSpineback = card("Thundering Spineback") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Other Dinosaurs you control get +1/+1.\n{5}{G}: Create a 3/3 green Dinosaur creature token with trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)"
+    power = 5
+    toughness = 5
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype(Subtype.DINOSAUR).youControl(),
+                excludeSelf = true,
+            ),
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{G}")
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 3,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Dinosaur"),
+            keywords = setOf(Keyword.TRAMPLE),
+        )
+        description = "{5}{G}: Create a 3/3 green Dinosaur creature token with trample."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "210"
+        artist = "Tomasz Jedruszek"
+        flavorText = "\"It appears that nature has risen against us.\"\n—Captain Brinely Rage"
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/35711da6-aac4-4c2a-b324-aebeaa843adc.jpg?1783935718"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/AER.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AER.json
@@ -77,6 +77,32 @@
     ]
 }
 
+// Gifted Aetherborn
+{
+    "name": "Gifted Aetherborn",
+    "manaCost": "{B}{B}",
+    "typeLine": "Creature — Aetherborn Vampire",
+    "oracleText": "Deathtouch, lifelink",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEATHTOUCH",
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "61",
+        "rarity": "UNCOMMON",
+        "artist": "Ryan Yee",
+        "flavorText": "A few aetherborn have discovered a way to sustain their own existences at the cost of an insatiable hunger for the life essence of other beings.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/abceb4fd-e3c5-400d-af7a-6dd17108a4b4.jpg?1783936763"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Lathnu Sailback
 {
     "name": "Lathnu Sailback",

--- a/mtg-sets/src/test/resources/snapshots/cards/AKH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AKH.json
@@ -1,3 +1,116 @@
+// Blighted Bat
+{
+    "name": "Blighted Bat",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie Bat",
+    "oracleText": "Flying\n{1}: This creature gains haste until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": "Self"
+                },
+                "descriptionOverride": "{1}: This creature gains haste until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "artist": "Nils Hamm",
+        "flavorText": "Amonkhet's dual suns don't allow for the darkness of night, so bats are most active under the gloom of the frequent sandstorms.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8da308e9-1862-46c1-a62a-90720b484d91.jpg?1783936512"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Bloodrage Brawler
+{
+    "name": "Bloodrage Brawler",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Minotaur Warrior",
+    "oracleText": "When this creature enters, discard a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 1 card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, discard a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "UNCOMMON",
+        "artist": "Lars Grant-West",
+        "flavorText": "To Hazoret, those who fight for her are her beloved children.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e6080f9e-2415-4e05-97a1-0fe4ad4fdf3b.jpg?1783936492"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Colossapede
 {
     "name": "Colossapede",
@@ -257,6 +370,55 @@
     ]
 }
 
+// Initiate's Companion
+{
+    "name": "Initiate's Companion",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Whenever this creature deals combat damage to a player, untap target creature or land.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or land"
+                    },
+                    "tap": false
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|land"
+                    },
+                    "id": "target creature or land"
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, untap target creature or land."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"I'd like to say that it's our pet, but the reverse may be closer to the truth.\"\n—Ixor, initiate of Rhet crop",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/0046b802-bc71-44af-8925-666684d5fc87.jpg?1783936472"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Liliana's Mastery
 {
     "name": "Liliana's Mastery",
@@ -377,6 +539,81 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Minotaur Sureshot
+{
+    "name": "Minotaur Sureshot",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Minotaur Archer",
+    "oracleText": "Reach (This creature can block creatures with flying.)\n{1}{R}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{1}{R}: This creature gets +1/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "artist": "Joseph Meehan",
+        "flavorText": "\"Those wings are no advantage. I will pin them to the ceiling of the Hekma.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/777b98c3-d0b8-4ee3-9d89-e86344269ff1.jpg?1783936484"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Pouncing Cheetah
+{
+    "name": "Pouncing Cheetah",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Flash",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "metadata": {
+        "collectorNumber": "179",
+        "artist": "Matt Stewart",
+        "flavorText": "Rhonas's monument is home to a wider variety of creatures than anywhere else in the city of Naktamun—a feature most initiates fail to appreciate.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fca8a590-75c1-4e85-b8b7-8c0c0f18b96e.jpg?1783936471"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -2183,6 +2183,73 @@
     ]
 }
 
+// Scroll of Avacyn
+{
+    "name": "Scroll of Avacyn",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, Sacrifice this artifact: Draw a card. If you control an Angel, you gain 5 life.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Exists",
+                                    "player": "You",
+                                    "zone": "Battlefield",
+                                    "filter": "permanent Angel"
+                                }
+                            },
+                            "then": {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                }
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "{1}, Sacrifice this artifact: Draw a card. If you control an Angel, you gain 5 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "artist": "Cliff Childs",
+        "flavorText": "Words to bless the eye that reads them, telling of a future beyond the reach of fear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/871e6e2a-7e45-446b-b964-94377eb6ca92.jpg?1783940650"
+    },
+    "colorIdentityOverride": []
+}
+
 // Seraph Sanctuary
 {
     "name": "Seraph Sanctuary",
@@ -2447,6 +2514,56 @@
         "rarity": "RARE",
         "artist": "Steve Argyle",
         "imageUri": "https://cards.scryfall.io/normal/front/4/0/409c0272-7a43-4a6c-ab3f-740397b1f5c8.jpg?1782714442"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Soul of the Harvest
+{
+    "name": "Soul of the Harvest",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Trample\nWhenever another nontoken creature you control enters, you may draw a card.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature nontoken ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                "descriptionOverride": "Whenever another nontoken creature you control enters, you may draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "rarity": "RARE",
+        "artist": "Eytan Zana",
+        "flavorText": "It's there when a seed sprouts, when gourds ripen on the vines, and when the reapers cut the grains under the Harvest Moon.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/078f5e79-18dd-44e5-a930-8dc288f0b535.jpg?1783940661"
     },
     "colorIdentityOverride": [
         "GREEN"

--- a/mtg-sets/src/test/resources/snapshots/cards/C14.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/C14.json
@@ -148,3 +148,71 @@
     },
     "colorIdentityOverride": []
 }
+
+// Unstable Obelisk
+{
+    "name": "Unstable Obelisk",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {C}.\n{7}, {T}, Sacrifice this artifact: Destroy target permanent.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{7}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent"
+                        }
+                    }
+                ],
+                "descriptionOverride": "{7}, {T}, Sacrifice this artifact: Destroy target permanent."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "rarity": "UNCOMMON",
+        "artist": "William Wu",
+        "flavorText": "Its collapse is like the lashing out of a long-dead civilization that resents being forgotten.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b331b231-f31f-479f-80a9-f32c64d35096.jpg?1783938864"
+    },
+    "colorIdentityOverride": []
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/CON_.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CON_.json
@@ -368,3 +368,61 @@
         "WHITE"
     ]
 }
+
+// Volcanic Fallout
+{
+    "name": "Volcanic Fallout",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Instant",
+    "oracleText": "This spell can't be countered.\nVolcanic Fallout deals 2 damage to each creature and each player.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "Each"
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": "Controller"
+                    }
+                }
+            ]
+        },
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "\"How can we outrun the sky?\"\n—Hadran, sunseeder of Naya",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/65536d12-e75c-42b5-b592-a3ad4f550a71.jpg?1783942477"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/CSP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CSP.json
@@ -130,6 +130,53 @@
     ]
 }
 
+// Ronom Unicorn
+{
+    "name": "Ronom Unicorn",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Unicorn",
+    "oracleText": "Sacrifice this creature: Destroy target enchantment.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "enchantment"
+                        }
+                    }
+                ],
+                "descriptionOverride": "Sacrifice this creature: Destroy target enchantment."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "artist": "Carl Critchlow",
+        "flavorText": "The aberrant magic of the Rimewind drew the unicorns back from the northern wastes to do battle once again.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae4764e1-e47c-4934-86a5-9b432c29a158.jpg?1783943367"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Simian Brawler
 {
     "name": "Simian Brawler",

--- a/mtg-sets/src/test/resources/snapshots/cards/DGM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DGM.json
@@ -217,6 +217,30 @@
     }
 }
 
+// Murmuring Phantasm
+{
+    "name": "Murmuring Phantasm",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Defender",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 5
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "metadata": {
+        "collectorNumber": "15",
+        "artist": "Peter Mohrbacher",
+        "flavorText": "\"The most insidious thing in the world is nonsense that sounds just plausible enough to listen to.\"\n—Lazav",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/9752644c-7c43-429e-a79c-1239b9a0bc8a.jpg?1783940041"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Unflinching Courage
 {
     "name": "Unflinching Courage",

--- a/mtg-sets/src/test/resources/snapshots/cards/DKA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DKA.json
@@ -1788,6 +1788,65 @@
     ]
 }
 
+// Torch Fiend
+{
+    "name": "Torch Fiend",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Devil",
+    "oracleText": "{R}, Sacrifice this creature: Destroy target artifact.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact"
+                        }
+                    }
+                ],
+                "descriptionOverride": "{R}, Sacrifice this creature: Destroy target artifact."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "artist": "Winona Nelson",
+        "flavorText": "Devils redecorate every room with fire.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d596feee-6ccc-4648-884b-ed2eeb1cffc0.jpg?1783940810"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Tower Geist
 {
     "name": "Tower Geist",

--- a/mtg-sets/src/test/resources/snapshots/cards/DST.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DST.json
@@ -748,6 +748,69 @@
     ]
 }
 
+// Mirrodin's Core
+{
+    "name": "Mirrodin's Core",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{T}: Put a charge counter on this land.\n{T}, Remove a charge counter from this land: Add one mana of any color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "charge",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "{T}: Put a charge counter on this land."
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "UNCOMMON",
+        "artist": "Greg Staples",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/f/cf0e60c9-1548-4981-ada1-6656804a772e.jpg?1783944413"
+    },
+    "colorIdentityOverride": []
+}
+
 // Myr Moonvessel
 {
     "name": "Myr Moonvessel",

--- a/mtg-sets/src/test/resources/snapshots/cards/DTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DTK.json
@@ -378,6 +378,82 @@
     ]
 }
 
+// Dragonloft Idol
+{
+    "name": "Dragonloft Idol",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Gargoyle",
+    "oracleText": "As long as you control a Dragon, this creature gets +1/+1 and has flying and trample.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent Dragon"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent Dragon"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent Dragon"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "UNCOMMON",
+        "artist": "Jung Park",
+        "flavorText": "The idols were forged during the time of the Khanfall, when the dragons came to rule Tarkir and its people aligned themselves with the five dragonlords.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c7463c18-5bef-42a0-a37e-6112809ebc78.jpg?1783938569"
+    },
+    "colorIdentityOverride": []
+}
+
 // Dragonlord's Servant
 {
     "name": "Dragonlord's Servant",
@@ -674,6 +750,62 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Shambling Goblin
+{
+    "name": "Shambling Goblin",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Zombie Goblin",
+    "oracleText": "When this creature dies, target creature an opponent controls gets -1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target creature an opponent controls"
+                },
+                "descriptionOverride": "When this creature dies, target creature an opponent controls gets -1/-1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "\"The Kolaghan send them at us. We kill and raise them. They fight the next wave the Kolaghan send. It's a neat little cycle.\"\n—Asmala, Silumgar sorcerer",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/9404c7d5-3450-4425-94e5-aa7d4e571d4e.jpg?1783938594"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/ELD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ELD.json
@@ -661,6 +661,106 @@
     "colorIdentityOverride": []
 }
 
+// Jousting Dummy
+{
+    "name": "Jousting Dummy",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Scarecrow Knight",
+    "oracleText": "{3}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{3}: This creature gets +1/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "artist": "Milivoj Ćeran",
+        "flavorText": "\"Don't let it fool you. Many of us got our first scars from Syr Nobody.\"\n—Syr Layne, knight of Embereth",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6601056-af08-4239-97d5-5e11597fce18.jpg?1783932584"
+    },
+    "colorIdentityOverride": []
+}
+
+// Keeper of Fables
+{
+    "name": "Keeper of Fables",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Whenever one or more non-Human creatures you control deal combat damage to a player, draw a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer",
+                    "sourceFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotSubtype",
+                                "subtype": "Human"
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "batch": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever one or more non-Human creatures you control deal combat damage to a player, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "rarity": "UNCOMMON",
+        "artist": "Alex Konstad",
+        "flavorText": "\"Only the lion knows more stories than I do.\"\n—Chulane, Teller of Tales",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/6754d6cf-3506-48b5-a0ef-8a90b8dd2701.jpg?1783932608"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Linden, the Steadfast Queen
 {
     "name": "Linden, the Steadfast Queen",
@@ -976,6 +1076,45 @@
     "colorIdentityOverride": [
         "BLUE"
     ]
+}
+
+// Signpost Scarecrow
+{
+    "name": "Signpost Scarecrow",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "Vigilance\n{2}: Add one mana of any color.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "artist": "Jung Park",
+        "flavorText": "\"Accursed scarecrow! Sending folk in every direction is the same as sending them nowhere at all.\"\n—Corliss the Wanderer",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2c5f336-c100-4bec-89d5-548f60064d7f.jpg?1783932583"
+    },
+    "colorIdentityOverride": []
 }
 
 // Syr Alin, the Lion's Claw

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -4927,6 +4927,72 @@
     ]
 }
 
+// Weaver of Lightning
+{
+    "name": "Weaver of Lightning",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "Reach (This creature can block creatures with flying.)\nWhenever you cast an instant or sorcery spell, this creature deals 1 damage to target creature an opponent controls.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target creature an opponent controls"
+                },
+                "descriptionOverride": "Whenever you cast an instant or sorcery spell, this creature deals 1 damage to target creature an opponent controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "149",
+        "rarity": "UNCOMMON",
+        "artist": "John Stanko",
+        "flavorText": "\"Lightning in a bottle? That's not where I need it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba1e6885-dca0-4a4b-abb8-0f32680f618d.jpg?1783937450"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Wolfkin Bond
 {
     "name": "Wolfkin Bond",

--- a/mtg-sets/src/test/resources/snapshots/cards/EVE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EVE.json
@@ -50,6 +50,96 @@
     ]
 }
 
+// Scarecrone
+{
+    "name": "Scarecrone",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "{1}, Sacrifice a Scarecrow: Draw a card.\n{4}, {T}: Return target artifact creature card from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "permanent Scarecrow"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "{1}, Sacrifice a Scarecrow: Draw a card."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact creature card in your graveyard"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact creature own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target artifact creature card in your graveyard"
+                    }
+                ],
+                "descriptionOverride": "{4}, {T}: Return target artifact creature card from your graveyard to the battlefield."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "172",
+        "rarity": "RARE",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Her poppets bring joy to the truly depraved.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/1978400d-a8f1-4df7-8caf-b9ca81334bce.jpg?1783942656"
+    },
+    "colorIdentityOverride": []
+}
+
 // Wickerbough Elder
 {
     "name": "Wickerbough Elder",

--- a/mtg-sets/src/test/resources/snapshots/cards/FRF.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FRF.json
@@ -1,3 +1,83 @@
+// Bathe in Dragonfire
+{
+    "name": "Bathe in Dragonfire",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Bathe in Dragonfire deals 4 damage to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "ContextTarget",
+                "index": 0
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "92",
+        "artist": "Chris Rallis",
+        "flavorText": "The scent of cooked flesh lingers in the charred landscape of Tarkir.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b8cc6931-2005-4d0a-a42a-ce8bc279372e.jpg?1783938691"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Collateral Damage
+{
+    "name": "Collateral Damage",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a creature.\nCollateral Damage deals 3 damage to any target.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "ContextTarget",
+                "index": 0
+            }
+        },
+        "targetRequirements": [
+            "AnyTarget"
+        ],
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "artist": "Ryan Barger",
+        "flavorText": "It is much easier to create fire than to contain it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb738362-b0b4-4811-9fbf-5f45c852c822.jpg?1783938691"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Feral Krushok
 {
     "name": "Feral Krushok",

--- a/mtg-sets/src/test/resources/snapshots/cards/GPT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GPT.json
@@ -766,6 +766,79 @@
     ]
 }
 
+// Plagued Rusalka
+{
+    "name": "Plagued Rusalka",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "{B}, Sacrifice a creature: Target creature gets -1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "{B}, Sacrifice a creature: Target creature gets -1/-1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "rarity": "UNCOMMON",
+        "artist": "Alex Horley-Orlandelli",
+        "flavorText": "\"Look at her, once filled with innocence. Death has a way of wringing away such . . . deficiencies.\"\n—Savra",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd84bbb3-8b99-4e6d-b514-b094ec93eaa0.jpg?1783943506"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Repeal
 {
     "name": "Repeal",

--- a/mtg-sets/src/test/resources/snapshots/cards/GRN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GRN.json
@@ -368,6 +368,58 @@
     ]
 }
 
+// Inspiring Unicorn
+{
+    "name": "Inspiring Unicorn",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Unicorn",
+    "oracleText": "Whenever this creature attacks, creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Whenever this creature attacks, creatures you control get +1/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "rarity": "UNCOMMON",
+        "artist": "Even Amundsen",
+        "flavorText": "There are two lives: the life you live before you see a unicorn, and the life you live after.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce8b745e-1e62-4c54-9e73-e2d0a40568a0.jpg?1783934199"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // March of the Multitudes
 {
     "name": "March of the Multitudes",

--- a/mtg-sets/src/test/resources/snapshots/cards/HOU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOU.json
@@ -197,6 +197,47 @@
     ]
 }
 
+// Feral Prowler
+{
+    "name": "Feral Prowler",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "When this creature dies, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "When this creature dies, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "Ben Wootten",
+        "flavorText": "Once favored companions, many cats were left to fend for themselves.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba0431ad-185a-4917-b994-e58dd9850f5e.jpg?1783936020"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Firebrand Archer
 {
     "name": "Firebrand Archer",

--- a/mtg-sets/src/test/resources/snapshots/cards/JMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/JMP.json
@@ -1,3 +1,113 @@
+// Archaeomender
+{
+    "name": "Archaeomender",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "When this creature enters, return target artifact card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact card in your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target artifact card in your graveyard"
+                },
+                "descriptionOverride": "When this creature enters, return target artifact card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "artist": "Miranda Meeks",
+        "flavorText": "\"Just as a broken relic can be mended, a shattered history can be made whole.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/2/22bb8779-ac19-43d6-b818-86eb8ee2f87d.jpg?1783930507"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Chained Brute
+{
+    "name": "Chained Brute",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Devil",
+    "oracleText": "This creature doesn't untap during your untap step.\n{1}, Sacrifice another creature: Untap this creature. Activate only during your turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "flags": [
+        "DOESNT_UNTAP"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                },
+                "restrictions": [
+                    "OnlyDuringYourTurn"
+                ],
+                "descriptionOverride": "{1}, Sacrifice another creature: Untap this creature. Activate only during your turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "A momentary lapse is all it needs to break free.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/d/1d4e5c23-3a7f-4a6b-99c4-6a1487a9b097.jpg?1783930504"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Corsair Captain
 {
     "name": "Corsair Captain",
@@ -46,6 +156,85 @@
     ]
 }
 
+// Lightning Visionary
+{
+    "name": "Lightning Visionary",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Minotaur Shaman",
+    "oracleText": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "PROWESS"
+    ],
+    "metadata": {
+        "collectorNumber": "22",
+        "artist": "Bryan Sola",
+        "flavorText": "\"The gods don't speak to mortals with gentle entreaties. They speak with thunder and fury.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/af648aaf-a8e0-4291-acf9-5f8533728f92.jpg?1783930502"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Lightning-Core Excavator
+{
+    "name": "Lightning-Core Excavator",
+    "manaCost": "{1}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "{5}, {T}, Sacrifice this creature: It deals 3 damage to any target.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirements": [
+                    "AnyTarget"
+                ],
+                "descriptionOverride": "{5}, {T}, Sacrifice this creature: It deals 3 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "artist": "Cristi Balanescu",
+        "flavorText": "\"That's the third time this month it's exploded on site. Maybe we should switch to something a little less defective.\"\n—Kerrin, archaeologist",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b1b959af-bb23-42e7-8848-7405ed597c8d.jpg?1783930499"
+    },
+    "colorIdentityOverride": []
+}
+
 // Release the Dogs
 {
     "name": "Release the Dogs",
@@ -75,6 +264,228 @@
         "artist": "Jason Kang",
         "flavorText": "They charge into battle and out for their morning walk with the same exuberance.",
         "imageUri": "https://cards.scryfall.io/normal/front/7/d/7df3cd89-02c9-4a1c-9a8a-d17a0b1030c9.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Sethron, Hurloon General
+{
+    "name": "Sethron, Hurloon General",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Legendary Creature — Minotaur Warrior",
+    "oracleText": "Whenever Sethron or another nontoken Minotaur you control enters, create a 2/3 red Minotaur creature token.\n{2}{B/R}: Minotaurs you control get +1/+0 and gain menace and haste until end of turn. ({B/R} can be paid with either {B} or {R}.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Minotaur nontoken ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 3,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Minotaur"
+                    ]
+                },
+                "descriptionOverride": "Whenever Sethron or another nontoken Minotaur you control enters, create a 2/3 red Minotaur creature token."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B/R}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature Minotaur ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "MENACE",
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "{2}{B/R}: Minotaurs you control get +1/+0 and gain menace and haste until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "rarity": "RARE",
+        "artist": "Jason Rainville",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/274cdb39-1454-4c9b-acd8-4f762a48e71f.jpg?1783930501"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Stone Haven Pilgrim
+{
+    "name": "Stone Haven Pilgrim",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Kor Cleric",
+    "oracleText": "Whenever this creature attacks, if you control an artifact or enchantment, this creature gets +1/+1 and gains lifelink until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "LIFELINK",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "interveningIf": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "artifact|enchantment"
+                },
+                "descriptionOverride": "Whenever this creature attacks, if you control an artifact or enchantment, this creature gets +1/+1 and gains lifelink until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "UNCOMMON",
+        "artist": "Cristi Balanescu",
+        "flavorText": "The persistence to overcome obstacles is the most esteemed of kor virtues.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5cd3287d-e4d8-4670-a2dd-b683055ae4b9.jpg?1783930508"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Trusty Retriever
+{
+    "name": "Trusty Retriever",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Dog",
+    "oracleText": "When this creature enters, choose one —\n• Put a +1/+1 counter on this creature.\n• Return target artifact or enchantment card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            },
+                            "description": "Put a +1/+1 counter on this creature"
+                        },
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Hand"
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "artifact|enchantment own:you",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ],
+                            "description": "Return target artifact or enchantment card from your graveyard to your hand"
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, choose one — Put a +1/+1 counter on this creature; or return target artifact or enchantment card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "artist": "Ralph Horsley",
+        "flavorText": "Wipe away the slobber and it's as good as new, give or take a few bite marks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab4eb490-acd0-4162-8e8a-7e7ff003d0f3.jpg?1783930507"
     },
     "colorIdentityOverride": [
         "WHITE"

--- a/mtg-sets/src/test/resources/snapshots/cards/JOU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/JOU.json
@@ -111,6 +111,43 @@
     ]
 }
 
+// Flurry of Horns
+{
+    "name": "Flurry of Horns",
+    "manaCost": "{4}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create two 2/3 red Minotaur creature tokens with haste.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "power": 2,
+            "toughness": 3,
+            "colors": [
+                "RED"
+            ],
+            "creatureTypes": [
+                "Minotaur"
+            ],
+            "keywords": [
+                "HASTE"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "96",
+        "artist": "Phill Simmer",
+        "flavorText": "A minotaur does not distinguish between human, satyr, and triton. They are all meat.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/333ff270-4bc7-48ee-9738-f8c70b8a7e40.jpg?1783939424"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Heroes' Bane
 {
     "name": "Heroes' Bane",
@@ -161,6 +198,63 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Lightning Diadem
+{
+    "name": "Lightning Diadem",
+    "manaCost": "{5}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, it deals 2 damage to any target.\nEnchanted creature gets +2/+2.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                },
+                "descriptionOverride": "When this Aura enters, it deals 2 damage to any target."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Ryan Alexander Lee",
+        "flavorText": "\"I fight for Keranos and for mortals. I see no contradiction.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4ce3f1c6-2e6f-4087-8619-a01fdcc6d4a3.jpg?1783939422"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -260,6 +354,40 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Sigiled Starfish
+{
+    "name": "Sigiled Starfish",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Starfish",
+    "oracleText": "{T}: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                },
+                "descriptionOverride": "{T}: Scry 1."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Nils Hamm",
+        "flavorText": "Kruphix hid the most dire prophecies about humankind where humans would never find them and tritons wouldn't care to read them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/85a61f99-44f8-4a2b-b7f2-7899a694552d.jpg?1783939442"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/KLD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KLD.json
@@ -865,6 +865,56 @@
     ]
 }
 
+// Lawless Broker
+{
+    "name": "Lawless Broker",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Aetherborn Rogue",
+    "oracleText": "When this creature dies, put a +1/+1 counter on target creature you control.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "descriptionOverride": "When this creature dies, put a +1/+1 counter on target creature you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "artist": "Darek Zabrocki",
+        "flavorText": "Kaladesh's illicit marketplaces are known as \"night markets,\" but if you know who to ask, you can find what you're looking for at any time of the day.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b5bfff7-aa23-42ef-af1b-bc3304bd3a17.jpg?1783937205"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Prakhata Club Security
 {
     "name": "Prakhata Club Security",

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -229,6 +229,41 @@
     ]
 }
 
+// Leaf Gilder
+{
+    "name": "Leaf Gilder",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "{T}: Add {G}.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "artist": "Quinton Hoover",
+        "flavorText": "Eidren, perfect of Lys Alana, ordered hundreds of trees uprooted and rearranged into a pattern he deemed beautiful. Thus the Gilt-Leaf Wood was born.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3aaff934-cc79-4a01-a4be-3c4936605e4e.jpg?1783942859"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Mosswort Bridge
 {
     "name": "Mosswort Bridge",
@@ -505,6 +540,35 @@
         "collectorNumber": "128",
         "artist": "Jeff Miracola",
         "imageUri": "https://cards.scryfall.io/normal/front/9/4/94b4e4d2-2358-48d2-9a2a-3d17afea28f5.jpg?1562358824"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Nightshade Stinger
+{
+    "name": "Nightshade Stinger",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Faerie Rogue",
+    "oracleText": "Flying\nThis creature can't block.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            "CantBlock"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "132",
+        "artist": "Mark Poole",
+        "flavorText": "\"Most faeries are harmless pranksters. Every now and again, though, you get one that crosses over from mischievous to malicious.\"\n—Gaddock Teeg",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aa341824-bf3a-49ce-a8a0-ee53f537d626.jpg?1783942886"
     },
     "colorIdentityOverride": [
         "BLACK"

--- a/mtg-sets/src/test/resources/snapshots/cards/M10.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M10.json
@@ -65,6 +65,30 @@
     ]
 }
 
+// Child of Night
+{
+    "name": "Child of Night",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Lifelink",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "88",
+        "artist": "Ash Wood",
+        "flavorText": "A vampire enacts vengeance on the entire world, claiming her debt two tiny pinpricks at a time.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e1f7a9a7-3679-4a18-a52a-e3a8ab16ad32.jpg?1783942385"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Divine Verdict
 {
     "name": "Divine Verdict",

--- a/mtg-sets/src/test/resources/snapshots/cards/M11.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M11.json
@@ -591,3 +591,102 @@
     },
     "colorIdentityOverride": []
 }
+
+// Sylvan Ranger
+{
+    "name": "Sylvan Ranger",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Scout Ranger",
+    "oracleText": "When this creature enters, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                },
+                "descriptionOverride": "When this creature enters, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "artist": "Christopher Moeller",
+        "flavorText": "\"Not all paths are found on the forest floor.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f73ea30-c6d2-4224-ae54-f6b89e006cf4.jpg?1783941792"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Wall of Vines
+{
+    "name": "Wall of Vines",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Plant Wall",
+    "oracleText": "Defender (This creature can't attack.)\nReach (This creature can block creatures with flying.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER",
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "199",
+        "artist": "John Stanko",
+        "flavorText": "Like all jungle plants, the vines must fight and claw for sunlight. Once their place is secured, they grow strong, sharp, and impenetrable.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/2050a168-870e-4c47-bc74-bc1c90dd7b3b.jpg?1783941792"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/M12.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M12.json
@@ -39,6 +39,60 @@
     "colorIdentityOverride": []
 }
 
+// Alabaster Mage
+{
+    "name": "Alabaster Mage",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{1}{W}: Target creature you control gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    }
+                ],
+                "descriptionOverride": "{1}{W}: Target creature you control gains lifelink until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "UNCOMMON",
+        "artist": "Izzy",
+        "flavorText": "\"We hold sacred the powers of light and life. Truth and honor are our greatest weapons.\"\n—Alabaster creed",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f82e6a81-6a45-45f9-829d-332859a32257.jpg?1783941106"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Amphin Cutthroat
 {
     "name": "Amphin Cutthroat",
@@ -171,6 +225,75 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Buried Ruin
+{
+    "name": "Buried Ruin",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{2}, {T}, Sacrifice this land: Return target artifact card from your graveyard to your hand.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact card in your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target artifact card in your graveyard"
+                    }
+                ],
+                "descriptionOverride": "{2}, {T}, Sacrifice this land: Return target artifact card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "rarity": "UNCOMMON",
+        "artist": "Franz Vohwinkel",
+        "flavorText": "History has buried its treasures deep.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/9/e910cf59-f7aa-44b1-bb8a-c2211179137c.jpg?1783941046"
+    },
+    "colorIdentityOverride": []
 }
 
 // Devouring Swarm

--- a/mtg-sets/src/test/resources/snapshots/cards/M13.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M13.json
@@ -123,6 +123,57 @@
     ]
 }
 
+// Bloodhunter Bat
+{
+    "name": "Bloodhunter Bat",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Bat",
+    "oracleText": "Flying\nWhen this creature enters, target player loses 2 life and you gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "from": {
+                        "type": "BoundVariable",
+                        "name": "target player"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                },
+                "descriptionOverride": "When this creature enters, target player loses 2 life and you gain 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "It returns eager to share the feast of blood and gore with its ghoulish master.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/99c10705-6e0e-46f6-a64c-0095b2796aaf.jpg?1783940499"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Captain's Call
 {
     "name": "Captain's Call",
@@ -190,6 +241,57 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Dragon Hatchling
+{
+    "name": "Dragon Hatchling",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\n{R}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{R}: This creature gets +1/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "artist": "David Palumbo",
+        "flavorText": "\"Those dragons grow fast. For a while they feed on squirrels and goblins and then suddenly you're missing a mammoth.\"\n—Hurdek, Mazar mammoth trainer",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/ed599d52-f2d9-4913-ad88-70f8aa4af7b9.jpg?1783940484"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -285,6 +387,42 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Mark of the Vampire
+{
+    "name": "Mark of the Vampire",
+    "manaCost": "{3}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +2/+2 and has lifelink.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "LIFELINK"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "artist": "Winona Nelson",
+        "flavorText": "\"My 'condition' is a trial. The weak are consumed by it. The strong transcend it.\"\n—Sorin Markov",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/90484815-2529-4a81-9f1b-f0f7382e4b66.jpg?1783940493"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -508,6 +646,65 @@
         "artist": "Svetlin Velinov",
         "flavorText": "After Talrand conquered the depths of Shandalar, his ambitions drove him skyward, joined by servants whose drive and curiosity equaled his own.",
         "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2cd809c-557a-42a5-950b-56b5b47b325b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Talrand, Sky Summoner
+{
+    "name": "Talrand, Sky Summoner",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Legendary Creature — Merfolk Wizard",
+    "oracleText": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Drake"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                },
+                "descriptionOverride": "Whenever you cast an instant or sorcery spell, create a 2/2 blue Drake creature token with flying."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "rarity": "RARE",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"The seas are vast, but the skies are even more so. Why be content with one kingdom when I can rule them both?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc1a6867-921d-4912-afae-c3c445ad81e7.jpg?1783940501"
     },
     "colorIdentityOverride": [
         "BLUE"

--- a/mtg-sets/src/test/resources/snapshots/cards/M14.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M14.json
@@ -1,3 +1,62 @@
+// Barrage of Expendables
+{
+    "name": "Barrage of Expendables",
+    "manaCost": "{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "{R}, Sacrifice a creature: This enchantment deals 1 damage to any target.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirements": [
+                    "AnyTarget"
+                ],
+                "descriptionOverride": "{R}, Sacrifice a creature: This enchantment deals 1 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "UNCOMMON",
+        "artist": "Trevor Claxton",
+        "flavorText": "Goblin generals don't distinguish between troops and ammunition.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9e0912d-b4b9-497c-bce7-ed80b79bab32.jpg?1783939918"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Encroaching Wastes
 {
     "name": "Encroaching Wastes",

--- a/mtg-sets/src/test/resources/snapshots/cards/M15.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M15.json
@@ -40,6 +40,74 @@
     ]
 }
 
+// Blood Host
+{
+    "name": "Blood Host",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "{1}{B}, Sacrifice another creature: Put a +1/+1 counter on this creature and you gain 2 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "{1}{B}, Sacrifice another creature: Put a +1/+1 counter on this creature and you gain 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "rarity": "UNCOMMON",
+        "artist": "Cynthia Sheppard",
+        "flavorText": "It would be ill-mannered to decline his invitation. It would be ill-advised to accept it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/1454a83d-f018-446c-89fb-21460924e589.jpg?1783939186"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Borderland Marauder
 {
     "name": "Borderland Marauder",

--- a/mtg-sets/src/test/resources/snapshots/cards/M19.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M19.json
@@ -1,3 +1,46 @@
+// Aegis of the Heavens
+{
+    "name": "Aegis of the Heavens",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +1/+7 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 1
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 7
+            },
+            "target": {
+                "type": "ContextTarget",
+                "index": 0
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "UNCOMMON",
+        "artist": "Anthony Palumbo",
+        "flavorText": "Inner strength is never seen until it makes all the difference.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/0503c55d-74bb-4165-9273-127c01bb2214.jpg?1783934612"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Aethershield Artificer
 {
     "name": "Aethershield Artificer",
@@ -212,6 +255,42 @@
         "imageUri": "https://cards.scryfall.io/normal/front/0/c/0ce4702d-f65b-413e-99da-112f632a0a63.jpg?1783934516"
     },
     "colorIdentityOverride": []
+}
+
+// Blood Divination
+{
+    "name": "Blood Divination",
+    "manaCost": "{3}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a creature.\nDraw three cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 3
+            }
+        },
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "rarity": "UNCOMMON",
+        "artist": "Filip Burburan",
+        "flavorText": "Predicting the future is a messy business.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6fe72bd9-825e-4451-9314-826882f75c85.jpg?1783934576"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
 }
 
 // Bogstomper
@@ -828,6 +907,50 @@
     ]
 }
 
+// Goblin Instigator
+{
+    "name": "Goblin Instigator",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Rogue",
+    "oracleText": "When this creature enters, create a 1/1 red Goblin creature token.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Goblin"
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, create a 1/1 red Goblin creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "artist": "Filip Burburan",
+        "flavorText": "\"We can take 'em. You go first!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/90cef94d-d941-4e08-afec-a116626b74fb.jpg?1783934551"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Herald of Faith
 {
     "name": "Herald of Faith",
@@ -979,6 +1102,30 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Knight of the Tusk
+{
+    "name": "Knight of the Tusk",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 7
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Jesper Ejsing",
+        "flavorText": "\"Horse? Who needs a horse?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/213b4584-420a-48c2-9709-7b07458e914b.jpg?1783934605"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -1155,6 +1302,61 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// Marauder's Axe
+{
+    "name": "Marauder's Axe",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 0
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "240",
+        "artist": "Mitchell Malloy",
+        "flavorText": "A sharp axe solves most problems.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2ca16ee-e415-4270-a453-47111d07a07f.jpg?1783934509"
+    },
+    "colorIdentityOverride": []
 }
 
 // Meteor Golem

--- a/mtg-sets/src/test/resources/snapshots/cards/M20.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M20.json
@@ -1,3 +1,48 @@
+// Agonizing Syphon
+{
+    "name": "Agonizing Syphon",
+    "manaCost": "{3}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Agonizing Syphon deals 3 damage to any target and you gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            "AnyTarget"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "artist": "Seb McKinnon",
+        "flavorText": "\"Your death will take a mere moment, but it will feel like an eternity.\"\n—Vilis, Broker of Blood",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0d8efd95-1c2f-4dd1-b70b-3cfb10ff3a28.jpg?1783933001"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Angel of Vitality
 {
     "name": "Angel of Vitality",
@@ -703,6 +748,62 @@
     ]
 }
 
+// Ironroot Warlord
+{
+    "name": "Ironroot Warlord",
+    "manaCost": "{1}{G}{W}",
+    "typeLine": "Creature — Treefolk Soldier",
+    "oracleText": "Ironroot Warlord's power is equal to the number of creatures you control.\n{3}{G}{W}: Create a 1/1 white Soldier creature token.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature"
+            }
+        },
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{G}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Soldier"
+                    ]
+                },
+                "descriptionOverride": "{3}{G}{W}: Create a 1/1 white Soldier creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "209",
+        "rarity": "UNCOMMON",
+        "artist": "Filip Burburan",
+        "flavorText": "\"Alone, it's a fortification. At the head of its troops, it's a battering ram.\"\n—Skerk Hobnett, wilderness guide",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/edec85ce-7daa-48c2-b25d-b22941e01e73.jpg?1783932951"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Kykar, Wind's Fury
 {
     "name": "Kykar, Wind's Fury",
@@ -811,6 +912,57 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Pyroclastic Elemental
+{
+    "name": "Pyroclastic Elemental",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "{1}{R}{R}: This creature deals 1 damage to target player.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirements": [
+                    "TargetPlayer"
+                ],
+                "descriptionOverride": "{1}{R}{R}: This creature deals 1 damage to target player."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "296",
+        "rarity": "UNCOMMON",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"Whoever thought of making mobile volcanoes was a genius.\"\n—Chandra Nalaar",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d57f8b5-fde9-498d-82bf-34bfb2370703.jpg?1783932918"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -1268,5 +1420,45 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Winged Words
+{
+    "name": "Winged Words",
+    "manaCost": "{2}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "This spell costs {1} less to cast if you control a creature with flying.\nDraw two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        },
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "FixedIfControlFilter",
+                        "amount": 1,
+                        "filter": "creature kw:flying"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "artist": "Chris Seaman",
+        "flavorText": "Magic written across the sky falls like rain on thirsty ground, bringing forth wisdom in its season.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff765065-b160-49b6-99ac-cd695bd0d903.jpg?1783933001"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/MMQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MMQ.json
@@ -203,6 +203,61 @@
     ]
 }
 
+// Cinder Elemental
+{
+    "name": "Cinder Elemental",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "{X}{R}, {T}, Sacrifice this creature: It deals X damage to any target.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}{R}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": "XValue",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirements": [
+                    "AnyTarget"
+                ],
+                "descriptionOverride": "{X}{R}, {T}, Sacrifice this creature: It deals X damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "rarity": "UNCOMMON",
+        "artist": "Greg Staples",
+        "flavorText": "Their rage can grow to such proportions that they explode in a cloud of fire.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/0/80b39056-2ee8-4cfd-acbd-ba99f74e788d.jpg?1783945942"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Cloud Sprite
 {
     "name": "Cloud Sprite",
@@ -628,6 +683,46 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Rishadan Airship
+{
+    "name": "Rishadan Airship",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Pirate",
+    "oracleText": "Flying\nThis creature can block only creatures with flying.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CanOnlyBlockCreaturesWith",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasKeyword",
+                            "keyword": "FLYING"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "91",
+        "artist": "Kev Walker",
+        "flavorText": "The view is truly spectacular—as long as you don't look at Rishada itself.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d8e596b-f5ef-405a-8910-c5d0b5c8c0fc.jpg?1783945964"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/NPH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/NPH.json
@@ -1,3 +1,34 @@
+// Alloy Myr
+{
+    "name": "Alloy Myr",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Myr",
+    "oracleText": "{T}: Add one mana of any color.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Cavotta",
+        "flavorText": "With or without witnesses, the suns continued their prismatic dance.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/abd3350b-89fb-40b4-a942-28e0c8c274aa.jpg?1783941297"
+    },
+    "colorIdentityOverride": []
+}
+
 // Dismember
 {
     "name": "Dismember",

--- a/mtg-sets/src/test/resources/snapshots/cards/ODY.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ODY.json
@@ -5909,6 +5909,50 @@
     ]
 }
 
+// Zombie Infestation
+{
+    "name": "Zombie Infestation",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Discard two cards: Create a 2/2 black Zombie creature token.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomDiscard",
+                        "count": 2
+                    }
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie"
+                    ]
+                },
+                "descriptionOverride": "Discard two cards: Create a 2/2 black Zombie creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "rarity": "UNCOMMON",
+        "artist": "Thomas M. Baxa",
+        "flavorText": "The nomads' funeral pyres are more practical than ceremonial.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/ccd5f98a-7ab5-44b3-850c-b50963dace66.jpg?1783945237"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Zombify
 {
     "name": "Zombify",

--- a/mtg-sets/src/test/resources/snapshots/cards/ORI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ORI.json
@@ -149,6 +149,30 @@
     ]
 }
 
+// Boggart Brute
+{
+    "name": "Boggart Brute",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "metadata": {
+        "collectorNumber": "133",
+        "artist": "Igor Kieryluk",
+        "flavorText": "He has the biggest bashing stick, so it's a safe bet he's the leader.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d735ebf-61a4-4507-9399-6d32c8903ded.jpg?1783938333"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Caustic Caterpillar
 {
     "name": "Caustic Caterpillar",
@@ -774,6 +798,47 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Languish
+{
+    "name": "Languish",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "All creatures get -4/-4 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": -4
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": -4
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "rarity": "RARE",
+        "artist": "Jeff Simpson",
+        "flavorText": "Life is such a fragile thing.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d3593efa-0a05-4061-9f6e-edd0a5ca9a1f.jpg?1783938340"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/PC2.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/PC2.json
@@ -43,6 +43,101 @@
     ]
 }
 
+// Beetleback Chief
+{
+    "name": "Beetleback Chief",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "When this creature enters, create two 1/1 red Goblin creature tokens.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Goblin"
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, create two 1/1 red Goblin creature tokens."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "rarity": "UNCOMMON",
+        "artist": "Wayne England",
+        "flavorText": "Whether trained, ridden, or eaten, few goblin military innovations have rivaled the bug.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e3ccf3d-583c-46b4-b51e-ae1b0628d506.jpg?1783940621"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Brindle Shoat
+{
+    "name": "Brindle Shoat",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Boar",
+    "oracleText": "When this creature dies, create a 3/3 green Boar creature token.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 3,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Boar"
+                    ]
+                },
+                "descriptionOverride": "When this creature dies, create a 3/3 green Boar creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "rarity": "UNCOMMON",
+        "artist": "Steven Belledin",
+        "flavorText": "Hunters lure the stripling boar into the open, hoping to trap greater prey.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e40569c-640b-4a1a-a586-bde37de5591f.jpg?1783940614"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Maelstrom Wanderer
 {
     "name": "Maelstrom Wanderer",

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -2951,6 +2951,56 @@
     ]
 }
 
+// Primordial Sage
+{
+    "name": "Primordial Sage",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Whenever you cast a creature spell, you may draw a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                "descriptionOverride": "Whenever you cast a creature spell, you may draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "rarity": "RARE",
+        "artist": "Justin Sweet",
+        "flavorText": "For each creature that arrives in its audience, the sage imparts another piece of ancient wisdom for all to hear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e11e6d8-d375-4278-8cb0-94deeecaeeca.jpg?1783943634"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Privileged Position
 {
     "name": "Privileged Position",

--- a/mtg-sets/src/test/resources/snapshots/cards/RIX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RIX.json
@@ -513,6 +513,53 @@
     ]
 }
 
+// Raging Regisaur
+{
+    "name": "Raging Regisaur",
+    "manaCost": "{2}{R}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Whenever this creature attacks, it deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                },
+                "descriptionOverride": "Whenever this creature attacks, it deals 1 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "rarity": "UNCOMMON",
+        "artist": "Bayard Wu",
+        "flavorText": "Its breath is a gale. Its roar is a volcano. Its anger tears soul from flesh.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad6c43a7-e9c5-4b1c-9a6d-0d8798303045.jpg?1783935270"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
 // Ravenous Chupacabra
 {
     "name": "Ravenous Chupacabra",

--- a/mtg-sets/src/test/resources/snapshots/cards/RNA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RNA.json
@@ -681,6 +681,46 @@
     ]
 }
 
+// Sylvan Brushstrider
+{
+    "name": "Sylvan Brushstrider",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "When this creature enters, you gain 2 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "When this creature enters, you gain 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "The mournful lowing of brushstriders warns of changing weather and ill winds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8bc288a3-ea56-450a-96fd-c2123121f663.jpg?1783933664"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Wilderness Reclamation
 {
     "name": "Wilderness Reclamation",

--- a/mtg-sets/src/test/resources/snapshots/cards/ROE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ROE.json
@@ -1,3 +1,62 @@
+// Affa Guard Hound
+{
+    "name": "Affa Guard Hound",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Dog",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, target creature gets +0/+3 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                },
+                "descriptionOverride": "When this creature enters, target creature gets +0/+3 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "rarity": "UNCOMMON",
+        "artist": "Ryan Pancoast",
+        "flavorText": "Once a welcoming hub for explorers, Affa became a place of guarded tongues and quick defenses.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/85623f54-1c18-4b1e-a8da-df66de3832a6.jpg?1783942011"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Artisan of Kozilek
 {
     "name": "Artisan of Kozilek",
@@ -127,6 +186,62 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Cadaver Imp
+{
+    "name": "Cadaver Imp",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Creature — Imp",
+    "oracleText": "Flying\nWhen this creature enters, you may return target creature card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature card in your graveyard"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card in your graveyard"
+                },
+                "descriptionOverride": "When this creature enters, you may return target creature card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "artist": "Dave Kendall",
+        "flavorText": "The mouth must be pried open before rigor mortis sets in. Otherwise the returning soul can find no ingress.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b2f83d5-9269-4297-b507-558c2bdec32b.jpg?1783941988"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -328,6 +443,62 @@
     ]
 }
 
+// Kiln Fiend
+{
+    "name": "Kiln Fiend",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Elemental Beast",
+    "oracleText": "Whenever you cast an instant or sorcery spell, this creature gets +3/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever you cast an instant or sorcery spell, this creature gets +3/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "artist": "Adi Granov",
+        "flavorText": "It traps an explosion within its stony skin.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c584268-67c3-411b-a26c-aee3adf23872.jpg?1783941974"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Lagac Lizard
 {
     "name": "Lagac Lizard",
@@ -478,6 +649,87 @@
         "imageUri": "https://cards.scryfall.io/normal/front/c/f/cfb90d44-8cb1-4b83-b2f2-92c19d6304fb.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Sea Gate Oracle
+{
+    "name": "Sea Gate Oracle",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "When this creature enters, look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Put on bottom"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "artist": "Daniel Ljunggren",
+        "flavorText": "\"The secret entrance should be near.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd056c91-5026-41ea-bc9e-68078d78ca82.jpg?1783941992"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // Wildheart Invoker

--- a/mtg-sets/src/test/resources/snapshots/cards/RTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RTR.json
@@ -1,3 +1,46 @@
+// Auger Spree
+{
+    "name": "Auger Spree",
+    "manaCost": "{1}{B}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +4/-4 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -4
+            },
+            "target": {
+                "type": "ContextTarget",
+                "index": 0
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "artist": "Raymond Swanland",
+        "flavorText": "\"Finally, a weapon the Boros can't confiscate!\"\n—Juri, proprietor of the Juri Revue",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/9580a40b-b413-4f0d-9b38-13903a9d367d.jpg?1783940345"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Axebane Stag
 {
     "name": "Axebane Stag",
@@ -60,6 +103,31 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLUE"
+    ]
+}
+
+// Brushstrider
+{
+    "name": "Brushstrider",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "117",
+        "rarity": "UNCOMMON",
+        "artist": "Raoul Vitale",
+        "flavorText": "Magistrate Ludy agreed to designate land for the brushstriders only after several broken windows and dozens of missing blini-cakes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/59bd1534-52d1-4946-b430-d26f039a9067.jpg?1783940350"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -160,6 +228,98 @@
         "rarity": "RARE",
         "artist": "Jason Chan",
         "imageUri": "https://cards.scryfall.io/normal/front/8/2/8242fade-754c-4404-b3fb-f3cccf84b3b6.jpg?1782714261"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Drainpipe Vermin
+{
+    "name": "Drainpipe Vermin",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Rat",
+    "oracleText": "When this creature dies, you may pay {B}. If you do, target player discards a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{B}"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "chooser": "TargetPlayer",
+                                "storeSelected": "discarded",
+                                "prompt": "Choose 1 card to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                },
+                "descriptionOverride": "When this creature dies, you may pay {B}. If you do, target player discards a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "artist": "Trevor Claxton",
+        "flavorText": "When times are tough, the poor eat the rats. When times are tougher, the rats eat the poor.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4d7251f3-df66-4611-a84c-1897f74431f7.jpg?1783940362"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -426,6 +586,65 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Knightly Valor
+{
+    "name": "Knightly Valor",
+    "manaCost": "{4}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, create a 2/2 white Knight creature token with vigilance. (Attacking doesn't cause it to tap.)\nEnchanted creature gets +2/+2 and has vigilance.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Knight"
+                    ],
+                    "keywords": [
+                        "VIGILANCE"
+                    ]
+                },
+                "descriptionOverride": "When this Aura enters, create a 2/2 white Knight creature token with vigilance."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "artist": "Matt Stewart",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/122d821f-c8dd-4a3c-a6d7-b42fe5491f02.jpg?1783940374"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/S99.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/S99.json
@@ -42,6 +42,58 @@
     ]
 }
 
+// Goblin Commando
+{
+    "name": "Goblin Commando",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Goblin",
+    "oracleText": "When this creature enters, it deals 2 damage to target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                },
+                "descriptionOverride": "When this creature enters, it deals 2 damage to target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "rarity": "UNCOMMON",
+        "artist": "Todd Lockwood",
+        "flavorText": "With a commando around, somebody's gonna get hurt.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/da90043b-0e67-4a68-b6fb-0ca53ca7defc.jpg?1783946030"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Sea Eagle
 {
     "name": "Sea Eagle",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -953,6 +953,49 @@
     ]
 }
 
+// Cathar's Companion
+{
+    "name": "Cathar's Companion",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Dog",
+    "oracleText": "Whenever you cast a noncreature spell, this creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever you cast a noncreature spell, this creature gains indestructible until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"Unwavering and loyal, they represent stability in uncertain times.\"\n—Rem Karolus, Slayer of Angels",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f4b9943-0fe6-4383-90a0-4a719dcf9499.jpg?1783937824"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Crow of Dark Tidings
 {
     "name": "Crow of Dark Tidings",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOM.json
@@ -520,6 +520,53 @@
     ]
 }
 
+// Perilous Myr
+{
+    "name": "Perilous Myr",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Phyrexian Myr",
+    "oracleText": "When this creature dies, it deals 2 damage to any target.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                },
+                "descriptionOverride": "When this creature dies, it deals 2 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "artist": "Jason Felix",
+        "flavorText": "To Mirrodin, an explosive. To Phyrexia, a missionary.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b942605-eb4a-452d-9b07-a4f912f96958.jpg?1783941699"
+    },
+    "colorIdentityOverride": []
+}
+
 // Plated Seastrider
 {
     "name": "Plated Seastrider",

--- a/mtg-sets/src/test/resources/snapshots/cards/STH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STH.json
@@ -421,6 +421,50 @@
     ]
 }
 
+// Wall of Blossoms
+{
+    "name": "Wall of Blossoms",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Plant Wall",
+    "oracleText": "Defender\nWhen this creature enters, draw a card.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "When this creature enters, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "UNCOMMON",
+        "artist": "Heather Hudson",
+        "flavorText": "Each flower identical, every leaf and petal disturbingly exact.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7eb4a1a3-efcf-4c9a-ad1f-0a3f8f2b456f.jpg?1783946546"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Youthful Knight
 {
     "name": "Youthful Knight",

--- a/mtg-sets/src/test/resources/snapshots/cards/THS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THS.json
@@ -133,6 +133,41 @@
     ]
 }
 
+// Feral Invocation
+{
+    "name": "Feral Invocation",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nEnchant creature\nEnchanted creature gets +2/+2.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "artist": "Mathias Kollros",
+        "flavorText": "Nylea's sacred lynx guards those who honor the Nessian Wood and hunts those who don't.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5c1f15a2-0058-4188-9696-385fa6974bd4.jpg?1783939745"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Hero's Downfall
 {
     "name": "Hero's Downfall",
@@ -292,6 +327,54 @@
     ]
 }
 
+// Minotaur Skullcleaver
+{
+    "name": "Minotaur Skullcleaver",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Minotaur Berserker",
+    "oracleText": "Haste\nWhen this creature enters, it gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "When this creature enters, it gets +2/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "artist": "Phill Simmer",
+        "flavorText": "\"Their only dreams are of full stomachs.\"\n—Kleon the Iron-Booted",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/6854c913-d4bd-42f7-901c-f3c25be5c4b2.jpg?1783939759"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Pheres-Band Centaurs
 {
     "name": "Pheres-Band Centaurs",
@@ -309,6 +392,56 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Prescient Chimera
+{
+    "name": "Prescient Chimera",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Chimera",
+    "oracleText": "Flying\nWhenever you cast an instant or sorcery spell, scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                },
+                "descriptionOverride": "Whenever you cast an instant or sorcery spell, scry 1."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "artist": "Daarken",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f9342aba-e3aa-4210-ad72-e609c7c027b8.jpg?1783939794"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -656,6 +789,50 @@
         "artist": "Howard Lyon",
         "flavorText": "At sunrise, the Champion and her companions awoke to find their supplies gone and Brygus, their sentry, dead. Carefully arranged piles of ornamental shells gave a clear warning: go no further.\n—*The Theriad*",
         "imageUri": "https://cards.scryfall.io/normal/front/d/8/d8f0fe22-dc89-4ad8-b5f6-6d91b61f1385.jpg?1783939787"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Voyage's End
+{
+    "name": "Voyage's End",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target creature to its owner's hand. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "artist": "Chris Rahn",
+        "flavorText": "Philosophers say those lost at sea ascended to a more perfect realm. Sailors say they drowned.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/3992ae67-ad0b-40be-a97d-d7fb36754918.jpg?1783939787"
     },
     "colorIdentityOverride": [
         "BLUE"

--- a/mtg-sets/src/test/resources/snapshots/cards/TSP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TSP.json
@@ -216,6 +216,78 @@
     ]
 }
 
+// Fortify
+{
+    "name": "Fortify",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Creatures you control get +2/+0 until end of turn.\n• Creatures you control get +0/+2 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Creatures you control get +2/+0 until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Creatures you control get +0/+2 until end of turn"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Christopher Moeller",
+        "flavorText": "\"Where metal is tainted and wood is scarce, we are best armed by faith.\"\n—Tavalus, acolyte of Korlis",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd063dc7-a35c-44c9-9f8d-b7bb2dc95bec.jpg?1783943254"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Havenwood Wurm
 {
     "name": "Havenwood Wurm",

--- a/mtg-sets/src/test/resources/snapshots/cards/WAR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WAR.json
@@ -43,6 +43,46 @@
     ]
 }
 
+// Bulwark Giant
+{
+    "name": "Bulwark Giant",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Giant Soldier",
+    "oracleText": "When this creature enters, you gain 5 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                },
+                "descriptionOverride": "When this creature enters, you gain 5 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "artist": "Victor Adame Minguez",
+        "flavorText": "\"Where did she come from? More importantly, are there more like her?\"\n—Gideon Jura",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11510817-edb3-40d4-bd27-6161fedadd11.jpg?1783933488"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Casualties of War
 {
     "name": "Casualties of War",
@@ -371,6 +411,155 @@
     ]
 }
 
+// Erratic Visionary
+{
+    "name": "Erratic Visionary",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{1}{U}, {T}: Draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "descriptionOverride": "{1}{U}, {T}: Draw a card, then discard a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "artist": "Randy Vargas",
+        "flavorText": "An Izzet experiment begins with a \"what if,\" gets approved with a \"why not,\" and concludes with a \"eureka!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/03188bc3-0ef1-40cd-9c3c-4bb4d806fb92.jpg?1783933466"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Eternal Taskmaster
+{
+    "name": "Eternal Taskmaster",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "This creature enters tapped.\nWhenever this creature attacks, you may pay {2}{B}. If you do, return target creature card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{2}{B}"
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature card in your graveyard"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card in your graveyard"
+                },
+                "descriptionOverride": "Whenever this creature attacks, you may pay {2}{B}. If you do, return target creature card from your graveyard to your hand."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "rarity": "UNCOMMON",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "\"They are called Eternals. They will never stop.\"\n—Jace Beleren",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/7789188e-5caa-4500-b3e4-bb95f7657903.jpg?1783933446"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Finale of Revelation
 {
     "name": "Finale of Revelation",
@@ -468,6 +657,48 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Heartfire
+{
+    "name": "Heartfire",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a creature or planeswalker.\nHeartfire deals 4 damage to any target.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "ContextTarget",
+                "index": 0
+            }
+        },
+        "targetRequirements": [
+            "AnyTarget"
+        ],
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature|planeswalker"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "artist": "Craig J Spearing",
+        "flavorText": "The mage looked within and realized there was still one piece of fuel to burn.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7db219ea-2ed1-4a86-955c-d61ecedbc019.jpg?1783933427"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -745,6 +976,46 @@
     ]
 }
 
+// Mana Geode
+{
+    "name": "Mana Geode",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, scry 1.\n{T}: Add one mana of any color.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                },
+                "descriptionOverride": "When this artifact enters, scry 1."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "artist": "Raoul Vitale",
+        "flavorText": "\"I don't care if it's an all-powerful relic or a street vendor's lucky charm. If it brings you courage, wear it.\"\n—Saheeli Rai",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/7/17315a12-a7f8-45ba-ac3b-a62c789e75d0.jpg?1783933371"
+    },
+    "colorIdentityOverride": []
+}
+
 // Naga Eternal
 {
     "name": "Naga Eternal",
@@ -869,6 +1140,81 @@
         "artist": "James Paick",
         "flavorText": "Freed from their respective labs, the two weirds formed a partnership, feeding on the arcane energies of war.",
         "imageUri": "https://cards.scryfall.io/normal/front/9/1/91551f85-4630-43a0-af72-8332d2ff0752.jpg?1557576817"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Tibalt's Rager
+{
+    "name": "Tibalt's Rager",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Devil",
+    "oracleText": "When this creature dies, it deals 1 damage to any target.\n{1}{R}: This creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                },
+                "descriptionOverride": "When this creature dies, it deals 1 damage to any target."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{1}{R}: This creature gets +2/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "rarity": "UNCOMMON",
+        "artist": "Yongjae Choi",
+        "flavorText": "\"Find out whose that is. I like its energy.\"\n—Judith",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/2985520d-dfce-414e-a4ac-61695be67406.jpg?1783933420"
     },
     "colorIdentityOverride": [
         "RED"

--- a/mtg-sets/src/test/resources/snapshots/cards/XLN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/XLN.json
@@ -277,6 +277,59 @@
     ]
 }
 
+// Drover of the Mighty
+{
+    "name": "Drover of the Mighty",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Druid",
+    "oracleText": "This creature gets +2/+2 as long as you control a Dinosaur.\n{T}: Add one mana of any color.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "permanent Dinosaur"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Deschamps",
+        "flavorText": "\"I do not lead. They do not follow. We walk together.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/1/51fdf2fc-d948-4c64-a34e-2f90eab83212.jpg?1783935726"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Fiery Cannonade
 {
     "name": "Fiery Cannonade",
@@ -1568,6 +1621,68 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Thundering Spineback
+{
+    "name": "Thundering Spineback",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Other Dinosaurs you control get +1/+1.\n{5}{G}: Create a 3/3 green Dinosaur creature token with trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 3,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Dinosaur"
+                    ],
+                    "keywords": [
+                        "TRAMPLE"
+                    ]
+                },
+                "descriptionOverride": "{5}{G}: Create a 3/3 green Dinosaur creature token with trample."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "permanent Dinosaur ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "rarity": "UNCOMMON",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "\"It appears that nature has risen against us.\"\n—Captain Brinely Rage",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/35711da6-aac4-4c2a-b324-aebeaa843adc.jpg?1783935718"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
@@ -981,6 +981,54 @@
     "colorIdentityOverride": []
 }
 
+// Molten Ravager
+{
+    "name": "Molten Ravager",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "{R}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{R}: This creature gets +1/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "artist": "Dave Kendall",
+        "flavorText": "\"Only the foolhardy would venture into the Akoum Mountains without a lullmage to tame the raging rocks and living fires.\"\n—Sachir, Akoum Expeditionary House",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9ebc7622-e7a7-419c-abb4-d9d339e6cdb0.jpg?1783942142"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Pillarfield Ox
 {
     "name": "Pillarfield Ox",


### PR DESCRIPTION
Implements every card Argentum Assay already reads whole that Jumpstart was still missing — the
⚡ **Assay-ready** filter on the Set Completion view, which is 101 of JMP's 460 booster cards.
Assay reading a card end to end means it needs no new SDK vocabulary, so all 96 non-land cards here
compose existing `Effects.*` / `Triggers.*` / `Patterns.*` primitives; nothing new was added to the SDK,
and no card was dropped from the batch.

JMP booster coverage: **145/460 → 246/460**. Assay-ready-but-missing: **101 → 0**.

## Where the cards live

Jumpstart is a reprint set, so only 7 of these are canonical here (Archaeomender, Chained Brute,
Lightning Visionary, Lightning-Core Excavator, Sethron Hurloon General, Stone Haven Pilgrim, Trusty
Retriever). The other 89 canonical `CardDefinition`s go to each card's earliest real printing across
47 sets, and Jumpstart gets a `Printing` row — plus rows in the 29 cards' other scaffolded reprint sets,
so `just check-card-printing` is clean for all 96.

Also adds Jumpstart's forty basic land arts and wires `basicLands` into `JumpstartSet`.

## The cards

**Vanilla / keyword-only** — Gifted Aetherborn, Pouncing Cheetah, Murmuring Phantasm, Child of Night,
Wall of Vines, Knight of the Tusk, Brushstrider, Boggart Brute, Lightning Visionary.

**Activated pumps and grants** (`Costs.Mana` + `Effects.ModifyStats` / `Effects.GrantKeyword`) —
Blighted Bat, Minotaur Sureshot, Jousting Dummy, Molten Ravager, Dragon Hatchling, Tibalt's Rager,
Alabaster Mage, Pyroclastic Elemental, Erratic Visionary.

**Enters-the-battlefield triggers** (`Triggers.EntersBattlefield`) — Bloodrage Brawler, Sylvan
Brushstrider, Bulwark Giant, Wall of Blossoms, Minotaur Skullcleaver, Bloodhunter Bat
(`Effects.DrainLife`), Goblin Commando, Affa Guard Hound, Cadaver Imp, Archaeomender, Goblin
Instigator, Beetleback Chief, Sea Gate Oracle (`Patterns.Library.lookAtTopAndKeep`), Sylvan Ranger
(`Patterns.Library.searchLibrary`), Mana Geode, Trusty Retriever (`ModalEffect.chooseOne`).

**Dies triggers** (`Triggers.Dies`) — Feral Prowler, Perilous Myr, Shambling Goblin, Lawless Broker,
Brindle Shoat, Drainpipe Vermin (`MayPayManaEffect`).

**Attack and combat-damage triggers** — Inspiring Unicorn, Raging Regisaur, Stone Haven Pilgrim
(`interveningIf`), Eternal Taskmaster (`EntersTapped` + `MayPayManaEffect`), Initiate's Companion,
Keeper of Fables (CR 603.2c batch trigger, `batch = true`).

**Cast triggers** — Kiln Fiend, Prescient Chimera, Talrand Sky Summoner, Weaver of Lightning,
Cathar's Companion, Primordial Sage, Soul of the Harvest, Sethron Hurloon General.

**Statics** — Nightshade Stinger (`CantBlock`), Rishadan Airship (`CanOnlyBlockCreaturesWith`),
Dragonloft Idol and Drover of the Mighty (`ConditionalStaticAbility` over
`Conditions.ControlPermanentOfType`), Thundering Spineback (subtype lord), Ironroot Warlord
(`dynamicPower` CDA), Chained Brute (`AbilityFlag.DOESNT_UNTAP`).

**Sacrifice and mana outlets** — Sigiled Starfish, Leaf Gilder, Alloy Myr, Signpost Scarecrow, Ronom
Unicorn, Torch Fiend, Lightning-Core Excavator, Cinder Elemental (`DynamicAmount.XValue`), Plagued
Rusalka, Barrage of Expendables, Blood Host, Zombie Infestation, Scroll of Avacyn, Unstable Obelisk,
Scarecrone, Buried Ruin, Mirrodin's Core (charge counters).

**Auras and Equipment** — Mark of the Vampire, Feral Invocation, Lightning Diadem, Knightly Valor,
Marauder's Axe.

**Instants and sorceries** — Aegis of the Heavens, Auger Spree, Bathe in Dragonfire, Agonizing Syphon,
Voyage's End, Flurry of Horns, Languish, Volcanic Fallout (`cantBeCountered`), Collateral Damage,
Heartfire, Blood Divination (additional sacrifice costs), Winged Words (`ModifySpellCost`), Fortify
(modal).

## Verification

- `just build` — green (engine, SDK, all era card suites, game-server).
- `CardLintTest`, `FacadeBoundaryTest`, `BasicLandArtOrderTest`, `MtgSetCatalogTest` — all pass.
- `just rebless-cards` — 48 per-set goldens moved, **purely additive**: zero removed lines across the
  whole snapshot diff, and every added entry is one of these cards.
- `just check-card-printing "<Card>"` — clean for all 96.

No scenario tests: per the `add-card` skill, a card built entirely from existing primitives is covered
by the snapshot and lint nets, and none of these needed new SDK vocabulary.

## One modelling note

**Sethron, Hurloon General** — "Whenever Sethron **or another nontoken Minotaur** you control enters" is
written as the corpus's existing shape for that sentence (Headless Rider): one `TriggerBinding.ANY`
trigger over a `nontoken()` filter. The "nontoken" qualifier therefore also applies to Sethron himself,
so a *token copy* of Sethron would not see its own entry. That matches how the repo already spells this
family; splitting it into a SELF trigger plus an OTHER trigger would be exact but would make the card
carry two abilities where the print has one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
