### PR TITLE
Add Jumpstart printing rows for its 79 remaining Assay-ready cards

### DIFF
--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AegisTurtleReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AegisTurtleReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aegis Turtle reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val AegisTurtleReprint = Printing(
+    oracleId = "f84c30e7-2ea8-43ff-9356-1f907558cfd9",
+    name = "Aegis Turtle",
+    setCode = "JMP",
+    collectorNumber = "138",
+    scryfallId = "7003ebae-5d82-4360-ae63-0e51c37977ed",
+    artist = "Milivoj Ćeran",
+    imageUri = "https://cards.scryfall.io/normal/front/7/0/7003ebae-5d82-4360-ae63-0e51c37977ed.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AetherSpellbombReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AetherSpellbombReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aether Spellbomb reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val AetherSpellbombReprint = Printing(
+    oracleId = "4b033a0a-c1ae-44d7-9662-72cbbfda024b",
+    name = "Aether Spellbomb",
+    setCode = "JMP",
+    collectorNumber = "456",
+    scryfallId = "a54e8ce9-edd7-4ae7-9521-6fb6727cf63b",
+    artist = "Jim Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a54e8ce9-edd7-4ae7-9521-6fb6727cf63b.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AngelOfMercyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AngelOfMercyReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angel of Mercy reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val AngelOfMercyReprint = Printing(
+    oracleId = "a2daaf32-dbfe-4618-892e-0da24f63a44a",
+    name = "Angel of Mercy",
+    setCode = "JMP",
+    collectorNumber = "84",
+    scryfallId = "2d22fdde-5590-4a4c-af2e-09711f4b5ffd",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/2/d/2d22fdde-5590-4a4c-af2e-09711f4b5ffd.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AngelicEdictReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AngelicEdictReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angelic Edict reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val AngelicEdictReprint = Printing(
+    oracleId = "36de8401-ee4e-413f-91ad-06924e39c857",
+    name = "Angelic Edict",
+    setCode = "JMP",
+    collectorNumber = "87",
+    scryfallId = "f14ed7f7-83c4-425b-a2b7-5bd76558ce76",
+    artist = "Trevor Claxton",
+    imageUri = "https://cards.scryfall.io/normal/front/f/1/f14ed7f7-83c4-425b-a2b7-5bd76558ce76.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AngelicPageReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/AngelicPageReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angelic Page reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val AngelicPageReprint = Printing(
+    oracleId = "f7f76abc-8656-4e97-9b7f-7f89ca3e6d93",
+    name = "Angelic Page",
+    setCode = "JMP",
+    collectorNumber = "88",
+    scryfallId = "ddf5db14-f2aa-4088-9894-7bd3a56dfe1e",
+    artist = "Chris Rahn",
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/ddf5db14-f2aa-4088-9894-7bd3a56dfe1e.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ArchonOfJusticeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ArchonOfJusticeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Archon of Justice reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val ArchonOfJusticeReprint = Printing(
+    oracleId = "d551931d-4ebe-4acc-9e87-6c628897071a",
+    name = "Archon of Justice",
+    setCode = "JMP",
+    collectorNumber = "89",
+    scryfallId = "042b0148-5821-4105-9cda-a0e405eb8bee",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/0/4/042b0148-5821-4105-9cda-a0e405eb8bee.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BattlegroundGeistReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BattlegroundGeistReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Battleground Geist reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val BattlegroundGeistReprint = Printing(
+    oracleId = "2450d35b-7d87-4885-b396-f8e1d3ac0b22",
+    name = "Battleground Geist",
+    setCode = "JMP",
+    collectorNumber = "139",
+    scryfallId = "52b2d108-16f2-4d9b-abc8-83ee3d2e8baf",
+    artist = "Clint Cearley",
+    imageUri = "https://cards.scryfall.io/normal/front/5/2/52b2d108-16f2-4d9b-abc8-83ee3d2e8baf.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BlackCatReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BlackCatReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Black Cat reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val BlackCatReprint = Printing(
+    oracleId = "10edf7e0-d6be-4510-819f-8834bedfba41",
+    name = "Black Cat",
+    setCode = "JMP",
+    collectorNumber = "203",
+    scryfallId = "c90a12af-b453-4d83-9a14-5411b562d480",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/c/9/c90a12af-b453-4d83-9a14-5411b562d480.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BlessedSpiritsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BlessedSpiritsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blessed Spirits reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val BlessedSpiritsReprint = Printing(
+    oracleId = "5fb899c1-3a2f-4b5e-a82d-fece51bdf786",
+    name = "Blessed Spirits",
+    setCode = "JMP",
+    collectorNumber = "92",
+    scryfallId = "2f060a74-dd75-4625-8842-27cb13a279e6",
+    artist = "Anna Steinbauer",
+    imageUri = "https://cards.scryfall.io/normal/front/2/f/2f060a74-dd75-4625-8842-27cb13a279e6.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BloodArtistReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BloodArtistReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blood Artist reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val BloodArtistReprint = Printing(
+    oracleId = "310f141c-7f37-4729-aed6-dd9c09db448d",
+    name = "Blood Artist",
+    setCode = "JMP",
+    collectorNumber = "206",
+    scryfallId = "465d8c18-c76b-488a-a4ec-ec0d2267a307",
+    artist = "Johannes Voss",
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/465d8c18-c76b-488a-a4ec-ec0d2267a307.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BoneSplintersReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BoneSplintersReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bone Splinters reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val BoneSplintersReprint = Printing(
+    oracleId = "0c936582-d4c0-4da8-bc7e-49da5a433939",
+    name = "Bone Splinters",
+    setCode = "JMP",
+    collectorNumber = "213",
+    scryfallId = "fc676672-1aeb-420a-b909-5a3215cc2ca6",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fc676672-1aeb-420a-b909-5a3215cc2ca6.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BorderlandMarauderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BorderlandMarauderReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Borderland Marauder reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val BorderlandMarauderReprint = Printing(
+    oracleId = "11fd2650-2150-4e62-8b64-e820d734a231",
+    name = "Borderland Marauder",
+    setCode = "JMP",
+    collectorNumber = "300",
+    scryfallId = "e3132919-58a7-429f-8a0f-9210d3c2c734",
+    artist = "Scott M. Fischer",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e3132919-58a7-429f-8a0f-9210d3c2c734.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BurglarRatReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BurglarRatReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Burglar Rat reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val BurglarRatReprint = Printing(
+    oracleId = "2f807301-37df-4724-871a-08e3512b07b3",
+    name = "Burglar Rat",
+    setCode = "JMP",
+    collectorNumber = "214",
+    scryfallId = "cb457c05-2a60-437a-8138-cfd581b22996",
+    artist = "Tyler Walpole",
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cb457c05-2a60-437a-8138-cfd581b22996.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CarvenCaryatidReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CarvenCaryatidReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Carven Caryatid reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val CarvenCaryatidReprint = Printing(
+    oracleId = "bddf5e9a-7c41-45a8-8fa1-18093c408e15",
+    name = "Carven Caryatid",
+    setCode = "JMP",
+    collectorNumber = "382",
+    scryfallId = "53847a21-aded-4aaa-9bf1-8592e67763ef",
+    artist = "Jim Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/5/3/53847a21-aded-4aaa-9bf1-8592e67763ef.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ChromaticSphereReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ChromaticSphereReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chromatic Sphere reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val ChromaticSphereReprint = Printing(
+    oracleId = "2e03e44a-9fff-4490-859f-b42e89e8563a",
+    name = "Chromatic Sphere",
+    setCode = "JMP",
+    collectorNumber = "462",
+    scryfallId = "edabc8b2-4413-48e4-8d6f-521b19d839a6",
+    artist = "Brian Snõddy",
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/edabc8b2-4413-48e4-8d6f-521b19d839a6.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CloudreaderSphinxReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CloudreaderSphinxReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cloudreader Sphinx reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val CloudreaderSphinxReprint = Printing(
+    oracleId = "b5a4bf91-4d31-4557-9ec4-a96ff4d9be6b",
+    name = "Cloudreader Sphinx",
+    setCode = "JMP",
+    collectorNumber = "143",
+    scryfallId = "149d4f00-106b-4aa7-a667-6360d2e149e7",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/1/4/149d4f00-106b-4aa7-a667-6360d2e149e7.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CrushingCanopyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CrushingCanopyReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crushing Canopy reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val CrushingCanopyReprint = Printing(
+    oracleId = "618cd1bc-4422-441b-906f-1a209277be93",
+    name = "Crushing Canopy",
+    setCode = "JMP",
+    collectorNumber = "386",
+    scryfallId = "01398f5f-f38e-45a7-b755-e65c8fa779f8",
+    artist = "Tomasz Jedruszek",
+    imageUri = "https://cards.scryfall.io/normal/front/0/1/01398f5f-f38e-45a7-b755-e65c8fa779f8.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DivineArrowReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DivineArrowReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Divine Arrow reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val DivineArrowReprint = Printing(
+    oracleId = "6add505a-9c0f-42e6-898d-be3194c3df33",
+    name = "Divine Arrow",
+    setCode = "JMP",
+    collectorNumber = "100",
+    scryfallId = "352c4997-2b96-45da-a4e1-70a86453c6fa",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/352c4997-2b96-45da-a4e1-70a86453c6fa.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DouseInGloomReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DouseInGloomReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Douse in Gloom reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val DouseInGloomReprint = Printing(
+    oracleId = "1fd754fd-c053-4638-b379-46d903357b01",
+    name = "Douse in Gloom",
+    setCode = "JMP",
+    collectorNumber = "223",
+    scryfallId = "e34fa15b-4559-4a8f-aa29-5c43eb4eeef9",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e34fa15b-4559-4a8f-aa29-5c43eb4eeef9.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DragonFodderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DragonFodderReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragon Fodder reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val DragonFodderReprint = Printing(
+    oracleId = "d0d2c45b-b6e3-4999-bdab-976e8f0d6617",
+    name = "Dragon Fodder",
+    setCode = "JMP",
+    collectorNumber = "309",
+    scryfallId = "cdb5eab0-5397-4c00-8cef-7d3baf38a171",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/c/d/cdb5eab0-5397-4c00-8cef-7d3baf38a171.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DragonlordSServantReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DragonlordSServantReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonlord's Servant reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val DragonlordSServantReprint = Printing(
+    oracleId = "faf81ae0-0b35-45ef-a50d-6cecf0c0eeeb",
+    name = "Dragonlord's Servant",
+    setCode = "JMP",
+    collectorNumber = "311",
+    scryfallId = "d8e5f3d8-c468-412c-a32b-92c5d8fc1e14",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/d/8/d8e5f3d8-c468-412c-a32b-92c5d8fc1e14.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DragonspeakerShamanReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DragonspeakerShamanReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonspeaker Shaman reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val DragonspeakerShamanReprint = Printing(
+    oracleId = "6a29f36b-7911-4d84-a3ae-546b131d5159",
+    name = "Dragonspeaker Shaman",
+    setCode = "JMP",
+    collectorNumber = "312",
+    scryfallId = "4ca8335b-21b1-40bc-970a-480e74874d03",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/4/c/4ca8335b-21b1-40bc-970a-480e74874d03.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DreamstoneHedronReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/DreamstoneHedronReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dreamstone Hedron reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val DreamstoneHedronReprint = Printing(
+    oracleId = "0e2575be-c596-4c8c-bf07-7941ca065721",
+    name = "Dreamstone Hedron",
+    setCode = "JMP",
+    collectorNumber = "464",
+    scryfallId = "58382d72-9b2b-44cf-8a02-b745deafc286",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/58382d72-9b2b-44cf-8a02-b745deafc286.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ExclusionMageReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ExclusionMageReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Exclusion Mage reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val ExclusionMageReprint = Printing(
+    oracleId = "fd28fe55-36cd-4242-8dd4-edb58fbb9895",
+    name = "Exclusion Mage",
+    setCode = "JMP",
+    collectorNumber = "153",
+    scryfallId = "c6344ecd-ca57-4104-a77a-d7d14264776d",
+    artist = "Chris Seaman",
+    imageUri = "https://cards.scryfall.io/normal/front/c/6/c6344ecd-ca57-4104-a77a-d7d14264776d.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FanaticalFirebrandReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FanaticalFirebrandReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fanatical Firebrand reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val FanaticalFirebrandReprint = Printing(
+    oracleId = "d36e11f1-6ab3-4273-8114-a8fbbe21c1c3",
+    name = "Fanatical Firebrand",
+    setCode = "JMP",
+    collectorNumber = "315",
+    scryfallId = "05469d01-0d2b-47b9-8a69-16cf0c3d43f8",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/0/5/05469d01-0d2b-47b9-8a69-16cf0c3d43f8.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FlameLashReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FlameLashReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flame Lash reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val FlameLashReprint = Printing(
+    oracleId = "c65e804b-9222-4fa8-88d1-df06a3279f22",
+    name = "Flame Lash",
+    setCode = "JMP",
+    collectorNumber = "316",
+    scryfallId = "8383e698-0dd7-4f35-aecb-53f0ee746999",
+    artist = "Viktor Titov",
+    imageUri = "https://cards.scryfall.io/normal/front/8/3/8383e698-0dd7-4f35-aecb-53f0ee746999.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FlametongueKavuReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FlametongueKavuReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flametongue Kavu reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val FlametongueKavuReprint = Printing(
+    oracleId = "b215196a-3716-451f-bdbd-d16c05ace5b4",
+    name = "Flametongue Kavu",
+    setCode = "JMP",
+    collectorNumber = "319",
+    scryfallId = "21a3f8d6-80ff-4292-871e-e19907841448",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/2/1/21a3f8d6-80ff-4292-871e-e19907841448.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FurnaceWhelpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FurnaceWhelpReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Furnace Whelp reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val FurnaceWhelpReprint = Printing(
+    oracleId = "8422f1e0-00ca-4ffb-a6b2-e2c9f96d7f23",
+    name = "Furnace Whelp",
+    setCode = "JMP",
+    collectorNumber = "323",
+    scryfallId = "2ce76e86-39f3-4ebf-b550-88ea7f23a91f",
+    artist = "Shreya Shetty",
+    imageUri = "https://cards.scryfall.io/normal/front/2/c/2ce76e86-39f3-4ebf-b550-88ea7f23a91f.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GhaltaPrimalHungerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GhaltaPrimalHungerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ghalta, Primal Hunger reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val GhaltaPrimalHungerReprint = Printing(
+    oracleId = "b0b6be0c-41cf-4757-9f0e-87227b6ba6b3",
+    name = "Ghalta, Primal Hunger",
+    setCode = "JMP",
+    collectorNumber = "399",
+    scryfallId = "8c342309-aef7-4733-ac1c-ff0b704539a7",
+    artist = "Chase Stone",
+    imageUri = "https://cards.scryfall.io/normal/front/8/c/8c342309-aef7-4733-ac1c-ff0b704539a7.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GoblinGoonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GoblinGoonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Goon reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val GoblinGoonReprint = Printing(
+    oracleId = "e91bcf01-113b-4532-9f78-2a155b17be4f",
+    name = "Goblin Goon",
+    setCode = "JMP",
+    collectorNumber = "326",
+    scryfallId = "5b629eb0-0e84-4eaf-bbc3-ec85ae17a8a7",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5b629eb0-0e84-4eaf-bbc3-ec85ae17a8a7.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GoblinRallyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GoblinRallyReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Rally reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val GoblinRallyReprint = Printing(
+    oracleId = "9ccb6ce8-ccb6-4809-a1cc-cebd38744815",
+    name = "Goblin Rally",
+    setCode = "JMP",
+    collectorNumber = "329",
+    scryfallId = "34d6a2d0-d855-4b87-9f4c-58dda0b81c82",
+    artist = "Nic Klein",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/34d6a2d0-d855-4b87-9f4c-58dda0b81c82.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GraveBrambleReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/GraveBrambleReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grave Bramble reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val GraveBrambleReprint = Printing(
+    oracleId = "9e2f854b-17f7-4d52-927c-abdfef86c1f8",
+    name = "Grave Bramble",
+    setCode = "JMP",
+    collectorNumber = "401",
+    scryfallId = "084446ca-fec5-446f-b6f8-edf32ecb57e3",
+    artist = "Anthony Jones",
+    imageUri = "https://cards.scryfall.io/normal/front/0/8/084446ca-fec5-446f-b6f8-edf32ecb57e3.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/HealerSHawkReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/HealerSHawkReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Healer's Hawk reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val HealerSHawkReprint = Printing(
+    oracleId = "28a52ba1-95da-44e1-8ac5-0dc23c902394",
+    name = "Healer's Hawk",
+    setCode = "JMP",
+    collectorNumber = "107",
+    scryfallId = "dd39dd28-1dc2-46a5-a3cf-9b5d267e16d6",
+    artist = "Milivoj Ćeran",
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/dd39dd28-1dc2-46a5-a3cf-9b5d267e16d6.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/HedronArchiveReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/HedronArchiveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hedron Archive reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val HedronArchiveReprint = Printing(
+    oracleId = "32263baa-d3f0-463f-92b3-4e9938476add",
+    name = "Hedron Archive",
+    setCode = "JMP",
+    collectorNumber = "468",
+    scryfallId = "c5112871-dd07-4257-9a11-a86523c4a8b6",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c5112871-dd07-4257-9a11-a86523c4a8b6.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/IndomitableWillReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/IndomitableWillReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Indomitable Will reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val IndomitableWillReprint = Printing(
+    oracleId = "cca60afe-b044-4401-8322-170aa015873c",
+    name = "Indomitable Will",
+    setCode = "JMP",
+    collectorNumber = "109",
+    scryfallId = "f5ba5d4b-5dbb-43d6-8f44-a2f80944df98",
+    artist = "Micah Epstein",
+    imageUri = "https://cards.scryfall.io/normal/front/f/5/f5ba5d4b-5dbb-43d6-8f44-a2f80944df98.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/InspiredChargeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/InspiredChargeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inspired Charge reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val InspiredChargeReprint = Printing(
+    oracleId = "d465a3d6-5830-456c-8e7a-908b464db846",
+    name = "Inspired Charge",
+    setCode = "JMP",
+    collectorNumber = "110",
+    scryfallId = "e9822b57-8e42-4158-981d-f0b0b0646fc9",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/e/9/e9822b57-8e42-4158-981d-f0b0b0646fc9.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/InspiringCaptainReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/InspiringCaptainReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inspiring Captain reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val InspiringCaptainReprint = Printing(
+    oracleId = "4a294001-645b-4691-bb32-c240ba5b5320",
+    name = "Inspiring Captain",
+    setCode = "JMP",
+    collectorNumber = "111",
+    scryfallId = "eac9c0ee-97a1-4c31-8a42-30408ef3a49c",
+    artist = "Ben Maier",
+    imageUri = "https://cards.scryfall.io/normal/front/e/a/eac9c0ee-97a1-4c31-8a42-30408ef3a49c.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/IronshellBeetleReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/IronshellBeetleReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ironshell Beetle reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val IronshellBeetleReprint = Printing(
+    oracleId = "693ca077-2b91-4de1-8136-8fe45f8ea5a7",
+    name = "Ironshell Beetle",
+    setCode = "JMP",
+    collectorNumber = "405",
+    scryfallId = "7d5573f8-5fdd-4050-af2a-fbdec51e4f37",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/7/d/7d5573f8-5fdd-4050-af2a-fbdec51e4f37.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/IsamaruHoundOfKondaReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/IsamaruHoundOfKondaReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Isamaru, Hound of Konda reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val IsamaruHoundOfKondaReprint = Printing(
+    oracleId = "cfb756dd-6fe1-430a-8f04-8b10cac62a86",
+    name = "Isamaru, Hound of Konda",
+    setCode = "JMP",
+    collectorNumber = "113",
+    scryfallId = "6afead32-3542-44c4-82d6-b6a81beb9f90",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/6/a/6afead32-3542-44c4-82d6-b6a81beb9f90.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LastGaspReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LastGaspReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Last Gasp reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val LastGaspReprint = Printing(
+    oracleId = "a82c3860-4dd6-4ffd-aa8f-ab8df687db6c",
+    name = "Last Gasp",
+    setCode = "JMP",
+    collectorNumber = "247",
+    scryfallId = "05d3b392-cbd0-437a-a21f-a36d5093a719",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/0/5/05d3b392-cbd0-437a-a21f-a36d5093a719.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LathlissDragonQueenReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LathlissDragonQueenReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lathliss, Dragon Queen reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val LathlissDragonQueenReprint = Printing(
+    oracleId = "15fef45d-f1a9-49b2-abaa-fe77bb9d1afd",
+    name = "Lathliss, Dragon Queen",
+    setCode = "JMP",
+    collectorNumber = "340",
+    scryfallId = "9460e3c6-e745-41d3-8e17-0b92fb126a16",
+    artist = "Alex Konstad",
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/9460e3c6-e745-41d3-8e17-0b92fb126a16.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LightningBoltReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LightningBoltReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Bolt reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val LightningBoltReprint = Printing(
+    oracleId = "4457ed35-7c10-48c8-9776-456485fdf070",
+    name = "Lightning Bolt",
+    setCode = "JMP",
+    collectorNumber = "342",
+    scryfallId = "ce711943-c1a1-43a0-8b89-8d169cfb8e06",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/c/e/ce711943-c1a1-43a0-8b89-8d169cfb8e06.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LightningElementalReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/LightningElementalReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Elemental reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val LightningElementalReprint = Printing(
+    oracleId = "58aee5cb-7b88-446e-ab10-9f83c10d7227",
+    name = "Lightning Elemental",
+    setCode = "JMP",
+    collectorNumber = "344",
+    scryfallId = "5f2a959e-7c17-4226-afcb-bc0bb5a4492b",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/5/f/5f2a959e-7c17-4226-afcb-bc0bb5a4492b.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MagmaJetReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MagmaJetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Magma Jet reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val MagmaJetReprint = Printing(
+    oracleId = "2f292253-64d3-4cf2-881f-a3eea4fda388",
+    name = "Magma Jet",
+    setCode = "JMP",
+    collectorNumber = "346",
+    scryfallId = "2975ce11-589a-4da8-a016-854bbaeb869c",
+    artist = "Maciej Kuciara",
+    imageUri = "https://cards.scryfall.io/normal/front/2/9/2975ce11-589a-4da8-a016-854bbaeb869c.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MesaUnicornReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MesaUnicornReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mesa Unicorn reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val MesaUnicornReprint = Printing(
+    oracleId = "5101ff9e-4680-4d38-80a5-b4c21bc67356",
+    name = "Mesa Unicorn",
+    setCode = "JMP",
+    collectorNumber = "122",
+    scryfallId = "e321bbb0-1660-4452-a9b7-d41674f7f743",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e321bbb0-1660-4452-a9b7-d41674f7f743.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MeteorGolemReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MeteorGolemReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meteor Golem reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val MeteorGolemReprint = Printing(
+    oracleId = "d9f11aa1-9219-42a8-85a9-a8f204160706",
+    name = "Meteor Golem",
+    setCode = "JMP",
+    collectorNumber = "474",
+    scryfallId = "a9a086bf-19d2-4827-af2c-a6f57d640782",
+    artist = "Lake Hurwitz",
+    imageUri = "https://cards.scryfall.io/normal/front/a/9/a9a086bf-19d2-4827-af2c-a6f57d640782.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MomentOfHeroismReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MomentOfHeroismReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moment of Heroism reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val MomentOfHeroismReprint = Printing(
+    oracleId = "a167d593-cded-43e1-b9bb-2287dbd0cbec",
+    name = "Moment of Heroism",
+    setCode = "JMP",
+    collectorNumber = "124",
+    scryfallId = "b17da4d0-f9fd-43af-85fc-ede9fa3962bf",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/b/1/b17da4d0-f9fd-43af-85fc-ede9fa3962bf.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MysticArchaeologistReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MysticArchaeologistReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mystic Archaeologist reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val MysticArchaeologistReprint = Printing(
+    oracleId = "b77dfe2a-ebc9-46b0-9134-2ecb2abdd8be",
+    name = "Mystic Archaeologist",
+    setCode = "JMP",
+    collectorNumber = "158",
+    scryfallId = "de19d2db-604b-4d5f-8184-9bb0a31c7405",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/d/e/de19d2db-604b-4d5f-8184-9bb0a31c7405.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/NebelgastHeraldReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/NebelgastHeraldReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nebelgast Herald reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val NebelgastHeraldReprint = Printing(
+    oracleId = "cf336e4c-a0d3-43aa-ad23-b98effb2b751",
+    name = "Nebelgast Herald",
+    setCode = "JMP",
+    collectorNumber = "160",
+    scryfallId = "768c0715-416c-4316-98ef-ff90bb3112ae",
+    artist = "Zezhou Chen",
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/768c0715-416c-4316-98ef-ff90bb3112ae.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/OctoprophetReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/OctoprophetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Octoprophet reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val OctoprophetReprint = Printing(
+    oracleId = "af6cfc23-b64b-4c8a-94b4-69d2b01cb3b9",
+    name = "Octoprophet",
+    setCode = "JMP",
+    collectorNumber = "161",
+    scryfallId = "fbbb3f9d-8629-4815-8b7d-f8ec9368b9b0",
+    artist = "Grzegorz Rutkowski",
+    imageUri = "https://cards.scryfall.io/normal/front/f/b/fbbb3f9d-8629-4815-8b7d-f8ec9368b9b0.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/OutnumberReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/OutnumberReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Outnumber reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val OutnumberReprint = Printing(
+    oracleId = "b72efd67-a234-44af-8296-3e182292c7e6",
+    name = "Outnumber",
+    setCode = "JMP",
+    collectorNumber = "354",
+    scryfallId = "a1214fc4-26ac-4a57-b894-6fd634d4d4fd",
+    artist = "Tyler Jacobson",
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a1214fc4-26ac-4a57-b894-6fd634d4d4fd.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PenumbraBobcatReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PenumbraBobcatReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Penumbra Bobcat reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val PenumbraBobcatReprint = Printing(
+    oracleId = "f0787397-8edb-4794-8ee1-22f97a057be8",
+    name = "Penumbra Bobcat",
+    setCode = "JMP",
+    collectorNumber = "418",
+    scryfallId = "496cce86-ff61-4d24-8d37-8c27acaff21c",
+    artist = "Heather Hudson",
+    imageUri = "https://cards.scryfall.io/normal/front/4/9/496cce86-ff61-4d24-8d37-8c27acaff21c.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PhyrexianBroodlingsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PhyrexianBroodlingsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Phyrexian Broodlings reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val PhyrexianBroodlingsReprint = Printing(
+    oracleId = "7d5e4033-bd58-4854-b9d3-a440240995ee",
+    name = "Phyrexian Broodlings",
+    setCode = "JMP",
+    collectorNumber = "263",
+    scryfallId = "edf4c9e1-eff6-4abc-ad4e-ffd7f1895d8d",
+    artist = "Daren Bader",
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/edf4c9e1-eff6-4abc-ad4e-ffd7f1895d8d.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PhyrexianDebaserReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PhyrexianDebaserReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Phyrexian Debaser reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val PhyrexianDebaserReprint = Printing(
+    oracleId = "554de904-086c-428c-9f32-b0b2498a6fd5",
+    name = "Phyrexian Debaser",
+    setCode = "JMP",
+    collectorNumber = "264",
+    scryfallId = "66e19435-59e5-44d4-b26f-f140f8bcaeb0",
+    artist = "Mark Tedin",
+    imageUri = "https://cards.scryfall.io/normal/front/6/6/66e19435-59e5-44d4-b26f-f140f8bcaeb0.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PhyrexianReclamationReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PhyrexianReclamationReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Phyrexian Reclamation reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val PhyrexianReclamationReprint = Printing(
+    oracleId = "647ca69e-cc01-4b2b-b376-bee2a98331e8",
+    name = "Phyrexian Reclamation",
+    setCode = "JMP",
+    collectorNumber = "267",
+    scryfallId = "fb0271e4-8ad1-4ad9-9b3e-7abf911f3059",
+    artist = "rk post",
+    imageUri = "https://cards.scryfall.io/normal/front/f/b/fb0271e4-8ad1-4ad9-9b3e-7abf911f3059.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PhyrexianTowerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PhyrexianTowerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Phyrexian Tower reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val PhyrexianTowerReprint = Printing(
+    oracleId = "1861e642-21d5-4232-89f3-b5557f2946c1",
+    name = "Phyrexian Tower",
+    setCode = "JMP",
+    collectorNumber = "493",
+    scryfallId = "05b2cc68-1d20-421f-9800-af0996071554",
+    artist = "Dimitar Marinski",
+    imageUri = "https://cards.scryfall.io/normal/front/0/5/05b2cc68-1d20-421f-9800-af0996071554.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PrimevalBountyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PrimevalBountyReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Primeval Bounty reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val PrimevalBountyReprint = Printing(
+    oracleId = "f633c16d-d943-421c-ad18-af35db9ec9fc",
+    name = "Primeval Bounty",
+    setCode = "JMP",
+    collectorNumber = "421",
+    scryfallId = "c8123d01-da65-4d03-9f23-3842fba5fc28",
+    artist = "Christine Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c8123d01-da65-4d03-9f23-3842fba5fc28.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PropheticPrismReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PropheticPrismReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prophetic Prism reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val PropheticPrismReprint = Printing(
+    oracleId = "134a9877-5cfb-4a2a-a0f0-930dce45f58b",
+    name = "Prophetic Prism",
+    setCode = "JMP",
+    collectorNumber = "478",
+    scryfallId = "a6f25660-97ec-4308-bc5b-1ee405b23399",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/a/6/a6f25660-97ec-4308-bc5b-1ee405b23399.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ProsperousPiratesReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ProsperousPiratesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prosperous Pirates reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val ProsperousPiratesReprint = Printing(
+    oracleId = "9dc6281b-08e0-4c66-9aef-abc7184ca36a",
+    name = "Prosperous Pirates",
+    setCode = "JMP",
+    collectorNumber = "165",
+    scryfallId = "f6db054e-8303-44c7-8c96-d031a8c85b34",
+    artist = "Josh Hass",
+    imageUri = "https://cards.scryfall.io/normal/front/f/6/f6db054e-8303-44c7-8c96-d031a8c85b34.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RaiseTheAlarmReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RaiseTheAlarmReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Raise the Alarm reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val RaiseTheAlarmReprint = Printing(
+    oracleId = "5b2364d7-a811-4595-a1b4-224c70555ffa",
+    name = "Raise the Alarm",
+    setCode = "JMP",
+    collectorNumber = "129",
+    scryfallId = "f552f9b6-0a60-44d8-985e-249617e04866",
+    artist = "Zoltan Boros",
+    imageUri = "https://cards.scryfall.io/normal/front/f/5/f552f9b6-0a60-44d8-985e-249617e04866.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RapaciousDragonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RapaciousDragonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rapacious Dragon reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val RapaciousDragonReprint = Printing(
+    oracleId = "0944ec2e-1dd9-459f-8f1d-667242cf52fe",
+    name = "Rapacious Dragon",
+    setCode = "JMP",
+    collectorNumber = "358",
+    scryfallId = "495c0dbf-1671-40f9-809c-98ef6d588512",
+    artist = "Johan Grenier",
+    imageUri = "https://cards.scryfall.io/normal/front/4/9/495c0dbf-1671-40f9-809c-98ef6d588512.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RavenousBalothReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RavenousBalothReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ravenous Baloth reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val RavenousBalothReprint = Printing(
+    oracleId = "ee771e66-72f8-480f-9920-92c68ab93c3b",
+    name = "Ravenous Baloth",
+    setCode = "JMP",
+    collectorNumber = "424",
+    scryfallId = "2f48df6c-8d5d-4d8a-b98a-793f6a56184d",
+    artist = "Todd Lockwood",
+    imageUri = "https://cards.scryfall.io/normal/front/2/f/2f48df6c-8d5d-4d8a-b98a-793f6a56184d.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RiptideLaboratoryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RiptideLaboratoryReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Riptide Laboratory reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val RiptideLaboratoryReprint = Printing(
+    oracleId = "444d50dd-a44a-42db-bbf6-d0978e3bd6a3",
+    name = "Riptide Laboratory",
+    setCode = "JMP",
+    collectorNumber = "494",
+    scryfallId = "8c6eadd8-71d8-4a87-8395-efe8cc9f0676",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/8/c/8c6eadd8-71d8-4a87-8395-efe8cc9f0676.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RuptureSpireReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RuptureSpireReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rupture Spire reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val RuptureSpireReprint = Printing(
+    oracleId = "7eadffcb-1e15-44c1-b1db-78c71b8ec1ce",
+    name = "Rupture Spire",
+    setCode = "JMP",
+    collectorNumber = "495",
+    scryfallId = "8a2c2fea-d657-49f1-af03-d5d3fef3ead0",
+    artist = "Jaime Jones",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8a2c2fea-d657-49f1-af03-d5d3fef3ead0.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SageSRowSavantReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SageSRowSavantReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sage's Row Savant reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val SageSRowSavantReprint = Printing(
+    oracleId = "6eaf5cdc-2843-4167-bd18-df4c2ac73ac0",
+    name = "Sage's Row Savant",
+    setCode = "JMP",
+    collectorNumber = "171",
+    scryfallId = "92c17066-c551-4aed-9258-1e5ed947385b",
+    artist = "Bastien L. Deharme",
+    imageUri = "https://cards.scryfall.io/normal/front/9/2/92c17066-c551-4aed-9258-1e5ed947385b.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SailorOfMeansReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SailorOfMeansReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sailor of Means reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val SailorOfMeansReprint = Printing(
+    oracleId = "c4efae03-99de-4439-925b-504602623bfd",
+    name = "Sailor of Means",
+    setCode = "JMP",
+    collectorNumber = "172",
+    scryfallId = "10c1e6ad-1227-4049-89bf-69ace48c3076",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/10c1e6ad-1227-4049-89bf-69ace48c3076.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SerraAngelReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SerraAngelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Serra Angel reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val SerraAngelReprint = Printing(
+    oracleId = "4b7ac066-e5c7-43e6-9e7e-2739b24a905d",
+    name = "Serra Angel",
+    setCode = "JMP",
+    collectorNumber = "132",
+    scryfallId = "9067f035-3437-4c5c-bae9-d3c9001a3411",
+    artist = "Donato Giancola",
+    imageUri = "https://cards.scryfall.io/normal/front/9/0/9067f035-3437-4c5c-bae9-d3c9001a3411.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SkitteringSurveyorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SkitteringSurveyorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skittering Surveyor reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val SkitteringSurveyorReprint = Printing(
+    oracleId = "85364398-923c-4ee9-8519-576fce1c26f7",
+    name = "Skittering Surveyor",
+    setCode = "JMP",
+    collectorNumber = "486",
+    scryfallId = "b8e9f488-db24-4bcd-bdf9-38c1e50f5504",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/b/8/b8e9f488-db24-4bcd-bdf9-38c1e50f5504.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SpectralSailorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SpectralSailorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spectral Sailor reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val SpectralSailorReprint = Printing(
+    oracleId = "a8fdbcdf-479d-4582-9ad5-9fbd4c740c29",
+    name = "Spectral Sailor",
+    setCode = "JMP",
+    collectorNumber = "178",
+    scryfallId = "3b591fef-21ca-4a3b-990b-d7897a405511",
+    artist = "Cristi Balanescu",
+    imageUri = "https://cards.scryfall.io/normal/front/3/b/3b591fef-21ca-4a3b-990b-d7897a405511.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SpittingEarthReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SpittingEarthReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spitting Earth reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val SpittingEarthReprint = Printing(
+    oracleId = "0c3bf4e1-d91e-4dd3-a800-e40971222c71",
+    name = "Spitting Earth",
+    setCode = "JMP",
+    collectorNumber = "364",
+    scryfallId = "de1aa8f9-8200-4ddd-9ab5-1a8181cc1792",
+    artist = "Michael Koelsch",
+    imageUri = "https://cards.scryfall.io/normal/front/d/e/de1aa8f9-8200-4ddd-9ab5-1a8181cc1792.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SporemoundReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/SporemoundReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sporemound reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val SporemoundReprint = Printing(
+    oracleId = "1be56a3d-a6c0-4b65-ae71-3d90ceefc6c0",
+    name = "Sporemound",
+    setCode = "JMP",
+    collectorNumber = "433",
+    scryfallId = "f2799310-c77a-47b2-b1a5-50c029600020",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/f/2/f2799310-c77a-47b2-b1a5-50c029600020.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/TalrandSInvocationReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/TalrandSInvocationReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Talrand's Invocation reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val TalrandSInvocationReprint = Printing(
+    oracleId = "43355ac4-bf8c-48f6-a322-fafbc9d132d1",
+    name = "Talrand's Invocation",
+    setCode = "JMP",
+    collectorNumber = "182",
+    scryfallId = "4b153c2f-fc87-49bc-9d1e-d5e7e25b2142",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/4/b/4b153c2f-fc87-49bc-9d1e-d5e7e25b2142.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ThragtuskReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ThragtuskReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thragtusk reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val ThragtuskReprint = Printing(
+    oracleId = "0dd0e91a-d16b-4718-8d11-1a3fcf8e0753",
+    name = "Thragtusk",
+    setCode = "JMP",
+    collectorNumber = "436",
+    scryfallId = "d0594c41-0361-4a3b-a9cd-60f4e3b0cffe",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/d/0/d0594c41-0361-4a3b-a9cd-60f4e3b0cffe.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/VolleyVeteranReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/VolleyVeteranReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Volley Veteran reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val VolleyVeteranReprint = Printing(
+    oracleId = "bf4268e6-170a-445b-b215-718f7494ae28",
+    name = "Volley Veteran",
+    setCode = "JMP",
+    collectorNumber = "369",
+    scryfallId = "b4c8e3b3-c8bb-415d-a19f-45ec679108ee",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b4c8e3b3-c8bb-415d-a19f-45ec679108ee.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WildheartInvokerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WildheartInvokerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wildheart Invoker reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val WildheartInvokerReprint = Printing(
+    oracleId = "ff8fb796-af5d-4d64-ab3c-7f2469dfa6bf",
+    name = "Wildheart Invoker",
+    setCode = "JMP",
+    collectorNumber = "444",
+    scryfallId = "6b146ba7-591c-4553-b250-0a6eed24f0b5",
+    artist = "Erica Yang",
+    imageUri = "https://cards.scryfall.io/normal/front/6/b/6b146ba7-591c-4553-b250-0a6eed24f0b5.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WizardSRetortReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WizardSRetortReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wizard's Retort reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val WizardSRetortReprint = Printing(
+    oracleId = "b828251c-86a9-454f-9852-d0876d0f5153",
+    name = "Wizard's Retort",
+    setCode = "JMP",
+    collectorNumber = "198",
+    scryfallId = "979cd394-80ce-4559-9f3a-57cd84299182",
+    artist = "Grzegorz Rutkowski",
+    imageUri = "https://cards.scryfall.io/normal/front/9/7/979cd394-80ce-4559-9f3a-57cd84299182.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WoodbornBehemothReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/WoodbornBehemothReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Woodborn Behemoth reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val WoodbornBehemothReprint = Printing(
+    oracleId = "9bc458ac-5566-4978-aeaa-73b600d4ec29",
+    name = "Woodborn Behemoth",
+    setCode = "JMP",
+    collectorNumber = "446",
+    scryfallId = "a2e49925-a4ab-4960-ad83-20583dcd2c2c",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/a/2/a2e49925-a4ab-4960-ad83-20583dcd2c2c.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/YoungPyromancerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/YoungPyromancerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Young Pyromancer reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val YoungPyromancerReprint = Printing(
+    oracleId = "5fac139a-07d3-4e6c-98e3-d98b199f7a6f",
+    name = "Young Pyromancer",
+    setCode = "JMP",
+    collectorNumber = "372",
+    scryfallId = "218af707-cc60-407e-af20-e21879a0e902",
+    artist = "Cynthia Sheppard",
+    imageUri = "https://cards.scryfall.io/normal/front/2/1/218af707-cc60-407e-af20-e21879a0e902.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ZendikarSRoilReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ZendikarSRoilReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zendikar's Roil reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val ZendikarSRoilReprint = Printing(
+    oracleId = "a842cc2b-52eb-4dc5-86c6-6575c2ed913d",
+    name = "Zendikar's Roil",
+    setCode = "JMP",
+    collectorNumber = "448",
+    scryfallId = "180aa3d6-8475-4c98-a140-af736a9c135e",
+    artist = "Sam Burley",
+    imageUri = "https://cards.scryfall.io/normal/front/1/8/180aa3d6-8475-4c98-a140-af736a9c135e.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)


### PR DESCRIPTION
Implements every card the Set Completion view still badges ⚡ **Assay-ready** in Jumpstart — Assay
verdict `whole` ∩ not yet in JMP's pool. That is **79** cards, and unlike a normal sweep every one of
them already had a canonical `CardDefinition` in an earlier set, so the entire change is `Printing`
rows: **79 new files, zero new `CardDefinition`s, zero SDK vocabulary**.

**JMP: 127/460 (28%) → 206/460 (45%). Assay-ready-but-missing: 79 → 0.**

## Why there were 79 left after #1946

#1946 swept the Assay-ready cards that needed *authoring* — 89 canonicals placed into their earliest
sets plus 7 JMP originals — and reported the remaining count as 0. It wasn't: these 79 are the other
half of the same filter, cards whose canonical had existed in the corpus for a long time and that
Jumpstart simply never got a row for. `SetCoverageService.assayReady` counts a card as authored when
its name appears in a set's `cards` + `basicLands` + `printings`, so a missing reprint row keeps a
card badged Assay-ready exactly like a missing canonical does. Measured before and after on this
branch rather than reasoned about; the ledger (`assay-verdicts.json`) has not been re-baked since
2026-08-17, so the verdicts are the same ones #1946 saw.

## How they were produced

`scripts/generate-reprints.py --set JMP` — the repo's own generator, no hand-authoring. Metadata comes
entirely from the local Scryfall caches:

- `~/.cache/scryfall/printings/<slug>.json` → `oracleId`, `scryfallId`, `collectorNumber`,
  `releaseDate`, `rarity` (40 of the 79 were past the 30-day TTL and were re-fetched first)
- `~/.cache/scryfall/jmp.json` → `artist`, `imageUri`

The generator's candidate list and the Assay-ready list were cross-checked against each other and
match exactly — 79 in both, no card in one and not the other. Every written file's `name`,
`collectorNumber` and `artist` were then diffed back against `jmp.json`: **0 mismatches**.

No basic lands are owed — #1946 added Jumpstart's forty basic land arts and wired `basicLands` into
`JumpstartSet`.

## The cards

Aegis Turtle, Aether Spellbomb, Angel of Mercy, Angelic Edict, Angelic Page, Archon of Justice,
Battleground Geist, Black Cat, Blessed Spirits, Blood Artist, Bone Splinters, Borderland Marauder,
Burglar Rat, Carven Caryatid, Chromatic Sphere, Cloudreader Sphinx, Crushing Canopy, Divine Arrow,
Douse in Gloom, Dragon Fodder, Dragonlord's Servant, Dragonspeaker Shaman, Dreamstone Hedron,
Exclusion Mage, Fanatical Firebrand, Flame Lash, Flametongue Kavu, Furnace Whelp, Ghalta Primal
Hunger, Goblin Goon, Goblin Rally, Grave Bramble, Healer's Hawk, Hedron Archive, Indomitable Will,
Inspired Charge, Inspiring Captain, Ironshell Beetle, Isamaru Hound of Konda, Last Gasp, Lathliss
Dragon Queen, Lightning Bolt, Lightning Elemental, Magma Jet, Mesa Unicorn, Meteor Golem, Moment of
Heroism, Mystic Archaeologist, Nebelgast Herald, Octoprophet, Outnumber, Penumbra Bobcat, Phyrexian
Broodlings, Phyrexian Debaser, Phyrexian Reclamation, Phyrexian Tower, Primeval Bounty, Prophetic
Prism, Prosperous Pirates, Raise the Alarm, Rapacious Dragon, Ravenous Baloth, Riptide Laboratory,
Rupture Spire, Sage's Row Savant, Sailor of Means, Serra Angel, Skittering Surveyor, Spectral Sailor,
Spitting Earth, Sporemound, Talrand's Invocation, Thragtusk, Volley Veteran, Wildheart Invoker,
Wizard's Retort, Woodborn Behemoth, Young Pyromancer, Zendikar's Roil.

## Verification

- `just card-status --set JMP` — 127 → 206 done, 254 missing, and those 254 read
  **249 `LINE_DECLINED` / 5 `LINES_DO_NOT_FOLD`** against the verdict ledger: no Assay-ready card left.
- `:mtg-sets:test` — **BUILD SUCCESSFUL**, including `CardDiscoveryEquivalenceTest` and
  `CardDiscoveryTest > discovery picks up Printing reprints declared in the cards package`, which are
  the tests that actually see these rows.
- Generated metadata diffed field-by-field against the JMP Scryfall payload — 0 mismatches.

`just assay-differential` was not run: it compares Assay's reading of a `CardDefinition` against what
was written, and this change adds no `CardDefinition`s. `set-totals.json` needs no re-bake either —
it holds the canonical *denominator*, which is unchanged; the server derives the numerator from
`MtgSetCatalog` at runtime.

## Note on canonical placement

Two of these cards' canonicals sit outside their earliest scaffolded printing — Ghalta, Primal Hunger
lives in BLC but was first printed in RIX, and Flame Lash lives in BLB but was first printed in KLD.
`missing-reprints.py` reports that separately as canonical drift, not as a missing reprint; it's a
`coverage-relocate` job and is deliberately left out of a data-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
