### PR TITLE
Add two Murders at Karlov Manor cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -122,6 +122,16 @@ section; do not let SDK additions land without a corresponding doc update.
   Like `morphFaceUpEffect` it rides the *turn-up procedure* (CR 702.37b's megamorph treatment), so
   a card put face down by cloak or manifest and flipped for its mana cost instead of its disguise
   cost does not get it.
+- `disguiseCostReduction: CostReductionSource?` — "Disguise {5}{R}. This cost is reduced by {1} for
+  each instant and sorcery card in your graveyard" (Fugitive Codebreaker). A **self**-scoped generic
+  reduction on this card's own disguise cost, carried on `KeywordAbility.Disguise.costReduction` and
+  travelling with the card into the face-down permanent's turn-up procedure — as distinct from
+  `SpellCostTarget.MorphActivation`, which is the battlefield-scanned modifier that prices *every*
+  player's turn-up (Exiled Doomsayer). Takes the same `CostReductionSource` values a
+  `ModifySpellCost` static does, and obeys the same rules: increases first, then reductions
+  (CR 601.2f), generic mana only, so a disguise cost's colored pips are a floor. Re-read at every
+  price check, so a card that hits the graveyard after the permanent came down moves the price. The
+  enumerated turn-up action quotes the reduced cost, so the button matches what is charged.
 - `warp: String?` — Warp alt-cost; exiles at end of turn.
 - `dash: String?` — Dash alt-cost (CR 702.109); gains haste and returns to owner's hand at the
   beginning of the next end step.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1961,13 +1961,17 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   "Sacrifice a creature.": the **ability's controller** sacrifices and no player is named. Distinct
   from `Effects.Sacrifice`, which is the edict and names the player who must sacrifice — writing the
   bare form as `Sacrifice(filter, 1, EffectTarget.Controller)` says the same thing the long way round.
-- `Effects.SacrificeAnyNumber(filter)` (= `SacrificeEffect(filter, any = true)`) — the *resolving*
+- `Effects.SacrificeAnyNumber(filter, excludeSource = false)`
+  (= `SacrificeEffect(filter, any = true, excludeSource)`) — the *resolving*
   player chooses 0+ of their own permanents matching `filter` to sacrifice. Distinct from
   `ForceSacrifice` (edict on a target) and from `Costs.pay.Sacrifice` (a cost): this is a
   resolution effect. The sacrificed permanents are recorded in the effect context, so a later
   composite step can read the count via `DynamicAmounts.permanentsSacrificedThisWay()` — e.g.
   "Sacrifice any number of lands. Reveal the top X cards … where X is the number of lands
-  sacrificed this way" (Hew the Entwood; same shape as Scapeshift).
+  sacrificed this way" (Hew the Entwood; same shape as Scapeshift) — or their combined power via
+  `DynamicAmounts.totalPowerSacrificedThisWay()` (Kylox, Visionary Inventor). `excludeSource = true`
+  keeps the ability's own source off the list, which is how "sacrifice any number of **other**
+  creatures" is spelled on a trigger whose source is itself a creature.
 - "Each player chooses \<one permanent per category\> they control, then \<does something to\> the
   rest" is a **pipeline composition**, not an effect type — see `chooseOnePerCategory` / `exclude` in
   §5.5. Liliana, Dreadhorde General's −9 is
@@ -9253,6 +9257,14 @@ both spellings, and the ability its bare-noun line grants says "Regenerate this 
   composite — the sibling-rider wiring from the sacrifice-snapshot work). Used by "each opponent
   sacrifices a creature … create a Food token for each creature sacrificed this way" (Voracious Fell
   Beast). Evaluates to 0 when nothing was sacrificed.
