### PR TITLE
Add Psychogenic Probe with a library-shuffle trigger

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5222,6 +5222,27 @@ Triggers.youCastSpell(
   variant is used by **Wan Shi Tong, Librarian** ("Whenever an opponent searches their library, put a
   +1/+1 counter on him and draw a card").
 
+### Library shuffle (CR 701.24)
+
+- `WheneverAPlayerShufflesTheirLibrary` — the shuffle twin of the search trigger, backed by the
+  `ShuffleLibraryEvent(player)` pattern + the engine `LibraryShuffledEvent`. Fires once per shuffle,
+  so every shuffle the engine performs on behalf of an effect drives it: `Effects.ShuffleLibrary`,
+  the shuffle leg of every search pipeline, `ZonePlacement.Shuffled` moves, and the
+  shuffle-into-library replacement effects (Darksteel Colossus). Used by **Psychogenic Probe**
+  ("Whenever a spell or ability causes a player to shuffle their library, this artifact deals 2
+  damage to that player"). `Player.TriggeringPlayer` inside the effect resolves to the shuffler, so
+  "that player" is reachable; the default `Player.Any` is the printed "a player" and includes the
+  ability's own controller.
+  - Being one event per shuffle gives three CR 701.24 clauses for free: a search-then-shuffle fires
+    it even though the found cards are held out of the randomization (701.24b), a library holding
+    zero or one cards still fires it (701.24e), and two effects shuffling one library simultaneously
+    fire it twice (701.24f).
+  - **Only spell- and ability-caused shuffles match**, which is the only printed wording. The game
+    rules also shuffle while setting the game up (CR 103.2) and when a player mulligans (CR 103.5);
+    the engine tags those two emission sites with `ShuffleCause.GAME_SETUP` / `ShuffleCause.MULLIGAN`
+    and the matcher drops them. `ShuffleCause.SPELL_OR_ABILITY` is the default, so a new
+    effect-driven shuffle site is picked up without opting in.
+
 ### Manifest Dread
 
 - `WheneverYouManifestDread` — fires once per manifest-dread resolution (CR 701.60), after the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -2550,6 +2550,28 @@ object Triggers {
     )
 
     // =========================================================================
+    // Library Shuffle Triggers (CR 701.24)
+    // =========================================================================
+
+    /**
+     * Whenever a spell or ability causes a player to shuffle their library (CR 701.24) — the
+     * shuffle twin of [WheneverYouSearchYourLibrary], used by Psychogenic Probe. Emitted by every
+     * shuffle the engine performs on behalf of an effect, so tutors, fetches, "shuffle it into its
+     * owner's library" replacement effects, and bare `Effects.ShuffleLibrary` all drive it.
+     *
+     * Scope it with [Player.You] / [Player.EachOpponent]; the default [Player.Any] is the printed
+     * "a player", which includes the ability's own controller. `Player.TriggeringPlayer` inside the
+     * effect resolves to the player who shuffled, so "that player" is reachable.
+     *
+     * The game-rules shuffles — setting up the game (CR 103.2) and mulliganing (CR 103.5) — are
+     * caused by neither a spell nor an ability and never fire this.
+     */
+    val WheneverAPlayerShufflesTheirLibrary: TriggerSpec = TriggerSpec(
+        event = ShuffleLibraryEvent(Player.Any),
+        binding = TriggerBinding.ANY
+    )
+
+    // =========================================================================
     // Manifest Dread Triggers (CR 701.60)
     // =========================================================================
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -735,6 +735,31 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
         override val description: String = "${player.description} searches their library"
     }
 
+    /**
+     * Whenever a spell or ability causes [player] to shuffle their library (CR 701.24). The
+     * search twin of [SearchLibraryEvent], and the shape Psychogenic Probe keys on.
+     *
+     * Deliberately restricted to spell- and ability-caused shuffles, matching the only printed
+     * wording: the game rules also shuffle each library while setting up (CR 103.2) and when a
+     * player mulligans (CR 103.5), and neither may fire an ability. The engine tags those two
+     * emission sites, so nothing here has to know about them.
+     *
+     * Every shuffle primitive emits it — `Effects.ShuffleLibrary`, the shuffle leg of every
+     * search pipeline, `ZonePlacement.Shuffled` moves, and the shuffle-into-library replacement
+     * effects (Darksteel Colossus). Three consequences of CR 701.24 come free from being one
+     * event per shuffle: a search-then-shuffle still fires it even though the found cards are
+     * held out of the randomization (701.24b), a library holding zero or one cards still fires
+     * it (701.24e), and two effects shuffling one library simultaneously fire it twice (701.24f).
+     */
+    @SerialName("ShuffleLibraryEvent")
+    @Serializable
+    data class ShuffleLibraryEvent(
+        val player: Player = Player.Any
+    ) : EventPattern {
+        override val description: String =
+            "a spell or ability causes ${player.description} to shuffle their library"
+    }
+
     // =========================================================================
     // Trigger-Only Events (below here — used only as trigger filters)
     // =========================================================================

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/PsychogenicProbe.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/PsychogenicProbe.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Psychogenic Probe — Mirrodin #231
+ * {2} · Artifact
+ *
+ * Whenever a spell or ability causes a player to shuffle their library, this artifact deals
+ * 2 damage to that player.
+ *
+ * A symmetric observer trigger on the shuffle event (CR 701.24), built on
+ * [Triggers.WheneverAPlayerShufflesTheirLibrary] — the shuffle twin of the library-search trigger.
+ * `Player.Any` is the printed "a player", so the Probe punishes its own controller too, and
+ * `Player.TriggeringPlayer` carries "that player" through to the damage.
+ *
+ * Three rules consequences fall out of the trigger firing once per shuffle rather than once per
+ * effect: a fetch land or tutor that searches and then shuffles fires it even though the found
+ * cards are held out of the randomization (CR 701.24b); an empty or one-card library still fires
+ * it (CR 701.24e, and the 2009 ruling below); and two effects shuffling the same library at once
+ * fire it twice (CR 701.24f). Shuffling to set the game up (CR 103.2) and to take a mulligan
+ * (CR 103.5) are caused by neither a spell nor an ability, so neither fires it.
+ */
+val PsychogenicProbe = card("Psychogenic Probe") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever a spell or ability causes a player to shuffle their library, " +
+        "this artifact deals 2 damage to that player."
+
+    triggeredAbility {
+        trigger = Triggers.WheneverAPlayerShufflesTheirLibrary
+        effect = Effects.DealDamage(2, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "231"
+        artist = "Jeremy Jarvis"
+        flavorText = "The same devices sold as surgeons' tools in Lumengrid are sold as " +
+            "implements of torture in Mephidross."
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/" +
+            "e83d1ed5-3a49-4cfa-bad2-e342ef28649e.jpg?1783944507"
+        ruling(
+            "2009-02-01",
+            "This ability will trigger even if the player's library is empty at the time they " +
+                "are supposed to shuffle it."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PsychogenicProbeScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PsychogenicProbeScenarioTest.kt
@@ -1,0 +1,193 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.LibraryShuffledEvent
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.ShuffleCause
+import com.wingedsheep.engine.core.TakeMulligan
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.Fabricate
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.MyrMindservant
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.PsychogenicProbe
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Psychogenic Probe (MRD #231) — "Whenever a spell or ability causes a player to shuffle their
+ * library, this artifact deals 2 damage to that player."
+ *
+ * The card is a one-line trigger over a new event shape, so the tests are all about *what counts
+ * as a shuffle*. Three of them come straight out of CR 701.24 and would each pass a naive
+ * implementation that fired only on a bare "shuffle your library" effect:
+ *
+ * - **701.24b** — a tutor's search-then-shuffle leg still shuffles, even though the found cards are
+ *   held out of the randomization. Fabricate covers it.
+ * - **701.24e** — an empty library is still shuffled, and the 2009 ruling on the card says so
+ *   explicitly. This is the one an "only shuffle if there's something to shuffle" short-circuit
+ *   in the executor would quietly break.
+ * - **701.24f** — the trigger is per *shuffle*, and each Probe is its own ability, so two Probes
+ *   watching one shuffle deal 4.
+ *
+ * The other half is the word **"causes"**: the game rules also shuffle every library while setting
+ * the game up (CR 103.2) and whenever a player mulligans (CR 103.5), and neither is a spell or an
+ * ability. Those two never reach a battlefield trigger in a real game because nothing is on the
+ * battlefield yet — which is exactly why the exclusion has to be asserted on the event's own
+ * `cause` tag rather than on a life total.
+ */
+class PsychogenicProbeScenarioTest : FunSpec({
+
+    val mindservantAbility = MyrMindservant.activatedAbilities.single().id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + PsychogenicProbe + MyrMindservant + Fabricate)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** Put a Myr Mindservant under [playerId] that can pay `{2}, {T}` right now. */
+    fun GameTestDriver.readyMindservant(playerId: EntityId): EntityId {
+        val myr = putCreatureOnBattlefield(playerId, "Myr Mindservant")
+        removeSummoningSickness(myr)
+        giveColorlessMana(playerId, 2)
+        return myr
+    }
+
+    /**
+     * Activate a ready Mindservant and let the shuffle — and any Probe trigger — resolve. The
+     * board is set up in player 1's main phase, so hand priority over first when the non-active
+     * player is the one activating.
+     */
+    fun GameTestDriver.shuffleWith(playerId: EntityId, myr: EntityId) {
+        while (priorityPlayer != playerId) passPriority(priorityPlayer!!)
+        submit(ActivateAbility(playerId, myr, mindservantAbility)).isSuccess shouldBe true
+        bothPass()
+        while (stackSize > 0) bothPass()
+    }
+
+    test("an ability that shuffles a player's library deals 2 to that player") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        d.putPermanentOnBattlefield(d.player1, "Psychogenic Probe")
+        val myr = d.readyMindservant(opponent)
+
+        d.shuffleWith(opponent, myr)
+
+        withClue("the shuffler takes the damage, not the Probe's controller") {
+            d.getLifeTotal(opponent) shouldBe 18
+            d.getLifeTotal(d.player1) shouldBe 20
+        }
+    }
+
+    test("the Probe is symmetric — its own controller shuffling takes 2 as well") {
+        // "a player", not "an opponent". A trigger scoped to Player.EachOpponent passes the test
+        // above and fails this one.
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        d.putPermanentOnBattlefield(d.player1, "Psychogenic Probe")
+        val myr = d.readyMindservant(d.player1)
+
+        d.shuffleWith(d.player1, myr)
+
+        withClue("the Probe punishes its controller too") {
+            d.getLifeTotal(d.player1) shouldBe 18
+            d.getLifeTotal(opponent) shouldBe 20
+        }
+    }
+
+    test("an empty library is still shuffled, and still deals 2 (CR 701.24e)") {
+        val d = driver()
+        d.putPermanentOnBattlefield(d.player1, "Psychogenic Probe")
+        val myr = d.readyMindservant(d.player1)
+        val library = ZoneKey(d.player1, Zone.LIBRARY)
+        d.replaceState(d.state.copy(zones = d.state.zones + (library to emptyList())))
+
+        d.shuffleWith(d.player1, myr)
+
+        withClue("the 2009 ruling: it triggers even with nothing to shuffle") {
+            d.state.getZone(library).shouldBeInstanceOf<List<EntityId>>().size shouldBe 0
+            d.getLifeTotal(d.player1) shouldBe 18
+        }
+    }
+
+    test("a tutor's search-then-shuffle deals 2 (CR 701.24b)") {
+        // Fabricate: "Search your library for an artifact card, reveal it, put it into your hand,
+        // then shuffle." The found card sits out of the randomization; the library is shuffled
+        // regardless, so the trigger fires.
+        val d = driver()
+        d.putPermanentOnBattlefield(d.player1, "Psychogenic Probe")
+        d.putCardOnTopOfLibrary(d.player1, "Myr Mindservant")
+        val fabricate = d.putCardInHand(d.player1, "Fabricate")
+        d.giveColorlessMana(d.player1, 2)
+        d.giveMana(d.player1, Color.BLUE, 1)
+
+        d.castSpell(d.player1, fabricate).isSuccess shouldBe true
+        d.bothPass()
+
+        val search = d.state.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        d.submitCardSelection(d.player1, search.options.take(1))
+        while (d.stackSize > 0 || d.state.pendingDecision != null) {
+            if (d.state.pendingDecision != null) d.autoResolveDecision() else d.bothPass()
+        }
+
+        withClue("the search's shuffle leg fires the Probe") {
+            d.getLifeTotal(d.player1) shouldBe 18
+        }
+    }
+
+    test("two Probes see one shuffle and deal 4 (CR 701.24f)") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        d.putPermanentOnBattlefield(d.player1, "Psychogenic Probe")
+        d.putPermanentOnBattlefield(d.player1, "Psychogenic Probe")
+        val myr = d.readyMindservant(opponent)
+
+        d.shuffleWith(opponent, myr)
+
+        withClue("each Probe is its own triggered ability") {
+            d.getLifeTotal(opponent) shouldBe 16
+        }
+    }
+
+    test("shuffling to set the game up is not caused by a spell or ability") {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + PsychogenicProbe)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingPlayer = 0)
+
+        val shuffles = d.events.filterIsInstance<LibraryShuffledEvent>()
+        withClue("every library is shuffled while the game is set up (CR 103.2)") {
+            shuffles.shouldNotBeEmpty()
+        }
+        withClue("…and none of them may fire a shuffle trigger") {
+            shuffles.all { it.cause == ShuffleCause.GAME_SETUP } shouldBe true
+        }
+    }
+
+    test("shuffling to take a mulligan is not caused by a spell or ability") {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + PsychogenicProbe)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = false, startingPlayer = 0)
+
+        d.submit(TakeMulligan(d.player1)).isSuccess shouldBe true
+
+        val mulliganShuffles = d.events.filterIsInstance<LibraryShuffledEvent>()
+            .filter { it.playerId == d.player1 && it.cause != ShuffleCause.GAME_SETUP }
+        withClue("the mulligan shuffled player 1's library (CR 103.5)") {
+            mulliganShuffles.shouldNotBeEmpty()
+        }
+        withClue("…tagged as a mulligan, so no shuffle trigger can see it") {
+            mulliganShuffles.all { it.cause == ShuffleCause.MULLIGAN } shouldBe true
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -9245,6 +9245,48 @@
     ]
 }
 
+// Psychogenic Probe
+{
+    "name": "Psychogenic Probe",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever a spell or ability causes a player to shuffle their library, this artifact deals 2 damage to that player.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "ShuffleLibraryEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "rarity": "RARE",
+        "artist": "Jeremy Jarvis",
+        "flavorText": "The same devices sold as surgeons' tools in Lumengrid are sold as implements of torture in Mephidross.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/8/e83d1ed5-3a49-4cfa-bad2-e342ef28649e.jpg?1783944507",
+        "rulings": [
+            {
+                "date": "2009-02-01",
+                "text": "This ability will trigger even if the player's library is empty at the time they are supposed to shuffle it."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Pyrite Spellbomb
 {
     "name": "Pyrite Spellbomb",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -1390,12 +1390,38 @@ data class DiscardRequiredEvent(
 ) : GameEvent
 
 /**
- * Library was shuffled.
+ * Why a library was shuffled. Only [SPELL_OR_ABILITY] satisfies "a spell or ability causes a
+ * player to shuffle their library" (Psychogenic Probe) — the other two are game rules shuffling
+ * as part of setting up, not effects, so no ability may key off them.
+ */
+enum class ShuffleCause {
+    /** An effect of a resolving spell, an ability, or a replacement effect (CR 701.24). */
+    SPELL_OR_ABILITY,
+
+    /** Shuffling each opening library while the game is set up (CR 103.2). */
+    GAME_SETUP,
+
+    /** Shuffling a hand back to take a mulligan (CR 103.5). */
+    MULLIGAN
+}
+
+/**
+ * Library was shuffled (CR 701.24).
+ *
+ * Emitted once per shuffle, so two effects shuffling the same library simultaneously produce two
+ * events and any shuffle trigger fires twice (CR 701.24f). A library holding zero or one cards is
+ * still shuffled and still emits (CR 701.24e), as is a search-then-shuffle where the found cards
+ * are held out of the randomization (CR 701.24b).
+ *
+ * [cause] defaults to [ShuffleCause.SPELL_OR_ABILITY] because every shuffle that happens once the
+ * game is under way is caused by one; the two game-rules shuffles ([ShuffleCause.GAME_SETUP],
+ * [ShuffleCause.MULLIGAN]) name themselves at their emission sites.
  */
 @Serializable
 @SerialName("LibraryShuffledEvent")
 data class LibraryShuffledEvent(
-    val playerId: EntityId
+    val playerId: EntityId,
+    val cause: ShuffleCause = ShuffleCause.SPELL_OR_ABILITY
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
@@ -367,7 +367,7 @@ class GameInitializer(
         // 4. Shuffle libraries
         for (playerId in playerIds) {
             state = shuffleLibrary(state, playerId)
-            events.add(LibraryShuffledEvent(playerId))
+            events.add(LibraryShuffledEvent(playerId, ShuffleCause.GAME_SETUP))
         }
 
         // 5. Draw initial hands

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -382,6 +382,10 @@ data class TriggerContext(
                     triggeringPlayerId = event.targetEntityId.takeIf { event.targetIsPlayer },
                     targetingSourceEntityId = event.sourceEntityId
                 )
+                is com.wingedsheep.engine.core.LibraryShuffledEvent -> TriggerContext(
+                    // "…deals 2 damage to that player" — the shuffler is the triggering player.
+                    triggeringPlayerId = event.playerId
+                )
                 is com.wingedsheep.engine.core.TargetsChosenEvent -> TriggerContext(
                     triggeringEntityId = event.stackObjectId,
                     triggeringPlayerId = event.chooserId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -89,6 +89,7 @@ enum class TriggerCategory {
     YOU_BEND,
     MANIFESTED_DREAD,
     SEARCH_LIBRARY,
+    SHUFFLE_LIBRARY,
     BECAME_SADDLED,
     CREW_OR_SADDLE_CONTRIBUTION,
     BECOMES_ATTACHED,
@@ -296,6 +297,7 @@ class TriggerIndex(
                 is SdkGameEvent.BendPerformedEvent -> BEND_LIST
                 is SdkGameEvent.ManifestedDreadEvent -> MANIFESTED_DREAD_LIST
                 is SdkGameEvent.SearchLibraryEvent -> SEARCH_LIBRARY_LIST
+                is SdkGameEvent.ShuffleLibraryEvent -> SHUFFLE_LIBRARY_LIST
                 is SdkGameEvent.BecameSaddledEvent -> BECAME_SADDLED_LIST
                 is SdkGameEvent.CrewsEvent,
                 is SdkGameEvent.SaddlesEvent -> CREW_OR_SADDLE_CONTRIBUTION_LIST
@@ -352,6 +354,7 @@ class TriggerIndex(
             is com.wingedsheep.engine.core.BendPerformedEvent -> BEND_LIST
             is com.wingedsheep.engine.core.ManifestedDreadEvent -> MANIFESTED_DREAD_LIST
             is com.wingedsheep.engine.core.LibrarySearchedEvent -> SEARCH_LIBRARY_LIST
+            is com.wingedsheep.engine.core.LibraryShuffledEvent -> SHUFFLE_LIBRARY_LIST
             is com.wingedsheep.engine.core.BecameSaddledEvent -> BECAME_SADDLED_LIST
             is CrewOrSaddleContributionEvent -> CREW_OR_SADDLE_CONTRIBUTION_LIST
             is com.wingedsheep.engine.core.PermanentAttachedEvent -> BECOMES_ATTACHED_LIST
@@ -400,6 +403,7 @@ class TriggerIndex(
         private val BEND_LIST = listOf(TriggerCategory.YOU_BEND)
         private val MANIFESTED_DREAD_LIST = listOf(TriggerCategory.MANIFESTED_DREAD)
         private val SEARCH_LIBRARY_LIST = listOf(TriggerCategory.SEARCH_LIBRARY)
+        private val SHUFFLE_LIBRARY_LIST = listOf(TriggerCategory.SHUFFLE_LIBRARY)
         private val BECAME_SADDLED_LIST = listOf(TriggerCategory.BECAME_SADDLED)
         private val CREW_OR_SADDLE_CONTRIBUTION_LIST =
             listOf(TriggerCategory.CREW_OR_SADDLE_CONTRIBUTION)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -736,6 +736,13 @@ class TriggerMatcher(
                 event is com.wingedsheep.engine.core.LibrarySearchedEvent &&
                     matchesPlayer(trigger.player, event.playerId, controllerId)
             }
+            is EventPattern.ShuffleLibraryEvent -> {
+                // "a *spell or ability* causes a player to shuffle" — the game-rules shuffles
+                // (game setup, mulligan) carry their own cause and must never fire this.
+                event is com.wingedsheep.engine.core.LibraryShuffledEvent &&
+                    event.cause == com.wingedsheep.engine.core.ShuffleCause.SPELL_OR_ABILITY &&
+                    matchesPlayer(trigger.player, event.playerId, controllerId)
+            }
             // ExtraTurnEvent is only used as a replacement effect filter, not a trigger
             is EventPattern.ExtraTurnEvent -> false
             // Batching trigger — handled in detectLibraryToGraveyardBatchTriggers

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/MulliganHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/MulliganHandler.kt
@@ -115,7 +115,7 @@ class MulliganHandler(
             .clearLibraryReveals(newState, playerId)
         val (shuffledLibrary, shuffledState) = newState.nextRandom { shuffle(newState.getZone(libraryKey)) }
         newState = shuffledState.copy(zones = shuffledState.zones + (libraryKey to shuffledLibrary))
-        events.add(LibraryShuffledEvent(playerId))
+        events.add(LibraryShuffledEvent(playerId, ShuffleCause.MULLIGAN))
 
         // 3. Update mulligan count
         val newMullState = mullState.takeMulligan()


### PR DESCRIPTION
Mirrodin is at 269/291 and every one of its remaining 22 cards needs new engine vocabulary — there is no composable pick left in the set. This is the cheapest of them, shipped with its primitive, one PR per new primitive as the house rule asks.

## The gap

`LibraryShuffledEvent` was already emitted at nine sites, but nothing read it: there was no `EventPattern` for "a spell or ability causes a player to shuffle their library", so the trigger shape didn't exist.

## The primitive

- **`EventPattern.ShuffleLibraryEvent(player)`** + **`Triggers.WheneverAPlayerShufflesTheirLibrary`** — the shuffle twin of the existing library-search trigger, and modelled on it: `TriggerIndex` category in both directions, a `TriggerMatcher` branch, and a `TriggerContext` branch so `Player.TriggeringPlayer` resolves to the shuffler ("that player").
- **`LibraryShuffledEvent.cause: ShuffleCause`** — the load-bearing word in the oracle text is *causes*. The game rules also shuffle every library while setting the game up (CR 103.2) and whenever a player mulligans (CR 103.5), and neither is a spell or an ability. Those two emission sites name themselves; `SPELL_OR_ABILITY` is the default, so the seven effect-driven sites are picked up without opting in — and so will a new one.

## The card

`Psychogenic Probe` (MRD #231, `{2}` Artifact) — one triggered ability composing the new trigger with `Effects.DealDamage(2, PlayerRef(TriggeringPlayer))`. Verified field-by-field against Scryfall; `just check-card-printing` is clean (MRD is the only printing).

## Tests

Firing once per *shuffle* rather than once per effect gives three CR 701.24 clauses for free, and `PsychogenicProbeScenarioTest` pins each — they would all pass a naive implementation that only fired on a bare "shuffle your library" effect:

- a tutor's search-then-shuffle counts, even though the found cards are held out of the randomization (**701.24b**, via Fabricate);
- an empty library still counts (**701.24e**, and the card's own 2009 ruling) — the case an "only shuffle if there's something to shuffle" short-circuit would quietly break;
- two Probes watching one shuffle deal 4 (**701.24f**).

Plus the symmetry ("a player" includes the Probe's own controller — a trigger scoped to `EachOpponent` passes the first test and fails this one) and the two excluded causes, asserted on the event's `cause` tag since neither can ever reach a battlefield trigger in a real game.

## Verification

`just test` green across all modules. `CardDefinitionSnapshotTest` re-blessed — the MRD golden diff is the new card and nothing else. MRD goes 269 → 270/291.

Docs: `docs/card-sdk-language-reference.md` gains a "Library shuffle (CR 701.24)" section next to the search one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)