### PR TITLE
Implement every Assay-ready card in Modern Horizons 2 (81 cards, 11/308 → 92/308)

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ZuranOrb.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ZuranOrb.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Zuran Orb — Ice Age #350
+ * {0} · Artifact
+ *
+ * Sacrifice a land: You gain 2 life.
+ *
+ * The whole card is one activated ability with no mana component: `Costs.Sacrifice` over
+ * [GameObjectFilter.Land] is the entire cost. `Sacrifice` rather than `SacrificeAnother` — Zuran Orb
+ * is an artifact, so it can never match a land filter, and the printed line places no "another"
+ * restriction. Repeatability is intentional: with no tap symbol and no once-per-turn rider the
+ * ability can be activated as many times as there are lands to feed it, which is exactly why the
+ * card is what it is.
+ *
+ * Overgrown Estate is the same shape at three life.
+ */
+val ZuranOrb = card("Zuran Orb") {
+    manaCost = "{0}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Sacrifice a land: You gain 2 life."
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Land)
+        effect = Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "350"
+        artist = "Sandra Everingham"
+        flavorText = "\"I will go to any length to achieve my goal. Eternal life is worth any sacrifice.\"\n—Zur the Enchanter"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3a9d1082-a862-45d4-9e5e-392e879fead6.jpg?1783947454"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/Greed.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/Greed.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Greed — Legends #101
+ * {3}{B} · Enchantment
+ *
+ * {B}, Pay 2 life: Draw a card.
+ *
+ * Legends is Greed's earliest printing, so the canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives here; Commander 2013 and Modern Horizons 2 contribute `Printing` rows only.
+ *
+ * The life payment is part of the *cost*, not an effect: [Costs.PayLife] inside a
+ * [Costs.Composite] alongside the mana, so activation is illegal unless the life can actually be
+ * paid, and the draw never happens on a failed activation. Life payment is legal at any total
+ * above zero — a player at 2 may pay and then lose to the state-based action.
+ */
+val Greed = card("Greed") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "{B}, Pay 2 life: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}"), Costs.PayLife(2))
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "101"
+        artist = "Phil Foglio"
+        flavorText = "\"There is no calamity greater than lavish desires./ There is no greater guilt than discontentment./ And there is no greater disaster than greed.\" —*Tao Tê Ching 46*"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/111a16a2-e875-4756-80db-290f9e8606db.jpg?1783948066"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ulg/cards/AngelicCurator.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ulg/cards/AngelicCurator.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.ulg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Angelic Curator — Urza's Legacy #1
+ * {1}{W} · Creature — Angel Spirit · 1 / 1
+ *
+ * Flying, protection from artifacts
+ *
+ * Urza's Legacy's cheap anti-artifact flier — a sideboard card for a block whose whole theme was
+ * artifacts, later reprinted into Modern Horizons 2 (the canonical definition stays here, at the
+ * earliest printing; MH2 contributes only a `Printing` row).
+ *
+ * The two halves take different SDK shapes because protection is parameterised. Flying is a plain
+ * enum ([Keyword.FLYING]); protection from artifacts is a [KeywordAbility.Protection] carrying a
+ * [ProtectionScope.CardType] of `"Artifact"`, which the engine projects as a scoped protection
+ * keyword. All four DEBT consequences (CR 702.16 — can't be Damaged, Enchanted/Equipped, Blocked,
+ * or Targeted by artifact sources) fall out of that projection, so nothing further is wired here:
+ * an artifact creature can't block it, an artifact's ability can't target it, and damage from an
+ * artifact source is prevented.
+ *
+ * Note this stops *artifact sources*, not artifact creatures specifically, and it does not stop an
+ * artifact creature's controller from blocking with it — protection prevents the Curator from
+ * being blocked, not from blocking.
+ */
+val AngelicCurator = card("Angelic Curator") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel Spirit"
+    power = 1
+    toughness = 1
+    oracleText = "Flying, protection from artifacts"
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.CardType("Artifact")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "1"
+        artist = "Greg Staples"
+        flavorText = "\"Do not treat your people as you treat your artifacts. Let them go, and they will live; seal them here, and they will die.\"\n—Urza, to Radiant"
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c63ba2da-6dea-44ac-8439-527222da565b.jpg?1783946254"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/QuirionRanger.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/QuirionRanger.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.vis.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Quirion Ranger — Visions #117
+ * {G} · Creature — Elf Ranger · 1 / 1
+ *
+ * Return a Forest you control to its owner's hand: Untap target creature. Activate only once each
+ * turn.
+ *
+ * The Forest is the whole cost — there is no mana in it — so [Costs.ReturnToHand] carries the
+ * filter. "A Forest" is the land subtype, not the basic land card named Forest, so the filter is
+ * `Land.withSubtype(Forest)`: a Savannah or a Dryad Arbor pays it too. The cost atom excludes the
+ * source, which costs the Ranger nothing here (it isn't a land).
+ *
+ * "Activate only once each turn" is [ActivationRestriction.OncePerTurn] — a restriction on the
+ * ability, checked at activation, so it is not reset by the Ranger leaving and re-entering the
+ * battlefield within a turn.
+ */
+val QuirionRanger = card("Quirion Ranger") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Ranger"
+    power = 1
+    toughness = 1
+    oracleText = "Return a Forest you control to its owner's hand: Untap target creature. Activate only once each turn."
+
+    activatedAbility {
+        cost = Costs.ReturnToHand(GameObjectFilter.Land.withSubtype(Subtype.FOREST))
+        val t = target("creature", Targets.Creature)
+        effect = Effects.Untap(t)
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "117"
+        artist = "Tom Kyffin"
+        flavorText = "\"Respect the earth, for it will one day be your shield and another day your blanket.\"\n—Liefellen, Quirion exarch"
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/56efe72c-6d7f-44f6-ac74-01af9305c4b6.jpg?1783946981"
+    }
+}