+- `TotalPowerSacrificedThisWay` (facade `DynamicAmounts.totalPowerSacrificedThisWay()`) — the sibling
+  of `PermanentsSacrificedThisWay` over the same `sacrificedPermanents` snapshots, summing each
+  snapshot's power instead of counting the entries: "sacrifice any number of other creatures, then
+  exile the top X cards of your library, where X is **their total power**" (Kylox, Visionary
+  Inventor). The snapshots are last-known information taken as each permanent was sacrificed
+  (Rule 608.2h) — which is what the wording has to mean, since they are all in the graveyard by the
+  time a later sibling effect reads them. A sacrificed noncreature contributes 0 rather than
+  erroring. Evaluates to 0 when nothing was sacrificed.
 - `LargestSharedCreatureTypeCount(player = You)` — the size of the largest creature-type tribe among
   the creatures `player` controls, i.e. "the greatest number of creatures you control that have a
   creature type in common." For every creature type present, tally how many of the player's creatures

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -309,6 +309,13 @@ class CardBuilder(private val name: String) {
     var disguiseFaceUpEffect: Effect? = null
 
     /**
+     * "This cost is reduced by {1} for each …" on the card's own disguise cost — Fugitive
+     * Codebreaker's "reduced by {1} for each instant and sorcery card in your graveyard".
+     * See [KeywordAbility.Disguise.costReduction]; applies to both [disguise] and [disguiseCost].
+     */
+    var disguiseCostReduction: CostReductionSource? = null
+
+    /**
      * Warp cost as a mana cost string (e.g., "{1}{R}").
      * When set, the card gains the Warp keyword ability.
      * Warp allows casting for an alternative cost; the permanent is exiled at end of turn
@@ -963,10 +970,13 @@ class CardBuilder(private val name: String) {
                 disguise != null -> add(
                     KeywordAbility.Disguise(
                         PayCost.Atom(CostAtom.Mana(ManaCost.parse(disguise!!))),
-                        disguiseFaceUpEffect
+                        disguiseFaceUpEffect,
+                        disguiseCostReduction
                     )
                 )
-                disguiseCost != null -> add(KeywordAbility.Disguise(disguiseCost!!, disguiseFaceUpEffect))
+                disguiseCost != null -> add(
+                    KeywordAbility.Disguise(disguiseCost!!, disguiseFaceUpEffect, disguiseCostReduction)
+                )
             }
             if (warp != null) add(KeywordAbility.Warp(ManaCost.parse(warp!!)))
             if (dash != null) add(KeywordAbility.Dash(ManaCost.parse(dash!!)))

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -710,6 +710,16 @@ object DynamicAmounts {
         DynamicAmount.PermanentsSacrificedThisWay
 
     /**
+     * Total power of the permanents sacrificed by the current resolving effect ("their total
+     * power"), read from the same `sacrificedPermanents` snapshots as
+     * [permanentsSacrificedThisWay]. See [DynamicAmount.TotalPowerSacrificedThisWay]. Used by
+     * "exile the top X cards of your library, where X is their total power" (Kylox, Visionary
+     * Inventor).
+     */
+    fun totalPowerSacrificedThisWay(): DynamicAmount =
+        DynamicAmount.TotalPowerSacrificedThisWay
+
+    /**
      * "That many" — the number of repetitions a
      * [com.wingedsheep.sdk.scripting.effects.PayManaCostRepeatedlyEffect] was paid, read back out
      * of the resolution pipeline. Pair it with the matching `storeCountAs` when the effect uses a

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -3884,10 +3884,19 @@ object Effects {
      * permanents matching [filter] to sacrifice. The sacrificed permanents are recorded in the
      * effect context, so a later step in the same composite can read the count via
      * [com.wingedsheep.sdk.dsl.DynamicAmounts.permanentsSacrificedThisWay] (e.g. "where X is the
-     * number of lands sacrificed this way" — Hew the Entwood, Scapeshift).
+     * number of lands sacrificed this way" — Hew the Entwood, Scapeshift) or their total power via
+     * [com.wingedsheep.sdk.dsl.DynamicAmounts.totalPowerSacrificedThisWay].
+     *
+     * @param excludeSource keeps the ability's own source off the list — "sacrifice any number of
+     *   **other** creatures" (Kylox, Visionary Inventor), which an attack trigger needs so the
+     *   attacker can't eat itself.
      */
-    fun SacrificeAnyNumber(filter: GameObjectFilter): Effect =
-        com.wingedsheep.sdk.scripting.effects.SacrificeEffect(filter = filter, any = true)
+    fun SacrificeAnyNumber(filter: GameObjectFilter, excludeSource: Boolean = false): Effect =
+        com.wingedsheep.sdk.scripting.effects.SacrificeEffect(
+            filter = filter,
+            any = true,
+            excludeSource = excludeSource
+        )
 
     /**
      * Sacrifice a specific permanent identified by target.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -428,7 +428,19 @@ sealed interface KeywordAbility {
          * exact sibling of [Morph.faceUpEffect] — it does *not* use the stack and can't be
          * responded to, which is what separates it from a `Triggers.TurnedFaceUp` ability.
          */
-        val faceUpEffect: com.wingedsheep.sdk.scripting.effects.Effect? = null
+        val faceUpEffect: com.wingedsheep.sdk.scripting.effects.Effect? = null,
+        /**
+         * "This cost is reduced by {1} for each …" (Fugitive Codebreaker). A *self*-scoped generic
+         * reduction on this card's own disguise cost, distinct from
+         * [com.wingedsheep.sdk.scripting.SpellCostTarget.MorphActivation], which is the global
+         * battlefield-scanned modifier every player's turn-up procedure pays (Exiled Doomsayer).
+         *
+         * Applied after that increase and generic-only (CR 601.2f, 202.2a): a disguise cost's
+         * colored pips survive however large the reduction gets, so Fugitive Codebreaker never
+         * flips for less than {R}. Null — the shape every other disguise card has — means the
+         * printed cost is the cost.
+         */
+        val costReduction: CostReductionSource? = null
     ) : KeywordAbility {
         /** Convenience constructor for mana-based disguise costs. */
         constructor(cost: ManaCost) : this(PayCost.Atom(CostAtom.Mana(cost)))

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/RemovalEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/RemovalEffects.kt
@@ -120,7 +120,11 @@ data class SacrificeEffect(
     override val description: String = buildString {
         append("sacrifice ")
         when {
-            any -> append("any number of ${filter.description}s")
+            any -> {
+                append("any number of ")
+                if (excludeSource) append("other ")
+                append("${filter.description}s")
+            }
             count == 1 -> {
                 if (excludeSource) append("another ") else append("a ")
                 append(filter.description)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -1557,6 +1557,27 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     }
 
     /**
+     * Total power of the permanents sacrificed by the current resolving effect ("their total
+     * power"). The sibling of [PermanentsSacrificedThisWay] over the same
+     * `EffectContext.sacrificedPermanents` snapshot list, summing each snapshot's power instead of
+     * counting the entries.
+     *
+     * The snapshots are last-known information taken as each permanent was sacrificed (Rule
+     * 608.2h), which is what "their total power" has to mean — the permanents are already in the
+     * graveyard by the time a later sibling effect reads them. Kylox, Visionary Inventor's ruling
+     * of 2024-02-02 says so explicitly: "Use the power of the sacrificed creatures as they last
+     * existed on the battlefield to determine the value of X."
+     *
+     * Negative power counts as written; the sum is floored at 0 by the effects that consume it
+     * (you can't exile a negative number of cards), not here.
+     */
+    @SerialName("TotalPowerSacrificedThisWay")
+    @Serializable
+    data object TotalPowerSacrificedThisWay : DynamicAmount {
+        override val description: String = "their total power"
+    }
+
+    /**
      * The size of the largest creature-type tribe among the creatures [player] controls — i.e.
      * "the greatest number of creatures you control that have a creature type in common."
      *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/ProjectionScopedAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/ProjectionScopedAmounts.kt
@@ -39,7 +39,8 @@ private val CONTEXT_SCOPED_SERIAL_NAMES: Set<String> = setOf(
     // DynamicAmount
     "XValue", "CastX", "CastChoice", "ContextProperty", "VariableReference", "StoredCardManaValue",
     "DistinctEntitiesInCollections", "DistinctCardTypesInCollections", "ManaValueSumOfCollection",
-    "TotalManaSpent", "ManaSpentOnX", "PermanentsSacrificedThisWay", "StationCharge",
+    "TotalManaSpent", "ManaSpentOnX", "PermanentsSacrificedThisWay",
+    "TotalPowerSacrificedThisWay", "StationCharge",
     "LastKnownSourceCounters", "LastKnownDamageDealtToSource",
     // EntityReference
     "Target", "Triggering", "Sacrificed", "TappedAsCost", "FromCostStorage", "AmassedArmy",

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/FugitiveCodebreaker.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/FugitiveCodebreaker.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Fugitive Codebreaker — Murders at Karlov Manor #127
+ * {1}{R} · Creature — Goblin Rogue · 2/1
+ *
+ * Prowess, haste
+ * Disguise {5}{R}. This cost is reduced by {1} for each instant and sorcery card in your graveyard.
+ * When this creature is turned face up, discard your hand, then draw three cards.
+ *
+ * Bedlam Reveler's reduction moved onto a disguise cost. The reduction source is literally the same
+ * one — [CostReductionSource.CardsInGraveyardMatchingFilter] over instants and sorceries — but it
+ * can't ride a `ModifySpellCost` static: that family scans the battlefield and prices *spells*,
+ * while this prices a special action taken by a permanent that, being face down, has no abilities
+ * at all to scan (CR 702.168a / 708.2). So it rides the disguise ability itself
+ * ([com.wingedsheep.sdk.scripting.KeywordAbility.Disguise.costReduction]) and travels with the card
+ * into the face-down permanent's turn-up procedure.
+ *
+ * Generic-only, like every other cost reduction: the {R} survives an arbitrarily stocked graveyard,
+ * so the floor is {R}, not free. And it is re-read at every price check rather than locked in when
+ * the permanent came down — casting an instant in response to your own turn-up plan makes the flip
+ * cheaper, which is the whole point of a card that wants you to have burned through your hand.
+ *
+ * The refill is a turned-face-up trigger, not an enters trigger, and the difference is the card:
+ * turning a permanent face up doesn't cause enters abilities to trigger (2024-02-02 ruling), so a
+ * hard-cast {1}{R} 2/1 gets no cards. Discard resolves fully before the draw, so the three new
+ * cards are never discarded, and an empty hand still draws three.
+ */
+val FugitiveCodebreaker = card("Fugitive Codebreaker") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Rogue"
+    oracleText = "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until " +
+        "end of turn.)\n" +
+        "Haste\n" +
+        "Disguise {5}{R}. This cost is reduced by {1} for each instant and sorcery card in your " +
+        "graveyard. (You may cast this card face down for {3} as a 2/2 creature with ward {2}. " +
+        "Turn it face up any time for its disguise cost.)\n" +
+        "When this creature is turned face up, discard your hand, then draw three cards."
+    power = 2
+    toughness = 1
+    keywords(Keyword.PROWESS, Keyword.HASTE)
+
+    disguise = "{5}{R}"
+    disguiseCostReduction = CostReductionSource.CardsInGraveyardMatchingFilter(
+        filter = GameObjectFilter.InstantOrSorcery,
+        amountPerCard = 1
+    )
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        effect = Effects.Composite(
+            Patterns.Hand.discardHand(),
+            Effects.DrawCards(3)
+        )
+        description = "When this creature is turned face up, discard your hand, then draw three cards."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "127"
+        artist = "Joseph Weston"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b682bf8a-06dc-4828-bc46-9e1427bf981f.jpg?1783912881"
+
+        ruling(
+            "2024-02-02",
+            "If you have no cards in hand when Fugitive Codebreaker's last ability resolves, you " +
+                "won't discard any cards, but you'll still draw three cards."
+        )
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to. Only a face-down permanent can " +
+                "be turned face up this way; a face-down spell cannot."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+        ruling(
+            "2024-02-02",
+            "If a face-down creature loses its abilities, it can't be turned face up with a " +
+                "disguise ability because it will no longer have a disguise ability (or a " +
+                "disguise cost) once face up."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/KyloxVisionaryInventor.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/KyloxVisionaryInventor.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Kylox, Visionary Inventor — Murders at Karlov Manor #214
+ * {5}{U}{R} · Legendary Creature — Lizard Artificer · 4/4
+ *
+ * Menace, ward {2}, haste
+ * Whenever Kylox attacks, sacrifice any number of other creatures, then exile the top X cards of
+ * your library, where X is their total power. You may cast any number of instant and/or sorcery
+ * spells from among the exiled cards without paying their mana costs.
+ *
+ * The attack trigger is the Villainous Wealth pipeline with a sacrifice bolted to the front, and
+ * the whole card turns on the seam between the two: the sacrifice has to hand its victims'
+ * characteristics to the step that counts them, and by then they are all in the graveyard.
+ * [Effects.SacrificeAnyNumber] already captures a last-known-information snapshot per sacrificed
+ * permanent (Rule 608.2h) and `CompositeEffect` merges those into the resolving context, so
+ * [DynamicAmount.TotalPowerSacrificedThisWay] can sum them afterwards — which is exactly what the
+ * 2024-02-02 ruling demands: "Use the power of the sacrificed creatures as they last existed on
+ * the battlefield."
+ *
+ * `excludeSource` is load-bearing, not decoration: without it Kylox is a legal choice for its own
+ * "any number of other creatures" and could be sacrificed mid-attack.
+ *
+ * Sacrificing nothing is a legal choice ("any number" includes zero), and X is then 0 — the gather
+ * exiles nothing and the cast step finds an empty collection. Nothing special-cases that; every
+ * step in the pipeline is already a no-op on an empty list.
+ *
+ * The cast step is [Effects.CastAnyNumberFromCollectionWithoutPayingCost], which casts during this
+ * ability's own resolution — the controller can't bank the exiled cards for later, and timing
+ * restrictions on the sorceries are ignored, both per the same ruling. Cards left uncast stay in
+ * exile.
+ */
+val KyloxVisionaryInventor = card("Kylox, Visionary Inventor") {
+    manaCost = "{5}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Lizard Artificer"
+    oracleText = "Menace, ward {2}, haste\n" +
+        "Whenever Kylox attacks, sacrifice any number of other creatures, then exile the top X " +
+        "cards of your library, where X is their total power. You may cast any number of instant " +
+        "and/or sorcery spells from among the exiled cards without paying their mana costs."
+    power = 4
+    toughness = 4
+    keywords(Keyword.MENACE, Keyword.HASTE)
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{2}")))
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Composite(
+            listOf(
+                Effects.SacrificeAnyNumber(GameObjectFilter.Creature, excludeSource = true),
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(
+                        DynamicAmount.TotalPowerSacrificedThisWay,
+                        player = Player.You
+                    ),
+                    storeAs = "exiled"
+                ),
+                MoveCollectionEffect(
+                    from = "exiled",
+                    destination = CardDestination.ToZone(Zone.EXILE, player = Player.You)
+                ),
+                FilterCollectionEffect(
+                    from = "exiled",
+                    filter = CollectionFilter.MatchesFilter(GameObjectFilter.InstantOrSorcery),
+                    storeMatching = "castable"
+                ),
+                Effects.CastAnyNumberFromCollectionWithoutPayingCost("castable")
+            )
+        )
+        description = "Whenever Kylox attacks, sacrifice any number of other creatures, then " +
+            "exile the top X cards of your library, where X is their total power. You may cast " +
+            "any number of instant and/or sorcery spells from among the exiled cards without " +
+            "paying their mana costs."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "214"
+        artist = "Lie Setiawan"
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/00faa272-91ad-407b-9175-8fa1d02585b8.jpg?1783912845"
+
+        ruling(
+            "2024-02-02",
+            "Use the power of the sacrificed creatures as they last existed on the battlefield to " +
+                "determine the value of X."
+        )
+        ruling(
+            "2024-02-02",
+            "You choose which spells to cast (if any) as Kylox, Visionary Inventor's last ability " +
+                "resolves. If you choose to cast any spells, you do so as part of the resolution " +
+                "of that ability. You can't wait to cast them later in the turn. Timing " +
+                "restrictions based on the cards' types are ignored."
+        )
+        ruling(
+            "2024-02-02",
+            "If you cast a spell \"without paying its mana cost\", you can't choose to cast it for " +
+                "any alternative costs. You can, however, pay additional costs, such as kicker " +
+                "costs. If the card has any mandatory additional costs, those must be paid to " +
+                "cast the spell."
+        )
+        ruling(
+            "2024-02-02",
+            "If the spell you cast has {X} in its mana cost, you must choose 0 as the value of X " +
+                "when casting it without paying its mana cost."
+        )
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FugitiveCodebreakerScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FugitiveCodebreakerScenarioTest.kt
@@ -1,0 +1,293 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.FugitiveCodebreaker
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Fugitive Codebreaker — "Disguise {5}{R}. This cost is reduced by {1} for each instant and sorcery
+ * card in your graveyard."
+ *
+ * The reduction is the first one to ride a *turn-up procedure* rather than a `ModifySpellCost`
+ * static, so what these tests pin down is that the new
+ * [com.wingedsheep.sdk.scripting.KeywordAbility.Disguise.costReduction] actually reaches the price
+ * at all three sites that quote it — the enumerated legal action, the action's validation, and the
+ * payment — and that it obeys the ordinary rules of a cost reduction while it's there:
+ *
+ * - only instants and sorceries count, not every card in the yard;
+ * - it eats generic mana only, so the {R} is a floor no graveyard can get under (CR 202.2a);
+ * - it is re-read at every price check, so a card that hits the graveyard between two checks moves
+ *   the price rather than locking in whatever it was when the permanent came down.
+ *
+ * The last test covers the card's other half: the refill is a turned-face-up trigger, so it fires
+ * on the flip and not on a hard cast.
+ */
+class FugitiveCodebreakerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(FugitiveCodebreaker)
+        return driver
+    }
+
+    /** Put the Codebreaker onto the battlefield face down under disguise, as a real cast would. */
+    fun GameTestDriver.putDisguised(playerId: EntityId): EntityId {
+        val id = putCreatureOnBattlefield(playerId, "Fugitive Codebreaker")
+        val cardDef = cardRegistry.requireCard("Fugitive Codebreaker")
+        replaceState(
+            state.updateEntity(id) { container ->
+                var c = container.with(FaceDownComponent).with(FaceDownModeComponent(FaceDownMode.DISGUISE))
+                FaceDownTurnUp.dataFor(cardDef, "Fugitive Codebreaker", FaceDownMode.DISGUISE)
+                    ?.let { c = c.with(it) }
+                c
+            }
+        )
+        removeSummoningSickness(id)
+        return id
+    }
+
+    /**
+     * The mana cost the turn-face-up legal action quotes for [permanentId].
+     *
+     * The enumerator only offers a turn-up the player can actually afford, so this floats the pool
+     * well above any price under test first — the question here is what is *quoted*, which is a
+     * separate matter from what is affordable (the tests that care about affordability set the pool
+     * exactly and submit the action).
+     */
+    fun GameTestDriver.quotedTurnUpCost(playerId: EntityId, permanentId: EntityId): String? {
+        giveMana(playerId, Color.RED, 2)
+        giveColorlessMana(playerId, 10)
+        return legalActions(playerId)
+            .firstOrNull { (it.action as? TurnFaceUp)?.sourceId == permanentId }
+            ?.manaCostString
+    }
+
+    test("an empty graveyard leaves the printed {5}{R}") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val codebreaker = driver.putDisguised(you)
+
+        withClue("nothing in the graveyard, so the action quotes the printed disguise cost") {
+            driver.quotedTurnUpCost(you, codebreaker) shouldBe "{5}{R}"
+        }
+    }
+
+    test("with an empty graveyard, five mana can't pay the unreduced flip") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val codebreaker = driver.putDisguised(you)
+        driver.giveMana(you, Color.RED, 1)
+        driver.giveColorlessMana(you, 4)
+
+        driver.submitExpectFailure(
+            TurnFaceUp(playerId = you, sourceId = codebreaker, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        withClue("the flip was rejected, so it is still face down") {
+            driver.state.getEntity(codebreaker)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+        }
+    }
+
+    test("each instant and sorcery in the graveyard shaves {1} off the flip") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val codebreaker = driver.putDisguised(you)
+        driver.putCardInGraveyard(you, "Lightning Bolt")
+        driver.putCardInGraveyard(you, "Giant Growth")
+        driver.putCardInGraveyard(you, "Careful Study")
+
+        withClue("two instants and a sorcery — {5}{R} minus {3}") {
+            driver.quotedTurnUpCost(you, codebreaker) shouldBe "{2}{R}"
+        }
+    }
+
+    test("the reduction reaches the payment, not just the quote") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val codebreaker = driver.putDisguised(you)
+        driver.putCardInGraveyard(you, "Lightning Bolt")
+        driver.putCardInGraveyard(you, "Giant Growth")
+        driver.putCardInGraveyard(you, "Careful Study")
+
+        // Exactly {2}{R} in the pool and not a mana more.
+        driver.giveMana(you, Color.RED, 1)
+        driver.giveColorlessMana(you, 2)
+        driver.submitSuccess(
+            TurnFaceUp(playerId = you, sourceId = codebreaker, paymentStrategy = PaymentStrategy.FromPool)
+        )
+
+        withClue("three mana paid a six-mana printed cost, so the reduction reached the payment too") {
+            driver.state.getEntity(codebreaker)?.get<FaceDownComponent>() shouldBe null
+        }
+    }
+
+    test("only instants and sorceries count — a graveyard of creatures changes nothing") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val codebreaker = driver.putDisguised(you)
+        driver.putCardInGraveyard(you, "Centaur Courser")
+        driver.putCardInGraveyard(you, "Savannah Lions")
+        driver.putCardInGraveyard(you, "Test Enchantment")
+
+        driver.quotedTurnUpCost(you, codebreaker) shouldBe "{5}{R}"
+    }
+
+    test("the opponent's instants don't help — the reduction reads your graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val codebreaker = driver.putDisguised(you)
+        repeat(4) { driver.putCardInGraveyard(opponent, "Lightning Bolt") }
+
+        driver.quotedTurnUpCost(you, codebreaker) shouldBe "{5}{R}"
+    }
+
+    test("the reduction is generic-only — a stuffed graveyard still leaves the {R}") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val codebreaker = driver.putDisguised(you)
+        repeat(9) { driver.putCardInGraveyard(you, "Lightning Bolt") }
+
+        withClue("nine instants is more than the {5} generic, and the {R} survives (CR 202.2a)") {
+            driver.quotedTurnUpCost(you, codebreaker) shouldBe "{R}"
+        }
+    }
+
+    test("the surviving {R} is a real floor — colorless alone can't pay it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val codebreaker = driver.putDisguised(you)
+        repeat(9) { driver.putCardInGraveyard(you, "Lightning Bolt") }
+
+        driver.giveColorlessMana(you, 5)
+        driver.submitExpectFailure(
+            TurnFaceUp(playerId = you, sourceId = codebreaker, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        withClue("colorless can't pay the {R}, however cheap the flip got") {
+            driver.state.getEntity(codebreaker)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+        }
+
+        driver.giveMana(you, Color.RED, 1)
+        driver.submitSuccess(
+            TurnFaceUp(playerId = you, sourceId = codebreaker, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        driver.state.getEntity(codebreaker)?.get<FaceDownComponent>() shouldBe null
+    }
+
+    test("the price is re-read, not locked in when the permanent came down") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val codebreaker = driver.putDisguised(you)
+        driver.quotedTurnUpCost(you, codebreaker) shouldBe "{5}{R}"
+
+        driver.putCardInGraveyard(you, "Counterspell")
+        driver.putCardInGraveyard(you, "Doom Blade")
+
+        withClue("two instants arrived after the permanent did, and the price moved with them") {
+            driver.quotedTurnUpCost(you, codebreaker) shouldBe "{3}{R}"
+        }
+    }
+
+    test("flipping it face up discards the hand, then draws three") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val codebreaker = driver.putDisguised(you)
+        repeat(5) { driver.putCardInGraveyard(you, "Lightning Bolt") }
+        driver.putCardInHand(you, "Giant Growth")
+        driver.putCardInHand(you, "Doom Blade")
+        val handBefore = driver.getHand(you).size
+
+        driver.giveMana(you, Color.RED, 1)
+        driver.submitSuccess(
+            TurnFaceUp(playerId = you, sourceId = codebreaker, paymentStrategy = PaymentStrategy.FromPool)
+        )
+
+        var guard = 0
+        while (!driver.isPaused && driver.state.stack.isNotEmpty() && guard++ < 10) driver.bothPass()
+
+        withClue("whatever the hand held ($handBefore cards), exactly three cards replaced it") {
+            driver.getHand(you).size shouldBe 3
+        }
+        withClue("the three drawn cards are not themselves discarded — discard resolves first") {
+            driver.getHand(you).all { driver.getCardName(it) == "Mountain" } shouldBe true
+        }
+    }
+
+    test("a hard cast gets no refill — the trigger is turned-face-up, not enters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val cardId = driver.putCardInHand(you, "Fugitive Codebreaker")
+        driver.putCardInHand(you, "Giant Growth")
+        driver.giveMana(you, Color.RED, 1)
+        driver.giveColorlessMana(you, 1)
+        val handBefore = driver.getHand(you).size
+
+        // Hard cast for {1}{R} — the real cast path, so an enters-trigger miswiring would fire here.
+        driver.castSpell(you, cardId).error shouldBe null
+        var guard = 0
+        while (!driver.isPaused && driver.state.stack.isNotEmpty() && guard++ < 10) driver.bothPass()
+
+        driver.assertPermanentExists(you, "Fugitive Codebreaker")
+        withClue("it entered face up, nothing was turned face up, so only the cast left the hand") {
+            driver.getHand(you).size shouldBe handBefore - 1
+        }
+    }
+
+    test("the card definition carries the disguise cost and its reduction") {
+        val disguise = FugitiveCodebreaker.keywordAbilities
+            .filterIsInstance<com.wingedsheep.sdk.scripting.KeywordAbility.Disguise>()
+            .single()
+        disguise.disguiseCost.description shouldBe "{5}{R}"
+        disguise.costReduction shouldBe com.wingedsheep.sdk.scripting.CostReductionSource
+            .CardsInGraveyardMatchingFilter(
+                filter = com.wingedsheep.sdk.scripting.GameObjectFilter.InstantOrSorcery,
+                amountPerCard = 1
+            )
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/KyloxVisionaryInventorScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/KyloxVisionaryInventorScenarioTest.kt
@@ -1,0 +1,211 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.KyloxVisionaryInventor
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Kylox, Visionary Inventor — "Whenever Kylox attacks, sacrifice any number of other creatures,
+ * then exile the top X cards of your library, where X is their total power. You may cast any
+ * number of instant and/or sorcery spells from among the exiled cards without paying their mana
+ * costs."
+ *
+ * The pipeline itself is Villainous Wealth's and already covered. What is new here is
+ * [com.wingedsheep.sdk.scripting.values.DynamicAmount.TotalPowerSacrificedThisWay], and every test
+ * below exists to pin one of its properties:
+ *
+ * - **It is last-known information.** By the time the gather step asks, the sacrificed creatures
+ *   are in the graveyard. A live-state read would see nothing and exile zero cards, so an X that
+ *   matches the creatures' power at all is the assertion (2024-02-02 ruling: "the power of the
+ *   sacrificed creatures as they last existed on the battlefield").
+ * - **It sums power, it doesn't count bodies.** Two creatures worth 3 and 2 must exile five cards,
+ *   not two — the failure mode if it were wired to `PermanentsSacrificedThisWay`.
+ * - **Zero is a legal answer.** "Any number" includes none, and X = 0 has to run the rest of the
+ *   pipeline as a no-op rather than erroring or exiling the whole library.
+ *
+ * The fourth test covers `excludeSource`: Kylox says "other creatures", so it must not be offered
+ * as fodder for its own trigger.
+ */
+class KyloxVisionaryInventorScenarioTest : FunSpec({
+
+    // Free-cast fodder with no targets and no decisions of their own, so the assertions stay about
+    // Kylox rather than about whatever the cast spell went on to ask.
+    val freeGain = card("Test Free Gain") {
+        manaCost = "{6}{U}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.GainLife(4) }
+    }
+    val freeDraw = card("Test Free Draw") {
+        manaCost = "{5}{R}"
+        typeLine = "Instant"
+        spell { effect = Effects.DrawCards(1) }
+    }
+    // A 2-power body, so "total power" and "number of creatures" can't both explain the result.
+    val bear = card("Test Two Power Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(KyloxVisionaryInventor, freeGain, freeDraw, bear))
+        return driver
+    }
+
+    fun GameTestDriver.exileNames(playerId: EntityId): List<String> =
+        state.getExile(playerId).mapNotNull { state.getEntity(it)?.get<CardComponent>()?.name }
+
+    fun optionNames(driver: GameTestDriver, decision: SelectCardsDecision): Set<String> =
+        decision.options.mapNotNull { driver.state.getEntity(it)?.get<CardComponent>()?.name }.toSet()
+
+    /** Attack with [attacker], then resolve the stack until something needs a decision. */
+    fun GameTestDriver.attackAndResolve(you: EntityId, attacker: EntityId) {
+        passPriorityUntil(Step.DECLARE_ATTACKERS)
+        declareAttackers(you, listOf(attacker), getOpponent(you)).error shouldBe null
+        var guard = 0
+        while (!isPaused && state.stack.isNotEmpty() && guard++ < 10) bothPass()
+    }
+
+    test("X is the sacrificed creatures' total power, and instants and sorceries exile-cast for free") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val kylox = driver.putCreatureOnBattlefield(you, "Kylox, Visionary Inventor")
+        driver.removeSummoningSickness(kylox)
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+        val twoPower = driver.putCreatureOnBattlefield(you, "Test Two Power Bear") // 2/2
+
+        // Top five of the library, top-most pushed last.
+        driver.putCardOnTopOfLibrary(you, "Mountain")
+        driver.putCardOnTopOfLibrary(you, "Mountain")
+        driver.putCardOnTopOfLibrary(you, "Centaur Courser")
+        driver.putCardOnTopOfLibrary(you, "Test Free Draw")
+        driver.putCardOnTopOfLibrary(you, "Test Free Gain")
+
+        val lifeBefore = driver.getLifeTotal(you)
+        driver.attackAndResolve(you, kylox)
+
+        val sacrificeDecision = driver.pendingDecision as SelectCardsDecision
+        withClue("the trigger opens on the sacrifice choice") {
+            optionNames(driver, sacrificeDecision) shouldBe setOf("Centaur Courser", "Test Two Power Bear")
+        }
+        driver.submitCardSelection(you, listOf(courser, twoPower))
+
+        var guard = 0
+        var castDecision: SelectCardsDecision? = null
+        while (guard++ < 12) {
+            val pending = driver.pendingDecision
+            if (pending is SelectCardsDecision) {
+                castDecision = pending
+                break
+            }
+            if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+        }
+
+        withClue("3 power + 2 power = X of 5, so five cards left the library for exile") {
+            driver.exileNames(you).size shouldBe 5
+        }
+        val castChoice = castDecision!!
+        withClue("only the instant and the sorcery are castable; the creature and lands are not") {
+            optionNames(driver, castChoice) shouldBe setOf("Test Free Gain", "Test Free Draw")
+        }
+
+        val gainId = castChoice.options.first {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Test Free Gain"
+        }
+        driver.submitCardSelection(you, listOf(gainId))
+        // The effect keeps offering the rest of the pile until the controller stops; decline, then
+        // let the free-cast spell resolve.
+        guard = 0
+        while (guard++ < 20) {
+            when {
+                driver.pendingDecision is SelectCardsDecision -> driver.submitCardSelection(you, emptyList())
+                driver.isPaused -> driver.autoResolveDecision()
+                driver.state.stack.isNotEmpty() -> driver.bothPass()
+                else -> break
+            }
+        }
+
+        withClue("the sorcery resolved without its {6}{U} being paid, mid-combat") {
+            driver.getLifeTotal(you) shouldBe lifeBefore + 4
+        }
+        withClue("cards not chosen stay in exile") {
+            driver.exileNames(you).contains("Test Free Draw") shouldBe true
+        }
+    }
+
+    test("sacrificing nothing makes X zero and exiles nothing") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val kylox = driver.putCreatureOnBattlefield(you, "Kylox, Visionary Inventor")
+        driver.removeSummoningSickness(kylox)
+        driver.putCreatureOnBattlefield(you, "Centaur Courser")
+
+        val librarySizeBefore = driver.state.getLibrary(you).size
+        driver.attackAndResolve(you, kylox)
+
+        val sacrificeDecision = driver.pendingDecision as SelectCardsDecision
+        withClue("\"any number\" allows choosing none") {
+            sacrificeDecision.minSelections shouldBe 0
+        }
+        driver.submitCardSelection(you, emptyList())
+
+        var guard = 0
+        while (!driver.isPaused && driver.state.stack.isNotEmpty() && guard++ < 10) driver.bothPass()
+
+        withClue("X = 0, so the library is untouched") {
+            driver.state.getLibrary(you).size shouldBe librarySizeBefore
+        }
+        driver.exileNames(you) shouldBe emptyList()
+        withClue("nothing was sacrificed — the Courser is still on the battlefield") {
+            (driver.findPermanent(you, "Centaur Courser") != null) shouldBe true
+            driver.getGraveyardCardNames(you).contains("Centaur Courser") shouldBe false
+        }
+    }
+
+    test("Kylox is not fodder for its own trigger — the clause says other creatures") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val kylox = driver.putCreatureOnBattlefield(you, "Kylox, Visionary Inventor")
+        driver.removeSummoningSickness(kylox)
+        driver.putCreatureOnBattlefield(you, "Centaur Courser")
+
+        driver.attackAndResolve(you, kylox)
+
+        val sacrificeDecision = driver.pendingDecision as SelectCardsDecision
+        withClue("the attacking Kylox must not appear among its own sacrifice options") {
+            sacrificeDecision.options.contains(kylox) shouldBe false
+        }
+        optionNames(driver, sacrificeDecision) shouldBe setOf("Centaur Courser")
+    }
+
+    test("the printed keywords are on the definition") {
+        KyloxVisionaryInventor.keywords.contains(Keyword.MENACE) shouldBe true
+        KyloxVisionaryInventor.keywords.contains(Keyword.HASTE) shouldBe true
+        KyloxVisionaryInventor.keywordAbilities
+            .filterIsInstance<com.wingedsheep.sdk.scripting.KeywordAbility.Ward>()
+            .size shouldBe 1
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -8952,6 +8952,108 @@
     ]
 }
 
+// Fugitive Codebreaker
+{
+    "name": "Fugitive Codebreaker",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Rogue",
+    "oracleText": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nHaste\nDisguise {5}{R}. This cost is reduced by {1} for each instant and sorcery card in your graveyard. (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, discard your hand, then draw three cards.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "PROWESS",
+        "HASTE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{5}{R}"
+                }
+            },
+            "costReduction": {
+                "type": "CardsInGraveyardMatchingFilter",
+                "filter": "instant|sorcery"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "discardedHand"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discardedHand",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature is turned face up, discard your hand, then draw three cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "RARE",
+        "artist": "Joseph Weston",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b682bf8a-06dc-4828-bc46-9e1427bf981f.jpg?1783912881",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If you have no cards in hand when Fugitive Codebreaker's last ability resolves, you won't discard any cards, but you'll still draw three cards."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a face-down creature loses its abilities, it can't be turned face up with a disguise ability because it will no longer have a disguise ability (or a disguise cost) once face up."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Furtive Courier
 {
     "name": "Furtive Courier",
@@ -12317,6 +12419,109 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Kylox, Visionary Inventor
+{
+    "name": "Kylox, Visionary Inventor",
+    "manaCost": "{5}{U}{R}",
+    "typeLine": "Legendary Creature — Lizard Artificer",
+    "oracleText": "Menace, ward {2}, haste\nWhenever Kylox attacks, sacrifice any number of other creatures, then exile the top X cards of your library, where X is their total power. You may cast any number of instant and/or sorcery spells from among the exiled cards without paying their mana costs.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "MENACE",
+        "HASTE",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Sacrifice",
+                            "filter": "creature",
+                            "any": true,
+                            "excludeSource": true
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": "TotalPowerSacrificedThisWay"
+                            },
+                            "storeAs": "exiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "exiled",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "instant|sorcery"
+                            },
+                            "storeMatching": "castable"
+                        },
+                        {
+                            "type": "CastAnyNumberFromCollectionWithoutPayingCost",
+                            "from": "castable"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever Kylox attacks, sacrifice any number of other creatures, then exile the top X cards of your library, where X is their total power. You may cast any number of instant and/or sorcery spells from among the exiled cards without paying their mana costs."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "RARE",
+        "artist": "Lie Setiawan",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/00faa272-91ad-407b-9175-8fa1d02585b8.jpg?1783912845",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Use the power of the sacrificed creatures as they last existed on the battlefield to determine the value of X."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "You choose which spells to cast (if any) as Kylox, Visionary Inventor's last ability resolves. If you choose to cast any spells, you do so as part of the resolution of that ability. You can't wait to cast them later in the turn. Timing restrictions based on the cards' types are ignored."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If you cast a spell \"without paying its mana cost\", you can't choose to cast it for any alternative costs. You can, however, pay additional costs, such as kicker costs. If the card has any mandatory additional costs, those must be paid to cast the spell."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If the spell you cast has {X} in its mana cost, you must choose 0 as the value of X when casting it without paying its mana cost."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -767,6 +767,14 @@ class DynamicAmountEvaluator(
 
             is DynamicAmount.PermanentsSacrificedThisWay -> context.sacrificedPermanents.size
 
+            // "Their total power" over the same snapshots — last-known power as each permanent was
+            // sacrificed (Rule 608.2h), because they are all in the graveyard by the time a later
+            // sibling effect asks. A snapshot with no power at all (a sacrificed noncreature) adds
+            // nothing rather than being an error: "sacrifice any number of other creatures" is the
+            // only shape that reaches here today, but the amount is defined over permanents.
+            is DynamicAmount.TotalPowerSacrificedThisWay ->
+                context.sacrificedPermanents.sumOf { it.power ?: 0 }
+
             // "The greatest number of creatures you control that have a creature type in common"
             // (White Lotus Tile). For every creature type present among the player's creatures,
             // tally how many of those creatures have it, then take the max. A creature with several

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
@@ -100,8 +100,6 @@ class TurnFaceUpHandler(
             ?: return "No such turn-up procedure: ${action.procedureIndex}"
 
         // Validate cost payment based on morph cost type.
-        // Apply morph cost increases from permanents like Exiled Doomsayer.
-        val morphCostIncrease = costCalculator.calculateMorphCostIncrease(state)
         val morphCost = procedure.cost
         val manaMorph = (morphCost as? PayCost.Atom)?.atom as? CostAtom.Mana
         when {
@@ -109,7 +107,11 @@ class TurnFaceUpHandler(
                 // Mana morph payment stays in this handler: it carries the rich up-front UX
                 // (explicit mana-source selection, X, auto-tap preview) that the shared
                 // CostPaymentService's yes/no mana path deliberately doesn't model.
-                val manaCost = costCalculator.increaseGenericCost(manaMorph.cost, morphCostIncrease)
+                // Increases (Exiled Doomsayer) then the procedure's own reduction (Fugitive
+                // Codebreaker) — the same pricing the enumerator quoted.
+                val manaCost = costCalculator.calculateTurnFaceUpCost(
+                    state, manaMorph.cost, procedure.costReduction, action.playerId, action.sourceId
+                )
                 val xValue = action.xValue ?: 0
                 when (action.paymentStrategy) {
                     is PaymentStrategy.AutoPay -> {
@@ -186,8 +188,7 @@ class TurnFaceUpHandler(
         val cardDef = cardRegistry.getCard(morphData.originalCardDefinitionId)
         val cardName = cardDef?.name ?: cardComponent?.name ?: "Unknown"
 
-        // Pay the morph cost (including any morph cost increases)
-        val morphCostIncrease = costCalculator.calculateMorphCostIncrease(currentState)
+        // Pay the morph cost (including any morph cost increases and self-scoped reductions)
         val xValue = action.xValue ?: 0
         val morphCost = procedure.cost
         // CR 702.37b ties megamorph's +1/+1 counter to the megamorph cost specifically, so the
@@ -197,7 +198,9 @@ class TurnFaceUpHandler(
         val manaMorph = (morphCost as? PayCost.Atom)?.atom as? CostAtom.Mana
         when {
             manaMorph != null -> {
-                val manaCost = costCalculator.increaseGenericCost(manaMorph.cost, morphCostIncrease)
+                val manaCost = costCalculator.calculateTurnFaceUpCost(
+                    currentState, manaMorph.cost, procedure.costReduction, action.playerId, action.sourceId
+                )
                 when (action.paymentStrategy) {
                     is PaymentStrategy.FromPool -> {
                         val poolComponent = currentState.getEntity(action.playerId)?.get<ManaPoolComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/FaceDownTurnUp.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/FaceDownTurnUp.kt
@@ -72,5 +72,7 @@ object FaceDownTurnUp {
 
     private fun disguiseProcedure(cardDef: CardDefinition?): TurnUpProcedure? =
         cardDef?.keywordAbilities?.filterIsInstance<KeywordAbility.Disguise>()?.firstOrNull()
-            ?.let { TurnUpProcedure(it.disguiseCost, FaceDownMode.DISGUISE, it.faceUpEffect) }
+            ?.let {
+                TurnUpProcedure(it.disguiseCost, FaceDownMode.DISGUISE, it.faceUpEffect, it.costReduction)
+            }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/TurnFaceUpEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/TurnFaceUpEnumerator.kt
@@ -50,22 +50,27 @@ class TurnFaceUpEnumerator : ActionEnumerator {
             // Must have turn-up data (to get the cost)
             val morphData = container.get<MorphDataComponent>() ?: continue
 
-            // Morph cost increases (Exiled Doomsayer) apply to every turn-up procedure alike.
-            val morphCostIncrease = context.costCalculator.calculateMorphCostIncrease(state)
-
             morphData.procedures.forEachIndexed { procedureIndex, procedure ->
                 val cost = procedure.cost
+                val manaMorph = (cost as? PayCost.Atom)?.atom as? CostAtom.Mana
+                // Global increases (Exiled Doomsayer) and the procedure's own reduction (Fugitive
+                // Codebreaker) both land here, so the button quotes the price actually charged
+                // rather than the printed one.
+                val effectiveCost = manaMorph?.let {
+                    context.costCalculator.calculateTurnFaceUpCost(
+                        state, it.cost, procedure.costReduction, playerId, entityId
+                    )
+                }
+                val costLabel = effectiveCost?.toString() ?: cost.description
                 // Only label the mechanic when there is a choice to make; a lone procedure reads
                 // the way it always has.
                 val label = if (morphData.procedures.size > 1) {
-                    "Turn face-up — ${procedure.label} (${cost.description})"
+                    "Turn face-up — ${procedure.label} ($costLabel)"
                 } else {
-                    "Turn face-up (${cost.description})"
+                    "Turn face-up ($costLabel)"
                 }
-                val manaMorph = (cost as? PayCost.Atom)?.atom as? CostAtom.Mana
                 when {
-                    manaMorph != null -> {
-                        val effectiveCost = context.costCalculator.increaseGenericCost(manaMorph.cost, morphCostIncrease)
+                    effectiveCost != null -> {
                         if (effectiveCost.hasX) {
                             // X turn-up cost (e.g., {X}{X}{R}) — always show as available with X selection
                             val availableSources = context.manaSolver.getAvailableManaCount(state, playerId, precomputedSources = context.availableManaSources)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -1381,6 +1381,42 @@ class CostCalculator(
     }
 
     /**
+     * The mana a player actually pays to turn a face-down permanent face up: the procedure's
+     * printed cost, plus every global [SpellCostTarget.MorphActivation] increase
+     * ([calculateMorphCostIncrease] — Exiled Doomsayer), minus the procedure's own self-scoped
+     * reduction (Fugitive Codebreaker's "reduced by {1} for each instant and sorcery card in your
+     * graveyard").
+     *
+     * Increases before reductions, per CR 601.2f, which the special action follows the same way a
+     * spell does. Both adjustments are generic-only, so the colored pips of a disguise cost always
+     * survive.
+     *
+     * The three sites that price a turn-up — enumeration, action validation, and payment — all go
+     * through here, so an enumerated price can never disagree with the one charged.
+     *
+     * @param printedCost the procedure's mana cost as printed
+     * @param reduction the procedure's [TurnUpProcedure.costReduction], or null for the ordinary
+     *   morph/disguise/manifest shape
+     * @param controllerId the player taking the special action — whose graveyard, permanents, and
+     *   speed the reduction reads
+     * @param permanentId the face-down permanent, passed as the reduction's ability source
+     */
+    fun calculateTurnFaceUpCost(
+        state: GameState,
+        printedCost: ManaCost,
+        reduction: CostReductionSource?,
+        controllerId: EntityId,
+        permanentId: EntityId
+    ): ManaCost {
+        val increased = increaseGenericCost(printedCost, calculateMorphCostIncrease(state))
+        if (reduction == null) return increased
+        return reduceGenericCost(
+            increased,
+            evaluateReduction(state, reduction, controllerId, abilitySourceId = permanentId)
+        )
+    }
+
+    /**
      * Apply a generic mana increase to an existing ManaCost.
      * Used to increase morph costs by adding generic mana.
      */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/FaceDownComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/FaceDownComponents.kt
@@ -1,6 +1,8 @@
 package com.wingedsheep.engine.state.components.identity
 
 import com.wingedsheep.engine.state.Component
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
@@ -32,7 +34,18 @@ data class TurnUpProcedure(
      */
     val mechanic: FaceDownMode,
     /** Effect applied as the permanent is turned face up this way (megamorph's +1/+1 counter). */
-    val faceUpEffect: Effect? = null
+    val faceUpEffect: Effect? = null,
+    /**
+     * Self-scoped generic reduction on [cost] — Fugitive Codebreaker's "this cost is reduced by
+     * {1} for each instant and sorcery card in your graveyard"
+     * ([KeywordAbility.Disguise.costReduction]).
+     *
+     * It rides the *procedure* rather than the component for the same reason [faceUpEffect] does:
+     * a cloaked card that also prints disguise offers both turn-up routes, and the reduction
+     * belongs only to the disguise one. Re-evaluated at every read, so a card milled between
+     * enumeration and payment moves the price.
+     */
+    val costReduction: CostReductionSource? = null
 ) {
     /** Player-facing mechanic name, e.g. "Disguise". */
     val label: String get() = mechanic.name.lowercase().replaceFirstChar { it.uppercase() }


### PR DESCRIPTION
MKM's tail has no composable cards left — every one of the 17 that were missing needs engine
vocabulary of some kind. These are the two whose gap is a small additive generalization, in the
shape of #1935. The set goes 259 → 261 of 276.

## Cards

- **Kylox, Visionary Inventor** ({5}{U}{R}, 4/4) — menace, ward {2}, haste; on attack, sacrifice any
  number of other creatures, exile the top X of your library where X is their total power, and free-
  cast any instants and sorceries from among them. The exile-and-cast half is Villainous Wealth's
  pipeline verbatim (`GatherCards` → `MoveCollection` → `FilterCollection` →
  `CastAnyNumberFromCollectionWithoutPayingCost`).
- **Fugitive Codebreaker** ({1}{R}, 2/1) — prowess, haste; disguise {5}{R} reduced by {1} per instant
  and sorcery in your graveyard; turned face up, discard your hand and draw three.

## Engine additions

**`DynamicAmount.TotalPowerSacrificedThisWay`** — the sibling of `PermanentsSacrificedThisWay` over
the same `EffectContext.sacrificedPermanents` snapshots, summing power instead of counting entries.
It has to read those snapshots rather than live state: the creatures are in the graveyard by the
time the gather step asks, which is exactly what Kylox's 2024-02-02 ruling means by "the power of
the sacrificed creatures as they last existed on the battlefield" (Rule 608.2h). `SacrificeEffect`
already captured them, so this is one variant plus one evaluator line.

**`Effects.SacrificeAnyNumber(filter, excludeSource)`** — `SacrificeEffect.excludeSource` already
existed; the facade just didn't expose it, so "any number of *other* creatures" couldn't be spelled.
The `any`-branch description gains an "other " only when the new flag is set, so no existing card's
text moves.

**`KeywordAbility.Disguise.costReduction`** (`disguiseCostReduction` in the card DSL) — a
self-scoped generic reduction on a card's own disguise cost. It can't be a `ModifySpellCost` static:
that family scans the battlefield and prices *spells*, while this prices a special action taken by a
permanent that, being face down, has no abilities at all to scan (CR 702.168a / 708.2). It rides the
disguise ability, and `FaceDownTurnUp` carries it onto the permanent's `TurnUpProcedure` — on the
procedure rather than the component, for the same reason `faceUpEffect` is there: a cloaked card that
also prints disguise offers both routes, and the reduction belongs only to the disguise one.

**`CostCalculator.calculateTurnFaceUpCost`** — folds the existing global
`SpellCostTarget.MorphActivation` increase (Exiled Doomsayer) and the procedure's own reduction into
one price: increases then reductions (CR 601.2f), generic-only, so a disguise cost's colored pips are
a floor. All three sites that price a turn-up — enumeration, action validation, payment — now go
through it, so an enumerated price can't disagree with the one charged. The turn-up button also now
quotes the effective cost rather than the printed one; with no cost modifiers in play those are the
same string.

## Verification

`just test` green. `just check` green. `just check-card-printing` clean for both (MKM is the earliest
real printing for each; the two `pmkm` rows are promos). Card fields re-verified field-by-field
against Scryfall, image URIs return 200. The MKM golden was re-blessed and only these two cards moved.

16 scenario tests across two files (one per card, per the house rule). Beyond the happy paths they
pin: X = 0 when nothing is sacrificed; Kylox absent from its own sacrifice options; only instants and
sorceries castable from the exiled pile; that the disguise reduction counts only instants and
sorceries, only in *your* graveyard, reaches the payment and not just the quote, leaves the {R} as a
hard floor, and is re-read rather than locked in when the permanent came down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