--- a/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ody/cards/Millikin.kt
+++ b/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ody/cards/Millikin.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.ody.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Millikin — Odyssey #302
+ * {2} · Artifact Creature — Construct · 0 / 1
+ *
+ * {T}, Mill a card: Add {C}. (Activate only as an instant. To mill a card, put the top card of your library into your graveyard.)
+ *
+ * Deranged Assistant's ability on an artifact body, and it is modelled the same way. The mill is
+ * part of the *cost*, not the effect — `Costs.MillCard` (CostAtom.Mill). Per CR 701.17b the ability
+ * can't be activated at all with an empty library, so the mill gates legal-action enumeration
+ * rather than fizzling at resolution.
+ *
+ * Not a mana ability, despite producing mana with no target. CR 605.1a requires that a mana
+ * ability's **cost** and effect not move any card to or from a library, and the mill cost does
+ * exactly that — so this is an ordinary activated ability: it uses the stack, can be responded to,
+ * and can't be activated while another cost is being paid. That is what the printed reminder text
+ * "Activate only as an instant" now spells out; the old rules classification (a mana ability, whose
+ * cost is paid on activation and can't be reversed when the spell being cast is) no longer
+ * describes how the card plays. `manaAbility` is therefore deliberately left at its `false` default.
+ */
+val Millikin = card("Millikin") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 0
+    toughness = 1
+    oracleText = "{T}, Mill a card: Add {C}. (Activate only as an instant. To mill a card, put the top card of your library into your graveyard.)"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.MillCard)
+        effect = Effects.AddColorlessMana(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "302"
+        artist = "Alex Horley-Orlandelli"
+        flavorText = "The toymaker frowned in bewilderment. None of his creations had ever sneezed before."
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/0550133b-22cf-4ecd-b89a-8c2f0beeaa22.jpg?1783945203"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GreedReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GreedReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Greed reprint in Commander 2013. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Legends (`leg`) `cards/` package; this file contributes only
+ * per-printing presentation data.
+ */
+val GreedReprint = Printing(
+    oracleId = "1ff62220-be95-4901-b8d8-812b9a1a1b0a",
+    name = "Greed",
+    setCode = "C13",
+    collectorNumber = "79",
+    scryfallId = "c39d94fb-a092-4307-b99b-73fb97998cc2",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/c/3/c39d94fb-a092-4307-b99b-73fb97998cc2.jpg?1783939675",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+    borderColor = "black",
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/ShardlessAgent.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/ShardlessAgent.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shardless Agent — Planechase 2012 #104
+ * {1}{G}{U} · Artifact Creature — Human Rogue · 2 / 2
+ *
+ * Cascade (When you cast this spell, exile cards from the top of your library until you exile a
+ * nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards
+ * on the bottom in a random order.)
+ *
+ * Planechase 2012 is the Agent's earliest real printing, so the canonical definition lives here;
+ * the Modern Horizons 2 appearance is a `Printing` row (`mh2/cards/ShardlessAgentReprint.kt`).
+ *
+ * [Keyword.CASCADE] is display-only vocabulary — nothing in the rules engine reads it. Cascade *is*
+ * a "when you cast this spell" triggered ability (CR 702.85a), so the behaviour lives in a
+ * [Triggers.WhenYouCastThisSpell] trigger feeding [Effects.Cascade], with the keyword kept only for
+ * the printed line — the canonical lowering in `arb/cards/BloodbraidElf.kt`. The trigger goes on the
+ * stack above the Agent itself, so the free spell resolves first and the 2/2 body lands after it.
+ */
+val ShardlessAgent = card("Shardless Agent") {
+    manaCost = "{1}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Artifact Creature — Human Rogue"
+    power = 2
+    toughness = 2
+    oracleText = "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)"
+
+    keywords(Keyword.CASCADE)
+
+    // Cascade — the cast trigger the keyword abbreviates (CR 702.85a).
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        effect = Effects.Cascade
+        description = "Cascade"
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "104"
+        artist = "Izzy"
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ceb4df89-a97e-4479-b7f0-7083417a9565.jpg?1783940595"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FiligreeAttendantReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FiligreeAttendantReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Filigree Attendant reprint in Jumpstart 2022. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Modern Horizons 2 (`mh2`) `cards/` package; this file contributes only
+ * per-printing presentation data.
+ */
+val FiligreeAttendantReprint = Printing(
+    oracleId = "ab7c9e72-8f30-47f7-918c-cd3c0593d704",
+    name = "Filigree Attendant",
+    setCode = "J22",
+    collectorNumber = "298",
+    scryfallId = "e70d6006-9f57-4db1-8e65-f2392689b5dd",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/e/7/e70d6006-9f57-4db1-8e65-f2392689b5dd.jpg?1783919061",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/ModernHorizons2Set.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/ModernHorizons2Set.kt
@@ -21,6 +21,10 @@ object ModernHorizons2Set : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/AngelicCuratorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/AngelicCuratorReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angelic Curator reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Urza's Legacy (`ulg`) `cards/` package; this file contributes only
+ * per-printing presentation data.
+ */
+val AngelicCuratorReprint = Printing(
+    oracleId = "cca29a9b-794f-4712-8e6c-36ce3da9cb8b",
+    name = "Angelic Curator",
+    setCode = "MH2",
+    collectorNumber = "262",
+    scryfallId = "332352c2-98f2-4eb8-b49a-026a39df227b",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/3/3/332352c2-98f2-4eb8-b49a-026a39df227b.jpg?1783926792",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.UNCOMMON,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ArcboundMouser.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ArcboundMouser.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Arcbound Mouser — Modern Horizons 2 #3
+ * {W} · Artifact Creature — Cat · 0 / 0
+ *
+ * Lifelink
+ * Modular 1 (This creature enters with a +1/+1 counter on it. When it dies, you may put its +1/+1
+ * counters on target artifact creature.)
+ *
+ * **Modular is lowered here, not handled by the engine.** [KeywordAbility.modular] is display-only
+ * vocabulary — nothing in the rules engine reads `Keyword.MODULAR` — so the two halves the reminder
+ * text spells out are wired explicitly, exactly as `mh3/cards/ArcboundCondor.kt` does:
+ *
+ *  - the ETB half is an [EntersWithCounters] replacement (`selfOnly`, one +1/+1 counter). That is
+ *    why the printed box is 0/0: a Mouser on the battlefield is a 1/1 made entirely of counters.
+ *  - the death half is an *optional* dies trigger reading
+ *    [ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT] rather than the live entity — the
+ *    counters cease to exist the moment the Mouser changes zones, so the count must come from
+ *    last-known information (CR 603.10 / 608.2h).
+ *
+ * That last point is also why this uses [Effects.AddDynamicCounters] with an explicit +1/+1 count
+ * rather than the neighbouring `Effects.MoveAllLastKnownCounters` shape (Servant of the Scale):
+ * moving *all* last-known counters would hand the target any leftover -1/-1 counters too, and
+ * modular only ever moves the +1/+1 ones.
+ */
+val ArcboundMouser = card("Arcbound Mouser") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Cat"
+    power = 0
+    toughness = 0
+    oracleText = "Lifelink\n" +
+        "Modular 1 (This creature enters with a +1/+1 counter on it. When it dies, you may put its +1/+1 counters on target artifact creature.)"
+
+    keywords(Keyword.LIFELINK)
+    keywordAbility(KeywordAbility.modular(1))
+
+    // Modular, half one: "This creature enters with a +1/+1 counter on it."
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = 1,
+            selfOnly = true
+        )
+    )
+
+    // Modular, half two: "When it dies, you may put its +1/+1 counters on target artifact creature."
+    triggeredAbility {
+        trigger = Triggers.Dies
+        target = TargetPermanent(filter = TargetFilter(GameObjectFilter.ArtifactCreature))
+        optional = true
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmount.ContextProperty(ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT),
+            EffectTarget.ContextTarget(0)
+        )
+        description = "When this creature dies, you may put its +1/+1 counters on target artifact creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "3"
+        artist = "Campbell White"
+        flavorText = "It doesn't purr. It hums."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d66e724-49ee-4f08-a160-584350de1d95.jpg?1783926896"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ArcboundPrototype.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ArcboundPrototype.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Arcbound Prototype — Modern Horizons 2 #4
+ * {1}{W} · Artifact Creature — Assembly-Worker · 0 / 0
+ *
+ * Modular 2 (This creature enters with two +1/+1 counters on it. When it dies, you may put its
+ * +1/+1 counters on target artifact creature.)
+ *
+ * A vanilla body plus modular, so the whole card *is* the lowering. [KeywordAbility.modular] is
+ * display-only vocabulary — nothing in the rules engine reads `Keyword.MODULAR` — so the two halves
+ * the reminder text spells out are wired explicitly, exactly as `mh3/cards/ArcboundCondor.kt` does:
+ *
+ *  - the ETB half is an [EntersWithCounters] replacement (`selfOnly`, two +1/+1 counters). That is
+ *    why the printed box is 0/0: a Prototype on the battlefield is a 2/2 made of counters, and it
+ *    dies immediately as a state-based action if it ever loses them.
+ *  - the death half is an *optional* dies trigger reading
+ *    [ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT] rather than the live entity — the
+ *    counters cease to exist the moment it changes zones, so the count must come from last-known
+ *    information (CR 603.10 / 608.2h).
+ *
+ * That last point is also why this uses [Effects.AddDynamicCounters] with an explicit +1/+1 count
+ * rather than the neighbouring `Effects.MoveAllLastKnownCounters` shape (Servant of the Scale):
+ * moving *all* last-known counters would hand the target any leftover -1/-1 counters too, and
+ * modular only ever moves the +1/+1 ones.
+ */
+val ArcboundPrototype = card("Arcbound Prototype") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Assembly-Worker"
+    power = 0
+    toughness = 0
+    oracleText = "Modular 2 (This creature enters with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)"
+
+    keywordAbility(KeywordAbility.modular(2))
+
+    // Modular, half one: "This creature enters with two +1/+1 counters on it."
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = 2,
+            selfOnly = true
+        )
+    )
+
+    // Modular, half two: "When it dies, you may put its +1/+1 counters on target artifact creature."
+    triggeredAbility {
+        trigger = Triggers.Dies
+        target = TargetPermanent(filter = TargetFilter(GameObjectFilter.ArtifactCreature))
+        optional = true
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmount.ContextProperty(ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT),
+            EffectTarget.ContextTarget(0)
+        )
+        description = "When this creature dies, you may put its +1/+1 counters on target artifact creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "4"
+        artist = "Svetlin Velinov"
+        flavorText = "It flickered to life, saw itself alone, and began to build."
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1cb0a1a4-9216-47f8-a4e3-20fe0de6a518.jpg?1783926897"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ArcboundSlasher.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ArcboundSlasher.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.riot
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Arcbound Slasher — Modern Horizons 2 #111
+ * {4}{R} · Artifact Creature — Cat · 0 / 0
+ *
+ * Modular 4 (This creature enters with four +1/+1 counters on it. When it dies, you may put its
+ * +1/+1 counters on target artifact creature.)
+ * Riot (This creature enters with your choice of an additional +1/+1 counter or haste.)
+ *
+ * Two entry-time mechanics stack here, and they are lowered differently because the SDK supports
+ * them differently.
+ *
+ * **Riot** has a helper: [riot] wires the whole Khans-Siege `EntersWithChoice(MODE)` pattern — the
+ * mode choice, the mode-gated +1/+1 counter, and the mode-gated haste grant. Nothing extra belongs
+ * next to it; adding a second [EntersWithCounters] for riot would double the counter.
+ *
+ * **Modular** has none: [KeywordAbility.modular] is display-only vocabulary — nothing in the rules
+ * engine reads `Keyword.MODULAR` — so the two halves the reminder text spells out are wired
+ * explicitly, exactly as `mh3/cards/ArcboundCondor.kt` does:
+ *
+ *  - the ETB half is its *own* [EntersWithCounters] replacement (`selfOnly`, four +1/+1 counters),
+ *    independent of riot's. Both replacement effects apply as the Slasher enters (CR 616.1), which
+ *    is exactly what "an **additional** +1/+1 counter" means: choose the counter mode and it enters
+ *    a 5/5, choose haste and it enters a hasty 4/4. The printed box is 0/0 because the body is made
+ *    entirely of those counters.
+ *  - the death half is an *optional* dies trigger reading
+ *    [ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT] rather than the live entity — the
+ *    counters cease to exist the moment it changes zones, so the count must come from last-known
+ *    information (CR 603.10 / 608.2h). Reading that key rather than the neighbouring
+ *    `Effects.MoveAllLastKnownCounters` shape also keeps riot's counter in scope (it is a plain
+ *    +1/+1 counter) while leaving any -1/-1 counters behind, which is what modular moves.
+ */
+val ArcboundSlasher = card("Arcbound Slasher") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact Creature — Cat"
+    power = 0
+    toughness = 0
+    oracleText = "Modular 4 (This creature enters with four +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)\n" +
+        "Riot (This creature enters with your choice of an additional +1/+1 counter or haste.)"
+
+    keywordAbility(KeywordAbility.modular(4))
+
+    // Modular, half one: "This creature enters with four +1/+1 counters on it."
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = 4,
+            selfOnly = true
+        )
+    )
+
+    // Modular, half two: "When it dies, you may put its +1/+1 counters on target artifact creature."
+    triggeredAbility {
+        trigger = Triggers.Dies
+        target = TargetPermanent(filter = TargetFilter(GameObjectFilter.ArtifactCreature))
+        optional = true
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmount.ContextProperty(ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT),
+            EffectTarget.ContextTarget(0)
+        )
+        description = "When this creature dies, you may put its +1/+1 counters on target artifact creature."
+    }
+
+    // Riot (printed) — the helper lowers the choice, the counter and the haste grant.
+    riot()
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "Campbell White"
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dcafff1a-e220-40ff-8c00-de6037219bc6.jpg?1783926851"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ArcboundWhelp.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ArcboundWhelp.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Arcbound Whelp — Modern Horizons 2 #113
+ * {3}{R} · Artifact Creature — Dragon · 0 / 0
+ *
+ * Flying
+ * {R}: This creature gets +1/+0 until end of turn.
+ * Modular 2 (This creature enters with two +1/+1 counters on it. When it dies, you may put its
+ * +1/+1 counters on target artifact creature.)
+ *
+ * The firebreathing line is the plain unrestricted shape — a bare [Costs.Mana] activation pumping
+ * [EffectTarget.Self], the same as `mh3/cards/FurnaceHellkite.kt`.
+ *
+ * **Modular is lowered here, not handled by the engine.** [KeywordAbility.modular] is display-only
+ * vocabulary — nothing in the rules engine reads `Keyword.MODULAR` — so the two halves the reminder
+ * text spells out are wired explicitly, exactly as `mh3/cards/ArcboundCondor.kt` does:
+ *
+ *  - the ETB half is an [EntersWithCounters] replacement (`selfOnly`, two +1/+1 counters). That is
+ *    why the printed box is 0/0: a Whelp on the battlefield is a 2/2 made of counters, and the
+ *    firebreathing pump is a layer-7c bonus on top of that, not part of the modular count.
+ *  - the death half is an *optional* dies trigger reading
+ *    [ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT] rather than the live entity — the
+ *    counters cease to exist the moment it changes zones, so the count must come from last-known
+ *    information (CR 603.10 / 608.2h).
+ *
+ * That last point is also why this uses [Effects.AddDynamicCounters] with an explicit +1/+1 count
+ * rather than the neighbouring `Effects.MoveAllLastKnownCounters` shape (Servant of the Scale):
+ * moving *all* last-known counters would hand the target any leftover -1/-1 counters too, and
+ * modular only ever moves the +1/+1 ones.
+ */
+val ArcboundWhelp = card("Arcbound Whelp") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact Creature — Dragon"
+    power = 0
+    toughness = 0
+    oracleText = "Flying\n" +
+        "{R}: This creature gets +1/+0 until end of turn.\n" +
+        "Modular 2 (This creature enters with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)"
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.modular(2))
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "{R}: This creature gets +1/+0 until end of turn."
+    }
+
+    // Modular, half one: "This creature enters with two +1/+1 counters on it."
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = 2,
+            selfOnly = true
+        )
+    )
+
+    // Modular, half two: "When it dies, you may put its +1/+1 counters on target artifact creature."
+    triggeredAbility {
+        trigger = Triggers.Dies
+        target = TargetPermanent(filter = TargetFilter(GameObjectFilter.ArtifactCreature))
+        optional = true
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmount.ContextProperty(ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT),
+            EffectTarget.ContextTarget(0)
+        )
+        description = "When this creature dies, you may put its +1/+1 counters on target artifact creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "113"
+        artist = "Craig J Spearing"
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/154ed1d3-e24a-48ba-8f7b-be254c08d1cc.jpg?1783926850"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/BattlePlan.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/BattlePlan.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Battle Plan — Modern Horizons 2 #114
+ * {3}{R} · Enchantment
+ *
+ * At the beginning of combat on your turn, target creature you control gets +2/+0 until end of turn.
+ * Basic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)
+ *
+ * [Triggers.BeginCombat] is the "at the beginning of combat on your turn" step trigger — a
+ * `StepEvent(BEGIN_COMBAT, Player.You)` — so the enchantment fires only in its controller's combat
+ * phase, once per turn. The target is chosen when the ability goes on the stack (CR 603.3d), so
+ * `Targets.CreatureYouControl` is the target requirement rather than a filter read at resolution.
+ *
+ * Basic landcycling is the [KeywordAbility.basicLandcycling] flavour of cycling: the shared
+ * typecycling machinery narrows the discard-and-search to *basic* land cards, so a nonbasic land
+ * that merely has a basic land type is not a legal fetch.
+ */
+val BattlePlan = card("Battle Plan") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of combat on your turn, target creature you control gets +2/+0 until end of turn.\n" +
+        "Basic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)"
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val t = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.ModifyStats(2, 0, t)
+    }
+
+    keywordAbility(KeywordAbility.basicLandcycling("{1}{R}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "114"
+        artist = "Paul Scott Canavan"
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2bc1e907-0e77-42ee-9eca-eae632020204.jpg?1783926850"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/BlazingRootwalla.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/BlazingRootwalla.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blazing Rootwalla — Modern Horizons 2 #115
+ * {R} · Creature — Lizard · 1 / 1
+ *
+ * {R}: This creature gets +2/+0 until end of turn. Activate only once each turn.
+ * Madness {0} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)
+ *
+ * "Activate only once each turn" is [ActivationRestriction.OncePerTurn] on the ability, not a
+ * cost or a condition — the engine refuses the activation outright once the per-turn counter is
+ * spent (CR 602.5d), which is what keeps it off the stack rather than fizzling it later.
+ *
+ * Madness {0} is a real zero cost, not the absence of one: `madness("{0}")` parses to a payable
+ * cost, so the madness trigger still asks whether you want to cast the card. `CardBuilder.build()`
+ * derives the printed `Keyword.MADNESS` from the keyword ability, so the bare keyword is never
+ * written next to it.
+ */
+val BlazingRootwalla = card("Blazing Rootwalla") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard"
+    power = 1
+    toughness = 1
+    oracleText = "{R}: This creature gets +2/+0 until end of turn. Activate only once each turn.\n" +
+        "Madness {0} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+    }
+
+    madness("{0}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "115"
+        artist = "Jokubas Uogintas"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/4404fc9c-ef02-479c-9638-0cc163f0b48f.jpg?1783926849"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/CabalInitiate.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/CabalInitiate.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cabal Initiate — Modern Horizons 2 #78
+ * {1}{B} · Creature — Human Warlock · 2 / 1
+ *
+ * Discard a card: This creature gains lifelink until end of turn.
+ * Threshold — This creature gets +1/+2 as long as there are seven or more cards in your graveyard.
+ *
+ * "Threshold" is an ability word, not a keyword — there is no `Keyword.THRESHOLD`, and nothing in
+ * the engine reads the word. It lives only in [oracleText]; the ability it labels is a plain
+ * [ConditionalStaticAbility] whose condition is re-evaluated during layer projection, so the bonus
+ * appears and disappears the instant the graveyard crosses seven cards (CR 702.21a — a static
+ * ability, never a trigger).
+ *
+ * [GroupFilter.source] scopes the [ModifyStats] to this permanent only. The two abilities feed each
+ * other: paying [Costs.DiscardCard] both buys lifelink and pushes the graveyard toward threshold.
+ */
+val CabalInitiate = card("Cabal Initiate") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warlock"
+    power = 2
+    toughness = 1
+    oracleText = "Discard a card: This creature gains lifelink until end of turn.\n" +
+        "Threshold — This creature gets +1/+2 as long as there are seven or more cards in your graveyard."
+
+    activatedAbility {
+        cost = Costs.DiscardCard
+        effect = Effects.GrantKeyword(Keyword.LIFELINK, EffectTarget.Self)
+    }
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 1, toughnessBonus = 2, filter = GroupFilter.source()),
+            condition = Conditions.CardsInGraveyardAtLeast(7),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "78"
+        artist = "Bastien L. Deharme"
+        flavorText = "\"Hear our prayers, oh Shadowed One, and bless us in bloody agony.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b279a03f-85ab-43f2-b5ca-1bc10563e5ad.jpg?1783926864"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/CounterspellReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/CounterspellReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Counterspell reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Alpha (`lea`) `cards/` package; this file contributes only per-printing
+ * presentation data.
+ */
+val CounterspellReprint = Printing(
+    oracleId = "cc187110-1148-4090-bbb8-e205694a39f5",
+    name = "Counterspell",
+    setCode = "MH2",
+    collectorNumber = "267",
+    scryfallId = "1920dae4-fb92-4f19-ae4b-eb3276b8dac7",
+    artist = "Zack Stella",
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/1920dae4-fb92-4f19-ae4b-eb3276b8dac7.jpg?1783926788",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.UNCOMMON,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/CrackOpen.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/CrackOpen.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crack Open — Modern Horizons 2 #154
+ * {2}{G} · Sorcery
+ *
+ * Destroy target artifact or enchantment. Create a Treasure token. (It's an artifact with "{T}, Sacrifice this token: Add one mana of any color.")
+ *
+ * `Targets.ArtifactOrEnchantment` is the single heterogeneous target requirement — one target that
+ * may be either card type, not two separate targets. [Effects.Destroy] lowers to a move to the
+ * graveyard flagged `byDestruction`, so regeneration and indestructible get their chance.
+ *
+ * The Treasure is created unconditionally: it is a separate sentence, not a rider on the
+ * destruction, so it still happens if the target has become illegal by resolution — only the
+ * destruction is skipped. [Effects.CreateTreasure] pulls the predefined token, whose own
+ * "{T}, Sacrifice this token: Add one mana of any color" ability is the reminder text above.
+ */
+val CrackOpen = card("Crack Open") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target artifact or enchantment. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+
+    spell {
+        val t = target("target artifact or enchantment", Targets.ArtifactOrEnchantment)
+        effect = Effects.Destroy(t) then Effects.CreateTreasure()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "154"
+        artist = "Yeong-Hao Han"
+        flavorText = "What no spell or lockpick could open, the forest coaxed apart."
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42b77a34-9b69-4b01-9f2c-2ff8de47fc12.jpg?1783926833"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/DarkmossBridge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/DarkmossBridge.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+
+/**
+ * Darkmoss Bridge — Modern Horizons 2 #245
+ * (no mana cost) · Artifact Land
+ *
+ * This land enters tapped.
+ * Indestructible
+ * {T}: Add {B} or {G}.
+ *
+ * The reference member of Modern Horizons 2's ten-card "Bridge" cycle — the other nine (Drossforge,
+ * Goldmire, Mistvault, Razortide, Rustvale, Silverbluff, Slagwoods, Tanglepool and Thornglint) are
+ * this card with two different mana symbols, and their KDoc points back here. Three modelling notes
+ * carry the whole cycle:
+ *
+ *  - **`manaCost = ""`, not `"{0}"`.** A land has no mana cost at all. The DSL reads the blank
+ *    string as "has no mana cost"; `"{0}"` would parse into a real, payable zero cost and quietly
+ *    make the card castable.
+ *  - **"{T}: Add {B} or {G}" is written as two separate mana abilities**, one per colour, rather
+ *    than a single ability whose colour is chosen while it resolves — the corpus shape every
+ *    dual-tapping land uses (`Golgari Guildgate`). Both satisfy CR 605.1a (no target, could add
+ *    mana, not a loyalty ability, and neither cost nor effect moves a card to or from a library), so
+ *    each is flagged `manaAbility = true` with [TimingRule.ManaAbility]. Splitting the "or" moves
+ *    the player's choice from resolution to activation, which is unobservable in play: a mana
+ *    ability never uses the stack and resolves the instant it is activated (CR 605.3b), so nothing
+ *    can be done between the choice and the mana arriving either way.
+ *  - **Indestructible is the bare [Keyword], not a `KeywordAbility`.** The engine reads
+ *    `Keyword.INDESTRUCTIBLE` directly for the CR 702.12b exemptions — destruction and the lethal
+ *    damage state-based action (CR 704.5g) both skip the permanent. `Darksteel Citadel` is the
+ *    Artifact-Land-plus-indestructible template. Note this does *not* protect the Bridge from
+ *    sacrifice or exile, which is the whole reason the cycle is playable.
+ *
+ * The enters-tapped clause is an [EntersTapped] replacement effect, not a triggered ability: the
+ * land is never briefly untapped, so nothing can tap it for mana in response.
+ *
+ * `colorIdentity` is "BG" — a land's identity comes from the mana symbols in its rules text
+ * (CR 903.4), since it has no mana cost to read them from.
+ */
+val DarkmossBridge = card("Darkmoss Bridge") {
+    manaCost = ""
+    colorIdentity = "BG"
+    typeLine = "Artifact Land"
+    oracleText = "This land enters tapped.\n" +
+        "Indestructible\n" +
+        "{T}: Add {B} or {G}."
+
+    replacementEffect(EntersTapped())
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "245"
+        artist = "Raoul Vitale"
+        flavorText = "The path to power is forged in ruthlessness."
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f11f0be9-b9f7-45d2-9499-c5d849d7289f.jpg?1783926797"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/DreyKeeper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/DreyKeeper.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Drey Keeper — Modern Horizons 2 #194
+ * {3}{B}{G} · Creature — Elf Druid · 2 / 2
+ *
+ * When this creature enters, create two 1/1 green Squirrel creature tokens.
+ * {3}{B}: Squirrels you control get +1/+0 and gain menace until end of turn.
+ *
+ * "Squirrels you control" is a **bare tribal noun**: it names every *permanent* you control with
+ * that subtype, not only the creature ones, so the filter is [GameObjectFilter.Permanent]
+ * `.withSubtype(...)` rather than `Creature.withSubtype(...)`. The distinction is unobservable
+ * with today's card pool — every printed Squirrel is a creature — but a noncreature Squirrel (or
+ * a Squirrel land) would be pumped by the printed text, and the creature form is what the
+ * differential gate flags as a defect.
+ *
+ * A pump-a-group effect is [Effects.ForEachInGroup] with [EffectTarget.Self] naming the *iterated*
+ * permanent, and the two clauses ("get +1/+0" and "gain menace") are one composite body applied
+ * per Squirrel — the group is snapshotted before iteration, so a Squirrel created afterwards this
+ * turn is untouched, exactly as the one-shot resolution should behave.
+ */
+val DreyKeeper = card("Drey Keeper") {
+    manaCost = "{3}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Elf Druid"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, create two 1/1 green Squirrel creature tokens.\n" +
+        "{3}{B}: Squirrels you control get +1/+0 and gain menace until end of turn."
+
+    // When this creature enters, create two 1/1 green Squirrel creature tokens.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Squirrel"),
+            count = 2
+        )
+    }
+
+    // {3}{B}: Squirrels you control get +1/+0 and gain menace until end of turn.
+    activatedAbility {
+        cost = Costs.Mana("{3}{B}")
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.SQUIRREL).youControl()),
+            Effects.Composite(
+                Effects.ModifyStats(1, 0, EffectTarget.Self),
+                Effects.GrantKeyword(Keyword.MENACE, EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "194"
+        artist = "Kev Walker"
+        flavorText = "He gave the squirrels acorns. They gave him vengeance."
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/995529d1-e2b0-4cce-bd40-56c7ef3c33da.jpg?1783926817"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/DrossforgeBridge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/DrossforgeBridge.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+
+/**
+ * Drossforge Bridge — Modern Horizons 2 #246
+ * (no mana cost) · Artifact Land
+ *
+ * This land enters tapped.
+ * Indestructible
+ * {T}: Add {B} or {R}.
+ *
+ * One of Modern Horizons 2's ten "Bridge" artifact lands. See [DarkmossBridge] for the cycle's
+ * modelling notes: the blank `manaCost`, why the printed "or" becomes two separate mana abilities
+ * rather than one resolution-time choice, and why indestructible is the bare [Keyword].
+ *
+ * `colorIdentity` is "BR" — read off the mana symbols in the rules text (CR 903.4), because a land
+ * has no mana cost to take it from.
+ */
+val DrossforgeBridge = card("Drossforge Bridge") {
+    manaCost = ""
+    colorIdentity = "BR"
+    typeLine = "Artifact Land"
+    oracleText = "This land enters tapped.\n" +
+        "Indestructible\n" +
+        "{T}: Add {B} or {R}."
+
+    replacementEffect(EntersTapped())
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "246"
+        artist = "Raoul Vitale"
+        flavorText = "The path to ruin is forged in pain."
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5b46b8d8-723a-4752-b97d-29ef83bd294c.jpg?1783926796"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/EnchantresssPresenceReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/EnchantresssPresenceReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Enchantress's Presence reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Onslaught (`ons`) `cards/` package; this file contributes only per-printing
+ * presentation data.
+ */
+val EnchantresssPresenceReprint = Printing(
+    oracleId = "795b096a-2bce-4588-a2c9-abc5ea40dc0c",
+    name = "Enchantress's Presence",
+    setCode = "MH2",
+    collectorNumber = "283",
+    scryfallId = "d18d62bc-5f3c-4b3b-88f2-693249635349",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d18d62bc-5f3c-4b3b-88f2-693249635349.jpg?1783926782",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.RARE,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/EtherswornSphinx.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/EtherswornSphinx.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Ethersworn Sphinx — Modern Horizons 2 #195
+ * {7}{W}{U} · Artifact Creature — Sphinx · 4 / 4
+ *
+ * Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ * Flying
+ * Cascade (When you cast this spell, exile cards from the top of your library until you exile a
+ * nonland card with lesser mana value. You may cast it without paying its mana cost. Put the exiled
+ * cards on the bottom in a random order.)
+ *
+ * Two keywords, lowered two different ways because the engine reads them differently.
+ *
+ * **Affinity** is engine-live, but only through the *ability*: the cost calculator inspects
+ * [KeywordAbility.Affinity], never `Keyword.AFFINITY`, so the ability is what gets written (the
+ * display keyword is derived from it). Affinity reduces generic mana only, so the {W}{U} pips floor
+ * the cost at two mana however many artifacts are out, and the Sphinx's mana value stays 9 — which
+ * is exactly what makes cascade here so large. Same shape as `mh3/cards/FurnaceHellkite.kt`.
+ *
+ * **Cascade** is not: [Keyword.CASCADE] is display-only vocabulary and nothing in the rules engine
+ * reads it. Cascade *is* a "when you cast this spell" triggered ability (CR 702.85a), so the
+ * behaviour lives in a [Triggers.WhenYouCastThisSpell] trigger feeding [Effects.Cascade], with the
+ * keyword kept only for the printed line — the canonical lowering in `arb/cards/BloodbraidElf.kt`.
+ * Note the two do not interact: cascade compares against the *printed* mana value, so affinity
+ * making the Sphinx cheap to cast never shrinks what cascade can hit.
+ */
+val EtherswornSphinx = card("Ethersworn Sphinx") {
+    manaCost = "{7}{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Artifact Creature — Sphinx"
+    power = 4
+    toughness = 4
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n" +
+        "Flying\n" +
+        "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card with lesser mana value. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)"
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+    keywords(Keyword.FLYING, Keyword.CASCADE)
+
+    // Cascade — the cast trigger the keyword abbreviates (CR 702.85a).
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        effect = Effects.Cascade
+        description = "Cascade"
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "195"
+        artist = "Irina Nordsol"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/315ae21a-4d95-488e-812b-0d018219af6c.jpg?1783926817"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/FaithlessSalvaging.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/FaithlessSalvaging.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Faithless Salvaging — Modern Horizons 2 #122
+ * {1}{R} · Instant
+ *
+ * Discard a card, then draw a card.
+ * Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)
+ *
+ * The "then" is load-bearing: the discard fully resolves before the draw, so the card you discard
+ * can never be the one you draw. [Patterns.Hand.discardCards] is the Gather → Select → Move
+ * pipeline, and it is kept as its own step inside [Effects.Composite] rather than chained with
+ * `then` — `then` flattens a composite receiver, which would dissolve the discard pipeline into
+ * the outer sequence.
+ *
+ * Like Terramorph in this same set, [Keyword.REBOUND] has a real consumer — `StackResolver` reads
+ * it off `cardDef.keywords` as the spell resolves — so the bare keyword is the whole rebound
+ * implementation; no exile-and-delayed-trigger wiring is needed here.
+ */
+val FaithlessSalvaging = card("Faithless Salvaging") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Discard a card, then draw a card.\n" +
+        "Rebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)"
+
+    keywords(Keyword.REBOUND)
+
+    spell {
+        effect = Effects.Composite(
+            Patterns.Hand.discardCards(1),
+            Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "122"
+        artist = "Bud Cook"
+        flavorText = "All that's left are broken beliefs."
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c6ed4077-4ed5-48fb-91c9-a9195d652978.jpg?1783926845"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/FiligreeAttendant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/FiligreeAttendant.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Filigree Attendant — Modern Horizons 2 #41
+ * {2}{U}{U} · Artifact Creature — Homunculus · * / 3
+ *
+ * Flying
+ * Filigree Attendant's power is equal to the number of artifacts you control.
+ *
+ * Cephalopod Sentry's shape exactly. The printed `*` power is a characteristic-defining ability
+ * (CR 604.3), so no `power =` is set at all — [dynamicPower] over
+ * [DynamicAmount.AggregateBattlefield] counting your artifacts *is* the power, recomputed in
+ * layer 7a (CR 613.4a) and functioning in every zone, rather than a layer-7c (CR 613.4c) static
+ * modification bolted onto a printed number.
+ *
+ * The Attendant is itself an artifact and so counts itself: on the battlefield it is never smaller
+ * than 1/3.
+ */
+val FiligreeAttendant = card("Filigree Attendant") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Homunculus"
+    // printed power is "*" — a characteristic-defining ability; see the Assay spec
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Filigree Attendant's power is equal to the number of artifacts you control."
+
+    keywords(Keyword.FLYING)
+    dynamicPower(DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Artifact))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "41"
+        artist = "Igor Kieryluk"
+        flavorText = "\"The perfect assistant is one that's responsive, dexterous, and capable of reaching all the high shelves.\"\n—Coruk, Esper artificer"
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0cb828c-a19b-4e6d-853f-85e5ea7cadf8.jpg?1783926880"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/FlameBlitz.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/FlameBlitz.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Flame Blitz — Modern Horizons 2 #124
+ * {R} · Enchantment
+ *
+ * At the beginning of your end step, this enchantment deals 5 damage to each planeswalker.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * "Each planeswalker" is untargeted group damage, so it is [Effects.ForEachInGroup] over a
+ * [GroupFilter] of every planeswalker on the battlefield — no controller predicate, so the
+ * enchantment burns its own controller's walkers too. Inside the loop, `EffectTarget.Self` names
+ * the *iterated* permanent (the group member currently being processed), not the enchantment; the
+ * damage source stays Flame Blitz because the ability's source is the enchantment.
+ *
+ * The whole board is hit by one ability resolution, so damage is dealt simultaneously and loyalty
+ * is checked once by state-based actions afterwards (CR 704.5i).
+ */
+val FlameBlitz = card("Flame Blitz") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your end step, this enchantment deals 5 damage to each planeswalker.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Planeswalker),
+            DealDamageEffect(5, EffectTarget.Self)
+        )
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "124"
+        artist = "Colin Boyer"
+        flavorText = "\"Blast it, not again!\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a93c6ba8-666b-4c05-8137-8ffa1d5d928b.jpg?1783926845"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/FodderTosser.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/FodderTosser.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fodder Tosser — Modern Horizons 2 #226
+ * {3} · Artifact
+ *
+ * {T}, Discard a card: This artifact deals 2 damage to target player or planeswalker.
+ *
+ * A colourless repeatable reach outlet that turns dead cards into face damage. The discard is an
+ * *activation cost*, so [Costs.DiscardCard] — "discard a card", any card in hand — rather than
+ * [Costs.DiscardSelf], which is the cycling-style "discard this card". Being a cost also means it
+ * is paid on activation, before the ability goes on the stack, which is what lets madness and
+ * "whenever you discard" payoffs see it even if the ability is later countered.
+ *
+ * "Target player or planeswalker" is the pre-"any target" wording that deliberately excludes
+ * creatures, so it is [Targets.PlayerOrPlaneswalker] and not [Targets.Any].
+ */
+val FodderTosser = card("Fodder Tosser") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}, Discard a card: This artifact deals 2 damage to target player or planeswalker."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.DiscardCard)
+        val t = target("target player or planeswalker", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(2, t)
+        description = "{T}, Discard a card: This artifact deals 2 damage to target player or planeswalker."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "226"
+        artist = "Gabor Szikszai"
+        flavorText = "\"In event of siege, load copiously with: hot oil, cannonballs, caltrops, rubble, old swords, mess-hall leftovers, chamber pots, broken chairs, salt, cousin Furt . . .\"\n—Trebuchet instructions"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd401525-b874-4af2-99a3-c2c83e22547e.jpg?1783926805"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/FoundationBreaker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/FoundationBreaker.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Foundation Breaker — Modern Horizons 2 #160
+ * {3}{G} · Creature — Elemental · 2 / 2
+ *
+ * When this creature enters, you may destroy target artifact or enchantment.
+ * Evoke {1}{G} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)
+ *
+ * Reclamation Sage's body on an evoke chassis. The enters trigger is the ordinary
+ * [Triggers.EntersBattlefield]; the printed "you may" is written as the builder's `optional = true`,
+ * which is shorthand the DSL lowers into a `Gate.MayDecide` around the effect — there is no
+ * `optional` field on the `TriggeredAbility` model itself. The consent is asked at resolution, but
+ * the target is still chosen when the ability goes on the stack (CR 603.3d), so with no artifact or
+ * enchantment anywhere on the battlefield the ability is simply removed and never asks.
+ *
+ * [Targets.ArtifactOrEnchantment] is the shared "artifact or enchantment" requirement rather than a
+ * hand-rolled disjunction, and [Effects.Destroy] is the destruction facade (a move to the graveyard
+ * with `byDestruction`, so indestructible and regeneration are honoured) rather than a raw move.
+ *
+ * `evoke` is a first-class alternative-cost field on the card DSL (CR 702.74a): the engine offers it
+ * as a second cast option and supplies the "when this permanent enters, if its evoke cost was paid,
+ * sacrifice it" trigger itself, so nothing else is authored for it. Both enters triggers go on the
+ * stack together and their controller orders them, and the destroy resolves either way — which is
+ * the entire point of an evoked Foundation Breaker: {1}{G} to blow up an artifact.
+ */
+val FoundationBreaker = card("Foundation Breaker") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, you may destroy target artifact or enchantment.\n" +
+        "Evoke {1}{G} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)"
+
+    evoke = "{1}{G}"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val t = target("target", Targets.ArtifactOrEnchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "160"
+        artist = "Yeong-Hao Han"
+        flavorText = "The castle finally got vengeance for enduring years of royally bad taste."
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f08381e-34f5-4d08-b737-8c37964719e0.jpg?1783926832"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/Gargadon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/Gargadon.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Gargadon — Modern Horizons 2 #128
+ * {5}{R}{R} · Creature — Beast · 7 / 5
+ *
+ * Trample
+ * Suspend 4—{1}{R} (Rather than cast this card from your hand, you may pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)
+ *
+ * A vanilla body plus the two printed keywords, so nothing is authored beyond them.
+ *
+ * `Keyword.SUSPEND` is display-only — the engine's `SuspendEnumerator` reads the *parameterized*
+ * [KeywordAbility.Suspend] (CR 702.62), never the bare enum, and `CardBuilder.build()` derives the
+ * enum from it. So suspend is written once, as `suspend(cost, timeCounters)` — **cost first, the
+ * count second** — exactly as on `tsp/cards/SearchForTomorrow.kt`. Trample, by contrast, is a real
+ * engine keyword and needs no lowering.
+ */
+val Gargadon = card("Gargadon") {
+    manaCost = "{5}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Beast"
+    power = 7
+    toughness = 5
+    oracleText = "Trample\n" +
+        "Suspend 4—{1}{R} (Rather than cast this card from your hand, you may pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)"
+
+    keywords(Keyword.TRAMPLE)
+
+    keywordAbility(KeywordAbility.suspend("{1}{R}", 4))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "128"
+        artist = "Chris Seaman"
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b672c59-7376-455d-961e-ce94d47a5ca4.jpg?1783926844"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/GoblinBombardmentReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/GoblinBombardmentReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Bombardment reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Tempest (`tmp`) `cards/` package; this file contributes only per-printing
+ * presentation data.
+ */
+val GoblinBombardmentReprint = Printing(
+    oracleId = "edad60c6-80de-4033-af1b-a703ac332983",
+    name = "Goblin Bombardment",
+    setCode = "MH2",
+    collectorNumber = "279",
+    scryfallId = "e262f55e-9239-4a97-a19e-9b08fb34502e",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/e/2/e262f55e-9239-4a97-a19e-9b08fb34502e.jpg?1783926784",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.RARE,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/GoldmireBridge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/GoldmireBridge.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+
+/**
+ * Goldmire Bridge — Modern Horizons 2 #247
+ * (no mana cost) · Artifact Land
+ *
+ * This land enters tapped.
+ * Indestructible
+ * {T}: Add {W} or {B}.
+ *
+ * One of Modern Horizons 2's ten "Bridge" artifact lands. See [DarkmossBridge] for the cycle's
+ * modelling notes: the blank `manaCost`, why the printed "or" becomes two separate mana abilities
+ * rather than one resolution-time choice, and why indestructible is the bare [Keyword].
+ *
+ * `colorIdentity` is "BW" — read off the mana symbols in the rules text (CR 903.4), because a land
+ * has no mana cost to take it from.
+ */
+val GoldmireBridge = card("Goldmire Bridge") {
+    manaCost = ""
+    colorIdentity = "BW"
+    typeLine = "Artifact Land"
+    oracleText = "This land enters tapped.\n" +
+        "Indestructible\n" +
+        "{T}: Add {W} or {B}."
+
+    replacementEffect(EntersTapped())
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "247"
+        artist = "Aaron Miller"
+        flavorText = "The path to glory is forged in ambition."
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/dbe2a1fa-196f-497f-a15f-0b3b04da9cbb.jpg?1783926796"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/GreedReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/GreedReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Greed reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Legends (`leg`) `cards/` package; this file contributes only
+ * per-printing presentation data.
+ */
+val GreedReprint = Printing(
+    oracleId = "1ff62220-be95-4901-b8d8-812b9a1a1b0a",
+    name = "Greed",
+    setCode = "MH2",
+    collectorNumber = "274",
+    scryfallId = "851f8d1f-163c-4c4f-beee-431b64ec8a99",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/8/5/851f8d1f-163c-4c4f-beee-431b64ec8a99.jpg?1783926785",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.UNCOMMON,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/HealersFlock.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/HealersFlock.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Healer's Flock — Modern Horizons 2 #16
+ * {W}{W}{W} · Creature — Bird · 3 / 3
+ *
+ * Flying, lifelink
+ *
+ * A vanilla-plus body: both words are engine-live keywords, so the whole card is one
+ * `keywords(...)` call. `CardBuilder.build()` derives the printed keyword line from the enum
+ * entries, so no `keywordAbility` wrapper is needed for a simple keyword with no cost.
+ */
+val HealersFlock = card("Healer's Flock") {
+    manaCost = "{W}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird"
+    power = 3
+    toughness = 3
+    oracleText = "Flying, lifelink"
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "16"
+        artist = "Joe Slucher"
+        flavorText = "The sight of a flock overhead is bittersweet. It means many are wounded, but it also means help is on the way."
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b93b5429-8512-4ab6-9ecd-fa270e0144f3.jpg?1783926891"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/HellMongrel.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/HellMongrel.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hell Mongrel — Modern Horizons 2 #88
+ * {3}{B} · Creature — Nightmare Dog · 4 / 3
+ *
+ * Discard a card: This creature gets +1/+1 until end of turn.
+ * Madness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)
+ *
+ * The Wild Mongrel shape: a free-to-activate pump whose only cost is a card. [Costs.DiscardCard]
+ * is "discard *a* card" (any card from hand) — not [Costs.DiscardSelf], which is the cycling-style
+ * "discard this card". Paying it while holding a madness card is the intended synergy: the discard
+ * is a cost, so it happens on activation and the madness trigger goes on the stack above the pump.
+ *
+ * `CardBuilder.build()` derives the printed `Keyword.MADNESS` from `madness(...)`, so the bare
+ * keyword is not written alongside it.
+ */
+val HellMongrel = card("Hell Mongrel") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Nightmare Dog"
+    power = 4
+    toughness = 3
+    oracleText = "Discard a card: This creature gets +1/+1 until end of turn.\n" +
+        "Madness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)"
+
+    activatedAbility {
+        cost = Costs.DiscardCard
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    madness("{2}{B}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "88"
+        artist = "Robbie Trevino"
+        flavorText = "It feeds on shadows, fear, and blood."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7da32a3-8e33-4603-abd2-8db144062f6a.jpg?1783926860"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/HerdBaloth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/HerdBaloth.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Herd Baloth — Modern Horizons 2 #165
+ * {3}{G}{G} · Creature — Beast · 4 / 4
+ *
+ * Whenever one or more +1/+1 counters are put on this creature, you may create a 4/4 green Beast
+ * creature token.
+ *
+ * [Triggers.countersPlacedOn] is a per-*batch* watcher, which is exactly what "one or more … are
+ * put on" asks for: five counters arriving from one resolution make one token, not five.
+ * [TriggerBinding.SELF] scopes it to the Baloth itself, so the event filter can stay
+ * [GameObjectFilter.Any].
+ *
+ * `firstTimeEachTurn` **defaults to `true`** on that facade (it is derived from `batch`), which
+ * would silently drop every counter batch after the first each turn — hence the explicit `false`.
+ *
+ * `optional = true` is the authoring shorthand for "you may": the builder lowers it into a
+ * consent gate around the token creation, so the controller is asked on resolution.
+ */
+val HerdBaloth = card("Herd Baloth") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 4
+    toughness = 4
+    oracleText = "Whenever one or more +1/+1 counters are put on this creature, you may create a 4/4 green Beast creature token."
+
+    triggeredAbility {
+        trigger = Triggers.countersPlacedOn(
+            filter = GameObjectFilter.Any,
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            firstTimeEachTurn = false,
+            binding = TriggerBinding.SELF,
+        )
+        optional = true
+        effect = Effects.CreateToken(
+            power = 4,
+            toughness = 4,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Beast")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "165"
+        artist = "Nicholas Gregory"
+        flavorText = "Baloth social structure is simple: the biggest one's the leader."
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1e9cef5-c55f-47d9-9d2f-300dab8fcb0b.jpg?1783926829"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/HuntingPackReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/HuntingPackReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hunting Pack reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Scourge (`scg`) `cards/` package; this file contributes only per-printing
+ * presentation data.
+ */
+val HuntingPackReprint = Printing(
+    oracleId = "d3e1848a-c236-4352-a7be-b0b4699af968",
+    name = "Hunting Pack",
+    setCode = "MH2",
+    collectorNumber = "284",
+    scryfallId = "8c9eb595-e8fa-4a5e-abca-d30613c0e28f",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/8/c/8c9eb595-e8fa-4a5e-abca-d30613c0e28f.jpg?1783926781",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.UNCOMMON,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/JadeAvenger.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/JadeAvenger.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Jade Avenger — Modern Horizons 2 #167
+ * {1}{G} · Creature — Frog Samurai · 2 / 2
+ *
+ * Bushido 2 (Whenever this creature blocks or becomes blocked, it gets +2/+2 until end of turn.)
+ *
+ * **Bushido is lowered here, not handled by the engine.** [KeywordAbility.bushido] is display-only
+ * vocabulary — nothing in the rules engine reads `Keyword.BUSHIDO` — so the ability it abbreviates
+ * is wired explicitly, the same way modular is lowered on the Arcbound cycle.
+ *
+ * CR 702.45a defines bushido N as a single triggered ability, "Whenever this creature blocks or
+ * becomes blocked, it gets +N/+N until end of turn." The SDK has no "blocks or becomes blocked"
+ * event covering both directions from the source's point of view — [Triggers.BlocksOrBecomesBlockedBy]
+ * is about a *partner* creature — so it is written as two triggers over the two distinct events,
+ * mirroring the attacks-or-blocks pair on `lci/cards/BurningSunCavalry.kt`. They are mutually
+ * exclusive for any one combat: the Avenger either declares a block or is blocked, never both, so
+ * the pump never doubles.
+ *
+ * The pump targets [EffectTarget.Self] rather than `TriggeringEntity` because [Triggers.Blocks]
+ * fires off a block event that does not bind the source as the triggering entity; every corpus
+ * "whenever this creature blocks, it gets …" card uses `Self` (`ulg/cards/SustainerOfTheRealm.kt`).
+ */
+val JadeAvenger = card("Jade Avenger") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Frog Samurai"
+    power = 2
+    toughness = 2
+    oracleText = "Bushido 2 (Whenever this creature blocks or becomes blocked, it gets +2/+2 until end of turn.)"
+
+    keywordAbility(KeywordAbility.bushido(2))
+
+    // Bushido 2, half one: "Whenever this creature blocks …"
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        description = "Bushido 2"
+    }
+
+    // Bushido 2, half two: "… or becomes blocked, it gets +2/+2 until end of turn."
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        description = "Bushido 2"
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "167"
+        artist = "Chris Seaman"
+        flavorText = "\"Froggy fighter at the gate.\nDraw your sword and meet your fate.\"\n—Traditional children's rhyme"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f81500be-c959-4f38-bcf2-d63519168f67.jpg?1783926829"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/JewelEyedCobra.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/JewelEyedCobra.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jewel-Eyed Cobra — Modern Horizons 2 #168
+ * {2}{G} · Creature — Snake · 3 / 1
+ *
+ * Deathtouch
+ * When this creature dies, create a Treasure token. (It's an artifact with "{T}, Sacrifice this
+ * token: Add one mana of any color.")
+ *
+ * [Triggers.Dies] is the battlefield → graveyard zone change bound to the source itself, so the
+ * ability reads last-known information about the Cobra — nothing here needs the dead permanent's
+ * characteristics, only the fact that it left. The Treasure is the predefined token
+ * ([Effects.CreateTreasure]) rather than a hand-rolled artifact token, so it shares the corpus's
+ * single Treasure definition and its art.
+ */
+val JewelEyedCobra = card("Jewel-Eyed Cobra") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Snake"
+    power = 3
+    toughness = 1
+    oracleText = "Deathtouch\n" +
+        "When this creature dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateTreasure()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Josu Hernaiz"
+        flavorText = "\"Sure, they're worth a lot, but I'd rather survive to spend my earnings.\"\n—Mokgar, Kalonian hunter"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8f8db60d-3adf-45e1-b4d0-3b5e24f5e01d.jpg?1783926831"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/KitchenImp.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/KitchenImp.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kitchen Imp — Modern Horizons 2 #89
+ * {3}{B} · Creature — Imp · 2 / 2
+ *
+ * Flying, haste
+ * Madness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)
+ *
+ * A vanilla evasive body whose whole point is the madness price: haste matters because madness
+ * (CR 702.35) lets you cast the creature at instant speed off someone else's discard, so it can
+ * attack the turn it lands even on a turn that isn't yours to start.
+ *
+ * `madness(...)` is the whole implementation of the last line — `CardBuilder.build()` derives the
+ * printed `Keyword.MADNESS` from the keyword ability, so only flying and haste are declared here.
+ */
+val KitchenImp = card("Kitchen Imp") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Imp"
+    power = 2
+    toughness = 2
+    oracleText = "Flying, haste\n" +
+        "Madness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)"
+
+    keywords(Keyword.FLYING, Keyword.HASTE)
+
+    madness("{B}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "Evyn Fong"
+        flavorText = "\"Order up! Ooze aspic and jellied anurid eyes!\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/836ae711-e62f-49ec-850e-d25f6fd2a4d4.jpg?1783926859"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/LateToDinner.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/LateToDinner.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Late to Dinner — Modern Horizons 2 #19
+ * {3}{W} · Sorcery
+ *
+ * Return target creature card from your graveyard to the battlefield. Create a Food token. (It's an artifact with "{2}, {T}, Sacrifice this token: You gain 3 life.")
+ *
+ * A white Zombify with a snack. `Targets.CreatureCardInYourGraveyard` is a graveyard-zoned target
+ * requirement, so the legality check reads the graveyard rather than the battlefield;
+ * [Effects.PutOntoBattlefieldFromGraveyard] carries the explicit `fromZone` so the move is a
+ * graveyard-to-battlefield reanimation rather than a generic blink.
+ *
+ * The Food is a separate sentence, not a rider, so it is still created if the creature card has
+ * left the graveyard by resolution.
+ */
+val LateToDinner = card("Late to Dinner") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature card from your graveyard to the battlefield. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")"
+
+    spell {
+        val creature = target("target creature card from your graveyard", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.PutOntoBattlefieldFromGraveyard(creature) then Effects.CreateFood()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Kev Walker"
+        flavorText = "\"I knew you were set in your ways, friend, but even I didn't expect you to keep our engagement, under the circumstances.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/6633cab9-23f9-474e-96f1-ca7c0c67691c.jpg?1783926889"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/LensFlare.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/LensFlare.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Lens Flare — Modern Horizons 2 #20
+ * {4}{W} · Instant
+ *
+ * Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ * Lens Flare deals 5 damage to target attacking or blocking creature.
+ *
+ * Pure composition, the Piercing Light / Divine Arrow combat-trick shape with an affinity rider.
+ * [KeywordAbility.Affinity] for [CardType.ARTIFACT] is engine-live vocabulary — the cost calculator
+ * reads the *KeywordAbility*, never a `Keyword.AFFINITY` enum entry, so the display keyword is left
+ * for `CardBuilder.build()` to derive. Affinity only shaves the generic portion of the cost, so five
+ * artifacts floor this at {W}: the coloured pip is never reduced away and the mana value stays 5.
+ *
+ * The combat restriction is [TargetFilter.AttackingOrBlockingCreature] rather than two separate
+ * target slots — it is one creature filter carrying a state-level "attacking or blocking"
+ * disjunction, which is evaluated against projected state like every other battlefield filter.
+ */
+val LensFlare = card("Lens Flare") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n" +
+        "Lens Flare deals 5 damage to target attacking or blocking creature."
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature))
+        effect = Effects.DealDamage(5, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "Josh Hass"
+        flavorText = "The key for surviving a war is never becoming its focus."
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d92f037-a121-428a-ac53-98437366ecfd.jpg?1783926889"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/LightningSpear.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/LightningSpear.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Lightning Spear — Modern Horizons 2 #134
+ * {1}{R} · Artifact — Equipment
+ *
+ * Equipped creature gets +1/+0 and has trample.
+ * {2}{R}, Sacrifice this Equipment: It deals 3 damage to any target.
+ * Equip {1}
+ *
+ * A cheap red Equipment that converts into a Lava Spike once the creature holding it is dead or
+ * outclassed.
+ *
+ * The printed line "gets +1/+0 **and** has trample" is one sentence but two continuous
+ * modifications in different layers — the power bonus in layer 7c, the keyword grant in layer 6 —
+ * so it is authored as two [staticAbility] blocks rather than a fused one, matching the corpus
+ * shape (see `Knife`). Both use [Filters.EquippedCreature], the attached-creature group filter, so
+ * they follow the Equipment as it moves and switch off the moment it is unattached.
+ *
+ * The damage ability's "It" is the Equipment, and it sacrifices itself as part of the cost, so the
+ * source is already in the graveyard on resolution — that is fine, damage still uses last-known
+ * information for the source's characteristics.
+ *
+ * "Equip {1}" goes through [equipAbility], never a hand-rolled activated ability: the helper sets
+ * `equipCost` *and* emits the properly flagged equip ability, which is what Forge Anew-style
+ * "equip costs less"/"equip at instant speed" effects key off.
+ */
+val LightningSpear = card("Lightning Spear") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+0 and has trample.\n" +
+        "{2}{R}, Sacrifice this Equipment: It deals 3 damage to any target.\n" +
+        "Equip {1}"
+
+    staticAbility {
+        ability = ModifyStats(+1, +0, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE, Filters.EquippedCreature)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}"), Costs.SacrificeSelf)
+        val t = target("any target", Targets.Any)
+        effect = Effects.DealDamage(3, t)
+        description = "{2}{R}, Sacrifice this Equipment: It deals 3 damage to any target."
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "134"
+        artist = "Steven Belledin"
+        flavorText = "When wielded, it begs to be released."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f72fcda4-feb4-46e4-87d9-88bd95474fe9.jpg?1783926842"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/MarbleGargoyle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/MarbleGargoyle.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Marble Gargoyle — Modern Horizons 2 #21
+ * {2}{W} · Artifact Creature — Gargoyle · 2 / 2
+ *
+ * Flying
+ * {W}: This creature gets +0/+1 until end of turn.
+ *
+ * The classic defensive gargoyle: a flier that can be pumped out of burn and combat range as long
+ * as the white mana holds out.
+ *
+ * The pump ability names the source, not a target — "this creature", not "target creature" — so
+ * the effect uses [EffectTarget.Self] and the ability declares no target requirement at all. It is
+ * therefore uncounterable-by-removal in the usual sense: killing the Gargoyle in response leaves
+ * the ability on the stack doing nothing, but it never fizzles for lack of a legal target.
+ *
+ * Each activation is a separate one-shot [Effects.ModifyStats] with the default end-of-turn
+ * duration, so the bonuses stack — activating four times makes it a 2/6 for the turn.
+ */
+val MarbleGargoyle = card("Marble Gargoyle") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Gargoyle"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "{W}: This creature gets +0/+1 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{W}")
+        effect = Effects.ModifyStats(0, 1, EffectTarget.Self)
+        description = "{W}: This creature gets +0/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "21"
+        artist = "Drew Tucker"
+        flavorText = "\"Once past the stony exterior, the meat is exquisite and can be stuffed with thallids or simmered in a broth of manticore venom.\"\n—Asmoranomardicadaistinaculdacar,\n*The Underworld Cookbook*"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c62efb9-11f2-4f82-af08-4587d58d6e3d.jpg?1783926889"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/MentalJourney.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/MentalJourney.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Mental Journey — Modern Horizons 2 #51
+ * {4}{U}{U} · Instant
+ *
+ * Draw three cards.
+ * Basic landcycling {1}{U} ({1}{U}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)
+ *
+ * A plain draw spell whose real text is the escape hatch: [KeywordAbility.basicLandcycling] narrows
+ * the shared typecycling search to *basic* land cards, so an expensive card in a mana-light opening
+ * hand converts into a land instead. The cycling ability is a discard-cost activated ability that
+ * functions only from hand (CR 702.29a), which is why it is a `keywordAbility` on the card rather
+ * than part of the spell script.
+ */
+val MentalJourney = card("Mental Journey") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Draw three cards.\n" +
+        "Basic landcycling {1}{U} ({1}{U}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)"
+
+    spell {
+        effect = Effects.DrawCards(3)
+    }
+
+    keywordAbility(KeywordAbility.basicLandcycling("{1}{U}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "51"
+        artist = "Jim Pavelec"
+        flavorText = "\"My wandering mind has always been an asset.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0ec38124-46ae-4a38-aab2-8a73cc22b1ef.jpg?1783926876"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/MillikinReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/MillikinReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Millikin reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Odyssey (`ody`) `cards/` package; this file contributes only
+ * per-printing presentation data.
+ */
+val MillikinReprint = Printing(
+    oracleId = "fa4dffda-6f04-4d0b-829d-28a1a5794dee",
+    name = "Millikin",
+    setCode = "MH2",
+    collectorNumber = "297",
+    scryfallId = "513ba8b6-9583-405f-84a5-9d2ca42f9597",
+    artist = "Joe Slucher",
+    imageUri = "https://cards.scryfall.io/normal/front/5/1/513ba8b6-9583-405f-84a5-9d2ca42f9597.jpg?1783926776",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.UNCOMMON,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/MistvaultBridge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/MistvaultBridge.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+
+/**
+ * Mistvault Bridge — Modern Horizons 2 #249
+ * (no mana cost) · Artifact Land
+ *
+ * This land enters tapped.
+ * Indestructible
+ * {T}: Add {U} or {B}.
+ *
+ * One of Modern Horizons 2's ten "Bridge" artifact lands. See [DarkmossBridge] for the cycle's
+ * modelling notes: the blank `manaCost`, why the printed "or" becomes two separate mana abilities
+ * rather than one resolution-time choice, and why indestructible is the bare [Keyword].
+ *
+ * `colorIdentity` is "BU" — read off the mana symbols in the rules text (CR 903.4), because a land
+ * has no mana cost to take it from.
+ */
+val MistvaultBridge = card("Mistvault Bridge") {
+    manaCost = ""
+    colorIdentity = "BU"
+    typeLine = "Artifact Land"
+    oracleText = "This land enters tapped.\n" +
+        "Indestructible\n" +
+        "{T}: Add {U} or {B}."
+
+    replacementEffect(EntersTapped())
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "249"
+        artist = "Mathias Kollros"
+        flavorText = "The path to knowledge is forged in hunger."
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f36a6e2-3e51-4a30-a225-10cfe6650b9d.jpg?1783926795"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ModernHorizons2BasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ModernHorizons2BasicLands.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Modern Horizons 2 Basic Lands
+ *
+ * MH2 prints two art variants of each basic land type (cards 481-490), each a retro-frame reprint
+ * of a classic piece: Plains 481-482, Island 483-484, Swamp 485-486, Mountain 487-488,
+ * Forest 489-490.
+ */
+
+// Plains (481-482)
+val Mh2Plains481 = basicLand("Plains") {
+    collectorNumber = "481"
+    artist = "Eric Peterson"
+    imageUri = "https://cards.scryfall.io/normal/front/d/5/d5aa2449-6b74-4319-858f-caa9282da5c1.jpg?1783926700"
+}
+val Mh2Plains482 = basicLand("Plains") {
+    collectorNumber = "482"
+    artist = "Alan Pollack"
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e14e6193-f60b-46c8-a7eb-02a437138568.jpg?1783926700"
+}
+
+// Island (483-484)
+val Mh2Island483 = basicLand("Island") {
+    collectorNumber = "483"
+    artist = "Donato Giancola"
+    imageUri = "https://cards.scryfall.io/normal/front/4/2/423927e6-2419-4d88-b0c4-425e5cac1a3f.jpg?1783926698"
+}
+val Mh2Island484 = basicLand("Island") {
+    collectorNumber = "484"
+    artist = "Douglas Shuler"
+    imageUri = "https://cards.scryfall.io/normal/front/9/5/95d781a5-2f5e-499f-b210-c4a5c50a180c.jpg?1783926702"
+}
+
+// Swamp (485-486)
+val Mh2Swamp485 = basicLand("Swamp") {
+    collectorNumber = "485"
+    artist = "Jerry Tiritilli"
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/ac8546d1-bfea-4cf7-bfa1-48555ea81bd4.jpg?1783926697"
+}
+val Mh2Swamp486 = basicLand("Swamp") {
+    collectorNumber = "486"
+    artist = "Pete Venters"
+    imageUri = "https://cards.scryfall.io/normal/front/9/5/959cb185-a280-493c-b85c-69b74e042c15.jpg?1783926697"
+}
+
+// Mountain (487-488)
+val Mh2Mountain487 = basicLand("Mountain") {
+    collectorNumber = "487"
+    artist = "Heather Hudson"
+    imageUri = "https://cards.scryfall.io/normal/front/a/4/a4be3032-c55b-43b5-9ae0-f4e7470f4f83.jpg?1783926696"
+}
+val Mh2Mountain488 = basicLand("Mountain") {
+    collectorNumber = "488"
+    artist = "Tony Szczudlo"
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0f5a0d49-71ae-42c4-a896-6828dc4f1e85.jpg?1783926694"
+}
+
+// Forest (489-490)
+val Mh2Forest489 = basicLand("Forest") {
+    collectorNumber = "489"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/46e93212-da68-48f8-9aeb-ee5eb92e9a54.jpg?1783926697"
+}
+val Mh2Forest490 = basicLand("Forest") {
+    collectorNumber = "490"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/1/7/17393110-c57e-487b-b07e-dc21a164efa7.jpg?1783926693"
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/Monoskelion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/Monoskelion.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Monoskelion — Modern Horizons 2 #229
+ * {2} · Artifact Creature — Construct · 1 / 1
+ *
+ * This creature enters with a +1/+1 counter on it.
+ * {1}, Remove a +1/+1 counter from this creature: It deals 1 damage to any target.
+ *
+ * Triskelion's two halves at one-third scale, plus a mana pip on the activation. The printed box is
+ * 1/1 and the counter is a separate [EntersWithCounters] replacement (`selfOnly`), so a Monoskelion
+ * on the battlefield is a 2/2 that shrinks back to 1/1 the moment it shoots — the counter is both
+ * the ammunition and the stat line, which is the whole card.
+ *
+ * The two counter vocabularies are not interchangeable: replacement effects name a counter with
+ * [CounterTypeFilter.PlusOnePlusOne], while costs and effects name one with the [Counters] string
+ * constant. Removing the counter is a *cost*, so it is paid on activation and the damage is on the
+ * stack independently — the ability still resolves if the Monoskelion dies in response.
+ */
+val Monoskelion = card("Monoskelion") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 1
+    toughness = 1
+    oracleText = "This creature enters with a +1/+1 counter on it.\n" +
+        "{1}, Remove a +1/+1 counter from this creature: It deals 1 damage to any target."
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = 1,
+            selfOnly = true
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.RemoveCounterFromSelf(Counters.PLUS_ONE_PLUS_ONE, 1)
+        )
+        val t = target("target", AnyTarget())
+        effect = Effects.DealDamage(1, t)
+        description = "{1}, Remove a +1/+1 counter from this creature: It deals 1 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "229"
+        artist = "Jason A. Engle"
+        flavorText = "An unfinished body with unfinished business."
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/4736aae2-5136-4f8f-9283-baf6b542a6a8.jpg?1783926802"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/MyrScrapling.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/MyrScrapling.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Myr Scrapling — Modern Horizons 2 #230
+ * {1} · Artifact Creature — Myr · 1 / 1
+ *
+ * Sacrifice this creature: Put a +1/+1 counter on target creature.
+ *
+ * A free sacrifice outlet that hands its body's worth of stats to something else — the artifact
+ * half makes it fodder for the set's Arcbound and affinity shells as well.
+ *
+ * The sacrifice is the whole cost ([Costs.SacrificeSelf], no mana), so the Myr is gone before the
+ * ability resolves. That matters for the target: "target creature" is unrestricted, but the Myr
+ * itself can never be the target it pays for, since a creature that has left the battlefield is
+ * no longer a legal target and the ability would simply be countered on resolution.
+ *
+ * Counters use the string vocabulary ([Counters.PLUS_ONE_PLUS_ONE]) here because this is an
+ * effect, not a replacement effect — `CounterTypeFilter` is the counterpart used by
+ * `EntersWithCounters`.
+ */
+val MyrScrapling = card("Myr Scrapling") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Myr"
+    power = 1
+    toughness = 1
+    oracleText = "Sacrifice this creature: Put a +1/+1 counter on target creature."
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+        description = "Sacrifice this creature: Put a +1/+1 counter on target creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "230"
+        artist = "Svetlin Velinov"
+        flavorText = "\"They're useful creatures, but quite replaceable. I find it best not to get too attached.\"\n—Pontifex, elder researcher"
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5b9072a5-bd7f-4007-a34a-ebe251c95356.jpg?1783926803"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/OrchardStrider.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/OrchardStrider.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Orchard Strider — Modern Horizons 2 #169
+ * {4}{G}{G} · Creature — Treefolk · 6 / 4
+ *
+ * When this creature enters, create two Food tokens. (They're artifacts with "{2}, {T}, Sacrifice this token: You gain 3 life.")
+ * Basic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)
+ *
+ * [Effects.CreateFood] is the predefined-token facade, so the Food's own "{2}, {T}, Sacrifice this
+ * token: You gain 3 life" ability comes from the shared token definition rather than being spelled
+ * out here — the reminder text in the Oracle line is exactly that ability.
+ *
+ * Basic landcycling ([KeywordAbility.basicLandcycling]) narrows the shared typecycling search to
+ * *basic* land cards, which is what makes a six-drop playable on turn two.
+ */
+val OrchardStrider = card("Orchard Strider") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Treefolk"
+    power = 6
+    toughness = 4
+    oracleText = "When this creature enters, create two Food tokens. (They're artifacts with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n" +
+        "Basic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateFood(2)
+    }
+
+    keywordAbility(KeywordAbility.basicLandcycling("{1}{G}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "169"
+        artist = "Raoul Vitale"
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/386da156-59cd-4b96-9276-a7cb2ddd0421.jpg?1783926827"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ParcelMyr.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ParcelMyr.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Parcel Myr — Modern Horizons 2 #54
+ * {1}{U} · Artifact Creature — Clue Myr · 2 / 1
+ *
+ * {2}, Sacrifice this creature: Draw a card.
+ *
+ * A Myr that is also a Clue — the subtype is on the printed type line, and Scryfall's standing
+ * ruling is that "a Clue" means any Clue artifact, not only a Clue token, so the set's
+ * "sacrifice a Clue" payoffs read it straight off the type line with no per-card wiring.
+ *
+ * The ability is the Clue's own printed sacrifice-to-draw, spelled out here rather than inherited:
+ * a Clue token's ability belongs to the token, and this is a real card. [Costs.SacrificeSelf] is
+ * the "Sacrifice this creature" atom, and because it is a cost the body is gone before the draw
+ * resolves — so the card can be sacrificed in response to removal and still cash in.
+ */
+val ParcelMyr = card("Parcel Myr") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Clue Myr"
+    power = 2
+    toughness = 1
+    oracleText = "{2}, Sacrifice this creature: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+        description = "{2}, Sacrifice this creature: Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "Wisnu Tan"
+        flavorText = "\"Crack it open. Maybe it knows something we can use.\"\n—Kara Vrist, Mirran resistance"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f288ee5-4bf9-476a-a89f-b6b8fa7e87dc.jpg?1783926875"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/PatchworkGnomesReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/PatchworkGnomesReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Patchwork Gnomes reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Tempest (`tmp`) `cards/` package; this file contributes only per-printing
+ * presentation data.
+ */
+val PatchworkGnomesReprint = Printing(
+    oracleId = "00ad27a1-9162-408d-ac75-970e45d7e06c",
+    name = "Patchwork Gnomes",
+    setCode = "MH2",
+    collectorNumber = "299",
+    scryfallId = "3002ccef-5322-4f99-9fce-3b4303347240",
+    artist = "Filip Burburan",
+    imageUri = "https://cards.scryfall.io/normal/front/3/0/3002ccef-5322-4f99-9fce-3b4303347240.jpg?1783926776",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.UNCOMMON,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/QuirionRangerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/QuirionRangerReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Quirion Ranger reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Visions (`vis`) `cards/` package; this file contributes only
+ * per-printing presentation data.
+ */
+val QuirionRangerReprint = Printing(
+    oracleId = "3ecaefc8-ead2-47a3-a7ea-b030faab65a7",
+    name = "Quirion Ranger",
+    setCode = "MH2",
+    collectorNumber = "285",
+    scryfallId = "320fdf89-e158-41c5-b0bf-fee9dec36a75",
+    artist = "Allen Williams",
+    imageUri = "https://cards.scryfall.io/normal/front/3/2/320fdf89-e158-41c5-b0bf-fee9dec36a75.jpg?1783926781",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.UNCOMMON,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/RazortideBridge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/RazortideBridge.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+
+/**
+ * Razortide Bridge — Modern Horizons 2 #252
+ * (no mana cost) · Artifact Land
+ *
+ * This land enters tapped.
+ * Indestructible
+ * {T}: Add {W} or {U}.
+ *
+ * One of Modern Horizons 2's ten "Bridge" artifact lands. See [DarkmossBridge] for the cycle's
+ * modelling notes: the blank `manaCost`, why the printed "or" becomes two separate mana abilities
+ * rather than one resolution-time choice, and why indestructible is the bare [Keyword].
+ *
+ * `colorIdentity` is "UW" — read off the mana symbols in the rules text (CR 903.4), because a land
+ * has no mana cost to take it from.
+ */
+val RazortideBridge = card("Razortide Bridge") {
+    manaCost = ""
+    colorIdentity = "UW"
+    typeLine = "Artifact Land"
+    oracleText = "This land enters tapped.\n" +
+        "Indestructible\n" +
+        "{T}: Add {W} or {U}."
+
+    replacementEffect(EntersTapped())
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "252"
+        artist = "Rob Alexander"
+        flavorText = "The path to unity is forged in understanding."
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e7ea7395-430e-4036-92c9-17a850ec2371.jpg?1783926796"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/RiftSower.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/RiftSower.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Rift Sower — Modern Horizons 2 #170
+ * {2}{G} · Creature — Elf Druid · 1 / 3
+ *
+ * {T}: Add one mana of any color.
+ * Suspend 2—{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)
+ *
+ * The mana ability is the stock Birds of Paradise shape: [Effects.AddManaOfChoice] with every
+ * default taken — all five colors, one mana, no restriction — which is precisely what "add one mana
+ * of any color" means. `manaAbility = true` is the only flag set; the builder derives
+ * `TimingRule.ManaAbility` from it (CR 605.1a: no target, produces mana, not a loyalty ability), so
+ * writing the timing again would be the same fact twice.
+ *
+ * Suspend is the parameterized [KeywordAbility.Suspend] (CR 702.62) — cost first, time counters
+ * second. The bare `Keyword.SUSPEND` is display-only and is derived from this by
+ * `CardBuilder.build()`; the engine's `SuspendEnumerator` reads the keyword *ability*.
+ */
+val RiftSower = card("Rift Sower") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid"
+    power = 1
+    toughness = 3
+    oracleText = "{T}: Add one mana of any color.\n" +
+        "Suspend 2—{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)"
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+    }
+
+    keywordAbility(KeywordAbility.suspend("{G}", 2))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "170"
+        artist = "Cristi Balanescu"
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/97dbd212-f1e8-429a-bf00-b2ea966d880e.jpg?1783926827"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/RiptideLaboratoryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/RiptideLaboratoryReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Riptide Laboratory reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Onslaught (`ons`) `cards/` package; this file contributes only per-printing
+ * presentation data.
+ */
+val RiptideLaboratoryReprint = Printing(
+    oracleId = "444d50dd-a44a-42db-bbf6-d0978e3bd6a3",
+    name = "Riptide Laboratory",
+    setCode = "MH2",
+    collectorNumber = "303",
+    scryfallId = "25a9cb87-e572-4885-8561-1d4b158ec7e4",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/2/5/25a9cb87-e572-4885-8561-1d4b158ec7e4.jpg?1783926775",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.RARE,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/RishadanDockhand.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/RishadanDockhand.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rishadan Dockhand — Modern Horizons 2 #59
+ * {U} · Creature — Merfolk · 1 / 2
+ *
+ * Islandwalk (This creature can't be blocked as long as defending player controls an Island.)
+ * {1}, {T}: Tap target land.
+ *
+ * Islandwalk is engine-live evasion read by the block-legality rules, so the bare
+ * [Keyword.ISLANDWALK] enum is the whole first line — no lowering needed.
+ *
+ * The activated ability taps *any* land, not just an opponent's: [Targets.Land] carries no
+ * controller predicate, matching the Oracle wording. Tapping is [Effects.Tap] on the bound
+ * target rather than a cost-side tap; the `{T}` in the cost belongs to the Dockhand itself.
+ */
+val RishadanDockhand = card("Rishadan Dockhand") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk"
+    power = 1
+    toughness = 2
+    oracleText = "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\n" +
+        "{1}, {T}: Tap target land."
+
+    keywords(Keyword.ISLANDWALK)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        val land = target("target land", Targets.Land)
+        effect = Effects.Tap(land)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "59"
+        artist = "Manuel Castañón"
+        flavorText = "It's not hard to find work in Rishada, so long as you've got a strong back and don't ask too many questions."
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc488a4c-2885-4727-8317-da93aee8fced.jpg?1783926871"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/RustvaleBridge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/RustvaleBridge.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+
+/**
+ * Rustvale Bridge — Modern Horizons 2 #253
+ * (no mana cost) · Artifact Land
+ *
+ * This land enters tapped.
+ * Indestructible
+ * {T}: Add {R} or {W}.
+ *
+ * One of Modern Horizons 2's ten "Bridge" artifact lands. See [DarkmossBridge] for the cycle's
+ * modelling notes: the blank `manaCost`, why the printed "or" becomes two separate mana abilities
+ * rather than one resolution-time choice, and why indestructible is the bare [Keyword].
+ *
+ * `colorIdentity` is "RW" — read off the mana symbols in the rules text (CR 903.4), because a land
+ * has no mana cost to take it from.
+ */
+val RustvaleBridge = card("Rustvale Bridge") {
+    manaCost = ""
+    colorIdentity = "RW"
+    typeLine = "Artifact Land"
+    oracleText = "This land enters tapped.\n" +
+        "Indestructible\n" +
+        "{T}: Add {R} or {W}."
+
+    replacementEffect(EntersTapped())
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "253"
+        artist = "Craig J Spearing"
+        flavorText = "The path to strength is forged in stability."
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/2207467a-b82a-47ae-8867-15a859328fe9.jpg?1783926793"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SanctumWeaver.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SanctumWeaver.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sanctum Weaver — Modern Horizons 2 #171
+ * {1}{G} · Enchantment Creature — Dryad · 0 / 2
+ *
+ * {T}: Add X mana of any one color, where X is the number of enchantments you control.
+ *
+ * "Any *one* color" is [Effects.AddAnyColorMana]: a single color is chosen for the whole batch of
+ * mana, not one color per mana — the same shape as Deathbloom Ritualist. X is counted on
+ * resolution by [DynamicAmount.AggregateBattlefield] over the enchantments its controller has on
+ * the battlefield (Serra's Sanctum's aggregate), which includes the Weaver itself: it is an
+ * enchantment creature, so an unaccompanied Weaver still taps for one mana.
+ *
+ * `manaAbility = true` is the only switch needed — the builder derives both the `isManaAbility`
+ * flag and the `ManaAbility` timing rule from it. This is a legal mana ability under CR 605.1a:
+ * it has no target, it isn't a loyalty ability, and it could add mana to a pool.
+ */
+val SanctumWeaver = card("Sanctum Weaver") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment Creature — Dryad"
+    power = 0
+    toughness = 2
+    oracleText = "{T}: Add X mana of any one color, where X is the number of enchantments you control."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(
+            DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Enchantment)
+        )
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "171"
+        artist = "Kimonas Theodossiou"
+        flavorText = "The arrival of spring's first flowers is a sacred occasion to Karametra's acolytes, who fill the Setessan woods with song in celebration."
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4d42e22d-f60e-40c5-b069-5e1708f3bebc.jpg?1783926826"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SealOfCleansingReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SealOfCleansingReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seal of Cleansing reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Nemesis (`nem`) `cards/` package; this file contributes only per-printing
+ * presentation data.
+ */
+val SealOfCleansingReprint = Printing(
+    oracleId = "a75dbe70-7e3e-446f-9a76-9fbb414f2e7c",
+    name = "Seal of Cleansing",
+    setCode = "MH2",
+    collectorNumber = "264",
+    scryfallId = "27885a9a-3bcd-476d-97a9-acaec0553a60",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/27885a9a-3bcd-476d-97a9-acaec0553a60.jpg?1783926790",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.UNCOMMON,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SealOfRemovalReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SealOfRemovalReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seal of Removal reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Nemesis (`nem`) `cards/` package; this file contributes only per-printing
+ * presentation data.
+ */
+val SealOfRemovalReprint = Printing(
+    oracleId = "f0801029-bcf7-4bdb-84bf-e88dcaa9dc03",
+    name = "Seal of Removal",
+    setCode = "MH2",
+    collectorNumber = "269",
+    scryfallId = "6dfc7060-e374-486f-8029-d3fdfe4b61e7",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6dfc7060-e374-486f-8029-d3fdfe4b61e7.jpg?1783926788",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.UNCOMMON,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ShardlessAgentReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ShardlessAgentReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shardless Agent reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Planechase 2012 (`pc2`) `cards/` package; this file contributes only
+ * per-printing presentation data.
+ */
+val ShardlessAgentReprint = Printing(
+    oracleId = "2afbaa9a-c171-4a8b-90f3-5250d8498356",
+    name = "Shardless Agent",
+    setCode = "MH2",
+    collectorNumber = "292",
+    scryfallId = "b0824e77-c84b-464a-aa0c-44af5f6faa50",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b0824e77-c84b-464a-aa0c-44af5f6faa50.jpg?1783926778",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.RARE,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SilverbluffBridge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SilverbluffBridge.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+
+/**
+ * Silverbluff Bridge — Modern Horizons 2 #255
+ * (no mana cost) · Artifact Land
+ *
+ * This land enters tapped.
+ * Indestructible
+ * {T}: Add {U} or {R}.
+ *
+ * One of Modern Horizons 2's ten "Bridge" artifact lands. See [DarkmossBridge] for the cycle's
+ * modelling notes: the blank `manaCost`, why the printed "or" becomes two separate mana abilities
+ * rather than one resolution-time choice, and why indestructible is the bare [Keyword].
+ *
+ * `colorIdentity` is "RU" — read off the mana symbols in the rules text (CR 903.4), because a land
+ * has no mana cost to take it from.
+ */
+val SilverbluffBridge = card("Silverbluff Bridge") {
+    manaCost = ""
+    colorIdentity = "RU"
+    typeLine = "Artifact Land"
+    oracleText = "This land enters tapped.\n" +
+        "Indestructible\n" +
+        "{T}: Add {U} or {R}."
+
+    replacementEffect(EntersTapped())
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "255"
+        artist = "Joseph Meehan"
+        flavorText = "The path to genius is forged in creativity."
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d80dc025-c2c4-48c2-8354-7d9ddb430eb9.jpg?1783926793"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SinisterStarfish.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SinisterStarfish.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sinister Starfish — Modern Horizons 2 #99
+ * {1}{B} · Creature — Starfish · 0 / 3
+ *
+ * {T}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)
+ *
+ * A free, repeatable surveil engine: the cost is a bare tap, no mana. `Patterns.Library.surveil`
+ * is the single facade for the whole "look at the top N, choose which go to the graveyard"
+ * decision flow, so the ability is one effect rather than a look/choose/move pipeline.
+ */
+val SinisterStarfish = card("Sinister Starfish") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Starfish"
+    power = 0
+    toughness = 3
+    oracleText = "{T}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)"
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Patterns.Library.surveil(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "99"
+        artist = "Nils Hamm"
+        flavorText = "\"Throw that one back. I don't like how it's looking at me.\"\n—Netos, Meletian fisherman"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db209732-c290-4999-a1aa-2369dfa8790c.jpg?1783926855"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SkirgeFamiliarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SkirgeFamiliarReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skirge Familiar reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Urza's Saga (`usg`) `cards/` package; this file contributes only per-printing
+ * presentation data.
+ */
+val SkirgeFamiliarReprint = Printing(
+    oracleId = "ba95f24d-42da-48ce-bcf1-1b7c4b3c45b5",
+    name = "Skirge Familiar",
+    setCode = "MH2",
+    collectorNumber = "276",
+    scryfallId = "2d92fcf1-2ccd-47d2-9a24-f44b766a0b68",
+    artist = "Uriah Voth",
+    imageUri = "https://cards.scryfall.io/normal/front/2/d/2d92fcf1-2ccd-47d2-9a24-f44b766a0b68.jpg?1783926785",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.UNCOMMON,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SlagStrider.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SlagStrider.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Slag Strider — Modern Horizons 2 #141
+ * {5}{R}{R} · Creature — Elemental · 3 / 3
+ *
+ * Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ * {1}, Sacrifice an artifact: This creature deals 1 damage to any target.
+ *
+ * Pure composition. [KeywordAbility.Affinity] for [CardType.ARTIFACT] is engine-live vocabulary —
+ * the cost calculator reads the *KeywordAbility*, never a `Keyword.AFFINITY` enum entry, so the
+ * printed keyword line is left for `CardBuilder.build()` to derive. Affinity only shaves generic
+ * mana, so this floors at {R}{R} no matter how wide the artifact board gets.
+ *
+ * The activated ability is a two-atom [Costs.Composite]: the mana and the sacrifice are both costs,
+ * so they are paid on activation and the ability is on the stack independent of the artifact it ate.
+ * [Costs.Sacrifice] (not `SacrificeAnother`) is deliberate — the Strider is *not* an artifact, so
+ * "an artifact" can never mean itself here, and the printed text carries no "another".
+ */
+val SlagStrider = card("Slag Strider") {
+    manaCost = "{5}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 3
+    toughness = 3
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n" +
+        "{1}, Sacrifice an artifact: This creature deals 1 damage to any target."
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Sacrifice(GameObjectFilter.Artifact))
+        val t = target("target", AnyTarget())
+        effect = Effects.DealDamage(1, t)
+        description = "{1}, Sacrifice an artifact: This creature deals 1 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "141"
+        artist = "Yeong-Hao Han"
+        flavorText = "Imbued with life by a stray bolt of spellcraft, it began to wander about the foundry, to the blacksmiths' alarm."
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3a271f3-ea5f-4947-aac3-b4cffdfa87ac.jpg?1783926838"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SlagwoodsBridge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SlagwoodsBridge.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+
+/**
+ * Slagwoods Bridge — Modern Horizons 2 #256
+ * (no mana cost) · Artifact Land
+ *
+ * This land enters tapped.
+ * Indestructible
+ * {T}: Add {R} or {G}.
+ *
+ * One of Modern Horizons 2's ten "Bridge" artifact lands. See [DarkmossBridge] for the cycle's
+ * modelling notes: the blank `manaCost`, why the printed "or" becomes two separate mana abilities
+ * rather than one resolution-time choice, and why indestructible is the bare [Keyword].
+ *
+ * `colorIdentity` is "GR" — read off the mana symbols in the rules text (CR 903.4), because a land
+ * has no mana cost to take it from.
+ */
+val SlagwoodsBridge = card("Slagwoods Bridge") {
+    manaCost = ""
+    colorIdentity = "GR"
+    typeLine = "Artifact Land"
+    oracleText = "This land enters tapped.\n" +
+        "Indestructible\n" +
+        "{T}: Add {R} or {G}."
+
+    replacementEffect(EntersTapped())
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "256"
+        artist = "Lucas Graciano"
+        flavorText = "The path to action is forged in confidence."
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e51b48e9-a75a-4acd-9462-5e1ac2b0d803.jpg?1783926793"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SolTalisman.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SolTalisman.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Sol Talisman — Modern Horizons 2 #236
+ * (no mana cost) · Artifact
+ *
+ * Suspend 3—{1} (Rather than cast this card from your hand, pay {1} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)
+ * {T}: Add {C}{C}.
+ *
+ * Printed with **no mana cost** — CR 202.1b/118.6 make that an unpayable cost, so the card can't be
+ * cast normally and suspend is its only route onto the battlefield (barring some other free-cast
+ * effect). `manaCost = ""` is what the DSL reads to set `hasNoManaCost`; `"{0}"` would parse to a
+ * payable zero cost and leave it castable for free, which is a different card. Unlike Ancestral
+ * Vision there is no `colorIndicator`: Sol Talisman is genuinely colorless (CR 202.2), not a colored
+ * card whose color the missing mana cost hides.
+ *
+ * Suspend is card-type agnostic (CR 702.62a) — the engine exiles the artifact with time counters
+ * and casts it when the last is removed, exactly as for a creature or a sorcery. It is written as
+ * the parameterized [KeywordAbility.Suspend], cost first and time counters second; the display-only
+ * `Keyword.SUSPEND` is derived from it by `CardBuilder.build()`. Note the reminder text has no "It
+ * has haste" clause: haste is granted only to permanents that are creatures.
+ *
+ * The mana ability is the Sol Ring shape, two colorless mana for a tap, with `manaAbility = true`
+ * deriving `TimingRule.ManaAbility`.
+ */
+val SolTalisman = card("Sol Talisman") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Suspend 3—{1} (Rather than cast this card from your hand, pay {1} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)\n" +
+        "{T}: Add {C}{C}."
+
+    keywordAbility(KeywordAbility.suspend("{1}", 3))
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(2)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "236"
+        artist = "Volkan Baǵa"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a51fb64d-cc0c-400d-971f-78c28d42043b.jpg?1783926801"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SoulOfMigration.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SoulOfMigration.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soul of Migration — Modern Horizons 2 #33
+ * {5}{W}{W} · Creature — Elemental · 2 / 4
+ *
+ * Flying
+ * When this creature enters, create two 1/1 white Bird creature tokens with flying.
+ * Evoke {3}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)
+ *
+ * The token half is one [Effects.CreateToken] with `count = 2`, not two effects: "create two … "
+ * is a single creation event, so a "whenever one or more creatures enter" watcher sees one batch.
+ * No `imageUri` is passed — the Bird token's art resolves from Modern Horizons 2's own token sheet
+ * via `TokenArtData`, and hard-coding a URL here would pin the card to some other set's printing.
+ *
+ * `evoke` is the first-class alternative-cost field on the card DSL (CR 702.74a); the engine offers
+ * the cheaper cast and supplies the "when this permanent enters, if its evoke cost was paid,
+ * sacrifice it" trigger itself, so nothing else is authored for it. Both enters triggers go on the
+ * stack together and their controller orders them; the Birds arrive either way, which is the whole
+ * point of the card — {3}{W} for two flying bodies.
+ */
+val SoulOfMigration = card("Soul of Migration") {
+    manaCost = "{5}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elemental"
+    power = 2
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When this creature enters, create two 1/1 white Bird creature tokens with flying.\n" +
+        "Evoke {3}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)"
+
+    keywords(Keyword.FLYING)
+
+    evoke = "{3}{W}"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Bird"),
+            keywords = setOf(Keyword.FLYING),
+            count = 2
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "33"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/4541217f-5e86-491b-918b-ed7a2eb3e4eb.jpg?1783926884"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SteelfinWhale.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SteelfinWhale.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Steelfin Whale — Modern Horizons 2 #65
+ * {5}{U} · Creature — Whale · 3 / 4
+ *
+ * Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ * Whenever an artifact you control enters, untap this creature.
+ *
+ * Pure composition. [KeywordAbility.Affinity] for [CardType.ARTIFACT] is engine-live vocabulary —
+ * the cost calculator reads the *KeywordAbility*, never a `Keyword.AFFINITY` enum entry, so the
+ * printed keyword line is left for `CardBuilder.build()` to derive. Affinity shaves generic mana
+ * only, flooring this at {U}.
+ *
+ * The trigger is the Thopter Architect / Perimeter Patrol shape: [Triggers.entersBattlefield] over
+ * `Artifact.youControl()` with [TriggerBinding.ANY]. `ANY` rather than `OTHER` because the printed
+ * text says "an artifact you control", not "*another* artifact" — the Whale is not itself an
+ * artifact, so the binding never actually matters for its own entry, but it does mean an artifact
+ * entering the same turn the Whale does still fires. The controller predicate lives on the filter,
+ * so an opponent's artifact entering does not untap it. It is per-permanent: several artifacts
+ * entering at once each fire it separately.
+ *
+ * "Untap this creature" targets nothing, so the effect points at [EffectTarget.Self] rather than the
+ * triggering entity — the artifact that entered is the trigger's subject, the Whale is its object.
+ */
+val SteelfinWhale = card("Steelfin Whale") {
+    manaCost = "{5}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Whale"
+    power = 3
+    toughness = 4
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n" +
+        "Whenever an artifact you control enters, untap this creature."
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.Untap(EffectTarget.Self)
+        description = "Whenever an artifact you control enters, untap this creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "65"
+        artist = "Milivoj Ćeran"
+        flavorText = "It feeds on metal filings suspended in the water, sieving flecks of precious ore through magnetic baleen."
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e7ca8b6-d7e0-4af2-a578-bf45a8731c19.jpg?1783926870"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SterlingGroveReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SterlingGroveReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sterling Grove reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Invasion (`inv`) `cards/` package; this file contributes only per-printing
+ * presentation data.
+ */
+val SterlingGroveReprint = Printing(
+    oracleId = "2c275a85-5a15-46cd-a6e7-add63f9b853d",
+    name = "Sterling Grove",
+    setCode = "MH2",
+    collectorNumber = "293",
+    scryfallId = "ba03e105-a76c-4769-a35a-d780448890ec",
+    artist = "Seb McKinnon",
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/ba03e105-a76c-4769-a35a-d780448890ec.jpg?1783926777",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.RARE,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/StormGodsOracle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/StormGodsOracle.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Storm God's Oracle — Modern Horizons 2 #213
+ * {1}{U}{R} · Enchantment Creature — Human Shaman · 1 / 3
+ *
+ * {1}: This creature gets +1/-1 until end of turn.
+ * When this creature dies, it deals 3 damage to any target.
+ *
+ * The pump is self-targeting ([EffectTarget.Self]), so it needs no target requirement — a
+ * repeatable colorless activation that trades toughness for power, and can kill the Oracle
+ * outright, which is the point: doing so sets off the death trigger.
+ *
+ * The dies trigger is [Triggers.Dies], the same battlefield-to-graveyard zone change Mudbutton
+ * Torchrunner uses. Its damage source is resolved from the zone-change event's last-known
+ * information rather than the live entity — the Oracle is already in the graveyard when the
+ * trigger resolves — so the effect is a plain [Effects.DealDamage] and the engine supplies the
+ * source.
+ */
+val StormGodsOracle = card("Storm God's Oracle") {
+    manaCost = "{1}{U}{R}"
+    colorIdentity = "RU"
+    typeLine = "Enchantment Creature — Human Shaman"
+    power = 1
+    toughness = 3
+    oracleText = "{1}: This creature gets +1/-1 until end of turn.\n" +
+        "When this creature dies, it deals 3 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val damaged = target("any target", Targets.Any)
+        effect = Effects.DealDamage(3, damaged)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        effect = Effects.ModifyStats(1, -1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "213"
+        artist = "Pauline Voss"
+        flavorText = "The lives of Keranos's chosen are brief and brilliant as lightning."
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6d22f24-f752-4bc8-ba97-061b2c060ec8.jpg?1783926810"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/StrikeItRich.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/StrikeItRich.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Strike It Rich — Modern Horizons 2 #143
+ * {R} · Sorcery
+ *
+ * Create a Treasure token. (It's an artifact with "{T}, Sacrifice this token: Add one mana of any color.")
+ * Flashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)
+ *
+ * Treasure is a predefined token, so [Effects.CreateTreasure] carries the token's own tap-sacrifice
+ * mana ability — the reminder text in [oracleText] is printed flavour, not a second thing to wire.
+ *
+ * Flashback is a real [KeywordAbility], not a bare `Keyword`: the engine reads the alternative cost
+ * off the keyword ability when it offers the graveyard cast, and exiles the card as it resolves
+ * (CR 702.34a). One net card for two casts is why the front half is a single red mana.
+ */
+val StrikeItRich = card("Strike It Rich") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\n" +
+        "Flashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    spell {
+        effect = Effects.CreateTreasure()
+    }
+
+    keywordAbility(KeywordAbility.flashback("{2}{R}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "143"
+        artist = "Volkan Baǵa"
+        flavorText = "A few coins soon grow into an obsession."
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1c7c2814-a617-4123-acdf-1b01b2768210.jpg?1783926837"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SylvanAnthem.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SylvanAnthem.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Sylvan Anthem — Modern Horizons 2 #176
+ * {G}{G} · Enchantment
+ *
+ * Green creatures you control get +1/+1.
+ * Whenever a green creature you control enters, scry 1.
+ *
+ * The lord is a plain [ModifyStats] static over a [GroupFilter] and deliberately does **not** pass
+ * `excludeSelf`: the anthem cards that do (Wilt-Leaf Liege) only need it because they are
+ * themselves creatures and their text says "other". Sylvan Anthem is an enchantment, so it can
+ * never be in its own affected set anyway.
+ *
+ * The scry trigger uses [TriggerBinding.ANY] for the same reason the Oracle text says "a green
+ * creature you control" rather than "*another* green creature": there is no self to exclude.
+ * (Contrast Ivy Lane Denizen, whose printed "another" is [TriggerBinding.OTHER].) The green check
+ * rides the trigger's [GameObjectFilter], which is evaluated against projected state, so a
+ * creature made green by another continuous effect as it enters still triggers.
+ */
+val SylvanAnthem = card("Sylvan Anthem") {
+    manaCost = "{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Green creatures you control get +1/+1.\n" +
+        "Whenever a green creature you control enters, scry 1."
+
+    // Green creatures you control get +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.withColor(Color.GREEN).youControl())
+        )
+    }
+
+    // Whenever a green creature you control enters, scry 1.
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.withColor(Color.GREEN).youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Patterns.Library.scry(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "176"
+        artist = "Franz Vohwinkel"
+        flavorText = "The harsher the winter, the more glorious the spring.\n—Yavimaya saying"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a119edc2-9e0f-43d1-a13d-25827f86e3e3.jpg?1783926824"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SythisHarvestsHand.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/SythisHarvestsHand.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sythis, Harvest's Hand — Modern Horizons 2 #214
+ * {G}{W} · Legendary Enchantment Creature — Nymph · 1 / 2
+ *
+ * Whenever you cast an enchantment spell, you gain 1 life and draw a card.
+ *
+ * [Triggers.YouCastEnchantment] watches the *cast*, so the trigger goes on the stack above the
+ * enchantment spell and resolves first — the life and the card arrive before the enchantment does
+ * (CR 603.3). Sythis is herself an enchantment creature, but casting *her* does not trigger this:
+ * the ability isn't on the battlefield yet when she is cast.
+ *
+ * "You gain 1 life and draw a card" is one instruction sequence, so it is a single composite
+ * effect (`then`) rather than two abilities — a second `triggeredAbility` would put two objects on
+ * the stack and let a player respond between the halves.
+ */
+val SythisHarvestsHand = card("Sythis, Harvest's Hand") {
+    manaCost = "{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Enchantment Creature — Nymph"
+    power = 1
+    toughness = 2
+    oracleText = "Whenever you cast an enchantment spell, you gain 1 life and draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastEnchantment
+        effect = Effects.GainLife(1) then Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "214"
+        artist = "Ryan Yee"
+        flavorText = "\"Through every verdant field, every bough that hangs heavy with fruit, Karametra shows her love.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0babfe00-9bad-48fc-b3b1-df8280242fd2.jpg?1783926809"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/TanglepoolBridge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/TanglepoolBridge.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+
+/**
+ * Tanglepool Bridge — Modern Horizons 2 #257
+ * (no mana cost) · Artifact Land
+ *
+ * This land enters tapped.
+ * Indestructible
+ * {T}: Add {G} or {U}.
+ *
+ * One of Modern Horizons 2's ten "Bridge" artifact lands. See [DarkmossBridge] for the cycle's
+ * modelling notes: the blank `manaCost`, why the printed "or" becomes two separate mana abilities
+ * rather than one resolution-time choice, and why indestructible is the bare [Keyword].
+ *
+ * `colorIdentity` is "GU" — read off the mana symbols in the rules text (CR 903.4), because a land
+ * has no mana cost to take it from.
+ */
+val TanglepoolBridge = card("Tanglepool Bridge") {
+    manaCost = ""
+    colorIdentity = "GU"
+    typeLine = "Artifact Land"
+    oracleText = "This land enters tapped.\n" +
+        "Indestructible\n" +
+        "{T}: Add {G} or {U}."
+
+    replacementEffect(EntersTapped())
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "257"
+        artist = "Randy Gallegos"
+        flavorText = "The path to change is forged in insight."
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/57d2b895-8921-4615-a674-fb85eed5ea3f.jpg?1783926793"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/TerminalAgony.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/TerminalAgony.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Terminal Agony — Modern Horizons 2 #215
+ * {2}{B}{R} · Sorcery
+ *
+ * Destroy target creature.
+ * Madness {B}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)
+ *
+ * [Effects.Destroy] is a `MoveToZoneEffect` to the graveyard with `byDestruction = true`, which is
+ * what lets indestructible, regeneration and totem armor see the destruction rather than a plain
+ * zone change (CR 701.7). No "can't be regenerated" rider is printed, so the plain form is right.
+ *
+ * Madness (CR 702.35) turns a four-mana sorcery into two-mana instant-speed removal whenever
+ * something discards it — the madness cast happens while the reflexive trigger resolves, so the
+ * sorcery timing restriction never applies. `CardBuilder.build()` derives the printed
+ * `Keyword.MADNESS` from `madness(...)`.
+ */
+val TerminalAgony = card("Terminal Agony") {
+    manaCost = "{2}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature.\n" +
+        "Madness {B}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)"
+
+    spell {
+        val t = target("target", TargetCreature())
+        effect = Effects.Destroy(t)
+    }
+
+    madness("{B}{R}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "215"
+        artist = "Lucas Graciano"
+        flavorText = "His mouth melted to slag, yet somehow he kept screaming."
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/314e94ad-0e12-48bb-aae1-2c842943114a.jpg?1783926810"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/TheUnderworldCookbook.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/TheUnderworldCookbook.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * The Underworld Cookbook — Modern Horizons 2 #240
+ * {1} · Artifact — Book
+ *
+ * {T}, Discard a card: Create a Food token. (It's an artifact with "{2}, {T}, Sacrifice this token: You gain 3 life.")
+ * {4}, {T}, Sacrifice this artifact: Return target creature card from your graveyard to your hand.
+ *
+ * Asmoranomardicadaistinaculdacar's recipe book: a one-mana discard outlet that pays you in Food,
+ * with a late-game escape hatch that trades the book itself for a creature back.
+ *
+ * Both halves are activated abilities. The discard is a *cost* ([Costs.DiscardCard] — any card in
+ * hand, not this one), which is exactly why the card is played alongside madness and
+ * "whenever you discard" payoffs. The Food itself is the predefined token facade
+ * [Effects.CreateFood]; the reminder text in the Oracle line is the token's own printed ability,
+ * so nothing here wires it.
+ *
+ * The second ability's cost order mirrors the printed line — mana, tap, sacrifice — and because
+ * sacrificing is part of the cost the book is already in the graveyard when the ability resolves.
+ * The target is a creature card in *your* graveyard ([TargetFilter.CreatureInYourGraveyard]),
+ * chosen on announcement, so it is picked before the book joins it there.
+ */
+val TheUnderworldCookbook = card("The Underworld Cookbook") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Book"
+    oracleText = "{T}, Discard a card: Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n" +
+        "{4}, {T}, Sacrifice this artifact: Return target creature card from your graveyard to your hand."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.DiscardCard)
+        effect = Effects.CreateFood()
+        description = "{T}, Discard a card: Create a Food token."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap, Costs.SacrificeSelf)
+        val t = target("target creature card from your graveyard", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
+        effect = Effects.Move(t, Zone.HAND)
+        description = "{4}, {T}, Sacrifice this artifact: Return target creature card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "240"
+        artist = "Joe Slucher"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/039d62b0-3309-4424-a2ea-5a0d88d4bd72.jpg?1783926799"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ThornglintBridge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ThornglintBridge.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+
+/**
+ * Thornglint Bridge — Modern Horizons 2 #258
+ * (no mana cost) · Artifact Land
+ *
+ * This land enters tapped.
+ * Indestructible
+ * {T}: Add {G} or {W}.
+ *
+ * One of Modern Horizons 2's ten "Bridge" artifact lands. See [DarkmossBridge] for the cycle's
+ * modelling notes: the blank `manaCost`, why the printed "or" becomes two separate mana abilities
+ * rather than one resolution-time choice, and why indestructible is the bare [Keyword].
+ *
+ * `colorIdentity` is "GW" — read off the mana symbols in the rules text (CR 903.4), because a land
+ * has no mana cost to take it from.
+ */
+val ThornglintBridge = card("Thornglint Bridge") {
+    manaCost = ""
+    colorIdentity = "GW"
+    typeLine = "Artifact Land"
+    oracleText = "This land enters tapped.\n" +
+        "Indestructible\n" +
+        "{T}: Add {G} or {W}."
+
+    replacementEffect(EntersTapped())
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "258"
+        artist = "Randy Gallegos"
+        flavorText = "The path to growth is forged in balance."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d483643-6a11-47f7-a0aa-190e0179525f.jpg?1783926792"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ThoughtMonitor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ThoughtMonitor.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Thought Monitor — Modern Horizons 2 #71
+ * {6}{U} · Artifact Creature — Construct · 2 / 2
+ *
+ * Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ * Flying
+ * When this creature enters, draw two cards.
+ *
+ * Mulldrifter's enters-draw-two body wearing affinity instead of evoke. [KeywordAbility.Affinity]
+ * for [CardType.ARTIFACT] is engine-live vocabulary — the cost calculator reads the *KeywordAbility*,
+ * never a `Keyword.AFFINITY` enum entry, so the printed keyword line is left for
+ * `CardBuilder.build()` to derive; [Keyword.FLYING] is a plain enum keyword and is written out.
+ *
+ * Affinity shaves generic mana only, so this floors at {U}. The Monitor is itself an artifact, but
+ * it counts artifacts *you control* while it is still a spell on the stack, so it never counts
+ * itself.
+ */
+val ThoughtMonitor = card("Thought Monitor") {
+    manaCost = "{6}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Construct"
+    power = 2
+    toughness = 2
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n" +
+        "Flying\n" +
+        "When this creature enters, draw two cards."
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(2)
+        description = "When this creature enters, draw two cards."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "71"
+        artist = "Martina Pilcerova"
+        flavorText = "It roams the skies over the Quicksilver Sea, alert for any hint of aberrant thought."
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/996c1952-8d10-4296-8960-ff8993833649.jpg?1783926868"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/VedalkenInfiltrator.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/VedalkenInfiltrator.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Vedalken Infiltrator — Modern Horizons 2 #73
+ * {1}{U} · Creature — Vedalken Rogue · 1 / 3
+ *
+ * This creature can't be blocked.
+ * Metalcraft — This creature gets +1/+0 as long as you control three or more artifacts.
+ *
+ * Two unrelated statics, each in its own vocabulary.
+ *
+ * "Can't be blocked" is not a [com.wingedsheep.sdk.core.Keyword] — there is no keyword for it to
+ * abbreviate — but an evasion [AbilityFlag], the same one Phantom Warrior carries. The blocking
+ * rules read the flag directly when legal blocks are enumerated.
+ *
+ * "Metalcraft" is an *ability word*: pure flavour with no rules meaning of its own (CR 207.2c), so
+ * there is no `Keyword.METALCRAFT` and nothing but the oracle line records it. What it introduces is
+ * an ordinary [ConditionalStaticAbility] — a layer-7c (CR 613.4c) [ModifyStats] over `GroupFilter.source()`
+ * gated by [Conditions.YouControlAtLeast], recomputed at projection so the bonus appears and
+ * disappears with the third artifact rather than being latched at any point in time.
+ */
+val VedalkenInfiltrator = card("Vedalken Infiltrator") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Vedalken Rogue"
+    power = 1
+    toughness = 3
+    oracleText = "This creature can't be blocked.\n" +
+        "Metalcraft — This creature gets +1/+0 as long as you control three or more artifacts."
+
+    flags(AbilityFlag.CANT_BE_BLOCKED)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 1, toughnessBonus = 0, filter = GroupFilter.source()),
+            condition = Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "73"
+        artist = "Izzy"
+        flavorText = "\"An expert always keeps their tools close at hand.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9ddfc6a8-7880-4810-8c0a-d9ea931138f2.jpg?1783926866"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ViashinoLashclaw.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ViashinoLashclaw.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Viashino Lashclaw — Modern Horizons 2 #146
+ * {1}{R} · Creature — Lizard Warrior · 2 / 2
+ *
+ * {T}, Discard a card: Creatures you control gain haste until end of turn.
+ *
+ * The cost is [Costs.DiscardCard] — discard *any* card from hand — not `Costs.DiscardSelf`,
+ * which is the cycling-style "discard this card".
+ *
+ * "Creatures you control gain haste" is a group grant, not a targeted one: [Effects.ForEachInGroup]
+ * iterates the battlefield group and [EffectTarget.Self] inside the body names the *iterated*
+ * creature, so each one picks up its own until-end-of-turn haste grant. The set is locked in on
+ * resolution, so a creature that enters afterwards this turn does not get haste (CR 611.2c).
+ */
+val ViashinoLashclaw = card("Viashino Lashclaw") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "{T}, Discard a card: Creatures you control gain haste until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.DiscardCard)
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self)
+        )
+        description = "Creatures you control gain haste until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Caio Monteiro"
+        flavorText = "\"Victory is the greatest motivator of all. So sayeth the bey.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/3457e346-a5de-4624-b577-f59d4c186537.jpg?1783926836"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/VindicateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/VindicateReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vindicate reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Apocalypse (`apc`) `cards/` package; this file contributes only per-printing
+ * presentation data.
+ */
+val VindicateReprint = Printing(
+    oracleId = "63c1ac21-e3d8-40c2-8c09-3f31c52992ef",
+    name = "Vindicate",
+    setCode = "MH2",
+    collectorNumber = "294",
+    scryfallId = "683c4e13-525c-45c9-8832-bfe67965c34e",
+    artist = "Brian Snõddy",
+    imageUri = "https://cards.scryfall.io/normal/front/6/8/683c4e13-525c-45c9-8832-bfe67965c34e.jpg?1783926778",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.RARE,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/WorldWeary.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/WorldWeary.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * World-Weary — Modern Horizons 2 #109
+ * {3}{B}{B} · Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets -4/-4.
+ * Basic landcycling {1}{B} ({1}{B}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)
+ *
+ * `auraTarget` carries the "Enchant creature" line — it is both the cast-time target and the
+ * standing attachment restriction (CR 303.4). The stat modification is a *filterless* [ModifyStats]
+ * static ability: with no filter it applies to whatever the Aura is attached to, so it needs no
+ * `Filters.EnchantedCreature` spelling and follows the attachment automatically. -4/-4 is a layer
+ * 7c modification, not damage, so the creature dies to state-based actions rather than being
+ * destroyed by the Aura.
+ *
+ * Basic landcycling ([KeywordAbility.basicLandcycling]) narrows the shared typecycling search to
+ * *basic* land cards.
+ */
+val WorldWeary = card("World-Weary") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets -4/-4.\n" +
+        "Basic landcycling {1}{B} ({1}{B}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)"
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(-4, -4)
+    }
+
+    keywordAbility(KeywordAbility.basicLandcycling("{1}{B}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "109"
+        artist = "Evan Shipard"
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6c7c1b08-3184-478f-92be-88db6cda33c5.jpg?1783926852"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ZuranOrbReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ZuranOrbReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zuran Orb reprint in Modern Horizons 2. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Ice Age (`ice`) `cards/` package; this file contributes only
+ * per-printing presentation data.
+ */
+val ZuranOrbReprint = Printing(
+    oracleId = "08cb8a30-9cb4-4517-bee5-8848aa60d1a2",
+    name = "Zuran Orb",
+    setCode = "MH2",
+    collectorNumber = "300",
+    scryfallId = "618c8ecc-686d-41de-b9b1-1a7ee9cc7c14",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/6/1/618c8ecc-686d-41de-b9b1-1a7ee9cc7c14.jpg?1783926775",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.UNCOMMON,
+    borderColor = "black",
+)

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/JadeAvengerScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/JadeAvengerScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mh2.cards.JadeAvenger
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Jade Avenger (MH2 #167) — {1}{G} Creature — Frog Samurai 2/2.
+ *
+ * Oracle: "Bushido 2 (Whenever this creature blocks or becomes blocked, it gets +2/+2 until end of
+ * turn.)"
+ *
+ * **The first bushido card in the corpus.** `Keyword.BUSHIDO` is display-only vocabulary — nothing
+ * in `rules-engine` reads it — so the ability CR 702.45a spells out is lowered by hand on the card
+ * as two triggers over the two distinct events (`Triggers.Blocks` and `Triggers.BecomesBlocked`),
+ * each pumping `EffectTarget.Self`. These tests pin that lowering end to end, because a card that
+ * carried only the keyword would compile, read correctly in the client, and do nothing.
+ *
+ * Covered:
+ *  1. Blocking fires bushido — the Avenger is a 4/4 for the rest of the turn.
+ *  2. Being blocked fires it too — the other half of the same printed ability.
+ *  3. Attacking *unblocked* fires neither, so the split into two triggers can't double-count or
+ *     leak a bonus into a combat where bushido does nothing.
+ */
+class JadeAvengerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(JadeAvenger)
+        return driver
+    }
+
+    fun GameTestDriver.power(id: EntityId): Int = state.projectedState.getPower(id) ?: 0
+    fun GameTestDriver.toughness(id: EntityId): Int = state.projectedState.getToughness(id) ?: 0
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: bushido, half one — "whenever this creature blocks"
+    // ─────────────────────────────────────────────────────────────────────────
+    test("blocking gives Jade Avenger +2/+2 until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val bears = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        driver.removeSummoningSickness(bears)
+        val avenger = driver.putCreatureOnBattlefield(defender, "Jade Avenger")
+
+        driver.power(avenger) shouldBe 2
+        driver.toughness(avenger) shouldBe 2
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(bears), defender)
+        driver.bothPass()
+
+        driver.declareBlockers(defender, mapOf(avenger to listOf(bears)))
+        // Resolve the blocks trigger.
+        driver.bothPass()
+
+        driver.power(avenger) shouldBe 4
+        driver.toughness(avenger) shouldBe 4
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: bushido, half two — "or becomes blocked"
+    // ─────────────────────────────────────────────────────────────────────────
+    test("becoming blocked gives Jade Avenger +2/+2 until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        val defender = driver.getOpponent(me)
+
+        val avenger = driver.putCreatureOnBattlefield(me, "Jade Avenger")
+        driver.removeSummoningSickness(avenger)
+        val blocker = driver.putCreatureOnBattlefield(defender, "Grizzly Bears")
+
+        driver.power(avenger) shouldBe 2
+        driver.toughness(avenger) shouldBe 2
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(avenger), defender)
+        driver.bothPass()
+
+        driver.declareBlockers(defender, mapOf(blocker to listOf(avenger)))
+        // Resolve the becomes-blocked trigger.
+        driver.bothPass()
+
+        driver.power(avenger) shouldBe 4
+        driver.toughness(avenger) shouldBe 4
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 3: control — an unblocked attack fires neither half
+    // ─────────────────────────────────────────────────────────────────────────
+    test("attacking unblocked leaves Jade Avenger a 2/2") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        val defender = driver.getOpponent(me)
+
+        val avenger = driver.putCreatureOnBattlefield(me, "Jade Avenger")
+        driver.removeSummoningSickness(avenger)
+        // The defender has nothing to block with.
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(avenger), defender)
+        driver.bothPass()
+
+        driver.declareBlockers(defender, emptyMap())
+        driver.bothPass()
+
+        driver.power(avenger) shouldBe 2
+        driver.toughness(avenger) shouldBe 2
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/ICE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ICE.json
@@ -921,3 +921,40 @@
         "BLACK"
     ]
 }
+
+// Zuran Orb
+{
+    "name": "Zuran Orb",
+    "manaCost": "{0}",
+    "typeLine": "Artifact",
+    "oracleText": "Sacrifice a land: You gain 2 life.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "land"
+                    }
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "350",
+        "rarity": "UNCOMMON",
+        "artist": "Sandra Everingham",
+        "flavorText": "\"I will go to any length to achieve my goal. Eternal life is worth any sacrifice.\"\n—Zur the Enchanter",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3a9d1082-a862-45d4-9e5e-392e879fead6.jpg?1783947454"
+    },
+    "colorIdentityOverride": []
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LEG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LEG.json
@@ -186,6 +186,57 @@
     ]
 }
 
+// Greed
+{
+    "name": "Greed",
+    "manaCost": "{3}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "{B}, Pay 2 life: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "rarity": "RARE",
+        "artist": "Phil Foglio",
+        "flavorText": "\"There is no calamity greater than lavish desires./ There is no greater guilt than discontentment./ And there is no greater disaster than greed.\" —*Tao Tê Ching 46*",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/111a16a2-e875-4756-80db-290f9e8606db.jpg?1783948066"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Headless Horseman
 {
     "name": "Headless Horseman",

--- a/mtg-sets/src/test/resources/snapshots/cards/MH2.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MH2.json
@@ -1,3 +1,549 @@
+// Arcbound Mouser
+{
+    "name": "Arcbound Mouser",
+    "manaCost": "{W}",
+    "typeLine": "Artifact Creature — Cat",
+    "oracleText": "Lifelink\nModular 1 (This creature enters with a +1/+1 counter on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "LIFELINK",
+        "MODULAR"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "MODULAR",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddDynamicCounters",
+                        "counterType": "+1/+1",
+                        "amount": {
+                            "type": "ContextProperty",
+                            "key": "LAST_KNOWN_PLUS_ONE_COUNTER_COUNT"
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact creature"
+                    }
+                },
+                "descriptionOverride": "When this creature dies, you may put its +1/+1 counters on target artifact creature."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "artist": "Campbell White",
+        "flavorText": "It doesn't purr. It hums.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d66e724-49ee-4f08-a160-584350de1d95.jpg?1783926896"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Arcbound Prototype
+{
+    "name": "Arcbound Prototype",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact Creature — Assembly",
+    "oracleText": "Modular 2 (This creature enters with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "MODULAR"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "MODULAR",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddDynamicCounters",
+                        "counterType": "+1/+1",
+                        "amount": {
+                            "type": "ContextProperty",
+                            "key": "LAST_KNOWN_PLUS_ONE_COUNTER_COUNT"
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact creature"
+                    }
+                },
+                "descriptionOverride": "When this creature dies, you may put its +1/+1 counters on target artifact creature."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 2,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "artist": "Svetlin Velinov",
+        "flavorText": "It flickered to life, saw itself alone, and began to build.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1cb0a1a4-9216-47f8-a4e3-20fe0de6a518.jpg?1783926897"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Arcbound Slasher
+{
+    "name": "Arcbound Slasher",
+    "manaCost": "{4}{R}",
+    "typeLine": "Artifact Creature — Cat",
+    "oracleText": "Modular 4 (This creature enters with four +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)\nRiot (This creature enters with your choice of an additional +1/+1 counter or haste.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "RIOT",
+        "MODULAR"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "MODULAR",
+            "n": 4
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddDynamicCounters",
+                        "counterType": "+1/+1",
+                        "amount": {
+                            "type": "ContextProperty",
+                            "key": "LAST_KNOWN_PLUS_ONE_COUNTER_COUNT"
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact creature"
+                    }
+                },
+                "descriptionOverride": "When this creature dies, you may put its +1/+1 counters on target artifact creature."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "haste"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 4,
+                "selfOnly": true
+            },
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "MODE",
+                "modeOptions": [
+                    {
+                        "id": "counter",
+                        "label": "A +1/+1 counter",
+                        "iconKey": "plusOneCounter"
+                    },
+                    {
+                        "id": "haste",
+                        "label": "Haste",
+                        "iconKey": "haste"
+                    }
+                ]
+            },
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "counter"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "artist": "Campbell White",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dcafff1a-e220-40ff-8c00-de6037219bc6.jpg?1783926851"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Arcbound Whelp
+{
+    "name": "Arcbound Whelp",
+    "manaCost": "{3}{R}",
+    "typeLine": "Artifact Creature — Dragon",
+    "oracleText": "Flying\n{R}: This creature gets +1/+0 until end of turn.\nModular 2 (This creature enters with two +1/+1 counters on it. When it dies, you may put its +1/+1 counters on target artifact creature.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "FLYING",
+        "MODULAR"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "MODULAR",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddDynamicCounters",
+                        "counterType": "+1/+1",
+                        "amount": {
+                            "type": "ContextProperty",
+                            "key": "LAST_KNOWN_PLUS_ONE_COUNTER_COUNT"
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact creature"
+                    }
+                },
+                "descriptionOverride": "When this creature dies, you may put its +1/+1 counters on target artifact creature."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{R}: This creature gets +1/+0 until end of turn."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 2,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "rarity": "UNCOMMON",
+        "artist": "Craig J Spearing",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/154ed1d3-e24a-48ba-8f7b-be254c08d1cc.jpg?1783926850"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Battle Plan
+{
+    "name": "Battle Plan",
+    "manaCost": "{3}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of combat on your turn, target creature you control gets +2/+0 until end of turn.\nBasic landcycling {1}{R} ({1}{R}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{R}",
+            "searchFilter": {
+                "cardPredicates": [
+                    "IsBasicLand"
+                ]
+            },
+            "displayPrefix": "Basic landcycling"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "artist": "Paul Scott Canavan",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2bc1e907-0e77-42ee-9eca-eae632020204.jpg?1783926850"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Blazing Rootwalla
+{
+    "name": "Blazing Rootwalla",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Lizard",
+    "oracleText": "{R}: This creature gets +2/+0 until end of turn. Activate only once each turn.\nMadness {0} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{0}"
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "restrictions": [
+                    "OncePerTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "rarity": "UNCOMMON",
+        "artist": "Jokubas Uogintas",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/4404fc9c-ef02-479c-9638-0cc163f0b48f.jpg?1783926849"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Cabal Initiate
+{
+    "name": "Cabal Initiate",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Warlock",
+    "oracleText": "Discard a card: This creature gains lifelink until end of turn.\nThreshold — This creature gets +1/+2 as long as there are seven or more cards in your graveyard.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": "AtomDiscard"
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "target": "Self"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 7
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "artist": "Bastien L. Deharme",
+        "flavorText": "\"Hear our prayers, oh Shadowed One, and bless us in bloody agony.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b279a03f-85ab-43f2-b5ca-1bc10563e5ad.jpg?1783926864"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Chatterstorm
 {
     "name": "Chatterstorm",
@@ -25,6 +571,1401 @@
         "artist": "Milivoj Ćeran",
         "flavorText": "\"Friends, foragers, fuzzy fighters! Tonight we're after more than just acorns!\"\n—Larrel, Deep Forest hermit",
         "imageUri": "https://cards.scryfall.io/normal/front/b/3/b34f0ac1-6894-4761-b62c-b85d927acf09.jpg?1783926835"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Crack Open
+{
+    "name": "Crack Open",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target artifact or enchantment. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact or enchantment"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target artifact or enchantment"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "What no spell or lockpick could open, the forest coaxed apart.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42b77a34-9b69-4b01-9f2c-2ff8de47fc12.jpg?1783926833"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Darkmoss Bridge
+{
+    "name": "Darkmoss Bridge",
+    "manaCost": "",
+    "typeLine": "Artifact Land",
+    "oracleText": "This land enters tapped.\nIndestructible\n{T}: Add {B} or {G}.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "245",
+        "artist": "Raoul Vitale",
+        "flavorText": "The path to power is forged in ruthlessness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f11f0be9-b9f7-45d2-9499-c5d849d7289f.jpg?1783926797"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Drey Keeper
+{
+    "name": "Drey Keeper",
+    "manaCost": "{3}{B}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "When this creature enters, create two 1/1 green Squirrel creature tokens.\n{3}{B}: Squirrels you control get +1/+0 and gain menace until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Squirrel"
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "permanent Squirrel ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "MENACE",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "artist": "Kev Walker",
+        "flavorText": "He gave the squirrels acorns. They gave him vengeance.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/995529d1-e2b0-4cce-bd40-56c7ef3c33da.jpg?1783926817"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Drossforge Bridge
+{
+    "name": "Drossforge Bridge",
+    "manaCost": "",
+    "typeLine": "Artifact Land",
+    "oracleText": "This land enters tapped.\nIndestructible\n{T}: Add {B} or {R}.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "246",
+        "artist": "Raoul Vitale",
+        "flavorText": "The path to ruin is forged in pain.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5b46b8d8-723a-4752-b97d-29ef83bd294c.jpg?1783926796"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Ethersworn Sphinx
+{
+    "name": "Ethersworn Sphinx",
+    "manaCost": "{7}{W}{U}",
+    "typeLine": "Artifact Creature — Sphinx",
+    "oracleText": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying\nCascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card with lesser mana value. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "CASCADE",
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": "Cascade",
+                "descriptionOverride": "Cascade"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "rarity": "UNCOMMON",
+        "artist": "Irina Nordsol",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/315ae21a-4d95-488e-812b-0d018219af6c.jpg?1783926817"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Faithless Salvaging
+{
+    "name": "Faithless Salvaging",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Discard a card, then draw a card.\nRebound (If you cast this spell from your hand, exile it as it resolves. At the beginning of your next upkeep, you may cast this card from exile without paying its mana cost.)",
+    "keywords": [
+        "REBOUND"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 1 card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "artist": "Bud Cook",
+        "flavorText": "All that's left are broken beliefs.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c6ed4077-4ed5-48fb-91c9-a9195d652978.jpg?1783926845"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Filigree Attendant
+{
+    "name": "Filigree Attendant",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Artifact Creature — Homunculus",
+    "oracleText": "Flying\nFiligree Attendant's power is equal to the number of artifacts you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "artifact"
+            }
+        },
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "41",
+        "rarity": "UNCOMMON",
+        "artist": "Igor Kieryluk",
+        "flavorText": "\"The perfect assistant is one that's responsive, dexterous, and capable of reaching all the high shelves.\"\n—Coruk, Esper artificer",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0cb828c-a19b-4e6d-853f-85e5ea7cadf8.jpg?1783926880"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Flame Blitz
+{
+    "name": "Flame Blitz",
+    "manaCost": "{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your end step, this enchantment deals 5 damage to each planeswalker.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "planeswalker"
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "rarity": "UNCOMMON",
+        "artist": "Colin Boyer",
+        "flavorText": "\"Blast it, not again!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a93c6ba8-666b-4c05-8137-8ffa1d5d928b.jpg?1783926845"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Fodder Tosser
+{
+    "name": "Fodder Tosser",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}, Discard a card: This artifact deals 2 damage to target player or planeswalker.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player or planeswalker"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayerOrPlaneswalker",
+                        "id": "target player or planeswalker"
+                    }
+                ],
+                "descriptionOverride": "{T}, Discard a card: This artifact deals 2 damage to target player or planeswalker."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "artist": "Gabor Szikszai",
+        "flavorText": "\"In event of siege, load copiously with: hot oil, cannonballs, caltrops, rubble, old swords, mess-hall leftovers, chamber pots, broken chairs, salt, cousin Furt . . .\"\n—Trebuchet instructions",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd401525-b874-4af2-99a3-c2c83e22547e.jpg?1783926805"
+    },
+    "colorIdentityOverride": []
+}
+
+// Foundation Breaker
+{
+    "name": "Foundation Breaker",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "When this creature enters, you may destroy target artifact or enchantment.\nEvoke {1}{G} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "EVOKE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Evoke",
+            "cost": "{1}{G}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact|enchantment"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "rarity": "UNCOMMON",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "The castle finally got vengeance for enduring years of royally bad taste.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f08381e-34f5-4d08-b737-8c37964719e0.jpg?1783926832"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Gargadon
+{
+    "name": "Gargadon",
+    "manaCost": "{5}{R}{R}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Trample\nSuspend 4—{1}{R} (Rather than cast this card from your hand, you may pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 5
+    },
+    "keywords": [
+        "TRAMPLE",
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{1}{R}",
+            "timeCounters": 4
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "128",
+        "artist": "Chris Seaman",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b672c59-7376-455d-961e-ce94d47a5ca4.jpg?1783926844"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Goldmire Bridge
+{
+    "name": "Goldmire Bridge",
+    "manaCost": "",
+    "typeLine": "Artifact Land",
+    "oracleText": "This land enters tapped.\nIndestructible\n{T}: Add {W} or {B}.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "artist": "Aaron Miller",
+        "flavorText": "The path to glory is forged in ambition.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/dbe2a1fa-196f-497f-a15f-0b3b04da9cbb.jpg?1783926796"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Healer's Flock
+{
+    "name": "Healer's Flock",
+    "manaCost": "{W}{W}{W}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying, lifelink",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "16",
+        "rarity": "UNCOMMON",
+        "artist": "Joe Slucher",
+        "flavorText": "The sight of a flock overhead is bittersweet. It means many are wounded, but it also means help is on the way.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b93b5429-8512-4ab6-9ecd-fa270e0144f3.jpg?1783926891"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Hell Mongrel
+{
+    "name": "Hell Mongrel",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Nightmare Dog",
+    "oracleText": "Discard a card: This creature gets +1/+1 until end of turn.\nMadness {2}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{2}{B}"
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": "AtomDiscard"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "artist": "Robbie Trevino",
+        "flavorText": "It feeds on shadows, fear, and blood.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7da32a3-8e33-4603-abd2-8db144062f6a.jpg?1783926860"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Herd Baloth
+{
+    "name": "Herd Baloth",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Whenever one or more +1/+1 counters are put on this creature, you may create a 4/4 green Beast creature token.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "CountersPlacedEvent",
+                    "counterType": "+1/+1"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "CreateToken",
+                        "power": 4,
+                        "toughness": 4,
+                        "colors": [
+                            "GREEN"
+                        ],
+                        "creatureTypes": [
+                            "Beast"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "UNCOMMON",
+        "artist": "Nicholas Gregory",
+        "flavorText": "Baloth social structure is simple: the biggest one's the leader.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c1e9cef5-c55f-47d9-9d2f-300dab8fcb0b.jpg?1783926829"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Jade Avenger
+{
+    "name": "Jade Avenger",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Frog Samurai",
+    "oracleText": "Bushido 2 (Whenever this creature blocks or becomes blocked, it gets +2/+2 until end of turn.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "BUSHIDO"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "BUSHIDO",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 2"
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Bushido 2"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "artist": "Chris Seaman",
+        "flavorText": "\"Froggy fighter at the gate.\nDraw your sword and meet your fate.\"\n—Traditional children's rhyme",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f81500be-c959-4f38-bcf2-d63519168f67.jpg?1783926829"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Jewel-Eyed Cobra
+{
+    "name": "Jewel-Eyed Cobra",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Snake",
+    "oracleText": "Deathtouch\nWhen this creature dies, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Josu Hernaiz",
+        "flavorText": "\"Sure, they're worth a lot, but I'd rather survive to spend my earnings.\"\n—Mokgar, Kalonian hunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8f8db60d-3adf-45e1-b4d0-3b5e24f5e01d.jpg?1783926831"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Kitchen Imp
+{
+    "name": "Kitchen Imp",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Imp",
+    "oracleText": "Flying, haste\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "HASTE",
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{B}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "89",
+        "artist": "Evyn Fong",
+        "flavorText": "\"Order up! Ooze aspic and jellied anurid eyes!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/836ae711-e62f-49ec-850e-d25f6fd2a4d4.jpg?1783926859"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Late to Dinner
+{
+    "name": "Late to Dinner",
+    "manaCost": "{3}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target creature card from your graveyard to the battlefield. Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card from your graveyard"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target creature card from your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Kev Walker",
+        "flavorText": "\"I knew you were set in your ways, friend, but even I didn't expect you to keep our engagement, under the circumstances.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/6633cab9-23f9-474e-96f1-ca7c0c67691c.jpg?1783926889"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Lens Flare
+{
+    "name": "Lens Flare",
+    "manaCost": "{4}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nLens Flare deals 5 damage to target attacking or blocking creature.",
+    "keywords": [
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "Josh Hass",
+        "flavorText": "The key for surviving a war is never becoming its focus.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d92f037-a121-428a-ac53-98437366ecfd.jpg?1783926889"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Lightning Spear
+{
+    "name": "Lightning Spear",
+    "manaCost": "{1}{R}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+0 and has trample.\n{2}{R}, Sacrifice this Equipment: It deals 3 damage to any target.\nEquip {1}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ],
+                "descriptionOverride": "{2}{R}, Sacrifice this Equipment: It deals 3 damage to any target."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "134",
+        "artist": "Steven Belledin",
+        "flavorText": "When wielded, it begs to be released.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f72fcda4-feb4-46e4-87d9-88bd95474fe9.jpg?1783926842"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Marble Gargoyle
+{
+    "name": "Marble Gargoyle",
+    "manaCost": "{2}{W}",
+    "typeLine": "Artifact Creature — Gargoyle",
+    "oracleText": "Flying\n{W}: This creature gets +0/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{W}: This creature gets +0/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "artist": "Drew Tucker",
+        "flavorText": "\"Once past the stony exterior, the meat is exquisite and can be stuffed with thallids or simmered in a broth of manticore venom.\"\n—Asmoranomardicadaistinaculdacar,\n*The Underworld Cookbook*",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c62efb9-11f2-4f82-af08-4587d58d6e3d.jpg?1783926889"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Mental Journey
+{
+    "name": "Mental Journey",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Draw three cards.\nBasic landcycling {1}{U} ({1}{U}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{U}",
+            "searchFilter": {
+                "cardPredicates": [
+                    "IsBasicLand"
+                ]
+            },
+            "displayPrefix": "Basic landcycling"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 3
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "artist": "Jim Pavelec",
+        "flavorText": "\"My wandering mind has always been an asset.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0ec38124-46ae-4a38-aab2-8a73cc22b1ef.jpg?1783926876"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Mistvault Bridge
+{
+    "name": "Mistvault Bridge",
+    "manaCost": "",
+    "typeLine": "Artifact Land",
+    "oracleText": "This land enters tapped.\nIndestructible\n{T}: Add {U} or {B}.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "249",
+        "artist": "Mathias Kollros",
+        "flavorText": "The path to knowledge is forged in hunger.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9f36a6e2-3e51-4a30-a225-10cfe6650b9d.jpg?1783926795"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
+// Monoskelion
+{
+    "name": "Monoskelion",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "This creature enters with a +1/+1 counter on it.\n{1}, Remove a +1/+1 counter from this creature: It deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "+1/+1",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{1}, Remove a +1/+1 counter from this creature: It deals 1 damage to any target."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "229",
+        "rarity": "UNCOMMON",
+        "artist": "Jason A. Engle",
+        "flavorText": "An unfinished body with unfinished business.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/4736aae2-5136-4f8f-9283-baf6b542a6a8.jpg?1783926802"
+    },
+    "colorIdentityOverride": []
+}
+
+// Myr Scrapling
+{
+    "name": "Myr Scrapling",
+    "manaCost": "{1}",
+    "typeLine": "Artifact Creature — Myr",
+    "oracleText": "Sacrifice this creature: Put a +1/+1 counter on target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "Sacrifice this creature: Put a +1/+1 counter on target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "230",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"They're useful creatures, but quite replaceable. I find it best not to get too attached.\"\n—Pontifex, elder researcher",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5b9072a5-bd7f-4007-a34a-ebe251c95356.jpg?1783926803"
+    },
+    "colorIdentityOverride": []
+}
+
+// Orchard Strider
+{
+    "name": "Orchard Strider",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Treefolk",
+    "oracleText": "When this creature enters, create two Food tokens. (They're artifacts with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\nBasic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{G}",
+            "searchFilter": {
+                "cardPredicates": [
+                    "IsBasicLand"
+                ]
+            },
+            "displayPrefix": "Basic landcycling"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "169",
+        "artist": "Raoul Vitale",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/386da156-59cd-4b96-9276-a7cb2ddd0421.jpg?1783926827"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -62,6 +2003,55 @@
         "imageUri": "https://cards.scryfall.io/normal/front/0/2/025b0f0f-daf6-4071-82e7-39c015447ce4.jpg?1783926803"
     },
     "colorIdentityOverride": []
+}
+
+// Parcel Myr
+{
+    "name": "Parcel Myr",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact Creature — Clue Myr",
+    "oracleText": "{2}, Sacrifice this creature: Draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "{2}, Sacrifice this creature: Draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "artist": "Wisnu Tan",
+        "flavorText": "\"Crack it open. Maybe it knows something we can use.\"\n—Kara Vrist, Mirran resistance",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f288ee5-4bf9-476a-a89f-b6b8fa7e87dc.jpg?1783926875"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // Ragavan, Nimble Pilferer
@@ -165,6 +2155,550 @@
     ]
 }
 
+// Razortide Bridge
+{
+    "name": "Razortide Bridge",
+    "manaCost": "",
+    "typeLine": "Artifact Land",
+    "oracleText": "This land enters tapped.\nIndestructible\n{T}: Add {W} or {U}.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "252",
+        "artist": "Rob Alexander",
+        "flavorText": "The path to unity is forged in understanding.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e7ea7395-430e-4036-92c9-17a850ec2371.jpg?1783926796"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Rift Sower
+{
+    "name": "Rift Sower",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "{T}: Add one mana of any color.\nSuspend 2—{G} (Rather than cast this card from your hand, you may pay {G} and exile it with two time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{G}",
+            "timeCounters": 2
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "artist": "Cristi Balanescu",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/97dbd212-f1e8-429a-bf00-b2ea966d880e.jpg?1783926827"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Rishadan Dockhand
+{
+    "name": "Rishadan Dockhand",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Merfolk",
+    "oracleText": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)\n{1}, {T}: Tap target land.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "ISLANDWALK"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target land"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land"
+                        },
+                        "id": "target land"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "rarity": "RARE",
+        "artist": "Manuel Castañón",
+        "flavorText": "It's not hard to find work in Rishada, so long as you've got a strong back and don't ask too many questions.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc488a4c-2885-4727-8317-da93aee8fced.jpg?1783926871"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Rustvale Bridge
+{
+    "name": "Rustvale Bridge",
+    "manaCost": "",
+    "typeLine": "Artifact Land",
+    "oracleText": "This land enters tapped.\nIndestructible\n{T}: Add {R} or {W}.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "253",
+        "artist": "Craig J Spearing",
+        "flavorText": "The path to strength is forged in stability.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/2/2207467a-b82a-47ae-8867-15a859328fe9.jpg?1783926793"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Sanctum Weaver
+{
+    "name": "Sanctum Weaver",
+    "manaCost": "{1}{G}",
+    "typeLine": "Enchantment Creature — Dryad",
+    "oracleText": "{T}: Add X mana of any one color, where X is the number of enchantments you control.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "enchantment"
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "RARE",
+        "artist": "Kimonas Theodossiou",
+        "flavorText": "The arrival of spring's first flowers is a sacred occasion to Karametra's acolytes, who fill the Setessan woods with song in celebration.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4d42e22d-f60e-40c5-b069-5e1708f3bebc.jpg?1783926826"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Silverbluff Bridge
+{
+    "name": "Silverbluff Bridge",
+    "manaCost": "",
+    "typeLine": "Artifact Land",
+    "oracleText": "This land enters tapped.\nIndestructible\n{T}: Add {U} or {R}.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "255",
+        "artist": "Joseph Meehan",
+        "flavorText": "The path to genius is forged in creativity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d80dc025-c2c4-48c2-8354-7d9ddb430eb9.jpg?1783926793"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
+}
+
+// Sinister Starfish
+{
+    "name": "Sinister Starfish",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Starfish",
+    "oracleText": "{T}: Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Surveil",
+                    "count": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "artist": "Nils Hamm",
+        "flavorText": "\"Throw that one back. I don't like how it's looking at me.\"\n—Netos, Meletian fisherman",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db209732-c290-4999-a1aa-2369dfa8790c.jpg?1783926855"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Slag Strider
+{
+    "name": "Slag Strider",
+    "manaCost": "{5}{R}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n{1}, Sacrifice an artifact: This creature deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{1}, Sacrifice an artifact: This creature deals 1 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "141",
+        "rarity": "UNCOMMON",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "Imbued with life by a stray bolt of spellcraft, it began to wander about the foundry, to the blacksmiths' alarm.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3a271f3-ea5f-4947-aac3-b4cffdfa87ac.jpg?1783926838"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Slagwoods Bridge
+{
+    "name": "Slagwoods Bridge",
+    "manaCost": "",
+    "typeLine": "Artifact Land",
+    "oracleText": "This land enters tapped.\nIndestructible\n{T}: Add {R} or {G}.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "256",
+        "artist": "Lucas Graciano",
+        "flavorText": "The path to action is forged in confidence.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e51b48e9-a75a-4acd-9462-5e1ac2b0d803.jpg?1783926793"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Sol Talisman
+{
+    "name": "Sol Talisman",
+    "manaCost": "",
+    "typeLine": "Artifact",
+    "oracleText": "Suspend 3—{1} (Rather than cast this card from your hand, pay {1} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)\n{T}: Add {C}{C}.",
+    "keywords": [
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{1}",
+            "timeCounters": 3
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "rarity": "RARE",
+        "artist": "Volkan Baǵa",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a51fb64d-cc0c-400d-971f-78c28d42043b.jpg?1783926801"
+    },
+    "colorIdentityOverride": [],
+    "hasNoManaCost": true
+}
+
+// Soul of Migration
+{
+    "name": "Soul of Migration",
+    "manaCost": "{5}{W}{W}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Flying\nWhen this creature enters, create two 1/1 white Bird creature tokens with flying.\nEvoke {3}{W} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "EVOKE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Evoke",
+            "cost": "{3}{W}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Bird"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "artist": "Kev Walker",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/4541217f-5e86-491b-918b-ed7a2eb3e4eb.jpg?1783926884"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Squirrel Sovereign
 {
     "name": "Squirrel Sovereign",
@@ -197,6 +2731,359 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Steelfin Whale
+{
+    "name": "Steelfin Whale",
+    "manaCost": "{5}{U}",
+    "typeLine": "Creature — Whale",
+    "oracleText": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nWhenever an artifact you control enters, untap this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                },
+                "descriptionOverride": "Whenever an artifact you control enters, untap this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "artist": "Milivoj Ćeran",
+        "flavorText": "It feeds on metal filings suspended in the water, sieving flecks of precious ore through magnetic baleen.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e7ca8b6-d7e0-4af2-a578-bf45a8731c19.jpg?1783926870"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Storm God's Oracle
+{
+    "name": "Storm God's Oracle",
+    "manaCost": "{1}{U}{R}",
+    "typeLine": "Enchantment Creature — Human Shaman",
+    "oracleText": "{1}: This creature gets +1/-1 until end of turn.\nWhen this creature dies, it deals 3 damage to any target.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "213",
+        "artist": "Pauline Voss",
+        "flavorText": "The lives of Keranos's chosen are brief and brilliant as lightning.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6d22f24-f752-4bc8-ba97-061b2c060ec8.jpg?1783926810"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
+}
+
+// Strike It Rich
+{
+    "name": "Strike It Rich",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nFlashback {2}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{2}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreatePredefinedToken",
+            "tokenType": "Treasure"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "rarity": "UNCOMMON",
+        "artist": "Volkan Baǵa",
+        "flavorText": "A few coins soon grow into an obsession.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1c7c2814-a617-4123-acdf-1b01b2768210.jpg?1783926837"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Sylvan Anthem
+{
+    "name": "Sylvan Anthem",
+    "manaCost": "{G}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Green creatures you control get +1/+1.\nWhenever a green creature you control enters, scry 1.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature green ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature green ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "176",
+        "rarity": "RARE",
+        "artist": "Franz Vohwinkel",
+        "flavorText": "The harsher the winter, the more glorious the spring.\n—Yavimaya saying",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a119edc2-9e0f-43d1-a13d-25827f86e3e3.jpg?1783926824"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Sythis, Harvest's Hand
+{
+    "name": "Sythis, Harvest's Hand",
+    "manaCost": "{G}{W}",
+    "typeLine": "Legendary Enchantment Creature — Nymph",
+    "oracleText": "Whenever you cast an enchantment spell, you gain 1 life and draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsEnchantment"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "RARE",
+        "artist": "Ryan Yee",
+        "flavorText": "\"Through every verdant field, every bough that hangs heavy with fruit, Karametra shows her love.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0babfe00-9bad-48fc-b3b1-df8280242fd2.jpg?1783926809"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Tanglepool Bridge
+{
+    "name": "Tanglepool Bridge",
+    "manaCost": "",
+    "typeLine": "Artifact Land",
+    "oracleText": "This land enters tapped.\nIndestructible\n{T}: Add {G} or {U}.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "257",
+        "artist": "Randy Gallegos",
+        "flavorText": "The path to change is forged in insight.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/57d2b895-8921-4615-a674-fb85eed5ea3f.jpg?1783926793"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
+// Terminal Agony
+{
+    "name": "Terminal Agony",
+    "manaCost": "{2}{B}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature.\nMadness {B}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "keywords": [
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{B}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "artist": "Lucas Graciano",
+        "flavorText": "His mouth melted to slag, yet somehow he kept screaming.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/314e94ad-0e12-48bb-aae1-2c842943114a.jpg?1783926810"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -255,6 +3142,285 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// The Underworld Cookbook
+{
+    "name": "The Underworld Cookbook",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Book",
+    "oracleText": "{T}, Discard a card: Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n{4}, {T}, Sacrifice this artifact: Return target creature card from your graveyard to your hand.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                },
+                "descriptionOverride": "{T}, Discard a card: Create a Food token."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card from your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target creature card from your graveyard"
+                    }
+                ],
+                "descriptionOverride": "{4}, {T}, Sacrifice this artifact: Return target creature card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "240",
+        "rarity": "UNCOMMON",
+        "artist": "Joe Slucher",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/039d62b0-3309-4424-a2ea-5a0d88d4bd72.jpg?1783926799"
+    },
+    "colorIdentityOverride": []
+}
+
+// Thornglint Bridge
+{
+    "name": "Thornglint Bridge",
+    "manaCost": "",
+    "typeLine": "Artifact Land",
+    "oracleText": "This land enters tapped.\nIndestructible\n{T}: Add {G} or {W}.",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "258",
+        "artist": "Randy Gallegos",
+        "flavorText": "The path to growth is forged in balance.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d483643-6a11-47f7-a0aa-190e0179525f.jpg?1783926792"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Thought Monitor
+{
+    "name": "Thought Monitor",
+    "manaCost": "{6}{U}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying\nWhen this creature enters, draw two cards.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "When this creature enters, draw two cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "rarity": "RARE",
+        "artist": "Martina Pilcerova",
+        "flavorText": "It roams the skies over the Quicksilver Sea, alert for any hint of aberrant thought.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/996c1952-8d10-4296-8960-ff8993833649.jpg?1783926868"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Vedalken Infiltrator
+{
+    "name": "Vedalken Infiltrator",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Vedalken Rogue",
+    "oracleText": "This creature can't be blocked.\nMetalcraft — This creature gets +1/+0 as long as you control three or more artifacts.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "flags": [
+        "CANT_BE_BLOCKED"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "rarity": "UNCOMMON",
+        "artist": "Izzy",
+        "flavorText": "\"An expert always keeps their tools close at hand.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9ddfc6a8-7880-4810-8c0a-d9ea931138f2.jpg?1783926866"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Viashino Lashclaw
+{
+    "name": "Viashino Lashclaw",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Lizard Warrior",
+    "oracleText": "{T}, Discard a card: Creatures you control gain haste until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "HASTE",
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Creatures you control gain haste until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "artist": "Caio Monteiro",
+        "flavorText": "\"Victory is the greatest motivator of all. So sayeth the bey.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/4/3457e346-a5de-4624-b577-f59d4c186537.jpg?1783926836"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -323,6 +3489,49 @@
         "artist": "Chris Cold",
         "flavorText": "The dead are lonely in the crypt and always eager for company.",
         "imageUri": "https://cards.scryfall.io/normal/front/d/8/d890ae71-da2b-44fa-8cfa-9c3016c9f696.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// World-Weary
+{
+    "name": "World-Weary",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets -4/-4.\nBasic landcycling {1}{B} ({1}{B}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{B}",
+            "searchFilter": {
+                "cardPredicates": [
+                    "IsBasicLand"
+                ]
+            },
+            "displayPrefix": "Basic landcycling"
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": -4,
+                "toughnessBonus": -4
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "artist": "Evan Shipard",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6c7c1b08-3184-478f-92be-88db6cda33c5.jpg?1783926852"
     },
     "colorIdentityOverride": [
         "BLACK"

--- a/mtg-sets/src/test/resources/snapshots/cards/ODY.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ODY.json
@@ -3327,6 +3327,50 @@
     ]
 }
 
+// Millikin
+{
+    "name": "Millikin",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "{T}, Mill a card: Add {C}. (Activate only as an instant. To mill a card, put the top card of your library into your graveyard.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomMill"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "302",
+        "rarity": "UNCOMMON",
+        "artist": "Alex Horley-Orlandelli",
+        "flavorText": "The toymaker frowned in bewilderment. None of his creations had ever sneezed before.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/0550133b-22cf-4ecd-b89a-8c2f0beeaa22.jpg?1783945203"
+    },
+    "colorIdentityOverride": []
+}
+
 // Minotaur Explorer
 {
     "name": "Minotaur Explorer",

--- a/mtg-sets/src/test/resources/snapshots/cards/PC2.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/PC2.json
@@ -174,3 +174,38 @@
         "GREEN"
     ]
 }
+
+// Shardless Agent
+{
+    "name": "Shardless Agent",
+    "manaCost": "{1}{G}{U}",
+    "typeLine": "Artifact Creature — Human Rogue",
+    "oracleText": "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "CASCADE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": "Cascade",
+                "descriptionOverride": "Cascade"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "104",
+        "rarity": "UNCOMMON",
+        "artist": "Izzy",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ceb4df89-a97e-4479-b7f0-7083417a9565.jpg?1783940595"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ULG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ULG.json
@@ -1,3 +1,36 @@
+// Angelic Curator
+{
+    "name": "Angelic Curator",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Angel Spirit",
+    "oracleText": "Flying, protection from artifacts",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.CardType",
+                "cardType": "Artifact"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "1",
+        "artist": "Greg Staples",
+        "flavorText": "\"Do not treat your people as you treat your artifacts. Let them go, and they will live; seal them here, and they will die.\"\n—Urza, to Radiant",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c63ba2da-6dea-44ac-8439-527222da565b.jpg?1783946254"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Archivist
 {
     "name": "Archivist",

--- a/mtg-sets/src/test/resources/snapshots/cards/VIS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VIS.json
@@ -669,6 +669,61 @@
     "colorIdentityOverride": []
 }
 
+// Quirion Ranger
+{
+    "name": "Quirion Ranger",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Elf Ranger",
+    "oracleText": "Return a Forest you control to its owner's hand: Untap target creature. Activate only once each turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomReturnToHand",
+                        "filter": "land Forest"
+                    }
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    },
+                    "tap": false
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "creature"
+                    }
+                ],
+                "restrictions": [
+                    "OncePerTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "artist": "Tom Kyffin",
+        "flavorText": "\"Respect the earth, for it will one day be your shield and another day your blanket.\"\n—Liefellen, Quirion exarch",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/56efe72c-6d7f-44f6-ac74-01af9305c4b6.jpg?1783946981"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Simoon
 {
     "name": "Simoon",


### PR DESCRIPTION
Implements **every Assay-ready card in Modern Horizons 2** — 81 cards. MH2 goes **11/308 → 92/308 (4% → 30%)**.

"Assay-ready" is the Set Completion view's read-whole badge (Assay verdict `whole`) intersected with not-yet-implemented. MH2's 297 missing cards read 216 `LINE_DECLINED` / 4 absent / **81 whole**.

## The four-way split

| Bucket | Count |
|---|---|
| New MH2 canonicals | 59 |
| Canonical belongs to an earlier scaffolded set (ULG, LEG, ODY, VIS, PC2, ICE) + its MH2 `Printing` row | 6 |
| `Printing` row only — the canonical already existed (Counterspell, Vindicate, Sterling Grove, Riptide Laboratory, …) | 11 |
| Basic land names, two art variants each (#481–490) | 5 |

Plus the tail that authoring those canonicals exposes: a **J22** row for Filigree Attendant and a **C13** row for Greed.

## Three display-only keywords, lowered by hand

`Keyword.MODULAR`, `Keyword.CASCADE` and `Keyword.BUSHIDO` exist in `mtg-sdk`, but **nothing in `rules-engine` reads them** — a card carrying only the keyword compiles, passes lint, renders correctly in the client, and does nothing. All three are lowered as the ability they abbreviate, keeping the `keywordAbility(...)` for the printed line:

- **Modular N** — Arcbound Mouser / Prototype / Slasher / Whelp. An `EntersWithCounters` replacement plus an *optional* dies trigger reading `ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT` (CR 603.10 / 608.2h — the counters are gone by resolution), following `mh3/cards/ArcboundCondor.kt`. Deliberately **not** `Effects.MoveAllLastKnownCounters`: that moves every counter kind, so a modular creature killed by -1/-1 counters would hand those over too.
- **Cascade** — Ethersworn Sphinx, Shardless Agent. `Triggers.WhenYouCastThisSpell()` → `Effects.Cascade`, following `arb/cards/BloodbraidElf.kt`.
- **Bushido 2** — Jade Avenger, **the first bushido card in the corpus**. Two triggers (`Triggers.Blocks`, `Triggers.BecomesBlocked`) each pumping `EffectTarget.Self`; they're mutually exclusive in any one combat, so the pump can't double. Because nothing had ever exercised bushido, it gets **`JadeAvengerScenarioTest`**: blocking pumps, becoming blocked pumps, and an unblocked attack does neither.

Everything else composes existing engine-live vocabulary — madness, suspend, evoke, affinity, cycling / basic landcycling, flashback, rebound, storm, riot, regenerate, protection-from-artifacts, islandwalk — and the ability words threshold and metalcraft are written as plain conditional statics (there is no `Keyword.THRESHOLD` / `Keyword.METALCRAFT`).

**No SDK or rules-engine change**, so `docs/card-sdk-language-reference.md` is unchanged.

## Verification

- **`just build` green** — no failures anywhere, including the full scenario suite.
- **Card snapshots re-blessed.** Only the seven touched sets move; MH2's 127 "deletions" are alphabetical re-ordering of Chatterstorm and Ornithopter of Paradise, not content changes.
- **`just assay-differential` — zero divergences among the 65 new cards.** Measured A/B with the same freshly built binary:

  | | before | after |
  |---|---|---|
  | compared | 3617 | 3675 |
  | confirmed | 3582 | 3640 |
  | **divergent** | **35** | **35** |

  All 35 divergences are pre-existing cards in other sets (LRW harbingers, SPM, DRK, DOM, …).
- **`check-card-printing` clean** on every canonical placed outside MH2 (Zuran Orb, Greed, Millikin, Quirion Ranger, Shardless Agent, Angelic Curator) and on spot-checked MH2 cards.
- **`JadeAvengerScenarioTest`** — 3/3 passing.

## Two findings worth a follow-up (not fixed here)

1. **`mh3/cards/ArcboundCondor.kt` cites CR 608.2g for last-known information.** Verified against the 2026-08-19 Comprehensive Rules: 608.2g is "casting a spell during resolution"; the LKI rule is **608.2h**. The four new modular cards cite 608.2h. Left the MH3 file alone since it's outside this change's scope.
2. **Assay reads Millikin's `{T}, Mill a card: Add {C}` as a mana ability** (`isManaAbility: true`). Per CR 605.1a it is not — the *cost* moves a card out of a library. The card matches `isd/cards/DerangedAssistant.kt` and leaves it false; the fix belongs in Assay's grammar, not the card. This is why Millikin lands in "script slot not modelled yet" rather than "compared".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
