### PR TITLE
Implement every Assay-ready Shadowmoor card (6/286 -> 100/286)

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/GleefulSabotageReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/GleefulSabotageReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gleeful Sabotage reprint in Archenemy. The canonical CardDefinition lives in Shadowmoor
+ * (`definitions/shm/cards/GleefulSabotage.kt`); this file contributes only per-printing presentation data.
+ */
+val GleefulSabotageReprint = Printing(
+    oracleId = "25fe48be-95c4-4011-8c60-4628fb5ecfcb",
+    name = "Gleeful Sabotage",
+    setCode = "ARC",
+    collectorNumber = "58",
+    scryfallId = "7802c7f8-ca2a-4bac-a579-77a8204aa5d4",
+    artist = "Todd Lockwood",
+    imageUri = "https://cards.scryfall.io/normal/front/7/8/7802c7f8-ca2a-4bac-a579-77a8204aa5d4.jpg?1783941903",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/GloomwidowReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/GloomwidowReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gloomwidow reprint in Avacyn Restored. The canonical CardDefinition lives in Shadowmoor
+ * (`definitions/shm/cards/Gloomwidow.kt`); this file contributes only per-printing presentation data.
+ */
+val GloomwidowReprint = Printing(
+    oracleId = "e5139376-cdb1-4f1e-b417-b956d6b713b9",
+    name = "Gloomwidow",
+    setCode = "AVR",
+    collectorNumber = "180",
+    scryfallId = "a016c872-09bd-42e1-94da-f587e8252492",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/a/0/a016c872-09bd-42e1-94da-f587e8252492.jpg?1783940667",
+    releaseDate = "2012-05-04",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/DroveOfElvesReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/DroveOfElvesReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Drove of Elves reprint in Commander 2014. The canonical CardDefinition lives in Shadowmoor
+ * (`definitions/shm/cards/DroveOfElves.kt`); this file contributes only per-printing presentation data.
+ */
+val DroveOfElvesReprint = Printing(
+    oracleId = "3ba81fbe-2c53-495b-9a2b-f124475bd71b",
+    name = "Drove of Elves",
+    setCode = "C14",
+    collectorNumber = "189",
+    scryfallId = "89531d1e-a3c9-4a7d-b3bb-9fa12d98cf44",
+    artist = "Larry MacDougall",
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/89531d1e-a3c9-4a7d-b3bb-9fa12d98cf44.jpg?1783938833",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SpectralProcessionReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SpectralProcessionReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spectral Procession reprint in Commander 2014. The canonical CardDefinition lives in Shadowmoor
+ * (`definitions/shm/cards/SpectralProcession.kt`); this file contributes only per-printing presentation data.
+ */
+val SpectralProcessionReprint = Printing(
+    oracleId = "376271a6-80f0-47a6-990a-5ec5517aae42",
+    name = "Spectral Procession",
+    setCode = "C14",
+    collectorNumber = "90",
+    scryfallId = "fbafbfe0-50c0-46a3-8a47-188857e3cb42",
+    artist = "Jeremy Enecio",
+    imageUri = "https://cards.scryfall.io/normal/front/f/b/fbafbfe0-50c0-46a3-8a47-188857e3cb42.jpg?1783938854",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/PlumeveilReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/PlumeveilReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plumeveil reprint in Commander. The canonical CardDefinition lives in Shadowmoor
+ * (`definitions/shm/cards/Plumeveil.kt`); this file contributes only per-printing presentation data.
+ */
+val PlumeveilReprint = Printing(
+    oracleId = "14fa0771-cf2b-4563-98b2-ff4ee24bce21",
+    name = "Plumeveil",
+    setCode = "CMD",
+    collectorNumber = "218",
+    scryfallId = "6b2d484d-b0fd-4add-a54f-0956d7401950",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/6/b/6b2d484d-b0fd-4add-a54f-0956d7401950.jpg?1783941172",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/GoldenglowMothReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/GoldenglowMothReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goldenglow Moth reprint in Magic 2011. The canonical CardDefinition lives in Shadowmoor
+ * (`definitions/shm/cards/GoldenglowMoth.kt`); this file contributes only per-printing presentation data.
+ */
+val GoldenglowMothReprint = Printing(
+    oracleId = "8dcfa697-5350-43b9-896f-c5eefcc3893a",
+    name = "Goldenglow Moth",
+    setCode = "M11",
+    collectorNumber = "15",
+    scryfallId = "8d6e31cb-98c5-4145-bdef-666f3cea7eab",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/8/d/8d6e31cb-98c5-4145-bdef-666f3cea7eab.jpg?1783941836",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/MassCalcifyReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/MassCalcifyReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mass Calcify reprint in Magic 2015. The canonical CardDefinition lives in Shadowmoor
+ * (`definitions/shm/cards/MassCalcify.kt`); this file contributes only per-printing presentation data.
+ */
+val MassCalcifyReprint = Printing(
+    oracleId = "3ab3996f-aa3f-4041-8634-8e197d51f108",
+    name = "Mass Calcify",
+    setCode = "M15",
+    collectorNumber = "18",
+    scryfallId = "316a2d2f-ca94-463f-ada4-2b12bce6312f",
+    artist = "Brandon Kitkouski",
+    imageUri = "https://cards.scryfall.io/normal/front/3/1/316a2d2f-ca94-463f-ada4-2b12bce6312f.jpg?1783939200",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/GlenElendraLiegeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/GlenElendraLiegeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glen Elendra Liege reprint in Planechase 2012. The canonical CardDefinition lives in Shadowmoor
+ * (`definitions/shm/cards/GlenElendraLiege.kt`); this file contributes only per-printing presentation data.
+ */
+val GlenElendraLiegeReprint = Printing(
+    oracleId = "946bba74-0951-408c-b06f-167739b10934",
+    name = "Glen Elendra Liege",
+    setCode = "PC2",
+    collectorNumber = "94",
+    scryfallId = "b42f2e85-c321-42f2-b466-2e7af3259a4b",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b42f2e85-c321-42f2-b466-2e7af3259a4b.jpg?1783940597",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Aethertow.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Aethertow.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Aethertow
+ * {3}{W/U}
+ * Instant
+ *
+ * Put target attacking or blocking creature on top of its owner's library.
+ * Conspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)
+ *
+ * - The target is a single [com.wingedsheep.sdk.scripting.targets.TargetObject] whose filter carries
+ *   the "attacking *or* blocking" disjunction as one state predicate
+ *   ([TargetFilter.AttackingOrBlockingCreature]) rather than two requirements — the spell targets one
+ *   creature, and the creature has to satisfy either half.
+ * - Conspire is declared as [KeywordAbility.Conspire] only. `CardBuilder` derives
+ *   `Keyword.CONSPIRE` into `keywords` from the keyword ability, so declaring it a second time via
+ *   `keywords(...)` would be redundant.
+ * - The copy chooses its own target, so a creature that stops attacking or blocking in between (or
+ *   the copy resolving first and moving the original target) is handled by ordinary target legality,
+ *   not by anything this card models.
+ */
+val Aethertow = card("Aethertow") {
+    manaCost = "{3}{W/U}"
+    typeLine = "Instant"
+    oracleText = "Put target attacking or blocking creature on top of its owner's library.\n" +
+        "Conspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)"
+
+    keywordAbility(KeywordAbility.Conspire)
+
+    spell {
+        val creature = target(
+            "target",
+            TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature)
+        )
+        effect = Effects.PutOnTopOfLibrary(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "136"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72a656e7-9c1c-40b6-91fe-0098f72d8384.jpg?1783942738"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ApothecaryInitiate.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ApothecaryInitiate.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Apothecary Initiate
+ * {W}
+ * Creature — Kithkin Cleric
+ * 1 / 1
+ *
+ * Whenever a player casts a white spell, you may pay {1}. If you do, you gain 1 life.
+ *
+ * - "A player" is *every* player, the Initiate's controller included, so this is
+ *   [Triggers.anyPlayerCasts] (ANY binding) rather than a "whenever you cast" trigger.
+ * - The spell filter is colour-based, not type-based: any white spell qualifies, including a white
+ *   land-less permanent spell or a multicoloured spell that is partly white.
+ * - "You may pay {1}. If you do, …" is the [MayPayManaEffect] gate — both the yes/no and the mana
+ *   payment happen on resolution, and declining simply does nothing. The Initiate's controller is
+ *   always the one who pays and gains the life, whoever cast the spell.
+ */
+val ApothecaryInitiate = card("Apothecary Initiate") {
+    manaCost = "{W}"
+    typeLine = "Creature — Kithkin Cleric"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever a player casts a white spell, you may pay {1}. If you do, you gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.anyPlayerCasts(GameObjectFilter.Any.withColor(Color.WHITE))
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}"),
+            effect = Effects.GainLife(1)
+        )
+        description = "Whenever a player casts a white spell, you may pay {1}. If you do, you gain 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "1"
+        artist = "Kev Walker"
+        flavorText = "Kithkin jealously hoard their knowledge of poultices and remedies so that no outside threat can benefit from their wisdom."
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b6ae637-bdb7-4117-8539-e424159bad6f.jpg?1783942770"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/AshenmoorGouger.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/AshenmoorGouger.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+
+/**
+ * Ashenmoor Gouger
+ * {B/R}{B/R}{B/R}
+ * Creature — Elemental Warrior
+ * 4 / 4
+ *
+ * This creature can't block.
+ *
+ * - "This creature can't block" is a self-scoped combat static, so [CantBlock] keeps its default
+ *   `GroupFilter.source()` filter rather than taking a battlefield-wide one.
+ */
+val AshenmoorGouger = card("Ashenmoor Gouger") {
+    manaCost = "{B/R}{B/R}{B/R}"
+    typeLine = "Creature — Elemental Warrior"
+    power = 4
+    toughness = 4
+    oracleText = "This creature can't block."
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "180"
+        artist = "Matt Cavotta"
+        flavorText = "After his hands had crumbled away, leaving only wickedly sharp points, he decided his only purpose was war."
+        imageUri = "https://cards.scryfall.io/normal/front/8/0/80c7931f-e979-4f43-81dd-c34166526f87.jpg?1783942728"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BarkshellBlessing.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BarkshellBlessing.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Barkshell Blessing
+ * {G/W}
+ * Instant
+ *
+ * Target creature gets +2/+2 until end of turn.
+ * Conspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)
+ *
+ * - "until end of turn" is [Effects.ModifyStats]'s default duration, so no duration is written.
+ * - Conspire is declared as [KeywordAbility.Conspire] only; `CardBuilder` derives
+ *   `Keyword.CONSPIRE` into `keywords`, so a separate `keywords(...)` line would be redundant.
+ * - {G/W} is a hybrid symbol: the card is both green and white, so either a green or a white pair
+ *   of untapped creatures can pay the conspire cost.
+ */
+val BarkshellBlessing = card("Barkshell Blessing") {
+    manaCost = "{G/W}"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+2 until end of turn.\n" +
+        "Conspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)"
+
+    keywordAbility(KeywordAbility.Conspire)
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(2, 2, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "224"
+        artist = "Steven Belledin"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd273ef2-4aed-4c7e-8c97-fe8b1af9ce69.jpg?1783942718"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BarrentonCragtreads.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BarrentonCragtreads.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Barrenton Cragtreads
+ * {2}{W/U}{W/U}
+ * Creature — Kithkin Scout
+ * 3 / 3
+ *
+ * This creature can't be blocked by red creatures.
+ *
+ * - The evasion is a single [CantBeBlockedBy] static over a coloured *creature* filter, not a
+ *   keyword: the blocker restriction is checked against projected state, so a creature that has
+ *   merely been *made* red (or has lost red) is judged by its current colour, not its printed one.
+ * - The hybrid cost `{W/U}` goes in `manaCost` verbatim; mana value (4) is derived by the parser.
+ */
+val BarrentonCragtreads = card("Barrenton Cragtreads") {
+    manaCost = "{2}{W/U}{W/U}"
+    typeLine = "Creature — Kithkin Scout"
+    power = 3
+    toughness = 3
+    oracleText = "This creature can't be blocked by red creatures."
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.withColor(Color.RED))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "138"
+        artist = "Daren Bader"
+        flavorText = "\"Boggarts are easy to get around. Just toss some mutton in another direction. Giants are a little harder. You have to be quick to avoid their steps. Cinders are the difficult ones, but even they have fears to be exploited.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/361dab9e-22f0-45e4-a793-aa6c97a96781.jpg?1783942738"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BlazethornScarecrow.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BlazethornScarecrow.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Blazethorn Scarecrow
+ * {5}
+ * Artifact Creature — Scarecrow
+ * 3 / 3
+ *
+ * This creature has haste as long as you control a red creature.
+ * This creature has wither as long as you control a green creature. (It deals damage to creatures
+ * in the form of -1/-1 counters.)
+ *
+ * - Two independent conditional statics, one per granted keyword — the two clauses have separate
+ *   conditions and either can be on without the other.
+ * - [GroupFilter.source] is the "this creature" scope: the grant applies only to the Scarecrow
+ *   itself, and it re-evaluates continuously, so the keyword switches off the moment the last red
+ *   or green creature leaves.
+ * - The colour checks read *creatures you control*, not permanents — Shadowmoor's cycle is worded
+ *   "a red creature", so a red artifact or land doesn't turn the ability on. Filtering by colour
+ *   goes through [GameObjectFilter] so the projected (post-continuous-effect) colour is what
+ *   counts, which is what makes an animated or colour-shifted creature switch it on.
+ */
+val BlazethornScarecrow = card("Blazethorn Scarecrow") {
+    manaCost = "{5}"
+    typeLine = "Artifact Creature — Scarecrow"
+    power = 3
+    toughness = 3
+    oracleText = "This creature has haste as long as you control a red creature.\n" +
+        "This creature has wither as long as you control a green creature. (It deals damage to creatures in the form of -1/-1 counters.)"
+
+    // This creature has haste as long as you control a red creature.
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE, GroupFilter.source())
+        condition = Conditions.YouControl(GameObjectFilter.Creature.withColor(Color.RED))
+    }
+
+    // This creature has wither as long as you control a green creature.
+    staticAbility {
+        ability = GrantKeyword(Keyword.WITHER, GroupFilter.source())
+        condition = Conditions.YouControl(GameObjectFilter.Creature.withColor(Color.GREEN))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "246"
+        artist = "Dave Kendall"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/44793043-82b4-415b-a9ab-d564fdbcd314.jpg?1783942713"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BlightSickle.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BlightSickle.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Blight Sickle
+ * {2}
+ * Artifact — Equipment
+ *
+ * Equipped creature gets +1/+0 and has wither. (It deals damage to creatures in the form of -1/-1 counters.)
+ * Equip {2}
+ *
+ * - The printed line is one sentence but two independent continuous effects (layer 7c for the stat
+ *   bump, layer 6 for the keyword), so it is two [staticAbility] blocks over the same
+ *   [Filters.EquippedCreature] group rather than one combined ability.
+ * - `equipAbility("{2}")` lowers the printed "Equip {2}" into the sorcery-speed attach ability; the
+ *   equip cost field is set by that helper, so it is not written separately.
+ */
+val BlightSickle = card("Blight Sickle") {
+    manaCost = "{2}"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+0 and has wither. (It deals damage to creatures in the form of -1/-1 counters.)\n" +
+        "Equip {2}"
+
+    // Equipped creature gets +1/+0 ...
+    staticAbility {
+        ability = ModifyStats(1, 0, Filters.EquippedCreature)
+    }
+
+    // ... and has wither.
+    staticAbility {
+        ability = GrantKeyword(Keyword.WITHER, Filters.EquippedCreature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "247"
+        artist = "John Avon"
+        flavorText = "Its scars cut deeper than its blade."
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c0f828c7-aedc-462b-8455-46e8a90feb85.jpg?1783942712"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BlisteringDieflyn.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BlisteringDieflyn.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blistering Dieflyn
+ * {3}{R}
+ * Creature — Imp
+ * 0 / 1
+ *
+ * Flying
+ * {B/R}: This creature gets +1/+0 until end of turn.
+ *
+ * - The hybrid activation cost goes into [Costs.Mana] verbatim; `{B/R}` is payable with either
+ *   {B} or {R} and the parser handles the hybrid symbol, so nothing is overridden here.
+ * - "This creature" is the source, so the pump targets [EffectTarget.Self] rather than declaring a
+ *   target — the ability doesn't target and can be activated any number of times.
+ */
+val BlisteringDieflyn = card("Blistering Dieflyn") {
+    manaCost = "{3}{R}"
+    typeLine = "Creature — Imp"
+    power = 0
+    toughness = 1
+    oracleText = "Flying\n" +
+        "{B/R}: This creature gets +1/+0 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{B/R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "82"
+        artist = "Scott Altmann"
+        flavorText = "Any kithkin smith would love to catch a dieflyn for her kiln, relieving her of ever having to gather fuel again."
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/5720a5b2-60ca-49f9-83e8-b801471c92ea.jpg?1783942751"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BloodmarkMentor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BloodmarkMentor.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Bloodmark Mentor
+ * {1}{R}
+ * Creature — Goblin Warrior
+ * 1 / 1
+ *
+ * Red creatures you control have first strike.
+ *
+ * - No "Other": the Mentor is red itself, so the [GroupFilter] deliberately has no `excludeSelf`
+ *   and it grants first strike to itself as well.
+ * - The colour test goes through the group filter so it reads projected state — a creature that is
+ *   only red because of a continuous effect gains first strike too, and loses it again when the
+ *   effect ends.
+ */
+val BloodmarkMentor = card("Bloodmark Mentor") {
+    manaCost = "{1}{R}"
+    typeLine = "Creature — Goblin Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "Red creatures you control have first strike."
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.FIRST_STRIKE,
+            GroupFilter(GameObjectFilter.Creature.withColor(Color.RED).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "83"
+        artist = "Dave Allsop"
+        flavorText = "Boggarts divide the world into two categories: things you can eat, and things you have to chase down and pummel before you can eat."
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/6322a389-44cc-4a3d-bd39-93c156640f8e.jpg?1783942750"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BoartuskLiege.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BoartuskLiege.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Boartusk Liege
+ * {1}{R/G}{R/G}{R/G}
+ * Creature — Goblin Knight
+ * 3 / 4
+ *
+ * Trample
+ * Other red creatures you control get +1/+1.
+ * Other green creatures you control get +1/+1.
+ *
+ * - Two deliberately separate [ModifyStats] statics, exactly as on Wilt-Leaf Liege: they stack, so
+ *   a creature you control that is both red *and* green gets +2/+2.
+ * - `excludeSelf = true` carries the printed "Other" — the Liege is red *and* green itself, so
+ *   without it it would pump itself twice.
+ * - The colour test reads projected state through the [GroupFilter], so a creature that only
+ *   becomes red or green from a continuous effect is still pumped.
+ */
+val BoartuskLiege = card("Boartusk Liege") {
+    manaCost = "{1}{R/G}{R/G}{R/G}"
+    typeLine = "Creature — Goblin Knight"
+    power = 3
+    toughness = 4
+    oracleText = "Trample\n" +
+        "Other red creatures you control get +1/+1.\n" +
+        "Other green creatures you control get +1/+1."
+
+    keywords(Keyword.TRAMPLE)
+
+    // Other red creatures you control get +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withColor(Color.RED).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    // Other green creatures you control get +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withColor(Color.GREEN).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "202"
+        artist = "Jesper Ejsing"
+        flavorText = "The boar leads its rider to victory in battle, but it doesn't know how close it is to becoming the victory feast."
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/318338f8-f52b-4b9a-8d38-08291bcc2e98.jpg?1783942723"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BoggartRamGang.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BoggartRamGang.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Boggart Ram-Gang
+ * {R/G}{R/G}{R/G}
+ * Creature — Goblin Warrior
+ * 3 / 3
+ *
+ * Haste
+ * Wither (This deals damage to creatures in the form of -1/-1 counters.)
+ *
+ * - Keyword-only creature: both [Keyword.HASTE] and [Keyword.WITHER] are engine-live, so the
+ *   reminder text needs no separate replacement effect.
+ */
+val BoggartRamGang = card("Boggart Ram-Gang") {
+    manaCost = "{R/G}{R/G}{R/G}"
+    typeLine = "Creature — Goblin Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "Haste\n" +
+        "Wither (This deals damage to creatures in the form of -1/-1 counters.)"
+
+    keywords(Keyword.HASTE, Keyword.WITHER)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "203"
+        artist = "Dave Allsop"
+        flavorText = "\"We're going to need a bigger gate.\"\n" +
+            "—Bowen, Barrenton guardcaptain"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63e25b70-fa21-4663-aabd-34b7e0b75c34.jpg?1783942723"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BurnTrail.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/BurnTrail.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Burn Trail
+ * {3}{R}
+ * Sorcery
+ *
+ * Burn Trail deals 3 damage to any target.
+ * Conspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)
+ *
+ * - "any target" is the single [Targets.Any] requirement (creature, player, battle or planeswalker),
+ *   not a creature-or-player union — the modern Oracle wording maps onto one `AnyTarget` slot.
+ * - Conspire is declared as [KeywordAbility.Conspire] only; `CardBuilder` derives
+ *   `Keyword.CONSPIRE` into `keywords`, so a separate `keywords(...)` line would be redundant.
+ * - The damage source is left implicit (the spell itself), so no `damageSource` override is written.
+ */
+val BurnTrail = card("Burn Trail") {
+    manaCost = "{3}{R}"
+    typeLine = "Sorcery"
+    oracleText = "Burn Trail deals 3 damage to any target.\n" +
+        "Conspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)"
+
+    keywordAbility(KeywordAbility.Conspire)
+
+    spell {
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(3, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86"
+        artist = "Nils Hamm"
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f01f9a0-f1d0-4241-a270-df4ed673d1fd.jpg?1783942750"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Cinderbones.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Cinderbones.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cinderbones
+ * {2}{B}
+ * Creature — Elemental Skeleton
+ * 1 / 1
+ *
+ * Wither (This deals damage to creatures in the form of -1/-1 counters.)
+ * {1}{B}: Regenerate this creature.
+ *
+ * - Wither is the plain engine-live keyword; the reminder text is printed on the Shadowmoor card
+ *   and is kept verbatim in the oracle text.
+ * - "Regenerate this creature" is [RegenerateEffect] on [EffectTarget.Self] — a shield that
+ *   replaces the next destruction this turn, not damage prevention, so it does nothing about the
+ *   -1/-1 counters wither leaves behind on Cinderbones itself.
+ */
+val Cinderbones = card("Cinderbones") {
+    manaCost = "{2}{B}"
+    typeLine = "Creature — Elemental Skeleton"
+    power = 1
+    toughness = 1
+    oracleText = "Wither (This deals damage to creatures in the form of -1/-1 counters.)\n" +
+        "{1}{B}: Regenerate this creature."
+
+    keywords(Keyword.WITHER)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{B}")
+        effect = RegenerateEffect(EffectTarget.Self)
+        description = "{1}{B}: Regenerate this creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "Carl Critchlow"
+        flavorText = "Not all coals lie quietly in their beds of cold ash."
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/22dcf40c-62fb-4205-807e-71655066a61b.jpg?1783942756"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/CorrosiveMentor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/CorrosiveMentor.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Corrosive Mentor
+ * {2}{B}
+ * Creature — Elemental Rogue
+ * 1 / 3
+ *
+ * Black creatures you control have wither. (They deal damage to creatures in the form of -1/-1 counters.)
+ *
+ * - No "Other": the Mentor is black itself, so the [GroupFilter] deliberately has no `excludeSelf`
+ *   and it grants wither to itself as well.
+ * - Wither is a granted keyword here, not a printed one, so it goes through [GrantKeyword] rather
+ *   than `keywords(...)` — the runtime keyword resolver is what the combat damage step reads.
+ * - The colour test goes through the group filter so it reads projected state — a creature that is
+ *   only black because of a continuous effect gains wither too.
+ */
+val CorrosiveMentor = card("Corrosive Mentor") {
+    manaCost = "{2}{B}"
+    typeLine = "Creature — Elemental Rogue"
+    power = 1
+    toughness = 3
+    oracleText = "Black creatures you control have wither. (They deal damage to creatures in the form of -1/-1 counters.)"
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.WITHER,
+            GroupFilter(GameObjectFilter.Creature.withColor(Color.BLACK).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "61"
+        artist = "Daarken"
+        flavorText = "Guttering cinders stoke their dying flames by snuffing out the lights of others."
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/140457ff-ee7d-48ec-8b91-ef5c2cc1ed74.jpg?1783942756"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/CrowdOfCinders.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/CrowdOfCinders.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Crowd of Cinders
+ * {3}{B}
+ * Creature — Elemental
+ * * / *
+ *
+ * Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)
+ * Crowd of Cinders's power and toughness are each equal to the number of black permanents you control.
+ *
+ * - The P/T is a characteristic-defining ability (CR 604.3), so it is written with `dynamicStats`
+ *   rather than a static `ModifyStats`: it applies in every zone and needs no printed base P/T.
+ *   No `power`/`toughness` is set — the dynamic value is the whole characteristic.
+ * - "black **permanents**", not creatures: the filter is `GameObjectFilter.Permanent.withColor`,
+ *   which counts black lands, artifacts and enchantments too, and counts Crowd of Cinders itself
+ *   while it is on the battlefield.
+ * - `AggregateBattlefield` is the corpus's majority spelling for a one-battlefield tally (the same
+ *   value as `Count(…, BATTLEFIELD, …)`); one printed form per model.
+ */
+val CrowdOfCinders = card("Crowd of Cinders") {
+    manaCost = "{3}{B}"
+    typeLine = "Creature — Elemental"
+    oracleText = "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\n" +
+        "Crowd of Cinders's power and toughness are each equal to the number of black permanents you control."
+
+    keywords(Keyword.FEAR)
+
+    dynamicStats(
+        DynamicAmount.AggregateBattlefield(
+            Player.You,
+            GameObjectFilter.Permanent.withColor(Color.BLACK)
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "63"
+        artist = "Carl Frank"
+        flavorText = "They envy the life-giving heat so much that they tear it from those who still possess it."
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0dd88305-d57b-4e77-aec9-f0a3ace42c37.jpg?1783942755"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/CultbrandCinder.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/CultbrandCinder.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Cultbrand Cinder
+ * {4}{B/R}
+ * Creature — Elemental Shaman
+ * 3 / 3
+ *
+ * When this creature enters, put a -1/-1 counter on target creature.
+ *
+ * - The target is mandatory and unrestricted: any creature on the battlefield, including one you
+ *   control and including the Cinder itself if it is the only creature around.
+ * - [Counters.MINUS_ONE_MINUS_ONE] is the named counter type, not a stat modification — the counter
+ *   persists and interacts with wither/persist, which is the whole point in Shadowmoor.
+ */
+val CultbrandCinder = card("Cultbrand Cinder") {
+    manaCost = "{4}{B/R}"
+    typeLine = "Creature — Elemental Shaman"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, put a -1/-1 counter on target creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 1, creature)
+        description = "When this creature enters, put a -1/-1 counter on target creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "182"
+        artist = "Christopher Moeller"
+        flavorText = "\"Your seared flesh will be the first step in your journey to dark enlightenment.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6b80a10-a9a9-445e-8040-6cc0155271d8.jpg?1783942728"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/DeepSlumberTitan.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/DeepSlumberTitan.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Deep-Slumber Titan
+ * {2}{R}{R}
+ * Creature — Giant Warrior
+ * 7 / 7
+ *
+ * This creature enters tapped.
+ * This creature doesn't untap during your untap step.
+ * Whenever this creature is dealt damage, untap it.
+ *
+ * - "Enters tapped" is a card-intrinsic self-replacement ([EntersTapped]), not a static or a
+ *   trigger — it is applied as the Titan enters and never sees the untapped state.
+ * - The untap restriction is the narrow [AbilityFlag.DOESNT_UNTAP] ("doesn't untap during your
+ *   untap step"), *not* [AbilityFlag.CANT_BECOME_UNTAPPED]: an untap *effect* — including the
+ *   Titan's own damage trigger below — still works.
+ * - [Triggers.TakesDamage] is the SELF-bound incoming-damage event. It fires on damage from any
+ *   source, combat or otherwise, and on any amount; the Titan surviving is not a condition, so a
+ *   lethal hit still queues the (now pointless) untap.
+ */
+val DeepSlumberTitan = card("Deep-Slumber Titan") {
+    manaCost = "{2}{R}{R}"
+    typeLine = "Creature — Giant Warrior"
+    power = 7
+    toughness = 7
+    oracleText = "This creature enters tapped.\n" +
+        "This creature doesn't untap during your untap step.\n" +
+        "Whenever this creature is dealt damage, untap it."
+
+    // "This creature enters tapped."
+    replacementEffect(EntersTapped())
+
+    // "This creature doesn't untap during your untap step."
+    flags(AbilityFlag.DOESNT_UNTAP)
+
+    // "Whenever this creature is dealt damage, untap it."
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        effect = Effects.Untap(EffectTarget.Self)
+        description = "Whenever this creature is dealt damage, untap it."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "89"
+        artist = "Steve Prescott"
+        flavorText = "Do not disturb."
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cbe3a68e-c29e-48a8-a2d7-49c8bff3dd8a.jpg?1783942749"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/DroveOfElves.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/DroveOfElves.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Drove of Elves
+ * {3}{G}
+ * Creature — Elf
+ * * / *
+ *
+ * Hexproof
+ * Drove of Elves's power and toughness are each equal to the number of green permanents you control.
+ *
+ * - The P/T is a characteristic-defining ability (CR 604.3): `dynamicStats`, no printed base P/T.
+ * - "green **permanents**", not creatures — `GameObjectFilter.Permanent.withColor(GREEN)` counts
+ *   green lands, artifacts and enchantments too, and Drove of Elves itself while on the battlefield.
+ * - Printed as "shroud" in Shadowmoor; the current Oracle text errata'd it to hexproof, which is
+ *   what the brief carries and what is authored here.
+ */
+val DroveOfElves = card("Drove of Elves") {
+    manaCost = "{3}{G}"
+    typeLine = "Creature — Elf"
+    oracleText = "Hexproof\n" +
+        "Drove of Elves's power and toughness are each equal to the number of green permanents you control."
+
+    keywords(Keyword.HEXPROOF)
+
+    dynamicStats(
+        DynamicAmount.AggregateBattlefield(
+            Player.You,
+            GameObjectFilter.Permanent.withColor(Color.GREEN)
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "112"
+        artist = "Larry MacDougall"
+        flavorText = "\"The light of beauty protects our journeys through darkness.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b657ad23-e84b-4b53-a6b6-80f359624ab8.jpg?1783942744"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ElvishHexhunter.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ElvishHexhunter.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elvish Hexhunter
+ * {G/W}
+ * Creature — Elf Shaman
+ * 1 / 1
+ *
+ * {G/W}, {T}, Sacrifice this creature: Destroy target enchantment.
+ *
+ * - The printed cost is three atoms in one composite: the hybrid mana, the {T} symbol (so the
+ *   ability is summoning-sickness-gated) and sacrificing the Hexhunter itself.
+ * - `Costs.SacrificeSelf` rather than a generic sacrifice-a-creature cost — "Sacrifice this
+ *   creature" names the source, not a choice.
+ * - [Effects.Destroy] lowers to a move-to-graveyard by destruction, so indestructible and
+ *   regeneration on the enchantment are honoured (relevant against Ghostly Prison-style
+ *   enchantments that have picked up indestructibility).
+ * - Modelled directly on Elvish Lyrist (USG), which has the identical ability in mono-green.
+ */
+val ElvishHexhunter = card("Elvish Hexhunter") {
+    manaCost = "{G/W}"
+    typeLine = "Creature — Elf Shaman"
+    power = 1
+    toughness = 1
+    oracleText = "{G/W}, {T}, Sacrifice this creature: Destroy target enchantment."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G/W}"), Costs.Tap, Costs.SacrificeSelf)
+        val t = target("target", Targets.Enchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "226"
+        artist = "Alex Horley-Orlandelli"
+        flavorText = "\"All manner of curses, blights, and luckspoils infect Shadowmoor. We stalk them all, one perilous quest at a time.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2b7f4d7-278b-45fc-98aa-b7c8b9162bcd.jpg?1783942717"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/EmberstrikeDuo.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/EmberstrikeDuo.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Emberstrike Duo
+ * {1}{B/R}
+ * Creature — Elemental Warrior Shaman
+ * 1 / 1
+ *
+ * Whenever you cast a black spell, this creature gets +1/+1 until end of turn.
+ * Whenever you cast a red spell, this creature gains first strike until end of turn.
+ *
+ * - Both triggers are `Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(...))`:
+ *   the spell filter matches *any* card type, since "a black spell" is not restricted to creatures.
+ * - The colour test is on the spell itself, so a hybrid or multicoloured spell that is (say) both
+ *   black and red triggers *both* abilities — that is correct for the Duo cycle.
+ * - `EffectTarget.Self` and the default `Duration.EndOfTurn` on both effects give the printed
+ *   "this creature ... until end of turn" wording; neither trigger targets.
+ */
+val EmberstrikeDuo = card("Emberstrike Duo") {
+    manaCost = "{1}{B/R}"
+    typeLine = "Creature — Elemental Warrior Shaman"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever you cast a black spell, this creature gets +1/+1 until end of turn.\n" +
+        "Whenever you cast a red spell, this creature gains first strike until end of turn."
+
+    // Whenever you cast a black spell, this creature gets +1/+1 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(Color.BLACK))
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    // Whenever you cast a red spell, this creature gains first strike until end of turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(Color.RED))
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "185"
+        artist = "Aleksi Briclot"
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9ccd4374-5339-4529-99f3-f7dcc939e874.jpg?1783942727"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/FaerieSwarm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/FaerieSwarm.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Faerie Swarm
+ * {3}{U}
+ * Creature — Faerie
+ * * / *
+ *
+ * Flying
+ * Faerie Swarm's power and toughness are each equal to the number of blue permanents you control.
+ *
+ * - The P/T is a characteristic-defining ability (CR 604.3): `dynamicStats`, no printed base P/T.
+ * - "blue **permanents**", not creatures — the filter is `GameObjectFilter.Permanent.withColor`,
+ *   so blue lands, artifacts and enchantments count, as does Faerie Swarm itself on the battlefield.
+ */
+val FaerieSwarm = card("Faerie Swarm") {
+    manaCost = "{3}{U}"
+    typeLine = "Creature — Faerie"
+    oracleText = "Flying\n" +
+        "Faerie Swarm's power and toughness are each equal to the number of blue permanents you control."
+
+    keywords(Keyword.FLYING)
+
+    dynamicStats(
+        DynamicAmount.AggregateBattlefield(
+            Player.You,
+            GameObjectFilter.Permanent.withColor(Color.BLUE)
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "37"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "Untouched by the Aurora, Oona's faeries greeted the night like any other day."
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/90598bb2-d96c-4f74-864b-1947b7d39e58.jpg?1783942761"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/FlameJavelin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/FlameJavelin.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flame Javelin
+ * {2/R}{2/R}{2/R}
+ * Instant
+ *
+ * ({2/R} can be paid with any two mana or with {R}. This card's mana value is 6.)
+ * Flame Javelin deals 4 damage to any target.
+ *
+ * - Monocoloured hybrid ("twobrid") goes into `manaCost` verbatim; the parser derives the mana
+ *   value of 6 from the three {2/R} symbols, so nothing is overridden here.
+ * - The first line is reminder text for the twobrid symbol and carries no rules content — it is
+ *   kept in `oracleText` because that is what Scryfall prints.
+ * - No `damageSource` is passed: the spell itself is the source, which is the facade's default.
+ */
+val FlameJavelin = card("Flame Javelin") {
+    manaCost = "{2/R}{2/R}{2/R}"
+    typeLine = "Instant"
+    oracleText = "({2/R} can be paid with any two mana or with {R}. This card's mana value is 6.)\n" +
+        "Flame Javelin deals 4 damage to any target."
+
+    spell {
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(4, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "92"
+        artist = "Trevor Hairsine"
+        flavorText = "Gyara Spearhurler would have been renowned for her deadly accuracy, if it weren't for her deadly accuracy."
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a567b570-81e4-4068-929c-9ce406fe7474.jpg?1783942749"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/FoxfireOak.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/FoxfireOak.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Foxfire Oak
+ * {5}{G}
+ * Creature — Treefolk Shaman
+ * 3 / 6
+ *
+ * {R/G}{R/G}{R/G}: This creature gets +3/+0 until end of turn.
+ *
+ * - The three hybrid symbols stay in the activation cost as written; each `{R/G}` is independently
+ *   payable with {R} or {G}, which the mana-cost parser derives — nothing is overridden.
+ * - No target: "this creature" is the source, so the pump uses [EffectTarget.Self].
+ */
+val FoxfireOak = card("Foxfire Oak") {
+    manaCost = "{5}{G}"
+    typeLine = "Creature — Treefolk Shaman"
+    power = 3
+    toughness = 6
+    oracleText = "{R/G}{R/G}{R/G}: This creature gets +3/+0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{R/G}{R/G}{R/G}")
+        effect = Effects.ModifyStats(3, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "Dave Kendall"
+        flavorText = "\"The brethren shall blaze with unnatural fire, and the flame shall consume and purify our rage.\"\n" +
+            "—Treefolk catastrophe myth"
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/46e23eae-7630-40db-b265-2fa00715878e.jpg?1783942743"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/FulminatorMage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/FulminatorMage.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Fulminator Mage
+ * {1}{B/R}{B/R}
+ * Creature — Elemental Shaman
+ * 2 / 2
+ *
+ * Sacrifice this creature: Destroy target nonbasic land.
+ *
+ * - The whole cost is the sacrifice — no {T}, so the ability works the turn the Mage enters and
+ *   works while it is tapped or attacking.
+ * - [TargetFilter.NonbasicLand] is `IsLand` plus `Not(IsBasicLand)`, so a land that is basic by
+ *   type (a Snow-Covered basic, or a nonbasic land turned into a basic type by a continuous
+ *   effect) is not a legal target — the check reads projected state.
+ * - [Effects.Destroy] lowers to a move-to-graveyard by destruction, so an indestructible or
+ *   regenerating land survives.
+ */
+val FulminatorMage = card("Fulminator Mage") {
+    manaCost = "{1}{B/R}{B/R}"
+    typeLine = "Creature — Elemental Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "Sacrifice this creature: Destroy target nonbasic land."
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        val t = target("target", TargetPermanent(filter = TargetFilter.NonbasicLand))
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "188"
+        artist = "rk post"
+        flavorText = "\"Unsafe Terrain Ahead—Turn Back\"\n" +
+            "—Sign near the former location of Pyrtagh Cairn"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be1df367-8e85-4fd8-aa6f-f02a478fecb3.jpg?1783942726"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/GhastlyDiscovery.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/GhastlyDiscovery.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Ghastly Discovery
+ * {2}{U}
+ * Sorcery
+ *
+ * Draw two cards, then discard a card.
+ * Conspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it.)
+ *
+ * - "then" is sequencing inside one resolution, so this is a single [Effects.Composite]: the draw
+ *   happens first and the discard chooses from the hand the draw just produced.
+ * - The discard is [Patterns.Hand].discardCards, i.e. the Gather → Select → Move pipeline with
+ *   `MoveType.Discard` — not a bare move to the graveyard, so "whenever you discard" triggers and
+ *   madness see it.
+ * - Conspire is declared as [KeywordAbility.Conspire] only; `CardBuilder` derives
+ *   `Keyword.CONSPIRE` into `keywords`, so a separate `keywords(...)` line would be redundant.
+ *   This card's reminder text has no "choose a new target" clause because the spell has no targets.
+ */
+val GhastlyDiscovery = card("Ghastly Discovery") {
+    manaCost = "{2}{U}"
+    typeLine = "Sorcery"
+    oracleText = "Draw two cards, then discard a card.\n" +
+        "Conspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it.)"
+
+    keywordAbility(KeywordAbility.Conspire)
+
+    spell {
+        effect = Effects.Composite(
+            Effects.DrawCards(2),
+            Patterns.Hand.discardCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Howard Lyon"
+        flavorText = "Korrigans, spirits bound to sources of water, shriek when they come upon their own drowned corpses."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9dbd510a-d71f-4b0c-bc6c-e403f632cbdb.jpg?1783942761"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/GleefulSabotage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/GleefulSabotage.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Gleeful Sabotage
+ * {1}{G}
+ * Sorcery
+ *
+ * Destroy target artifact or enchantment.
+ * Conspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)
+ *
+ * - "artifact or enchantment" is one target slot with a disjunctive card predicate
+ *   (`GameObjectFilter.Artifact or GameObjectFilter.Enchantment`), not two requirements — an
+ *   artifact enchantment satisfies it once.
+ * - [Effects.Destroy] is the move-to-graveyard-by-destruction shape, so indestructible,
+ *   regeneration and "dies" triggers all behave (a plain move would bypass them).
+ * - Conspire is declared as [KeywordAbility.Conspire] only; `CardBuilder` derives
+ *   `Keyword.CONSPIRE` into `keywords`, so a separate `keywords(...)` line would be redundant.
+ */
+val GleefulSabotage = card("Gleeful Sabotage") {
+    manaCost = "{1}{G}"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target artifact or enchantment.\n" +
+        "Conspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)"
+
+    keywordAbility(KeywordAbility.Conspire)
+
+    spell {
+        val t = target(
+            "target",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Artifact or GameObjectFilter.Enchantment))
+        )
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "116"
+        artist = "Todd Lockwood"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d1b7d043-5f52-4df6-8dcf-5174a5b0c9cc.jpg?1783942743"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/GlenElendraLiege.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/GlenElendraLiege.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Glen Elendra Liege
+ * {1}{U/B}{U/B}{U/B}
+ * Creature — Faerie Knight
+ * 2 / 3
+ *
+ * Flying
+ * Other blue creatures you control get +1/+1.
+ * Other black creatures you control get +1/+1.
+ *
+ * - Two deliberately separate [ModifyStats] statics, exactly as on Wilt-Leaf Liege: they stack, so
+ *   a creature you control that is both blue *and* black gets +2/+2.
+ * - `excludeSelf = true` carries the printed "Other" — the Liege is blue *and* black itself, so
+ *   without it it would pump itself twice.
+ * - The colour test reads projected state through the [GroupFilter], so a creature that only
+ *   becomes blue or black from a continuous effect is still pumped.
+ */
+val GlenElendraLiege = card("Glen Elendra Liege") {
+    manaCost = "{1}{U/B}{U/B}{U/B}"
+    typeLine = "Creature — Faerie Knight"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Other blue creatures you control get +1/+1.\n" +
+        "Other black creatures you control get +1/+1."
+
+    keywords(Keyword.FLYING)
+
+    // Other blue creatures you control get +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withColor(Color.BLUE).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    // Other black creatures you control get +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withColor(Color.BLACK).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "163"
+        artist = "Kev Walker"
+        flavorText = "Those who displease Oona soon learn the extent of the armies she commands."
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/94cc72b7-b593-438f-a07a-35f2452e1c48.jpg?1783942732"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Gloomwidow.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Gloomwidow.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CanOnlyBlockCreaturesWith
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Gloomwidow
+ * {2}{G}
+ * Creature — Spider
+ * 3 / 3
+ *
+ * Reach
+ * This creature can block only creatures with flying.
+ *
+ * - Reach and the blocking restriction pull in opposite directions and both apply: reach lets it
+ *   block fliers, and [CanOnlyBlockCreaturesWith] then forbids it from blocking anything else.
+ * - The restriction is a static over projected state, so a creature that gains or loses flying
+ *   after blockers would be declared is judged by its current keyword set, not its printed one.
+ */
+val Gloomwidow = card("Gloomwidow") {
+    manaCost = "{2}{G}"
+    typeLine = "Creature — Spider"
+    power = 3
+    toughness = 3
+    oracleText = "Reach\n" +
+        "This creature can block only creatures with flying."
+
+    keywords(Keyword.REACH)
+
+    staticAbility {
+        ability = CanOnlyBlockCreaturesWith(blockerFilter = GameObjectFilter.Creature.withKeyword(Keyword.FLYING))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "117"
+        artist = "Mark Tedin"
+        flavorText = "When gloomwidows mature, they abandon venom in favor of massive webs that span the eaves of cliffs."
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/99bda306-1e37-4359-a649-fcd8a5a7e2fc.jpg?1783942742"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/GnarledEffigy.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/GnarledEffigy.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gnarled Effigy
+ * {4}
+ * Artifact
+ *
+ * {4}, {T}: Put a -1/-1 counter on target creature.
+ *
+ * - The target is any creature, not just an opponent's — the printed line has no controller
+ *   restriction, so [Targets.Creature] is left unfiltered.
+ * - Instant-speed by default: an activated ability with no timing clause needs no [TimingRule].
+ */
+val GnarledEffigy = card("Gnarled Effigy") {
+    manaCost = "{4}"
+    typeLine = "Artifact"
+    oracleText = "{4}, {T}: Put a -1/-1 counter on target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap)
+        target = Targets.Creature
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 1, EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "251"
+        artist = "Ron Brown"
+        flavorText = "\"Bits of fallen scarecrow, laces of elfskin leather, teeth of an axeshark merrow . . . An industrious soul can find new uses for the most mundane items.\"\n" +
+            "—Mowagh the Gwyllion"
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e6aee954-2a04-425d-8d05-09dad58af656.jpg?1783942712"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/GoldenglowMoth.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/GoldenglowMoth.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goldenglow Moth
+ * {W}
+ * Creature — Insect
+ * 0 / 1
+ *
+ * Flying
+ * Whenever this creature blocks, you may gain 4 life.
+ *
+ * - [Triggers.Blocks] is the SELF-bound "this creature blocks" event, so it fires once the Moth is
+ *   declared as a blocker — not on the attacker becoming blocked, and regardless of whether combat
+ *   damage is ever dealt.
+ * - "You may gain 4 life" is a resolution-time yes/no with no cost, so it is the `optional = true`
+ *   shorthand (a [com.wingedsheep.sdk.scripting.effects.Gate.MayDecide] around the gain).
+ */
+val GoldenglowMoth = card("Goldenglow Moth") {
+    manaCost = "{W}"
+    typeLine = "Creature — Insect"
+    power = 0
+    toughness = 1
+    oracleText = "Flying\n" +
+        "Whenever this creature blocks, you may gain 4 life."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        optional = true
+        effect = Effects.GainLife(4)
+        description = "Whenever this creature blocks, you may gain 4 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "6"
+        artist = "Howard Lyon"
+        flavorText = "Ordinary moths follow it, drawn to its light."
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/12030927-7af2-448f-bc6b-c2035e0b799d.jpg?1783942769"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/GravelgillAxeshark.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/GravelgillAxeshark.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gravelgill Axeshark
+ * {4}{U/B}
+ * Creature — Merfolk Soldier
+ * 3 / 3
+ *
+ * Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield
+ * under its owner's control with a -1/-1 counter on it.)
+ *
+ * - Persist is engine-live: [Keyword.PERSIST] is read by the death-trigger detector, so the keyword
+ *   alone carries the whole behaviour. No triggered ability is authored for the reminder text.
+ * - `{U/B}` is a plain hybrid pip in `manaCost`; mana value (5) is derived by the parser.
+ */
+val GravelgillAxeshark = card("Gravelgill Axeshark") {
+    manaCost = "{4}{U/B}"
+    typeLine = "Creature — Merfolk Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "Persist (When this creature dies, if it had no -1/-1 counters on it, return it " +
+        "to the battlefield under its owner's control with a -1/-1 counter on it.)"
+
+    keywords(Keyword.PERSIST)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "164"
+        artist = "Dave Kendall"
+        flavorText = "\"Their sharp scales would make good armor, if they'd just stay dead.\"\n" +
+            "—Taeryn, cinder armorkeep"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5efc174a-f710-4602-aace-c2165473f6c2.jpg?1783942733"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/GravelgillDuo.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/GravelgillDuo.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gravelgill Duo
+ * {2}{U/B}
+ * Creature — Merfolk Rogue Warrior
+ * 2 / 1
+ *
+ * Whenever you cast a blue spell, this creature gets +1/+1 until end of turn.
+ * Whenever you cast a black spell, this creature gains fear until end of turn. (It can't be blocked
+ * except by artifact creatures and/or black creatures.)
+ *
+ * - Both triggers are `Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(...))`:
+ *   "a blue spell" covers every card type, so the filter stays `Any`.
+ * - A spell that is both blue and black triggers both abilities — correct for the Duo cycle.
+ * - Fear is granted with the plain `Effects.GrantKeyword` facade (as Shriek of Dread does); the
+ *   evasion check reads runtime-granted keywords, so no separate evasion effect is needed.
+ */
+val GravelgillDuo = card("Gravelgill Duo") {
+    manaCost = "{2}{U/B}"
+    typeLine = "Creature — Merfolk Rogue Warrior"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever you cast a blue spell, this creature gets +1/+1 until end of turn.\n" +
+        "Whenever you cast a black spell, this creature gains fear until end of turn. (It can't be blocked except by artifact creatures and/or black creatures.)"
+
+    // Whenever you cast a blue spell, this creature gets +1/+1 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(Color.BLUE))
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    // Whenever you cast a black spell, this creature gains fear until end of turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(Color.BLACK))
+        effect = Effects.GrantKeyword(Keyword.FEAR, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "165"
+        artist = "Brandon Kitkouski"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f2fd4959-bfff-46dc-b568-b6d69ef8eac9.jpg?1783942733"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/HeapDoll.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/HeapDoll.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Heap Doll
+ * {1}
+ * Artifact Creature — Scarecrow
+ * 1 / 1
+ *
+ * Sacrifice this creature: Exile target card from a graveyard.
+ *
+ * - The sacrifice is a *cost*, so it is paid on activation and the ability resolves even if the
+ *   Doll is somehow gone — the target card still gets exiled.
+ * - [Targets.CardInGraveyard] is any card in any graveyard, not just an opponent's: the printed
+ *   wording is "a graveyard", so one of your own cards is a legal target too.
+ * - No `fromZone` gate on the exile. The target is already zone-scoped to the graveyard by the
+ *   target requirement, and CR 608.2b fizzles the ability if the card has moved on.
+ */
+val HeapDoll = card("Heap Doll") {
+    manaCost = "{1}"
+    typeLine = "Artifact Creature — Scarecrow"
+    power = 1
+    toughness = 1
+    oracleText = "Sacrifice this creature: Exile target card from a graveyard."
+
+    // Sacrifice this creature: Exile target card from a graveyard.
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        val t = target("target", Targets.CardInGraveyard)
+        effect = Effects.Exile(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "253"
+        artist = "John Avon"
+        flavorText = "\"I know one night it won't come back. Then I'll know it's truly done its job.\"\n" +
+            "—Braenna, cobblesmith"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/86d726e1-a363-4d77-97d4-e8c94f93fd51.jpg?1783942712"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/HordeOfBoggarts.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/HordeOfBoggarts.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Horde of Boggarts
+ * {3}{R}
+ * Creature — Goblin
+ * * / *
+ *
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ * Horde of Boggarts's power and toughness are each equal to the number of red permanents you control.
+ *
+ * - The P/T is a characteristic-defining ability (CR 604.3): `dynamicStats`, no printed base P/T.
+ * - "red **permanents**", not creatures — `GameObjectFilter.Permanent.withColor(RED)` counts red
+ *   lands, artifacts and enchantments too, and Horde of Boggarts itself while on the battlefield.
+ * - Printed with "can't be blocked except by two or more creatures"; the current Oracle text
+ *   errata'd that to the menace keyword, which is what is authored here.
+ */
+val HordeOfBoggarts = card("Horde of Boggarts") {
+    manaCost = "{3}{R}"
+    typeLine = "Creature — Goblin"
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "Horde of Boggarts's power and toughness are each equal to the number of red permanents you control."
+
+    keywords(Keyword.MENACE)
+
+    dynamicStats(
+        DynamicAmount.AggregateBattlefield(
+            Player.You,
+            GameObjectFilter.Permanent.withColor(Color.RED)
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "94"
+        artist = "Steve Prescott"
+        flavorText = "Strategies don't come easily to the boggarts' feral minds, but full-on assault hasn't failed them yet."
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/023562bf-da7d-486d-93fc-60353f55b8a7.jpg?1783942749"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/HungrySpriggan.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/HungrySpriggan.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hungry Spriggan
+ * {2}{G}
+ * Creature — Goblin Warrior
+ * 1 / 1
+ *
+ * Trample
+ * Whenever this creature attacks, it gets +3/+3 until end of turn.
+ *
+ * - The pump is a *triggered* ability, not a static: it goes on the stack when attackers are
+ *   declared and can be responded to, and it only fires when this creature itself attacks
+ *   ([Triggers.Attacks] is the SELF-bound attack trigger).
+ * - [EffectTarget.Self] rather than a target — "it" is the source, so nothing is targeted and the
+ *   bonus still applies if the Spriggan is later removed from combat.
+ * - `Effects.ModifyStats` defaults to `Duration.EndOfTurn`, which is exactly "until end of turn".
+ */
+val HungrySpriggan = card("Hungry Spriggan") {
+    manaCost = "{2}{G}"
+    typeLine = "Creature — Goblin Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "Trample\n" +
+        "Whenever this creature attacks, it gets +3/+3 until end of turn."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ModifyStats(3, 3, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "120"
+        artist = "Drew Tucker"
+        flavorText = "If a spriggan's eyes are larger than its stomach, it has ways to remedy the situation."
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8be81b15-eb12-452b-8fdd-bde64807f422.jpg?1783942742"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/JuvenileGloomwidow.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/JuvenileGloomwidow.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Juvenile Gloomwidow
+ * {G}{G}
+ * Creature — Spider
+ * 1 / 3
+ *
+ * Reach (This creature can block creatures with flying.)
+ * Wither (This deals damage to creatures in the form of -1/-1 counters.)
+ *
+ * - Keyword-only creature. This is plain [Keyword.REACH], not the older Gloomwidow "can block only
+ *   creatures with flying" restriction — the printed line grants blocking, it does not limit it.
+ */
+val JuvenileGloomwidow = card("Juvenile Gloomwidow") {
+    manaCost = "{G}{G}"
+    typeLine = "Creature — Spider"
+    power = 1
+    toughness = 3
+    oracleText = "Reach (This creature can block creatures with flying.)\n" +
+        "Wither (This deals damage to creatures in the form of -1/-1 counters.)"
+
+    keywords(Keyword.REACH, Keyword.WITHER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "121"
+        artist = "Thomas M. Baxa"
+        flavorText = "Gloomwidow venom is particularly virulent during the spider's first years, when it does most of its hunting near the forest floor."
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d7f323d5-f26c-46e9-9d6a-be5c254fe8b6.jpg?1783942742"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/KitchenFinks.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/KitchenFinks.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kitchen Finks
+ * {1}{G/W}{G/W}
+ * Creature — Ouphe
+ * 3 / 2
+ *
+ * When this creature enters, you gain 2 life.
+ * Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield
+ * under its owner's control with a -1/-1 counter on it.)
+ *
+ * - Persist is engine-live: [Keyword.PERSIST] is read by the death-trigger detector, so the keyword
+ *   alone carries the return. The ETB gain-life rides back with the body, which is the card's point.
+ * - The ETB is a plain untargeted [Triggers.EntersBattlefield] + [Effects.GainLife], matching Assay's
+ *   `ZoneChangeEvent -> Battlefield` / `GainLife(Fixed 2)` reading.
+ */
+val KitchenFinks = card("Kitchen Finks") {
+    manaCost = "{1}{G/W}{G/W}"
+    typeLine = "Creature — Ouphe"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, you gain 2 life.\n" +
+        "Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the " +
+        "battlefield under its owner's control with a -1/-1 counter on it.)"
+
+    keywords(Keyword.PERSIST)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(2)
+        description = "When this creature enters, you gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "229"
+        artist = "Kev Walker"
+        flavorText = "Accept one favor from an ouphe, and you're doomed to accept another."
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d203208-8a21-4c68-afa2-4efd8726f026.jpg?1783942717"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/KithkinRabble.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/KithkinRabble.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Kithkin Rabble
+ * {3}{W}
+ * Creature — Kithkin
+ * * / *
+ *
+ * Vigilance
+ * Kithkin Rabble's power and toughness are each equal to the number of white permanents you control.
+ *
+ * - The P/T is a characteristic-defining ability (CR 604.3): `dynamicStats`, no printed base P/T.
+ * - "white **permanents**", not creatures — `GameObjectFilter.Permanent.withColor(WHITE)` counts
+ *   white lands, artifacts and enchantments too, and Kithkin Rabble itself on the battlefield.
+ */
+val KithkinRabble = card("Kithkin Rabble") {
+    manaCost = "{3}{W}"
+    typeLine = "Creature — Kithkin"
+    oracleText = "Vigilance\n" +
+        "Kithkin Rabble's power and toughness are each equal to the number of white permanents you control."
+
+    keywords(Keyword.VIGILANCE)
+
+    dynamicStats(
+        DynamicAmount.AggregateBattlefield(
+            Player.You,
+            GameObjectFilter.Permanent.withColor(Color.WHITE)
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "9"
+        artist = "Omar Rayyan"
+        flavorText = "If even the slightest hint of panic enters the thoughtweft, bakers, potters, and even medics drop their spoons and salves to take up arms."
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f9a0afa-50e6-4bce-b261-4559fd31295e.jpg?1783942768"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/KithkinShielddare.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/KithkinShielddare.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kithkin Shielddare
+ * {1}{W}
+ * Creature — Kithkin Soldier
+ * 1 / 1
+ *
+ * {W}, {T}: Target blocking creature gets +2/+2 until end of turn.
+ *
+ * - "Target blocking creature" is [Targets.BlockingCreature], whose filter is
+ *   `GameObjectFilter.Creature.blocking()` — a creature-typed predicate plus the *state* predicate
+ *   "is blocking", read off projected state. It is not restricted to creatures you control, so it
+ *   can pump an opponent's blocker.
+ * - The cost is a composite of the mana symbol and the tap symbol, in printed order.
+ */
+val KithkinShielddare = card("Kithkin Shielddare") {
+    manaCost = "{1}{W}"
+    typeLine = "Creature — Kithkin Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "{W}, {T}: Target blocking creature gets +2/+2 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val blocker = target("target", Targets.BlockingCreature)
+        effect = Effects.ModifyStats(2, 2, blocker)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "Christopher Moeller"
+        flavorText = "The nova glyph is a potent symbol. A shield embossed with it can resist the force of even the most determined giant."
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e5102a7-2147-4e22-b683-c08b4a725617.jpg?1783942768"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/LochKorrigan.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/LochKorrigan.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Loch Korrigan
+ * {3}{B}
+ * Creature — Spirit
+ * 1 / 1
+ *
+ * {U/B}: This creature gets +1/+1 until end of turn.
+ *
+ * - The hybrid `{U/B}` stays in the activation cost as written; it is payable with either {U} or
+ *   {B} and the parser derives that from the symbol.
+ * - No target: "this creature" is the source, so the pump uses [EffectTarget.Self].
+ */
+val LochKorrigan = card("Loch Korrigan") {
+    manaCost = "{3}{B}"
+    typeLine = "Creature — Spirit"
+    power = 1
+    toughness = 1
+    oracleText = "{U/B}: This creature gets +1/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{U/B}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "71"
+        artist = "Daarken"
+        flavorText = "\"Don't look upon still waters without first breaking the surface. The korrigan will catch you with her gaze and drag you to your death.\"\n" +
+            "—Kithkin superstition"
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/2964b501-5b7f-4225-9dd3-e7519bf34048.jpg?1783942753"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/MassCalcify.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/MassCalcify.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Mass Calcify
+ * {5}{W}{W}
+ * Sorcery
+ *
+ * Destroy all nonwhite creatures.
+ *
+ * - [Effects.DestroyAll] lowers to the gather-then-move-collection pipeline, so indestructible
+ *   and regeneration are honoured per permanent rather than short-circuiting the whole sweep.
+ * - `notColor(WHITE)` reads the creature's *current* colours off projected state, so a
+ *   multicoloured creature that is partly white survives, and a creature turned white by a
+ *   continuous effect survives too.
+ */
+val MassCalcify = card("Mass Calcify") {
+    manaCost = "{5}{W}{W}"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all nonwhite creatures."
+
+    spell {
+        effect = Effects.DestroyAll(GameObjectFilter.Creature.notColor(Color.WHITE))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "12"
+        artist = "Brandon Kitkouski"
+        flavorText = "The dead serve as their own tombstones."
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d24be94-9922-43bb-83c8-98090adc3f32.jpg?1783942768"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/MerrowGrimeblotter.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/MerrowGrimeblotter.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Merrow Grimeblotter
+ * {3}{U/B}
+ * Creature — Merfolk Wizard
+ * 2 / 2
+ *
+ * {1}{U/B}, {Q}: Target creature gets -2/-0 until end of turn. ({Q} is the untap symbol.)
+ *
+ * - `{Q}` is [Costs.Untap]: the Grimeblotter must already be **tapped** to pay it, and — like `{T}`
+ *   — CR 302.6 gates it behind summoning sickness. That makes it a once-per-turn-cycle ability in
+ *   practice (tap it for something, untap it in your untap step, activate).
+ * - The `{U/B}` pip in the activation cost stays hybrid: the parser reads it out of the string, so
+ *   either {U} or {B} pays it. Nothing is overridden.
+ * - The stat modifier is authored as -2/-0 rather than -2/0 in text only; the effect carries a
+ *   toughness modifier of exactly 0, so it never touches toughness (a 1/1 target survives at 0/1).
+ */
+val MerrowGrimeblotter = card("Merrow Grimeblotter") {
+    manaCost = "{3}{U/B}"
+    typeLine = "Creature — Merfolk Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "{1}{U/B}, {Q}: Target creature gets -2/-0 until end of turn. ({Q} is the untap symbol.)"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U/B}"), Costs.Untap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(-2, 0, t)
+        description = "{1}{U/B}, {Q}: Target creature gets -2/-0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "171"
+        artist = "Cyril Van Der Haegen"
+        flavorText = "Grimeblotters spend so much time in the Dark Meanders that they're able to bring a piece with them wherever they go."
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b839c9d0-ef08-4661-8009-3bcb256bf508.jpg?1783942730"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/MerrowWavebreakers.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/MerrowWavebreakers.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Merrow Wavebreakers
+ * {4}{U}
+ * Creature — Merfolk Soldier
+ * 3 / 3
+ *
+ * {1}{U}, {Q}: This creature gains flying until end of turn. ({Q} is the untap symbol.)
+ *
+ * - `{Q}` is [Costs.Untap]: the Wavebreakers must already be **tapped** to pay it, and CR 302.6
+ *   gates the untap symbol behind summoning sickness exactly like `{T}`.
+ * - The grant targets [EffectTarget.Self] rather than a chosen target — "this creature" is the
+ *   source, so the ability has no target requirement at all.
+ * - [Effects.GrantKeyword] defaults to `Duration.EndOfTurn`, which is the printed duration; nothing
+ *   is passed explicitly.
+ */
+val MerrowWavebreakers = card("Merrow Wavebreakers") {
+    manaCost = "{4}{U}"
+    typeLine = "Creature — Merfolk Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "{1}{U}, {Q}: This creature gains flying until end of turn. ({Q} is the untap symbol.)"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}"), Costs.Untap)
+        effect = Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+        description = "{1}{U}, {Q}: This creature gains flying until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "44"
+        artist = "Alex Horley-Orlandelli"
+        flavorText = "The merrows' prey have retreated from the shore, so they have learned to follow."
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/9919382e-3dcd-4f83-8135-be71345e57c0.jpg?1783942760"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Morselhoarder.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Morselhoarder.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaOfChoiceEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.values.ManaColorSet
+
+/**
+ * Morselhoarder
+ * {4}{R/G}{R/G}
+ * Creature — Elemental
+ * 6 / 4
+ *
+ * This creature enters with two -1/-1 counters on it.
+ * Remove a -1/-1 counter from this creature: Add one mana of any color.
+ *
+ * - The printed 6/4 is the real base P/T; the two -1/-1 counters are an [EntersWithCounters]
+ *   replacement (`selfOnly = true`), which is what makes it a 4/2 on the battlefield. Removing a
+ *   counter to pay the mana ability grows the body back, so the counters are the ability's fuel
+ *   rather than a permanent drawback (the Wickerbough Elder idiom).
+ * - The activation has no mana in its cost, only [Costs.RemoveCounterFromSelf], so the whole ability
+ *   is a mana ability: it doesn't use the stack and can't be responded to. `manaAbility = true` plus
+ *   [TimingRule.ManaAbility] is what tells the engine that.
+ */
+val Morselhoarder = card("Morselhoarder") {
+    manaCost = "{4}{R/G}{R/G}"
+    typeLine = "Creature — Elemental"
+    power = 6
+    toughness = 4
+    oracleText = "This creature enters with two -1/-1 counters on it.\n" +
+        "Remove a -1/-1 counter from this creature: Add one mana of any color."
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.MinusOneMinusOne,
+            count = 2,
+            selfOnly = true
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.RemoveCounterFromSelf(Counters.MINUS_ONE_MINUS_ONE)
+        effect = AddManaOfChoiceEffect(ManaColorSet.AnyColor, 1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "212"
+        artist = "Anthony S. Waters"
+        flavorText = "It scours the hills for living matter, savoring even the tang of poisonous fungi."
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/589f477e-fd69-4410-b9ba-1d45b25fec31.jpg?1783942721"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/MudbrawlerRaiders.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/MudbrawlerRaiders.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Mudbrawler Raiders
+ * {2}{R/G}{R/G}
+ * Creature — Goblin Warrior
+ * 3 / 3
+ *
+ * This creature can't be blocked by blue creatures.
+ *
+ * - The evasion is a single [CantBeBlockedBy] static over a coloured *creature* filter, evaluated
+ *   against projected state so a blocker's current colour decides, not its printed one.
+ * - The hybrid cost `{R/G}` goes in `manaCost` verbatim; mana value (4) is derived by the parser.
+ */
+val MudbrawlerRaiders = card("Mudbrawler Raiders") {
+    manaCost = "{2}{R/G}{R/G}"
+    typeLine = "Creature — Goblin Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "This creature can't be blocked by blue creatures."
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.withColor(Color.BLUE))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "213"
+        artist = "Ron Spencer"
+        flavorText = "To reach the ravine of the Wanderbrine River, they were told to take the shortcut \"through the mountains.\" They took the directions literally."
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cbe4af47-d913-4c19-a027-501e2c78758c.jpg?1783942721"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/NurturerInitiate.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/NurturerInitiate.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Nurturer Initiate
+ * {G}
+ * Creature — Elf Shaman
+ * 1 / 1
+ *
+ * Whenever a player casts a green spell, you may pay {1}. If you do, target creature gets +1/+1
+ * until end of turn.
+ *
+ * - "A player" is *every* player, the Initiate's controller included, so this is
+ *   [Triggers.anyPlayerCasts] (ANY binding) rather than a "whenever you cast" trigger.
+ * - The target is chosen when the ability goes on the stack (a `targetRequirement` on the trigger),
+ *   *before* the optional {1} is paid — declining the payment still consumed the target choice.
+ * - "You may pay {1}. If you do, …" is the [MayPayManaEffect] gate; the pump is the gate's `then`,
+ *   so nothing happens if the controller declines.
+ */
+val NurturerInitiate = card("Nurturer Initiate") {
+    manaCost = "{G}"
+    typeLine = "Creature — Elf Shaman"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever a player casts a green spell, you may pay {1}. If you do, target creature gets +1/+1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.anyPlayerCasts(GameObjectFilter.Any.withColor(Color.GREEN))
+        val creature = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}"),
+            effect = Effects.ModifyStats(1, 1, creature)
+        )
+        description = "Whenever a player casts a green spell, you may pay {1}. If you do, " +
+            "target creature gets +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "124"
+        artist = "Jim Pavelec"
+        flavorText = "The elves alone preserve the few shreds of beauty left. There is no one else who cares."
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/2330c78d-1655-4074-a650-27740be4cee1.jpg?1783942741"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/OonasGatewarden.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/OonasGatewarden.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oona's Gatewarden
+ * {U/B}
+ * Creature — Faerie Soldier
+ * 2 / 1
+ *
+ * Defender, flying
+ * Wither (This deals damage to creatures in the form of -1/-1 counters.)
+ *
+ * - Keyword-only creature. [Keyword.WITHER] is engine-live — damage this deals to a creature
+ *   becomes -1/-1 counters — so the reminder text needs no separate replacement effect.
+ */
+val OonasGatewarden = card("Oona's Gatewarden") {
+    manaCost = "{U/B}"
+    typeLine = "Creature — Faerie Soldier"
+    power = 2
+    toughness = 1
+    oracleText = "Defender, flying\n" +
+        "Wither (This deals damage to creatures in the form of -1/-1 counters.)"
+
+    keywords(Keyword.DEFENDER, Keyword.FLYING, Keyword.WITHER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "173"
+        artist = "Mike Dringenberg"
+        flavorText = "\"So now you've seen Glen Elendra. Take a good look. It will be the last thing you'll ever see.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/972bb6e4-300c-49f5-8305-459a3ba67baa.jpg?1783942729"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/OversoulOfDusk.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/OversoulOfDusk.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Oversoul of Dusk
+ * {G/W}{G/W}{G/W}{G/W}{G/W}
+ * Creature — Spirit Avatar
+ * 5 / 5
+ *
+ * Protection from blue, from black, and from red
+ *
+ * - CR 702.16g: "protection from [quality A] and from [quality B]" is shorthand for three (here)
+ *   *separate* protection abilities, so this is three [KeywordAbility.Protection] instances with a
+ *   single-colour [ProtectionScope.Color] each — not one [ProtectionScope.Colors] holding a set.
+ *   That matters when something removes or counts abilities individually.
+ * - The five-symbol monocoloured-hybrid cost goes in `manaCost` verbatim; mana value (5) is
+ *   derived by the parser, and the card is green-white regardless of how it was paid.
+ */
+val OversoulOfDusk = card("Oversoul of Dusk") {
+    manaCost = "{G/W}{G/W}{G/W}{G/W}{G/W}"
+    typeLine = "Creature — Spirit Avatar"
+    power = 5
+    toughness = 5
+    oracleText = "Protection from blue, from black, and from red"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.BLUE)))
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.BLACK)))
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.RED)))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "234"
+        artist = "Scott M. Fischer"
+        flavorText = "\"Some say she hid the sun herself, a desperate act to save it from its ultimate extinction.\"\n" +
+            "—*The Seer's Parables*"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/8893842f-aa3f-45f6-8139-ca775d33792b.jpg?1783942716"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ParapetWatchers.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ParapetWatchers.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Parapet Watchers
+ * {2}{U}
+ * Creature — Kithkin Soldier
+ * 2 / 2
+ *
+ * {W/U}: This creature gets +0/+1 until end of turn.
+ *
+ * - The hybrid `{W/U}` stays in the activation cost as written; it is payable with either {W} or
+ *   {U} and the parser derives that from the symbol.
+ * - The power modifier is an explicit `0` so the effect still matches the printed "+0/+1"; no
+ *   target is declared because "this creature" is the source ([EffectTarget.Self]).
+ */
+val ParapetWatchers = card("Parapet Watchers") {
+    manaCost = "{2}{U}"
+    typeLine = "Creature — Kithkin Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "{W/U}: This creature gets +0/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{W/U}")
+        effect = Effects.ModifyStats(0, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "45"
+        artist = "Scott Altmann"
+        flavorText = "A kithkin doun is not so much a town as a fortress, built to withstand the constantly besieging darkness. Only those most watchful and trustworthy are tasked with guarding its walls."
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/499f9987-87d8-4cd3-98c4-b6976c70739e.jpg?1783942760"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/PiliPala.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/PiliPala.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Pili-Pala
+ * {2}
+ * Artifact Creature — Scarecrow
+ * 1 / 1
+ *
+ * Flying
+ * {2}, {Q}: Add one mana of any color. ({Q} is the untap symbol.)
+ *
+ * - The ability produces mana and doesn't target, so it is a mana ability (CR 605.1a):
+ *   `manaAbility = true` plus [TimingRule.ManaAbility], the same pairing Shire Scarecrow uses.
+ * - `{Q}` is [Costs.Untap] — Pili-Pala must already be **tapped**, and CR 302.6 gates the untap
+ *   symbol behind summoning sickness. That is what makes the classic Grand Architect loop need a
+ *   cost reducer rather than just two permanents.
+ * - [Effects.AddManaOfChoice] with no arguments is exactly "add one mana of any color": it defaults
+ *   to `ManaColorSet.AnyColor` and one mana.
+ */
+val PiliPala = card("Pili-Pala") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Scarecrow"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "{2}, {Q}: Add one mana of any color. ({Q} is the untap symbol.)"
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Untap)
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{2}, {Q}: Add one mana of any color."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "258"
+        artist = "Ron Spencer"
+        flavorText = "It wasn't really expected to fly. Then again, it wasn't expected to move, either."
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/4892c152-1f4a-4616-8e7f-0ca4911e621a.jpg?1783942710"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Plumeveil.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Plumeveil.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plumeveil
+ * {W/U}{W/U}{W/U}
+ * Creature — Elemental
+ * 4 / 4
+ *
+ * Flash
+ * Defender, flying
+ *
+ * - Keyword-only creature. The keywords are declared in printed order (flash, defender, flying) so
+ *   the definition mirrors the oracle text line for line.
+ */
+val Plumeveil = card("Plumeveil") {
+    manaCost = "{W/U}{W/U}{W/U}"
+    typeLine = "Creature — Elemental"
+    power = 4
+    toughness = 4
+    oracleText = "Flash\n" +
+        "Defender, flying"
+
+    keywords(Keyword.FLASH, Keyword.DEFENDER, Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "145"
+        artist = "Nils Hamm"
+        flavorText = "\"It was vast, a great sheet of soaring wings, and equally silent. It caught us unawares and blocked our view of the kithkin stronghold.\"\n" +
+            "—Grensch, merrow cutthroat"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e8b0449-3ae5-4fee-b870-af12be5e5a64.jpg?1783942736"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/PyreCharger.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/PyreCharger.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pyre Charger
+ * {R}{R}
+ * Creature — Elemental Warrior
+ * 1 / 1
+ *
+ * Haste
+ * {R}: This creature gets +1/+0 until end of turn.
+ *
+ * - No target: "this creature" is the source, so the pump uses [EffectTarget.Self]. Haste means the
+ *   firebreathing is live the turn it enters.
+ */
+val PyreCharger = card("Pyre Charger") {
+    manaCost = "{R}{R}"
+    typeLine = "Creature — Elemental Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "Haste\n" +
+        "{R}: This creature gets +1/+0 until end of turn."
+
+    keywords(Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "103"
+        artist = "Mark Zug"
+        flavorText = "His blade was forged over coals of moaning treefolk, curved at the optimum angle for severing heads, and heated to volcanic temperatures by his touch."
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/de320e0d-c1e9-4b5e-84a0-057f3f162bbf.jpg?1783942746"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/RageReflection.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/RageReflection.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Rage Reflection
+ * {4}{R}{R}
+ * Enchantment
+ *
+ * Creatures you control have double strike.
+ *
+ * - A single [GrantKeyword] over every creature you control. No `excludeSelf` — Rage Reflection is
+ *   an enchantment, so it never matches the creature filter anyway.
+ * - The filter is evaluated continuously against projected state, so creatures that enter after
+ *   the enchantment (or that change controller onto your side) pick double strike up immediately.
+ */
+val RageReflection = card("Rage Reflection") {
+    manaCost = "{4}{R}{R}"
+    typeLine = "Enchantment"
+    oracleText = "Creatures you control have double strike."
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.DOUBLE_STRIKE,
+            GroupFilter(GameObjectFilter.Creature.youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "104"
+        artist = "Terese Nielsen & Ron Spencer"
+        flavorText = "Vengeance is a dish best served twice."
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/275e118d-1d50-47ee-a2c9-76169ce372cf.jpg?1783942746"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/RattleblazeScarecrow.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/RattleblazeScarecrow.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Rattleblaze Scarecrow
+ * {6}
+ * Artifact Creature — Scarecrow
+ * 5 / 3
+ *
+ * This creature has persist as long as you control a black creature. (When this creature dies, if
+ * it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a
+ * -1/-1 counter on it.)
+ * This creature has haste as long as you control a red creature.
+ *
+ * - Two independent conditional statics, one per granted keyword — the clauses have separate
+ *   conditions and either can be on without the other.
+ * - Persist is engine-live ([Keyword.PERSIST] is read by the death-trigger detector), so granting
+ *   the keyword is the whole implementation. What matters is *when* the grant is checked: persist
+ *   is a leaves-the-battlefield trigger, so the game uses the Scarecrow's last known information —
+ *   it persists only if you controlled a black creature as it died.
+ * - The colour checks read *creatures you control*, not permanents; a black artifact or land does
+ *   not turn the ability on. [GameObjectFilter] filtering reads projected colour, so an animated
+ *   or colour-shifted creature counts.
+ */
+val RattleblazeScarecrow = card("Rattleblaze Scarecrow") {
+    manaCost = "{6}"
+    typeLine = "Artifact Creature — Scarecrow"
+    power = 5
+    toughness = 3
+    oracleText = "This creature has persist as long as you control a black creature. (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)\n" +
+        "This creature has haste as long as you control a red creature."
+
+    // This creature has persist as long as you control a black creature.
+    staticAbility {
+        ability = GrantKeyword(Keyword.PERSIST, GroupFilter.source())
+        condition = Conditions.YouControl(GameObjectFilter.Creature.withColor(Color.BLACK))
+    }
+
+    // This creature has haste as long as you control a red creature.
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE, GroupFilter.source())
+        condition = Conditions.YouControl(GameObjectFilter.Creature.withColor(Color.RED))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "259"
+        artist = "Trevor Hairsine"
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b46425f-516c-42f5-8df1-79af17d02a4a.jpg?1783942710"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/RavensRunDragoon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/RavensRunDragoon.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Raven's Run Dragoon
+ * {2}{G/W}{G/W}
+ * Creature — Elf Knight
+ * 3 / 3
+ *
+ * This creature can't be blocked by black creatures.
+ *
+ * - The evasion is a single [CantBeBlockedBy] static over a coloured *creature* filter, evaluated
+ *   against projected state so a blocker's current colour decides, not its printed one.
+ * - The hybrid cost `{G/W}` goes in `manaCost` verbatim; mana value (4) is derived by the parser.
+ */
+val RavensRunDragoon = card("Raven's Run Dragoon") {
+    manaCost = "{2}{G/W}{G/W}"
+    typeLine = "Creature — Elf Knight"
+    power = 3
+    toughness = 3
+    oracleText = "This creature can't be blocked by black creatures."
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.withColor(Color.BLACK))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "235"
+        artist = "Daren Bader"
+        flavorText = "\"I have a gift. The ability to sense encroaching darkness has saved many lives. And yet constantly feeling the force of so much ugliness is a terrible burden.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b868da85-9d19-4407-a0c3-fc3b2b237cda.jpg?1783942716"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ReaperKing.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ReaperKing.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Reaper King
+ * {2/W}{2/U}{2/B}{2/R}{2/G}
+ * Legendary Artifact Creature — Scarecrow
+ * 6 / 6
+ *
+ * ({2/W} can be paid with any two mana or with {W}. This card's mana value is 10.)
+ * Other Scarecrow creatures you control get +1/+1.
+ * Whenever another Scarecrow you control enters, destroy target permanent.
+ *
+ * - The mana cost is monocoloured hybrid ("twobrid"); mana value 10 is derived from the written
+ *   cost, so nothing is overridden here. The reminder text is part of the printed oracle text and
+ *   stays in the card's oracle text.
+ * - The lord clause says "Scarecrow **creatures**", so it filters creatures
+ *   ([GameObjectFilter.Creature]); `excludeSelf = true` is the printed "Other".
+ * - The trigger clause says only "another Scarecrow you control", with no "creature" — a bare
+ *   tribal noun means *permanents*, so a Scarecrow permanent that isn't currently a creature
+ *   still triggers it. That asymmetry between the two printed lines is why the lord uses
+ *   `GameObjectFilter.Creature` and the trigger uses `GameObjectFilter.Permanent`.
+ * - The trigger is mandatory and targets, so it must target a permanent if one exists — including
+ *   the Reaper King itself or the Scarecrow that just entered when nothing else is on the board.
+ */
+val ReaperKing = card("Reaper King") {
+    manaCost = "{2/W}{2/U}{2/B}{2/R}{2/G}"
+    typeLine = "Legendary Artifact Creature — Scarecrow"
+    power = 6
+    toughness = 6
+    oracleText = "({2/W} can be paid with any two mana or with {W}. This card's mana value is 10.)\n" +
+        "Other Scarecrow creatures you control get +1/+1.\n" +
+        "Whenever another Scarecrow you control enters, destroy target permanent."
+
+    // Whenever another Scarecrow you control enters, destroy target permanent.
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.SCARECROW).youControl(),
+            binding = TriggerBinding.OTHER
+        )
+        val t = target("target", TargetPermanent())
+        effect = Effects.Destroy(t)
+    }
+
+    // Other Scarecrow creatures you control get +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.SCARECROW).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "260"
+        artist = "Jim Murray"
+        flavorText = "It's harvest time."
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/502740bf-0bff-4358-8996-1a27e5f0343f.jpg?1783942710"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Reknit.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Reknit.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+
+/**
+ * Reknit
+ * {1}{G/W}
+ * Instant
+ *
+ * Regenerate target permanent.
+ *
+ * - The target is `Targets.Permanent`, not `Targets.Creature`: Reknit is one of the few
+ *   regeneration spells that shields *any* permanent, so it can pre-empt a Disenchant or a
+ *   land-destruction spell as well as combat damage.
+ * - [RegenerateEffect] is target-type-agnostic — it creates a regeneration shield on whatever
+ *   permanent it is pointed at — so no creature-specific vocabulary is needed.
+ * - There is no `Effects.Regenerate` facade; the effect class is the shipped spelling
+ *   (see Crypt Sliver).
+ */
+val Reknit = card("Reknit") {
+    manaCost = "{1}{G/W}"
+    typeLine = "Instant"
+    oracleText = "Regenerate target permanent."
+
+    spell {
+        val t = target("target", Targets.Permanent)
+        effect = RegenerateEffect(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "236"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "\"An axe may break upon a ribbon if the ribbon's will is the stronger.\"\n" +
+            "—Awylla, elvish safewright"
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/10bde9be-0ad8-4f42-a9a9-838bc476c7a6.jpg?1783942716"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ResplendentMentor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ResplendentMentor.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Resplendent Mentor
+ * {4}{W}
+ * Creature — Kithkin Cleric
+ * 2 / 2
+ *
+ * White creatures you control have "{T}: You gain 1 life."
+ *
+ * - The quoted ability is a real granted [ActivatedAbility] ([GrantActivatedAbility] over a group,
+ *   like Citanul Hierophants), not a keyword or a trigger: each white creature gets its own
+ *   instance, so each can be tapped for the life independently and is summoning-sickness-gated on
+ *   its own.
+ * - No "Other": the Mentor is white itself, so the [GroupFilter] deliberately has no `excludeSelf`
+ *   and it gains the ability as well.
+ * - "You" in the granted ability is the ability's controller, which is [Effects.GainLife]'s default
+ *   `EffectTarget.Controller` — so a creature that changes controller gains life for its *new*
+ *   controller.
+ */
+val ResplendentMentor = card("Resplendent Mentor") {
+    manaCost = "{4}{W}"
+    typeLine = "Creature — Kithkin Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "White creatures you control have \"{T}: You gain 1 life.\""
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Tap,
+                effect = Effects.GainLife(1)
+            ),
+            filter = GroupFilter(GameObjectFilter.Creature.withColor(Color.WHITE).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "19"
+        artist = "Franz Vohwinkel"
+        flavorText = "Thoughtweft gives new meaning to the phrase \"common knowledge.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be87e59d-422c-4dd7-8867-423e784830a2.jpg?1783942766"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/RevelsongHorn.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/RevelsongHorn.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Revelsong Horn
+ * {2}
+ * Artifact
+ *
+ * {1}, {T}, Tap an untapped creature you control: Target creature gets +1/+1 until end of turn.
+ *
+ * - Three cost atoms in printed order: the mana, the Horn's own {T}, and a *separate*
+ *   [Costs.TapPermanents] for the creature. `Costs.Tap` is the `{T}` symbol on the source;
+ *   `Costs.TapPermanents(1, …)` is the "tap an untapped creature you control" clause, which is a
+ *   different cost and can be paid with a summoning-sick creature (CR 302.6 only gates `{T}` in the
+ *   creature's *own* ability).
+ * - The tapped creature may be any creature you control, including one already chosen as the
+ *   ability's target — the printed line puts no restriction on the overlap.
+ * - [Effects.ModifyStats] defaults to `Duration.EndOfTurn`, which is the printed "until end of turn".
+ */
+val RevelsongHorn = card("Revelsong Horn") {
+    manaCost = "{2}"
+    typeLine = "Artifact"
+    oracleText = "{1}, {T}, Tap an untapped creature you control: Target creature gets +1/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.Tap,
+            Costs.TapPermanents(1, GameObjectFilter.Creature)
+        )
+        target = Targets.Creature
+        effect = Effects.ModifyStats(1, 1, EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "261"
+        artist = "Franz Vohwinkel"
+        flavorText = "A deflated sigh breathed into the horn emerges as an inspiring melody."
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/10a4801c-fa69-47a0-bdfa-f5f110fd0976.jpg?1783942710"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/RoughshodMentor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/RoughshodMentor.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Roughshod Mentor
+ * {5}{G}
+ * Creature — Giant Warrior
+ * 5 / 4
+ *
+ * Green creatures you control have trample.
+ *
+ * - No "Other": the Mentor is green itself, so the [GroupFilter] deliberately has no `excludeSelf`
+ *   and it grants trample to itself as well.
+ * - Trample is granted, not printed, so it goes through [GrantKeyword] rather than `keywords(...)`.
+ * - The colour test goes through the group filter so it reads projected state — a creature that is
+ *   only green because of a continuous effect gains trample too.
+ */
+val RoughshodMentor = card("Roughshod Mentor") {
+    manaCost = "{5}{G}"
+    typeLine = "Creature — Giant Warrior"
+    power = 5
+    toughness = 4
+    oracleText = "Green creatures you control have trample."
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.TRAMPLE,
+            GroupFilter(GameObjectFilter.Creature.withColor(Color.GREEN).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "128"
+        artist = "Steven Belledin"
+        flavorText = "He didn't hear the cries of the treefolk whose branches he snapped or of the elves caught underfoot. He had eyes only for the path ahead."
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abe77862-516f-4eb2-9a41-0c6401d02843.jpg?1783942740"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/RuneCervinRider.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/RuneCervinRider.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rune-Cervin Rider
+ * {3}{W}
+ * Creature — Elf Knight
+ * 2 / 2
+ *
+ * Flying
+ * {G/W}{G/W}: This creature gets +1/+1 until end of turn.
+ *
+ * - Both hybrid symbols stay in the activation cost as written; each `{G/W}` is independently
+ *   payable with {G} or {W}.
+ * - No target: "this creature" is the source, so the pump uses [EffectTarget.Self].
+ */
+val RuneCervinRider = card("Rune-Cervin Rider") {
+    manaCost = "{3}{W}"
+    typeLine = "Creature — Elf Knight"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "{G/W}{G/W}: This creature gets +1/+1 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{G/W}{G/W}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "Dan Murayama Scott"
+        flavorText = "Things of beauty are in constant peril. The riders whisk them to safety, ahead of the encroaching darkness."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d9574f6-40b3-4fe2-950c-234bc358ecf6.jpg?1783942766"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/RustrazorButcher.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/RustrazorButcher.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rustrazor Butcher
+ * {1}{R}
+ * Creature — Goblin Warrior
+ * 1 / 2
+ *
+ * First strike
+ * Wither (This deals damage to creatures in the form of -1/-1 counters.)
+ *
+ * - Keyword-only creature. The two keywords combine in the engine's own damage steps: the
+ *   first-strike damage is what gets converted into -1/-1 counters, so neither needs scripting.
+ */
+val RustrazorButcher = card("Rustrazor Butcher") {
+    manaCost = "{1}{R}"
+    typeLine = "Creature — Goblin Warrior"
+    power = 1
+    toughness = 2
+    oracleText = "First strike\n" +
+        "Wither (This deals damage to creatures in the form of -1/-1 counters.)"
+
+    keywords(Keyword.FIRST_STRIKE, Keyword.WITHER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Ron Spencer"
+        flavorText = "A Bloodwort's blade is salted with blood and peppered with rust, seasoning and slaughtering in a single swipe."
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/daa0dd3e-51d1-4d75-b0f4-835992f420d6.jpg?1783942745"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SafeholdDuo.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SafeholdDuo.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Safehold Duo
+ * {3}{G/W}
+ * Creature — Elf Warrior Shaman
+ * 2 / 4
+ *
+ * Whenever you cast a green spell, this creature gets +1/+1 until end of turn.
+ * Whenever you cast a white spell, this creature gains vigilance until end of turn.
+ *
+ * - Both triggers are `Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(...))`:
+ *   "a green spell" is not limited to creature spells, so the filter stays `Any`.
+ * - A spell that is both green and white triggers both abilities — correct for the Duo cycle.
+ * - `EffectTarget.Self` with the facades' default `Duration.EndOfTurn` gives the printed wording.
+ */
+val SafeholdDuo = card("Safehold Duo") {
+    manaCost = "{3}{G/W}"
+    typeLine = "Creature — Elf Warrior Shaman"
+    power = 2
+    toughness = 4
+    oracleText = "Whenever you cast a green spell, this creature gets +1/+1 until end of turn.\n" +
+        "Whenever you cast a white spell, this creature gains vigilance until end of turn."
+
+    // Whenever you cast a green spell, this creature gets +1/+1 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(Color.GREEN))
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    // Whenever you cast a white spell, this creature gains vigilance until end of turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(Color.WHITE))
+        effect = Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "238"
+        artist = "Izzy"
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/32b70339-9918-4f7e-9cd0-d4ce36b65997.jpg?1783942715"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SafeholdElite.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SafeholdElite.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Safehold Elite
+ * {1}{G/W}
+ * Creature — Elf Scout
+ * 2 / 2
+ *
+ * Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield
+ * under its owner's control with a -1/-1 counter on it.)
+ *
+ * - Persist is engine-live: [Keyword.PERSIST] is read by the death-trigger detector, so the keyword
+ *   alone carries the whole behaviour. No triggered ability is authored for the reminder text.
+ */
+val SafeholdElite = card("Safehold Elite") {
+    manaCost = "{1}{G/W}"
+    typeLine = "Creature — Elf Scout"
+    power = 2
+    toughness = 2
+    oracleText = "Persist (When this creature dies, if it had no -1/-1 counters on it, return it " +
+        "to the battlefield under its owner's control with a -1/-1 counter on it.)"
+
+    keywords(Keyword.PERSIST)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "239"
+        artist = "Richard Whitters"
+        flavorText = "\"I refuse to die—not at the hands of one such as you.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/14dee5be-94fd-4b5d-9265-edd1b58c8026.jpg?1783942714"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SafeholdSentry.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SafeholdSentry.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Safehold Sentry
+ * {1}{W}
+ * Creature — Elf Warrior
+ * 2 / 2
+ *
+ * {2}{W}, {Q}: This creature gets +0/+2 until end of turn. ({Q} is the untap symbol.)
+ *
+ * - `{Q}` is [Costs.Untap]: the Sentry must already be **tapped** to pay it (so the pump is
+ *   normally a follow-up to attacking), and CR 302.6 gates the untap symbol behind summoning
+ *   sickness exactly like `{T}`.
+ * - "This creature" is the source, so the modifier lands on [EffectTarget.Self] and the ability
+ *   takes no target.
+ * - [Effects.ModifyStats] defaults to `Duration.EndOfTurn`, the printed duration.
+ */
+val SafeholdSentry = card("Safehold Sentry") {
+    manaCost = "{1}{W}"
+    typeLine = "Creature — Elf Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "{2}{W}, {Q}: This creature gets +0/+2 until end of turn. ({Q} is the untap symbol.)"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{W}"), Costs.Untap)
+        effect = Effects.ModifyStats(0, 2, EffectTarget.Self)
+        description = "{2}{W}, {Q}: This creature gets +0/+2 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "22"
+        artist = "William O'Connor"
+        flavorText = "\"These bracers were worn by my father and by his mother before him. Boggart fangs have shattered on them. Cinder flames have withered at their touch. While I wear them, the safehold will not fall.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/caa8bd74-9897-4515-b1a0-50d5f1bda673.jpg?1783942764"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Scar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Scar.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scar
+ * {B/R}
+ * Instant
+ *
+ * Put a -1/-1 counter on target creature.
+ *
+ * - [Counters.MINUS_ONE_MINUS_ONE] is the canonical `-1/-1` string constant; spelling the
+ *   counter type by hand is the classic way to end up with a counter the engine treats as a
+ *   bespoke named counter instead of the real one.
+ * - The counter is a permanent stat change, not a until-end-of-turn pump, so no duration is
+ *   involved — and a creature reduced to 0 toughness dies to state-based actions.
+ */
+val Scar = card("Scar") {
+    manaCost = "{B/R}"
+    typeLine = "Instant"
+    oracleText = "Put a -1/-1 counter on target creature."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "194"
+        artist = "Pete Venters"
+        flavorText = "\"What is a scar? A sign of courage in the face of danger? A mere trick of flesh? Or a constant reminder of agonizing pain, and the follies of war.\"\n" +
+            "—Illulia of Nighthearth"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b34e3f7c-468a-456c-8ed0-0cb88f6d86fc.jpg?1783942724"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ScuzzbackMarauders.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ScuzzbackMarauders.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scuzzback Marauders
+ * {4}{R/G}
+ * Creature — Goblin Warrior
+ * 5 / 2
+ *
+ * Trample
+ * Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield
+ * under its owner's control with a -1/-1 counter on it.)
+ *
+ * - Both abilities are plain keywords; trample first, then persist, matching the printed order Assay
+ *   reads off the oracle text.
+ * - Persist is engine-live: [Keyword.PERSIST] is read by the death-trigger detector, so the keyword
+ *   alone carries the whole behaviour. No triggered ability is authored for the reminder text.
+ */
+val ScuzzbackMarauders = card("Scuzzback Marauders") {
+    manaCost = "{4}{R/G}"
+    typeLine = "Creature — Goblin Warrior"
+    power = 5
+    toughness = 2
+    oracleText = "Trample\n" +
+        "Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the " +
+        "battlefield under its owner's control with a -1/-1 counter on it.)"
+
+    keywords(Keyword.TRAMPLE, Keyword.PERSIST)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "216"
+        artist = "Pete Venters"
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/6738d2b7-2773-4146-8f95-8d95b8402266.jpg?1783942720"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ScuzzbackScrapper.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ScuzzbackScrapper.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scuzzback Scrapper
+ * {R/G}
+ * Creature — Goblin Warrior
+ * 1 / 1
+ *
+ * Wither (This deals damage to creatures in the form of -1/-1 counters.)
+ *
+ * - Keyword-only creature: [Keyword.WITHER] is engine-live, so the reminder text needs no separate
+ *   replacement effect.
+ */
+val ScuzzbackScrapper = card("Scuzzback Scrapper") {
+    manaCost = "{R/G}"
+    typeLine = "Creature — Goblin Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "Wither (This deals damage to creatures in the form of -1/-1 counters.)"
+
+    keywords(Keyword.WITHER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "217"
+        artist = "Scott Altmann"
+        flavorText = "The Scuzzback gang scavenges rusty armor covered in barbed protrusions. No threat is more effective than the threat of infection."
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e2ed66f-75bd-43d8-90c4-cb0a5827b2f0.jpg?1783942719"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SeedcradleWitch.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SeedcradleWitch.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seedcradle Witch
+ * {G/W}
+ * Creature — Elf Shaman
+ * 1 / 1
+ *
+ * {2}{G}{W}: Target creature gets +3/+3 until end of turn. Untap that creature.
+ *
+ * - "That creature" in the second sentence is the same object as the first sentence's target, so
+ *   both halves reference the one named target rather than declaring a second one.
+ * - Ordered composite: the pump resolves before the untap, matching the printed sentence order.
+ *   The untap is unconditional — it happens even if the creature is already untapped.
+ * - The activation cost is the printed hybrid-free `{2}{G}{W}`; only the card's own mana cost is
+ *   hybrid.
+ */
+val SeedcradleWitch = card("Seedcradle Witch") {
+    manaCost = "{G/W}"
+    typeLine = "Creature — Elf Shaman"
+    power = 1
+    toughness = 1
+    oracleText = "{2}{G}{W}: Target creature gets +3/+3 until end of turn. Untap that creature."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}{W}")
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 3, creature),
+            Effects.Untap(creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "241"
+        artist = "Steven Belledin"
+        flavorText = "She whispered a prayer for strength, and her wishes wafted away like seeds on the wind."
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a0ae8525-ce10-40bd-8980-a05fb81a0fac.jpg?1783942714"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ShadowmoorBasicLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ShadowmoorBasicLands.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/** Shadowmoor's four art variants for each basic land type (collector numbers 282–301). */
+val Plains282 = basicLand("Plains") {
+    collectorNumber = "282"
+    artist = "Omar Rayyan"
+    imageUri = "https://cards.scryfall.io/normal/front/a/d/adf67e21-3306-4c4e-a021-9b997cc8c48c.jpg?1783942704"
+}
+
+val Plains283 = basicLand("Plains") {
+    collectorNumber = "283"
+    artist = "Lars Grant-West"
+    imageUri = "https://cards.scryfall.io/normal/front/b/2/b2a646c9-8347-4b62-829e-6af6b275346a.jpg?1783942704"
+}
+
+val Plains284 = basicLand("Plains") {
+    collectorNumber = "284"
+    artist = "Dave Kendall"
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1b104eb8-7095-4aba-a155-d8e147639692.jpg?1783942704"
+}
+
+val Plains285 = basicLand("Plains") {
+    collectorNumber = "285"
+    artist = "Larry MacDougall"
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/19ba7ff5-7f2a-4268-9bdd-96061ce5e86a.jpg?1783942704"
+}
+
+val Island286 = basicLand("Island") {
+    collectorNumber = "286"
+    artist = "Omar Rayyan"
+    imageUri = "https://cards.scryfall.io/normal/front/9/8/98d84005-faac-4e02-9fea-40757b43cf03.jpg?1783942703"
+}
+
+val Island287 = basicLand("Island") {
+    collectorNumber = "287"
+    artist = "Warren Mahy"
+    imageUri = "https://cards.scryfall.io/normal/front/9/a/9ae96b4b-7568-4463-b26c-a567e4a418d7.jpg?1783942703"
+}
+
+val Island288 = basicLand("Island") {
+    collectorNumber = "288"
+    artist = "Brandon Kitkouski"
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/196a004a-ec08-4e1b-8eeb-2ad766fccd25.jpg?1783942703"
+}
+
+val Island289 = basicLand("Island") {
+    collectorNumber = "289"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/2/8/28da317c-8512-4342-9be5-d14b87a509c7.jpg?1783942703"
+}
+
+val Swamp290 = basicLand("Swamp") {
+    collectorNumber = "290"
+    artist = "Lars Grant-West"
+    imageUri = "https://cards.scryfall.io/normal/front/4/3/4324380c-68b8-4955-ad92-76f921e6ffc1.jpg?1783942703"
+}
+
+val Swamp291 = basicLand("Swamp") {
+    collectorNumber = "291"
+    artist = "Warren Mahy"
+    imageUri = "https://cards.scryfall.io/normal/front/3/a/3a310639-99ca-4a7e-9f65-731779f3ea46.jpg?1783942702"
+}
+
+val Swamp292 = basicLand("Swamp") {
+    collectorNumber = "292"
+    artist = "rk post"
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1ee0be63-ec99-4291-b504-e17061c15a67.jpg?1783942701"
+}
+
+val Swamp293 = basicLand("Swamp") {
+    collectorNumber = "293"
+    artist = "Chippy"
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a1d2dedf-d0d8-42c5-a498-31e172a1b503.jpg?1783942702"
+}
+
+val Mountain294 = basicLand("Mountain") {
+    collectorNumber = "294"
+    artist = "Dave Kendall"
+    imageUri = "https://cards.scryfall.io/normal/front/0/4/0497551e-eb90-48db-90e9-0f917da41d9e.jpg?1783942701"
+}
+
+val Mountain295 = basicLand("Mountain") {
+    collectorNumber = "295"
+    artist = "Brandon Kitkouski"
+    imageUri = "https://cards.scryfall.io/normal/front/7/2/72cc8e7e-3d78-456a-b4ef-c9f2eaa6ec7c.jpg?1783942701"
+}
+
+val Mountain296 = basicLand("Mountain") {
+    collectorNumber = "296"
+    artist = "rk post"
+    imageUri = "https://cards.scryfall.io/normal/front/7/d/7d671616-f58c-4ee9-9ed7-78ebc385948a.jpg?1783942701"
+}
+
+val Mountain297 = basicLand("Mountain") {
+    collectorNumber = "297"
+    artist = "Steve Prescott"
+    imageUri = "https://cards.scryfall.io/normal/front/d/8/d8a63f1a-8224-4c66-9a3a-6c04c656c73b.jpg?1783942700"
+}
+
+val Forest298 = basicLand("Forest") {
+    collectorNumber = "298"
+    artist = "Larry MacDougall"
+    imageUri = "https://cards.scryfall.io/normal/front/b/7/b763764f-efb0-48c6-b353-1831164c2db5.jpg?1783942701"
+}
+
+val Forest299 = basicLand("Forest") {
+    collectorNumber = "299"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/4/f/4fa690e4-dbc8-4490-8958-6eb323a05daa.jpg?1783942701"
+}
+
+val Forest300 = basicLand("Forest") {
+    collectorNumber = "300"
+    artist = "Chippy"
+    imageUri = "https://cards.scryfall.io/normal/front/b/6/b6424d21-d852-4af5-96d7-cda2ba0e5912.jpg?1783942700"
+}
+
+val Forest301 = basicLand("Forest") {
+    collectorNumber = "301"
+    artist = "Steve Prescott"
+    imageUri = "https://cards.scryfall.io/normal/front/6/2/62131862-1256-4082-a83d-a0048714acb1.jpg?1783942700"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SickleRipper.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SickleRipper.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sickle Ripper
+ * {1}{B}
+ * Creature — Elemental Warrior
+ * 2 / 1
+ *
+ * Wither (This deals damage to creatures in the form of -1/-1 counters.)
+ *
+ * - Keyword-only creature: [Keyword.WITHER] is engine-live, so the reminder text needs no separate
+ *   replacement effect.
+ */
+val SickleRipper = card("Sickle Ripper") {
+    manaCost = "{1}{B}"
+    typeLine = "Creature — Elemental Warrior"
+    power = 2
+    toughness = 1
+    oracleText = "Wither (This deals damage to creatures in the form of -1/-1 counters.)"
+
+    keywords(Keyword.WITHER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "77"
+        artist = "Dan Murayama Scott"
+        flavorText = "His sickle was forged in the heat of another cinder's funeral pyre."
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e07c4e5f-5de7-45ec-b502-0e6d7c5c359d.jpg?1783942752"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SilkbindFaerie.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SilkbindFaerie.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silkbind Faerie
+ * {2}{W/U}
+ * Creature — Faerie Rogue
+ * 1 / 3
+ *
+ * Flying
+ * {1}{W/U}, {Q}: Tap target creature. ({Q} is the untap symbol.)
+ *
+ * - `{Q}` is [Costs.Untap]: the Faerie must already be **tapped** to pay it, and CR 302.6 gates the
+ *   untap symbol behind summoning sickness just like `{T}`. The usual line is to attack, then untap
+ *   during your untap step and tap a blocker on the next turn.
+ * - The target is any creature, not just an opponent's — the printed text has no controller
+ *   restriction, so it is the bare [Targets.Creature] requirement.
+ * - The `{W/U}` pip in the activation cost stays hybrid in the string; either {W} or {U} pays it.
+ */
+val SilkbindFaerie = card("Silkbind Faerie") {
+    manaCost = "{2}{W/U}"
+    typeLine = "Creature — Faerie Rogue"
+    power = 1
+    toughness = 3
+    oracleText = "Flying\n" +
+        "{1}{W/U}, {Q}: Tap target creature. ({Q} is the untap symbol.)"
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W/U}"), Costs.Untap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.Tap(t)
+        description = "{1}{W/U}, {Q}: Tap target creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Matt Cavotta"
+        flavorText = "\"The bigger they are, the more fun it is to watch them fall flat on their faces.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/12d06328-a124-40e4-a9d8-2342a881970e.jpg?1783942736"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SmolderInitiate.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SmolderInitiate.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Smolder Initiate
+ * {B}
+ * Creature — Elemental Shaman
+ * 1 / 1
+ *
+ * Whenever a player casts a black spell, you may pay {1}. If you do, target player loses 1 life.
+ *
+ * - "A player" is *every* player, the Initiate's controller included, so this is
+ *   [Triggers.anyPlayerCasts] (ANY binding) rather than a "whenever you cast" trigger.
+ * - "Target player" is unrestricted ([Targets.Player]) — you may point it at yourself. It is chosen
+ *   when the ability goes on the stack, before the optional {1} is paid.
+ * - "You may pay {1}. If you do, …" is the [MayPayManaEffect] gate; the life loss is the gate's
+ *   `then`, so declining does nothing.
+ */
+val SmolderInitiate = card("Smolder Initiate") {
+    manaCost = "{B}"
+    typeLine = "Creature — Elemental Shaman"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever a player casts a black spell, you may pay {1}. If you do, target player loses 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.anyPlayerCasts(GameObjectFilter.Any.withColor(Color.BLACK))
+        val player = target("target", Targets.Player)
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}"),
+            effect = Effects.LoseLife(1, player)
+        )
+        description = "Whenever a player casts a black spell, you may pay {1}. If you do, " +
+            "target player loses 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "78"
+        artist = "Chippy"
+        flavorText = "\"Life is a circle. Death is a vicious circle.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/16ecbed3-3a41-4823-8cd2-498daaaa0d4f.jpg?1783942752"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Somnomancer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Somnomancer.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Somnomancer
+ * {1}{W/U}
+ * Creature — Kithkin Wizard
+ * 2 / 1
+ *
+ * When this creature enters, you may tap target creature.
+ *
+ * - The target is mandatory at announcement even though the tap is optional: the trigger carries a
+ *   `targetRequirement`, so a creature must be chosen when the ability goes on the stack, and the
+ *   "you may" is only the resolution-time yes/no (`optional = true` lowers to a `Gate.MayDecide`).
+ * - Any creature is legal, including one you control — the printed line has no controller clause.
+ */
+val Somnomancer = card("Somnomancer") {
+    manaCost = "{1}{W/U}"
+    typeLine = "Creature — Kithkin Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature enters, you may tap target creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val creature = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Tap(creature)
+        description = "When this creature enters, you may tap target creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "149"
+        artist = "Lars Grant-West"
+        flavorText = "\"Are you tired? You look tired.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/eaf51122-fd7c-40b5-b759-65e21c28e3d6.jpg?1783942735"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Sootwalkers.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/Sootwalkers.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Sootwalkers
+ * {2}{B/R}{B/R}
+ * Creature — Elemental Rogue
+ * 3 / 3
+ *
+ * This creature can't be blocked by white creatures.
+ *
+ * - The evasion is a single [CantBeBlockedBy] static over a coloured *creature* filter, evaluated
+ *   against projected state so a blocker's current colour decides, not its printed one.
+ * - The hybrid cost `{B/R}` goes in `manaCost` verbatim; mana value (4) is derived by the parser.
+ */
+val Sootwalkers = card("Sootwalkers") {
+    manaCost = "{2}{B/R}{B/R}"
+    typeLine = "Creature — Elemental Rogue"
+    power = 3
+    toughness = 3
+    oracleText = "This creature can't be blocked by white creatures."
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.withColor(Color.WHITE))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "196"
+        artist = "Nils Hamm"
+        flavorText = "\"Why allow the fires of others to burn, when ours do not? Why leave them content, while we suffer? If there is to be misery, let it be borne by all.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f36c7932-cc1e-4b1f-ae39-2f04b84bcddb.jpg?1783942724"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SpectralProcession.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/SpectralProcession.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spectral Procession
+ * {2/W}{2/W}{2/W}
+ * Sorcery
+ *
+ * Create three 1/1 white Spirit creature tokens with flying.
+ *
+ * - Monocoloured hybrid ("twobrid") goes into `manaCost` verbatim; the three {2/W} symbols give
+ *   this a mana value of 6, which the parser derives — nothing is overridden.
+ * - One [Effects.CreateToken] with `count = 3` rather than three separate effects: the tokens are
+ *   identical, and a single effect keeps "create three" as one event for triggers that count them.
+ */
+val SpectralProcession = card("Spectral Procession") {
+    manaCost = "{2/W}{2/W}{2/W}"
+    typeLine = "Sorcery"
+    oracleText = "Create three 1/1 white Spirit creature tokens with flying."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            keywords = setOf(Keyword.FLYING),
+            count = 3
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "23"
+        artist = "Jeremy Enecio"
+        flavorText = "\"The dead have it easy. They suffer no more. If breaking their rest helps the living, so be it.\"\n" +
+            "—Olka, mistmeadow witch"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e26bd0c-5ec7-4653-8e63-747157c20af1.jpg?1783942765"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/TattermungeDuo.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/TattermungeDuo.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tattermunge Duo
+ * {2}{R/G}
+ * Creature — Goblin Warrior Shaman
+ * 2 / 3
+ *
+ * Whenever you cast a red spell, this creature gets +1/+1 until end of turn.
+ * Whenever you cast a green spell, this creature gains forestwalk until end of turn. (It can't be
+ * blocked as long as defending player controls a Forest.)
+ *
+ * - Both triggers are `Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(...))`:
+ *   "a red spell" covers every card type, so the filter stays `Any`.
+ * - A spell that is both red and green triggers both abilities — correct for the Duo cycle.
+ * - Forestwalk is granted with the plain `Effects.GrantKeyword` facade (as Unseen Walker does);
+ *   the landwalk evasion check reads runtime-granted keywords.
+ */
+val TattermungeDuo = card("Tattermunge Duo") {
+    manaCost = "{2}{R/G}"
+    typeLine = "Creature — Goblin Warrior Shaman"
+    power = 2
+    toughness = 3
+    oracleText = "Whenever you cast a red spell, this creature gets +1/+1 until end of turn.\n" +
+        "Whenever you cast a green spell, this creature gains forestwalk until end of turn. (It can't be blocked as long as defending player controls a Forest.)"
+
+    // Whenever you cast a red spell, this creature gets +1/+1 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(Color.RED))
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    // Whenever you cast a green spell, this creature gains forestwalk until end of turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(Color.GREEN))
+        effect = Effects.GrantKeyword(Keyword.FORESTWALK, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "218"
+        artist = "Jesper Ejsing"
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/ac93faba-8b40-48f4-b4eb-7c8677ed07e2.jpg?1783942719"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ThistledownDuo.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ThistledownDuo.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Thistledown Duo
+ * {2}{W/U}
+ * Creature — Kithkin Soldier Wizard
+ * 2 / 2
+ *
+ * Whenever you cast a white spell, this creature gets +1/+1 until end of turn.
+ * Whenever you cast a blue spell, this creature gains flying until end of turn.
+ *
+ * - Both triggers are `Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(...))`:
+ *   "a white spell" is not limited to creature spells, so the filter stays `Any`.
+ * - A spell that is both white and blue triggers both abilities — correct for the Duo cycle.
+ * - `EffectTarget.Self` with the facades' default `Duration.EndOfTurn` gives the printed wording.
+ */
+val ThistledownDuo = card("Thistledown Duo") {
+    manaCost = "{2}{W/U}"
+    typeLine = "Creature — Kithkin Soldier Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever you cast a white spell, this creature gets +1/+1 until end of turn.\n" +
+        "Whenever you cast a blue spell, this creature gains flying until end of turn."
+
+    // Whenever you cast a white spell, this creature gets +1/+1 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(Color.WHITE))
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    // Whenever you cast a blue spell, this creature gains flying until end of turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.withColor(Color.BLUE))
+        effect = Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "152"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d57ba0ce-0390-42fd-9473-2436fac53631.jpg?1783942735"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ThistledownLiege.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ThistledownLiege.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Thistledown Liege
+ * {1}{W/U}{W/U}{W/U}
+ * Creature — Kithkin Knight
+ * 1 / 3
+ *
+ * Flash
+ * Other white creatures you control get +1/+1.
+ * Other blue creatures you control get +1/+1.
+ *
+ * - Two deliberately separate [ModifyStats] statics, exactly as on Wilt-Leaf Liege: they stack, so
+ *   a creature you control that is both white *and* blue gets +2/+2.
+ * - `excludeSelf = true` carries the printed "Other" — the Liege is white *and* blue itself, so
+ *   without it it would pump itself twice.
+ * - The colour test reads projected state through the [GroupFilter], so a creature that only
+ *   becomes white or blue from a continuous effect is still pumped.
+ */
+val ThistledownLiege = card("Thistledown Liege") {
+    manaCost = "{1}{W/U}{W/U}{W/U}"
+    typeLine = "Creature — Kithkin Knight"
+    power = 1
+    toughness = 3
+    oracleText = "Flash\n" +
+        "Other white creatures you control get +1/+1.\n" +
+        "Other blue creatures you control get +1/+1."
+
+    keywords(Keyword.FLASH)
+
+    // Other white creatures you control get +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withColor(Color.WHITE).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    // Other blue creatures you control get +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withColor(Color.BLUE).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "153"
+        artist = "Adam Rex"
+        flavorText = "The thoughtweft is his informant, and he its devoted guardian."
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/20e34233-0972-4aa7-a5ab-eabed2235148.jpg?1783942735"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ThornwatchScarecrow.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ThornwatchScarecrow.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Thornwatch Scarecrow
+ * {6}
+ * Artifact Creature — Scarecrow
+ * 4 / 4
+ *
+ * This creature has wither as long as you control a green creature. (It deals damage to creatures
+ * in the form of -1/-1 counters.)
+ * This creature has vigilance as long as you control a white creature.
+ *
+ * - Two independent conditional statics, one per granted keyword — the clauses have separate
+ *   conditions and either can be on without the other.
+ * - [GroupFilter.source] scopes each grant to this creature alone, and the conditions re-evaluate
+ *   continuously: the keyword switches off the instant the last green or white creature leaves.
+ * - The colour checks read *creatures you control*, not permanents; a green artifact or land does
+ *   not turn wither on. [GameObjectFilter] filtering reads projected colour, so an animated or
+ *   colour-shifted creature counts.
+ */
+val ThornwatchScarecrow = card("Thornwatch Scarecrow") {
+    manaCost = "{6}"
+    typeLine = "Artifact Creature — Scarecrow"
+    power = 4
+    toughness = 4
+    oracleText = "This creature has wither as long as you control a green creature. (It deals damage to creatures in the form of -1/-1 counters.)\n" +
+        "This creature has vigilance as long as you control a white creature."
+
+    // This creature has wither as long as you control a green creature.
+    staticAbility {
+        ability = GrantKeyword(Keyword.WITHER, GroupFilter.source())
+        condition = Conditions.YouControl(GameObjectFilter.Creature.withColor(Color.GREEN))
+    }
+
+    // This creature has vigilance as long as you control a white creature.
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter.source())
+        condition = Conditions.YouControl(GameObjectFilter.Creature.withColor(Color.WHITE))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "265"
+        artist = "Chuck Lukacs"
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/3489ac0a-cbdb-43d5-be73-6cb65ae54a20.jpg?1783942708"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/TorporDust.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/TorporDust.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Torpor Dust
+ * {2}{U/B}
+ * Enchantment — Aura
+ *
+ * Flash
+ * Enchant creature
+ * Enchanted creature gets -3/-0.
+ *
+ * - "Enchant creature" is the `auraTarget`, not a targeting requirement on a spell effect: the Aura
+ *   picks its target on cast and attaches on resolution.
+ * - The penalty is a flat -3/-0 continuous effect over [GroupFilter.attachedCreature], so it tracks
+ *   the creature the Dust is currently attached to (including after a control change or a move).
+ * - Flash plus a power-only penalty is the printed combat trick: cast it after blockers, and the
+ *   creature survives (toughness untouched) but deals 3 less damage.
+ */
+val TorporDust = card("Torpor Dust") {
+    manaCost = "{2}{U/B}"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\n" +
+        "Enchant creature\n" +
+        "Enchanted creature gets -3/-0."
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(-3, 0, GroupFilter.attachedCreature())
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "177"
+        artist = "Jesper Ejsing"
+        flavorText = "\"Some folk these days are too restless to dream the dreams we need. We need to teach them to stop and catch their breath.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/8840551f-d43a-487f-a960-9b220dec5df4.jpg?1783942728"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/TripNoose.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/TripNoose.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Trip Noose
+ * {2}
+ * Artifact
+ *
+ * {2}, {T}: Tap target creature.
+ *
+ * - Ostiary Thrull's shape on an artifact body: a mana + `{T}` composite cost and a plain
+ *   [Effects.Tap] on the single target. The target may already be tapped — the printed line has no
+ *   "untapped" restriction, so the ability just does nothing in that case.
+ */
+val TripNoose = card("Trip Noose") {
+    manaCost = "{2}"
+    typeLine = "Artifact"
+    oracleText = "{2}, {T}: Tap target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        target = Targets.Creature
+        effect = Effects.Tap(EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "266"
+        artist = "Randy Gallegos"
+        flavorText = "A taut slipknot trigger is the only thing standing between you and standing."
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b2b3dd8-cedb-4577-8897-967952dd3c13.jpg?1783942709"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WanderbrineRootcutters.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WanderbrineRootcutters.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Wanderbrine Rootcutters
+ * {2}{U/B}{U/B}
+ * Creature — Merfolk Rogue
+ * 3 / 3
+ *
+ * This creature can't be blocked by green creatures.
+ *
+ * - The evasion is a single [CantBeBlockedBy] static over a coloured *creature* filter, evaluated
+ *   against projected state so a blocker's current colour decides, not its printed one.
+ * - The hybrid cost `{U/B}` goes in `manaCost` verbatim; mana value (4) is derived by the parser.
+ */
+val WanderbrineRootcutters = card("Wanderbrine Rootcutters") {
+    manaCost = "{2}{U/B}{U/B}"
+    typeLine = "Creature — Merfolk Rogue"
+    power = 3
+    toughness = 3
+    oracleText = "This creature can't be blocked by green creatures."
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.withColor(Color.GREEN))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "178"
+        artist = "Chippy"
+        flavorText = "Most dirtwalkers only know of the vicious merrows that dwell in the shallows. They can't begin to fathom the wickedness that skulks in the Dark Meanders."
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab739d64-cdcd-4f07-9854-e067c37c4f41.jpg?1783942728"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WaspLancer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WaspLancer.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wasp Lancer
+ * {U/B}{U/B}{U/B}
+ * Creature — Faerie Soldier
+ * 3 / 2
+ *
+ * Flying
+ *
+ * - Keyword-only creature: [Keyword.FLYING] is engine-live, so no scripted ability is needed.
+ */
+val WaspLancer = card("Wasp Lancer") {
+    manaCost = "{U/B}{U/B}{U/B}"
+    typeLine = "Creature — Faerie Soldier"
+    power = 3
+    toughness = 2
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "179"
+        artist = "Warren Mahy"
+        flavorText = "\"I doubt that faeries understand how short their lives are, compared to the rest of us. If they did, would they so readily charge into battle, heedless of the danger before them?\"\n" +
+            "—Awylla, elvish safewright"
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/ac48a4ff-433b-4fd0-b0d1-43b188ee81b6.jpg?1783942728"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WatchwingScarecrow.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WatchwingScarecrow.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Watchwing Scarecrow
+ * {4}
+ * Artifact Creature — Scarecrow
+ * 2 / 4
+ *
+ * This creature has vigilance as long as you control a white creature.
+ * This creature has flying as long as you control a blue creature.
+ *
+ * - Two independent conditional statics, one per granted keyword — the clauses have separate
+ *   conditions and either can be on without the other.
+ * - [GroupFilter.source] scopes each grant to this creature alone, and the conditions re-evaluate
+ *   continuously: losing your last blue creature takes flying straight back off, mid-combat
+ *   included (an already-declared block stays legal — blocking restrictions are only checked as
+ *   blockers are declared).
+ * - The colour checks read *creatures you control*, not permanents; a blue artifact or land does
+ *   not turn flying on. [GameObjectFilter] filtering reads projected colour, so an animated or
+ *   colour-shifted creature counts.
+ */
+val WatchwingScarecrow = card("Watchwing Scarecrow") {
+    manaCost = "{4}"
+    typeLine = "Artifact Creature — Scarecrow"
+    power = 2
+    toughness = 4
+    oracleText = "This creature has vigilance as long as you control a white creature.\n" +
+        "This creature has flying as long as you control a blue creature."
+
+    // This creature has vigilance as long as you control a white creature.
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter.source())
+        condition = Conditions.YouControl(GameObjectFilter.Creature.withColor(Color.WHITE))
+    }
+
+    // This creature has flying as long as you control a blue creature.
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING, GroupFilter.source())
+        condition = Conditions.YouControl(GameObjectFilter.Creature.withColor(Color.BLUE))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "268"
+        artist = "Chuck Lukacs"
+        flavorText = "The wings are held in place by wicker rods. The rods are held in place by pure faith."
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5c7774fd-3460-46e3-9c9c-7aa70f2ff6d8.jpg?1783942708"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WildslayerElves.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WildslayerElves.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wildslayer Elves
+ * {3}{G}
+ * Creature — Elf Warrior
+ * 3 / 3
+ *
+ * Wither (This deals damage to creatures in the form of -1/-1 counters.)
+ *
+ * - Keyword-only creature: [Keyword.WITHER] is engine-live, so the reminder text needs no separate
+ *   replacement effect.
+ */
+val WildslayerElves = card("Wildslayer Elves") {
+    manaCost = "{3}{G}"
+    typeLine = "Creature — Elf Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "Wither (This deals damage to creatures in the form of -1/-1 counters.)"
+
+    keywords(Keyword.WITHER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "133"
+        artist = "Dave Kendall"
+        flavorText = "Some elves battled too long in the deep shadow, their swords dipped too often in tainted flesh and poisoned blood."
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/3323467c-132f-469a-90fc-9d3b0fb004aa.jpg?1783942739"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WiltLeafCavaliers.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WiltLeafCavaliers.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wilt-Leaf Cavaliers
+ * {G/W}{G/W}{G/W}
+ * Creature — Elf Knight
+ * 3 / 4
+ *
+ * Vigilance
+ *
+ * - Keyword-only creature: [Keyword.VIGILANCE] is engine-live, so no scripted ability is needed.
+ */
+val WiltLeafCavaliers = card("Wilt-Leaf Cavaliers") {
+    manaCost = "{G/W}{G/W}{G/W}"
+    typeLine = "Creature — Elf Knight"
+    power = 3
+    toughness = 4
+    oracleText = "Vigilance"
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "244"
+        artist = "Steve Prescott"
+        flavorText = "Every elf in Shadowmoor is charged from birth with a terrible duty: to strike back against the ugliness and darkness, even though they are all around and seemingly without end."
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b8ffe320-c88a-4eb7-a091-e128e6c1f37c.jpg?1783942714"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WindbriskRaptor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WindbriskRaptor.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Windbrisk Raptor
+ * {5}{W}{W}
+ * Creature — Bird
+ * 5 / 7
+ *
+ * Flying
+ * Attacking creatures you control have lifelink.
+ *
+ * - "Attacking" is a *state* predicate on the group filter, not a duration: creatures gain lifelink
+ *   the moment they're declared as attackers and lose it when they stop attacking, which is the
+ *   same shape as Crossway Troublemakers.
+ * - No `excludeSelf` — the Raptor itself has lifelink while it is attacking.
+ */
+val WindbriskRaptor = card("Windbrisk Raptor") {
+    manaCost = "{5}{W}{W}"
+    typeLine = "Creature — Bird"
+    power = 5
+    toughness = 7
+    oracleText = "Flying\n" +
+        "Attacking creatures you control have lifelink."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.LIFELINK,
+            GroupFilter(GameObjectFilter.Creature.attacking().youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "26"
+        artist = "Omar Rayyan"
+        flavorText = "It awakened to gloom-fouled skies and responded with a righteous rage that shook the heavens."
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5df7b710-d44c-4ebc-be5b-f81d697086c4.jpg?1783942764"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WingrattleScarecrow.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/WingrattleScarecrow.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Wingrattle Scarecrow
+ * {3}
+ * Artifact Creature — Scarecrow
+ * 2 / 2
+ *
+ * This creature has flying as long as you control a blue creature.
+ * This creature has persist as long as you control a black creature. (When this creature dies, if
+ * it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a
+ * -1/-1 counter on it.)
+ *
+ * - Two independent conditional statics, one per granted keyword — the clauses have separate
+ *   conditions and either can be on without the other.
+ * - Persist is engine-live ([Keyword.PERSIST] is read by the death-trigger detector), so granting
+ *   the keyword is the whole implementation. Because persist is a leaves-the-battlefield trigger,
+ *   the game uses last known information: the Scarecrow persists only if you controlled a black
+ *   creature as it died.
+ * - The colour checks read *creatures you control*, not permanents; a blue artifact or land does
+ *   not turn flying on. [GameObjectFilter] filtering reads projected colour, so an animated or
+ *   colour-shifted creature counts.
+ */
+val WingrattleScarecrow = card("Wingrattle Scarecrow") {
+    manaCost = "{3}"
+    typeLine = "Artifact Creature — Scarecrow"
+    power = 2
+    toughness = 2
+    oracleText = "This creature has flying as long as you control a blue creature.\n" +
+        "This creature has persist as long as you control a black creature. (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)"
+
+    // This creature has flying as long as you control a blue creature.
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING, GroupFilter.source())
+        condition = Conditions.YouControl(GameObjectFilter.Creature.withColor(Color.BLUE))
+    }
+
+    // This creature has persist as long as you control a black creature.
+    staticAbility {
+        ability = GrantKeyword(Keyword.PERSIST, GroupFilter.source())
+        condition = Conditions.YouControl(GameObjectFilter.Creature.withColor(Color.BLACK))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "270"
+        artist = "Trevor Hairsine"
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61c5d86e-1ce1-4386-b70f-73b24351d6ae.jpg?1783942707"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ZealousGuardian.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/ZealousGuardian.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zealous Guardian
+ * {W/U}
+ * Creature — Kithkin Soldier
+ * 1 / 1
+ *
+ * Flash
+ *
+ * - Keyword-only creature: [Keyword.FLASH] is engine-live and carries the casting-timing
+ *   permission on its own, so no scripted ability is needed.
+ */
+val ZealousGuardian = card("Zealous Guardian") {
+    manaCost = "{W/U}"
+    typeLine = "Creature — Kithkin Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "Flash"
+
+    keywords(Keyword.FLASH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "157"
+        artist = "Steven Belledin"
+        flavorText = "Parapet watchers patrol the outer edges of the doun, signaling to others who wait patiently in shadow."
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/9951214b-43a9-4c51-bbb4-05bac81b9866.jpg?1783942733"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/GloomwidowReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/GloomwidowReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gloomwidow reprint in Shadows over Innistrad. The canonical CardDefinition lives in Shadowmoor
+ * (`definitions/shm/cards/Gloomwidow.kt`); this file contributes only per-printing presentation data.
+ */
+val GloomwidowReprint = Printing(
+    oracleId = "e5139376-cdb1-4f1e-b417-b956d6b713b9",
+    name = "Gloomwidow",
+    setCode = "SOI",
+    collectorNumber = "206",
+    scryfallId = "ee04dfd8-e704-46d7-bdf8-b0b2ee747a49",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/ee04dfd8-e704-46d7-bdf8-b0b2ee747a49.jpg?1783937730",
+    releaseDate = "2016-04-08",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BurnTrailScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BurnTrailScenarioTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CopyOfComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.state.components.stack.TargetsComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.shm.cards.BurnTrail
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Burn Trail (SHM) — {3}{R} Sorcery
+ *
+ * "Burn Trail deals 3 damage to any target.
+ *  Conspire (As you cast this spell, you may tap two untapped creatures you control that share a
+ *  color with it. When you do, copy it and you may choose a new target for the copy.)"
+ *
+ * Shadowmoor is the first set in the corpus to *print* conspire — the only prior coverage
+ * (`ConspireTest`) exercises the keyword **granted** by Raiding Schemes. The two paths differ:
+ * a granted conspire lives on `SpellGrantedKeywordsComponent`, while a printed one has to survive
+ * `CardBuilder`'s derivation of `Keyword.CONSPIRE` from `keywordAbility(KeywordAbility.Conspire)`
+ * into `CardDefinition.keywords`, which is what `GrantedKeywordResolver.hasKeyword` reads. These
+ * tests are that derivation's only end-to-end coverage.
+ *
+ * Burn Trail is a **sorcery**, which matters: `CastSpellHandler` only builds the conspire copy
+ * trigger when `cardDef.script.spellEffect != null`, so conspire on a permanent spell would tap
+ * the creatures and produce no copy. Every conspire card in Shadowmoor is an instant or a sorcery.
+ */
+class BurnTrailScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BurnTrail))
+        return driver
+    }
+
+    test("printed Conspire is derived onto the card's keywords") {
+        BurnTrail.keywords.contains(Keyword.CONSPIRE) shouldBe true
+    }
+
+    test("tapping two red creatures copies the spell and the copy can be retargeted") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+
+        // Two untapped red creatures — Burn Trail is red, so they share a color with it.
+        val goblin1 = driver.putCreatureOnBattlefield(caster, "Goblin Guide")
+        val goblin2 = driver.putCreatureOnBattlefield(caster, "Goblin Guide")
+        repeat(4) { driver.putLandOnBattlefield(caster, "Mountain") }
+        val burnTrail = driver.putCardInHand(caster, "Burn Trail")
+
+        driver.submit(
+            CastSpell(
+                playerId = caster,
+                cardId = burnTrail,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                paymentStrategy = PaymentStrategy.AutoPay,
+                conspiredCreatures = listOf(goblin1, goblin2)
+            )
+        ).isSuccess shouldBe true
+
+        // Conspire's additional cost taps both creatures.
+        driver.state.getEntity(goblin1)!!.has<TappedComponent>() shouldBe true
+        driver.state.getEntity(goblin2)!!.has<TappedComponent>() shouldBe true
+
+        // The reflexive "when you do" trigger resolves and pauses to retarget the copy.
+        var guard = 0
+        while (driver.state.pendingDecision !is ChooseTargetsDecision && guard < 20) {
+            driver.bothPass()
+            guard++
+        }
+        (driver.state.pendingDecision is ChooseTargetsDecision) shouldBe true
+
+        driver.submitTargetSelection(caster, listOf(caster)).isSuccess shouldBe true
+
+        val copyId = driver.state.stack.single { id ->
+            val e = driver.state.getEntity(id)
+            e?.get<SpellOnStackComponent>() != null && e.has<CopyOfComponent>()
+        }
+        driver.state.getEntity(copyId)!!.get<TargetsComponent>()?.targets shouldBe
+            listOf(ChosenTarget.Player(caster))
+    }
+
+    test("declining Conspire leaves the creatures untapped and makes no copy") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+
+        val goblin1 = driver.putCreatureOnBattlefield(caster, "Goblin Guide")
+        val goblin2 = driver.putCreatureOnBattlefield(caster, "Goblin Guide")
+        repeat(4) { driver.putLandOnBattlefield(caster, "Mountain") }
+        val burnTrail = driver.putCardInHand(caster, "Burn Trail")
+
+        driver.castSpell(caster, burnTrail, listOf(opponent)).isSuccess shouldBe true
+
+        driver.state.getEntity(goblin1)!!.has<TappedComponent>() shouldBe false
+        driver.state.getEntity(goblin2)!!.has<TappedComponent>() shouldBe false
+        driver.state.stack.any { driver.state.getEntity(it)?.has<CopyOfComponent>() == true } shouldBe false
+    }
+
+    test("Conspire rejects creatures that share no color with the spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+
+        val redGoblin = driver.putCreatureOnBattlefield(caster, "Goblin Guide")
+        // Centaur Courser is green — Burn Trail is mono-red, so this pairing is illegal.
+        val greenCentaur = driver.putCreatureOnBattlefield(caster, "Centaur Courser")
+        repeat(4) { driver.putLandOnBattlefield(caster, "Mountain") }
+        val burnTrail = driver.putCardInHand(caster, "Burn Trail")
+
+        driver.submit(
+            CastSpell(
+                playerId = caster,
+                cardId = burnTrail,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                paymentStrategy = PaymentStrategy.AutoPay,
+                conspiredCreatures = listOf(redGoblin, greenCentaur)
+            )
+        ).isSuccess shouldBe false
+    }
+})

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SilkbindFaerieScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SilkbindFaerieScenarioTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.shm.cards.SilkbindFaerie
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Silkbind Faerie (SHM) — {2}{W/U} 1/3 Creature — Faerie Rogue
+ *
+ * "Flying
+ *  {1}{W/U}, {Q}: Tap target creature. ({Q} is the untap symbol.)"
+ *
+ * Shadowmoor's untap-symbol cycle is the first *shipped* use of `Costs.Untap` (CR 107.6 / 702).
+ * Until now the only coverage of the `AbilityCost.Untap` branch was the synthetic "Test Untapper"
+ * in `ActivateAbilitiesAsThoughHastyTest`, so these tests are what a real card's `{Q}` rests on.
+ *
+ * Two properties are load-bearing and easy to get wrong:
+ * - `{Q}` means "untap this permanent", so the source must already be **tapped** to pay it.
+ * - CR 302.6 gates `{Q}` behind summoning sickness exactly as it gates `{T}`.
+ *
+ * Note what "not offered" means for a *composite* cost like this one. A bare `Costs.Untap` that
+ * can't be paid is dropped from the legal-action list outright, but `ActivatedAbilityEnumerator`
+ * surfaces an unpayable **composite** as a greyed-out `affordable = false` entry so the client can
+ * still show the player the ability exists. The contract these tests pin is therefore the pair that
+ * actually matters: no *affordable* activation, and `ActivateAbilityHandler` refusing the action.
+ */
+class SilkbindFaerieScenarioTest : FunSpec({
+
+    fun List<LegalAction>.activationsOf(sourceId: EntityId): List<LegalAction> =
+        filter { (it.action as? ActivateAbility)?.sourceId == sourceId }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SilkbindFaerie))
+        return driver
+    }
+
+    test("an untapped Silkbind Faerie cannot pay {Q}, so the ability is unaffordable and refused") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val faerie = driver.putCreatureOnBattlefield(you, "Silkbind Faerie")
+        val victim = driver.putCreatureOnBattlefield(driver.getOpponent(you), "Centaur Courser")
+        repeat(2) { driver.putLandOnBattlefield(you, "Plains") }
+        driver.removeSummoningSickness(faerie)
+
+        withClue("{Q} untaps the source, so an untapped source can't pay it") {
+            driver.legalActions(you).activationsOf(faerie).count { it.affordable } shouldBe 0
+        }
+        driver.submit(
+            ActivateAbility(
+                playerId = you,
+                sourceId = faerie,
+                abilityId = SilkbindFaerie.script.activatedAbilities.single().id,
+                targets = listOf(ChosenTarget.Permanent(victim))
+            )
+        ).isSuccess shouldBe false
+    }
+
+    test("a tapped, non-sick Silkbind Faerie untaps itself and taps the target") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        val faerie = driver.putCreatureOnBattlefield(you, "Silkbind Faerie")
+        val victim = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        repeat(2) { driver.putLandOnBattlefield(you, "Plains") }
+        driver.removeSummoningSickness(faerie)
+        driver.tapPermanent(faerie)
+
+        val offered = driver.legalActions(you).activationsOf(faerie)
+        withClue("a tapped, non-sick source should have its {Q} ability enumerated") {
+            offered.size shouldBe 1
+        }
+
+        driver.submit(
+            ActivateAbility(
+                playerId = you,
+                sourceId = faerie,
+                abilityId = SilkbindFaerie.script.activatedAbilities.single().id,
+                targets = listOf(ChosenTarget.Permanent(victim))
+            )
+        ).isSuccess shouldBe true
+
+        withClue("paying {Q} untaps the source as part of the cost") {
+            driver.state.getEntity(faerie)!!.has<TappedComponent>() shouldBe false
+        }
+
+        driver.bothPass()
+        withClue("the ability resolves and taps its target") {
+            driver.state.getEntity(victim)!!.has<TappedComponent>() shouldBe true
+        }
+    }
+
+    test("a summoning-sick Silkbind Faerie's {Q} ability is gated like {T} (CR 302.6)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val faerie = driver.putCreatureOnBattlefield(you, "Silkbind Faerie")
+        val victim = driver.putCreatureOnBattlefield(driver.getOpponent(you), "Centaur Courser")
+        repeat(2) { driver.putLandOnBattlefield(you, "Plains") }
+        driver.tapPermanent(faerie) // tapped, so the only thing left blocking it is sickness
+
+        withClue("a summoning-sick creature's {Q} ability must not be affordable") {
+            driver.legalActions(you).activationsOf(faerie).count { it.affordable } shouldBe 0
+        }
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = you,
+                sourceId = faerie,
+                abilityId = SilkbindFaerie.script.activatedAbilities.single().id,
+                targets = listOf(ChosenTarget.Permanent(victim))
+            )
+        ).error shouldBe "This creature has summoning sickness"
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/SHM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SHM.json
@@ -1,3 +1,897 @@
+// Aethertow
+{
+    "name": "Aethertow",
+    "manaCost": "{3}{W/U}",
+    "typeLine": "Instant",
+    "oracleText": "Put target attacking or blocking creature on top of its owner's library.\nConspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
+    "keywords": [
+        "CONSPIRE"
+    ],
+    "keywordAbilities": [
+        "Conspire"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Library",
+            "placement": "Top"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "artist": "Warren Mahy",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72a656e7-9c1c-40b6-91fe-0098f72d8384.jpg?1783942738"
+    }
+}
+
+// Apothecary Initiate
+{
+    "name": "Apothecary Initiate",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Kithkin Cleric",
+    "oracleText": "Whenever a player casts a white spell, you may pay {1}. If you do, you gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "WHITE"
+                            }
+                        ]
+                    },
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                "descriptionOverride": "Whenever a player casts a white spell, you may pay {1}. If you do, you gain 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "artist": "Kev Walker",
+        "flavorText": "Kithkin jealously hoard their knowledge of poultices and remedies so that no outside threat can benefit from their wisdom.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b6ae637-bdb7-4117-8539-e424159bad6f.jpg?1783942770"
+    }
+}
+
+// Ashenmoor Gouger
+{
+    "name": "Ashenmoor Gouger",
+    "manaCost": "{B/R}{B/R}{B/R}",
+    "typeLine": "Creature — Elemental Warrior",
+    "oracleText": "This creature can't block.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            "CantBlock"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "180",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Cavotta",
+        "flavorText": "After his hands had crumbled away, leaving only wickedly sharp points, he decided his only purpose was war.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/0/80c7931f-e979-4f43-81dd-c34166526f87.jpg?1783942728"
+    }
+}
+
+// Barkshell Blessing
+{
+    "name": "Barkshell Blessing",
+    "manaCost": "{G/W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 until end of turn.\nConspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
+    "keywords": [
+        "CONSPIRE"
+    ],
+    "keywordAbilities": [
+        "Conspire"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "artist": "Steven Belledin",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd273ef2-4aed-4c7e-8c97-fe8b1af9ce69.jpg?1783942718"
+    }
+}
+
+// Barrenton Cragtreads
+{
+    "name": "Barrenton Cragtreads",
+    "manaCost": "{2}{W/U}{W/U}",
+    "typeLine": "Creature — Kithkin Scout",
+    "oracleText": "This creature can't be blocked by red creatures.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasColor",
+                            "color": "RED"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "artist": "Daren Bader",
+        "flavorText": "\"Boggarts are easy to get around. Just toss some mutton in another direction. Giants are a little harder. You have to be quick to avoid their steps. Cinders are the difficult ones, but even they have fears to be exploited.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/361dab9e-22f0-45e4-a793-aa6c97a96781.jpg?1783942738"
+    }
+}
+
+// Blazethorn Scarecrow
+{
+    "name": "Blazethorn Scarecrow",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "This creature has haste as long as you control a red creature.\nThis creature has wither as long as you control a green creature. (It deals damage to creatures in the form of -1/-1 counters.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature red"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "WITHER",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature green"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "246",
+        "artist": "Dave Kendall",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/44793043-82b4-415b-a9ab-d564fdbcd314.jpg?1783942713"
+    }
+}
+
+// Blight Sickle
+{
+    "name": "Blight Sickle",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+0 and has wither. (It deals damage to creatures in the form of -1/-1 counters.)\nEquip {2}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "WITHER"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "247",
+        "artist": "John Avon",
+        "flavorText": "Its scars cut deeper than its blade.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c0f828c7-aedc-462b-8455-46e8a90feb85.jpg?1783942712"
+    }
+}
+
+// Blistering Dieflyn
+{
+    "name": "Blistering Dieflyn",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Imp",
+    "oracleText": "Flying\n{B/R}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B/R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "artist": "Scott Altmann",
+        "flavorText": "Any kithkin smith would love to catch a dieflyn for her kiln, relieving her of ever having to gather fuel again.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/5720a5b2-60ca-49f9-83e8-b801471c92ea.jpg?1783942751"
+    }
+}
+
+// Bloodmark Mentor
+{
+    "name": "Bloodmark Mentor",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Red creatures you control have first strike.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE",
+                "filter": {
+                    "baseFilter": "creature red ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "UNCOMMON",
+        "artist": "Dave Allsop",
+        "flavorText": "Boggarts divide the world into two categories: things you can eat, and things you have to chase down and pummel before you can eat.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/6322a389-44cc-4a3d-bd39-93c156640f8e.jpg?1783942750"
+    }
+}
+
+// Boartusk Liege
+{
+    "name": "Boartusk Liege",
+    "manaCost": "{1}{R/G}{R/G}{R/G}",
+    "typeLine": "Creature — Goblin Knight",
+    "oracleText": "Trample\nOther red creatures you control get +1/+1.\nOther green creatures you control get +1/+1.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature red ctrl:you",
+                    "excludeSelf": true
+                }
+            },
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature green ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "202",
+        "rarity": "RARE",
+        "artist": "Jesper Ejsing",
+        "flavorText": "The boar leads its rider to victory in battle, but it doesn't know how close it is to becoming the victory feast.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/318338f8-f52b-4b9a-8d38-08291bcc2e98.jpg?1783942723"
+    }
+}
+
+// Boggart Ram-Gang
+{
+    "name": "Boggart Ram-Gang",
+    "manaCost": "{R/G}{R/G}{R/G}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Haste\nWither (This deals damage to creatures in the form of -1/-1 counters.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "HASTE",
+        "WITHER"
+    ],
+    "metadata": {
+        "collectorNumber": "203",
+        "rarity": "UNCOMMON",
+        "artist": "Dave Allsop",
+        "flavorText": "\"We're going to need a bigger gate.\"\n—Bowen, Barrenton guardcaptain",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/63e25b70-fa21-4663-aabd-34b7e0b75c34.jpg?1783942723"
+    }
+}
+
+// Burn Trail
+{
+    "name": "Burn Trail",
+    "manaCost": "{3}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Burn Trail deals 3 damage to any target.\nConspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
+    "keywords": [
+        "CONSPIRE"
+    ],
+    "keywordAbilities": [
+        "Conspire"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "artist": "Nils Hamm",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f01f9a0-f1d0-4241-a270-df4ed673d1fd.jpg?1783942750"
+    }
+}
+
+// Cinderbones
+{
+    "name": "Cinderbones",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Elemental Skeleton",
+    "oracleText": "Wither (This deals damage to creatures in the form of -1/-1 counters.)\n{1}{B}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "WITHER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                },
+                "descriptionOverride": "{1}{B}: Regenerate this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "artist": "Carl Critchlow",
+        "flavorText": "Not all coals lie quietly in their beds of cold ash.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/2/22dcf40c-62fb-4205-807e-71655066a61b.jpg?1783942756"
+    }
+}
+
+// Corrosive Mentor
+{
+    "name": "Corrosive Mentor",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Elemental Rogue",
+    "oracleText": "Black creatures you control have wither. (They deal damage to creatures in the form of -1/-1 counters.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "WITHER",
+                "filter": {
+                    "baseFilter": "creature black ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "rarity": "UNCOMMON",
+        "artist": "Daarken",
+        "flavorText": "Guttering cinders stoke their dying flames by snuffing out the lights of others.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/140457ff-ee7d-48ec-8b91-ef5c2cc1ed74.jpg?1783942756"
+    }
+}
+
+// Crowd of Cinders
+{
+    "name": "Crowd of Cinders",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nCrowd of Cinders's power and toughness are each equal to the number of black permanents you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent black"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent black"
+            }
+        }
+    },
+    "keywords": [
+        "FEAR"
+    ],
+    "metadata": {
+        "collectorNumber": "63",
+        "rarity": "UNCOMMON",
+        "artist": "Carl Frank",
+        "flavorText": "They envy the life-giving heat so much that they tear it from those who still possess it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0dd88305-d57b-4e77-aec9-f0a3ace42c37.jpg?1783942755"
+    }
+}
+
+// Cultbrand Cinder
+{
+    "name": "Cultbrand Cinder",
+    "manaCost": "{4}{B/R}",
+    "typeLine": "Creature — Elemental Shaman",
+    "oracleText": "When this creature enters, put a -1/-1 counter on target creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "-1/-1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "When this creature enters, put a -1/-1 counter on target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "artist": "Christopher Moeller",
+        "flavorText": "\"Your seared flesh will be the first step in your journey to dark enlightenment.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6b80a10-a9a9-445e-8040-6cc0155271d8.jpg?1783942728"
+    }
+}
+
+// Deep-Slumber Titan
+{
+    "name": "Deep-Slumber Titan",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Giant Warrior",
+    "oracleText": "This creature enters tapped.\nThis creature doesn't untap during your untap step.\nWhenever this creature is dealt damage, untap it.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "flags": [
+        "DOESNT_UNTAP"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                },
+                "descriptionOverride": "Whenever this creature is dealt damage, untap it."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "rarity": "RARE",
+        "artist": "Steve Prescott",
+        "flavorText": "Do not disturb.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cbe3a68e-c29e-48a8-a2d7-49c8bff3dd8a.jpg?1783942749"
+    }
+}
+
+// Drove of Elves
+{
+    "name": "Drove of Elves",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf",
+    "oracleText": "Hexproof\nDrove of Elves's power and toughness are each equal to the number of green permanents you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent green"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent green"
+            }
+        }
+    },
+    "keywords": [
+        "HEXPROOF"
+    ],
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "UNCOMMON",
+        "artist": "Larry MacDougall",
+        "flavorText": "\"The light of beauty protects our journeys through darkness.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b657ad23-e84b-4b53-a6b6-80f359624ab8.jpg?1783942744"
+    }
+}
+
+// Elvish Hexhunter
+{
+    "name": "Elvish Hexhunter",
+    "manaCost": "{G/W}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "{G/W}, {T}, Sacrifice this creature: Destroy target enchantment.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G/W}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "enchantment"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "artist": "Alex Horley-Orlandelli",
+        "flavorText": "\"All manner of curses, blights, and luckspoils infect Shadowmoor. We stalk them all, one perilous quest at a time.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2b7f4d7-278b-45fc-98aa-b7c8b9162bcd.jpg?1783942717"
+    }
+}
+
+// Emberstrike Duo
+{
+    "name": "Emberstrike Duo",
+    "manaCost": "{1}{B/R}",
+    "typeLine": "Creature — Elemental Warrior Shaman",
+    "oracleText": "Whenever you cast a black spell, this creature gets +1/+1 until end of turn.\nWhenever you cast a red spell, this creature gains first strike until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "BLACK"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "RED"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "artist": "Aleksi Briclot",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9ccd4374-5339-4529-99f3-f7dcc939e874.jpg?1783942727"
+    }
+}
+
+// Faerie Swarm
+{
+    "name": "Faerie Swarm",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Faerie",
+    "oracleText": "Flying\nFaerie Swarm's power and toughness are each equal to the number of blue permanents you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent blue"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent blue"
+            }
+        }
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "37",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "Untouched by the Aurora, Oona's faeries greeted the night like any other day.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/90598bb2-d96c-4f74-864b-1947b7d39e58.jpg?1783942761"
+    }
+}
+
 // Farhaven Elf
 {
     "name": "Farhaven Elf",
@@ -71,6 +965,792 @@
     ]
 }
 
+// Flame Javelin
+{
+    "name": "Flame Javelin",
+    "manaCost": "{2/R}{2/R}{2/R}",
+    "typeLine": "Instant",
+    "oracleText": "({2/R} can be paid with any two mana or with {R}. This card's mana value is 6.)\nFlame Javelin deals 4 damage to any target.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "92",
+        "rarity": "UNCOMMON",
+        "artist": "Trevor Hairsine",
+        "flavorText": "Gyara Spearhurler would have been renowned for her deadly accuracy, if it weren't for her deadly accuracy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a567b570-81e4-4068-929c-9ce406fe7474.jpg?1783942749"
+    }
+}
+
+// Foxfire Oak
+{
+    "name": "Foxfire Oak",
+    "manaCost": "{5}{G}",
+    "typeLine": "Creature — Treefolk Shaman",
+    "oracleText": "{R/G}{R/G}{R/G}: This creature gets +3/+0 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 6
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R/G}{R/G}{R/G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "Dave Kendall",
+        "flavorText": "\"The brethren shall blaze with unnatural fire, and the flame shall consume and purify our rage.\"\n—Treefolk catastrophe myth",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/46e23eae-7630-40db-b265-2fa00715878e.jpg?1783942743"
+    }
+}
+
+// Fulminator Mage
+{
+    "name": "Fulminator Mage",
+    "manaCost": "{1}{B/R}{B/R}",
+    "typeLine": "Creature — Elemental Shaman",
+    "oracleText": "Sacrifice this creature: Destroy target nonbasic land.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsLand",
+                                    {
+                                        "type": "Not",
+                                        "predicate": "IsBasicLand"
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "188",
+        "rarity": "RARE",
+        "artist": "rk post",
+        "flavorText": "\"Unsafe Terrain Ahead—Turn Back\"\n—Sign near the former location of Pyrtagh Cairn",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/be1df367-8e85-4fd8-aa6f-f02a478fecb3.jpg?1783942726"
+    }
+}
+
+// Ghastly Discovery
+{
+    "name": "Ghastly Discovery",
+    "manaCost": "{2}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Draw two cards, then discard a card.\nConspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it.)",
+    "keywords": [
+        "CONSPIRE"
+    ],
+    "keywordAbilities": [
+        "Conspire"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 1 card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "Howard Lyon",
+        "flavorText": "Korrigans, spirits bound to sources of water, shriek when they come upon their own drowned corpses.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9dbd510a-d71f-4b0c-bc6c-e403f632cbdb.jpg?1783942761"
+    }
+}
+
+// Gleeful Sabotage
+{
+    "name": "Gleeful Sabotage",
+    "manaCost": "{1}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target artifact or enchantment.\nConspire (As you cast this spell, you may tap two untapped creatures you control that share a color with it. When you do, copy it and you may choose a new target for the copy.)",
+    "keywords": [
+        "CONSPIRE"
+    ],
+    "keywordAbilities": [
+        "Conspire"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "116",
+        "artist": "Todd Lockwood",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1b7d043-5f52-4df6-8dcf-5174a5b0c9cc.jpg?1783942743"
+    }
+}
+
+// Glen Elendra Liege
+{
+    "name": "Glen Elendra Liege",
+    "manaCost": "{1}{U/B}{U/B}{U/B}",
+    "typeLine": "Creature — Faerie Knight",
+    "oracleText": "Flying\nOther blue creatures you control get +1/+1.\nOther black creatures you control get +1/+1.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature blue ctrl:you",
+                    "excludeSelf": true
+                }
+            },
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature black ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "rarity": "RARE",
+        "artist": "Kev Walker",
+        "flavorText": "Those who displease Oona soon learn the extent of the armies she commands.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/94cc72b7-b593-438f-a07a-35f2452e1c48.jpg?1783942732"
+    }
+}
+
+// Gloomwidow
+{
+    "name": "Gloomwidow",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Reach\nThis creature can block only creatures with flying.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CanOnlyBlockCreaturesWith",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasKeyword",
+                            "keyword": "FLYING"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Tedin",
+        "flavorText": "When gloomwidows mature, they abandon venom in favor of massive webs that span the eaves of cliffs.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/99bda306-1e37-4359-a649-fcd8a5a7e2fc.jpg?1783942742"
+    }
+}
+
+// Gnarled Effigy
+{
+    "name": "Gnarled Effigy",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "{4}, {T}: Put a -1/-1 counter on target creature.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "-1/-1",
+                    "count": 1,
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "251",
+        "rarity": "UNCOMMON",
+        "artist": "Ron Brown",
+        "flavorText": "\"Bits of fallen scarecrow, laces of elfskin leather, teeth of an axeshark merrow . . . An industrious soul can find new uses for the most mundane items.\"\n—Mowagh the Gwyllion",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e6aee954-2a04-425d-8d05-09dad58af656.jpg?1783942712"
+    }
+}
+
+// Goldenglow Moth
+{
+    "name": "Goldenglow Moth",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Flying\nWhenever this creature blocks, you may gain 4 life.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    }
+                },
+                "descriptionOverride": "Whenever this creature blocks, you may gain 4 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "artist": "Howard Lyon",
+        "flavorText": "Ordinary moths follow it, drawn to its light.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/12030927-7af2-448f-bc6b-c2035e0b799d.jpg?1783942769"
+    }
+}
+
+// Gravelgill Axeshark
+{
+    "name": "Gravelgill Axeshark",
+    "manaCost": "{4}{U/B}",
+    "typeLine": "Creature — Merfolk Soldier",
+    "oracleText": "Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "PERSIST"
+    ],
+    "metadata": {
+        "collectorNumber": "164",
+        "artist": "Dave Kendall",
+        "flavorText": "\"Their sharp scales would make good armor, if they'd just stay dead.\"\n—Taeryn, cinder armorkeep",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5efc174a-f710-4602-aace-c2165473f6c2.jpg?1783942733"
+    }
+}
+
+// Gravelgill Duo
+{
+    "name": "Gravelgill Duo",
+    "manaCost": "{2}{U/B}",
+    "typeLine": "Creature — Merfolk Rogue Warrior",
+    "oracleText": "Whenever you cast a blue spell, this creature gets +1/+1 until end of turn.\nWhenever you cast a black spell, this creature gains fear until end of turn. (It can't be blocked except by artifact creatures and/or black creatures.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "BLUE"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "BLACK"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FEAR",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "artist": "Brandon Kitkouski",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2fd4959-bfff-46dc-b568-b6d69ef8eac9.jpg?1783942733"
+    }
+}
+
+// Heap Doll
+{
+    "name": "Heap Doll",
+    "manaCost": "{1}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "Sacrifice this creature: Exile target card from a graveyard.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Exile"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "253",
+        "rarity": "UNCOMMON",
+        "artist": "John Avon",
+        "flavorText": "\"I know one night it won't come back. Then I'll know it's truly done its job.\"\n—Braenna, cobblesmith",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/86d726e1-a363-4d77-97d4-e8c94f93fd51.jpg?1783942712"
+    }
+}
+
+// Horde of Boggarts
+{
+    "name": "Horde of Boggarts",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Goblin",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\nHorde of Boggarts's power and toughness are each equal to the number of red permanents you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent red"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent red"
+            }
+        }
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "metadata": {
+        "collectorNumber": "94",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Prescott",
+        "flavorText": "Strategies don't come easily to the boggarts' feral minds, but full-on assault hasn't failed them yet.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/023562bf-da7d-486d-93fc-60353f55b8a7.jpg?1783942749"
+    }
+}
+
+// Hungry Spriggan
+{
+    "name": "Hungry Spriggan",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Trample\nWhenever this creature attacks, it gets +3/+3 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "artist": "Drew Tucker",
+        "flavorText": "If a spriggan's eyes are larger than its stomach, it has ways to remedy the situation.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8be81b15-eb12-452b-8fdd-bde64807f422.jpg?1783942742"
+    }
+}
+
+// Juvenile Gloomwidow
+{
+    "name": "Juvenile Gloomwidow",
+    "manaCost": "{G}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Reach (This creature can block creatures with flying.)\nWither (This deals damage to creatures in the form of -1/-1 counters.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH",
+        "WITHER"
+    ],
+    "metadata": {
+        "collectorNumber": "121",
+        "artist": "Thomas M. Baxa",
+        "flavorText": "Gloomwidow venom is particularly virulent during the spider's first years, when it does most of its hunting near the forest floor.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d7f323d5-f26c-46e9-9d6a-be5c254fe8b6.jpg?1783942742"
+    }
+}
+
+// Kitchen Finks
+{
+    "name": "Kitchen Finks",
+    "manaCost": "{1}{G/W}{G/W}",
+    "typeLine": "Creature — Ouphe",
+    "oracleText": "When this creature enters, you gain 2 life.\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "PERSIST"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "When this creature enters, you gain 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "229",
+        "rarity": "UNCOMMON",
+        "artist": "Kev Walker",
+        "flavorText": "Accept one favor from an ouphe, and you're doomed to accept another.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d203208-8a21-4c68-afa2-4efd8726f026.jpg?1783942717"
+    }
+}
+
+// Kithkin Rabble
+{
+    "name": "Kithkin Rabble",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Kithkin",
+    "oracleText": "Vigilance\nKithkin Rabble's power and toughness are each equal to the number of white permanents you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent white"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "permanent white"
+            }
+        }
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "UNCOMMON",
+        "artist": "Omar Rayyan",
+        "flavorText": "If even the slightest hint of panic enters the thoughtweft, bakers, potters, and even medics drop their spoons and salves to take up arms.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f9a0afa-50e6-4bce-b261-4559fd31295e.jpg?1783942768"
+    }
+}
+
+// Kithkin Shielddare
+{
+    "name": "Kithkin Shielddare",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Kithkin Soldier",
+    "oracleText": "{W}, {T}: Target blocking creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature blocking"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "artist": "Christopher Moeller",
+        "flavorText": "The nova glyph is a potent symbol. A shield embossed with it can resist the force of even the most determined giant.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e5102a7-2147-4e22-b683-c08b4a725617.jpg?1783942768"
+    }
+}
+
 // Loamdragger Giant
 {
     "name": "Loamdragger Giant",
@@ -92,6 +1772,354 @@
     ]
 }
 
+// Loch Korrigan
+{
+    "name": "Loch Korrigan",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "{U/B}: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U/B}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "artist": "Daarken",
+        "flavorText": "\"Don't look upon still waters without first breaking the surface. The korrigan will catch you with her gaze and drag you to your death.\"\n—Kithkin superstition",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/2964b501-5b7f-4225-9dd3-e7519bf34048.jpg?1783942753"
+    }
+}
+
+// Mass Calcify
+{
+    "name": "Mass Calcify",
+    "manaCost": "{5}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy all nonwhite creatures.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "NotColor",
+                                    "color": "WHITE"
+                                }
+                            ]
+                        }
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "rarity": "RARE",
+        "artist": "Brandon Kitkouski",
+        "flavorText": "The dead serve as their own tombstones.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d24be94-9922-43bb-83c8-98090adc3f32.jpg?1783942768"
+    }
+}
+
+// Merrow Grimeblotter
+{
+    "name": "Merrow Grimeblotter",
+    "manaCost": "{3}{U/B}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "{1}{U/B}, {Q}: Target creature gets -2/-0 until end of turn. ({Q} is the untap symbol.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U/B}"
+                            }
+                        },
+                        "CostUntap"
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{1}{U/B}, {Q}: Target creature gets -2/-0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "UNCOMMON",
+        "artist": "Cyril Van Der Haegen",
+        "flavorText": "Grimeblotters spend so much time in the Dark Meanders that they're able to bring a piece with them wherever they go.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b839c9d0-ef08-4661-8009-3bcb256bf508.jpg?1783942730"
+    }
+}
+
+// Merrow Wavebreakers
+{
+    "name": "Merrow Wavebreakers",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Merfolk Soldier",
+    "oracleText": "{1}{U}, {Q}: This creature gains flying until end of turn. ({Q} is the untap symbol.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
+                        },
+                        "CostUntap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": "Self"
+                },
+                "descriptionOverride": "{1}{U}, {Q}: This creature gains flying until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "artist": "Alex Horley-Orlandelli",
+        "flavorText": "The merrows' prey have retreated from the shore, so they have learned to follow.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/9919382e-3dcd-4f83-8135-be71345e57c0.jpg?1783942760"
+    }
+}
+
+// Morselhoarder
+{
+    "name": "Morselhoarder",
+    "manaCost": "{4}{R/G}{R/G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "This creature enters with two -1/-1 counters on it.\nRemove a -1/-1 counter from this creature: Add one mana of any color.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomRemoveCounters",
+                        "counterType": "-1/-1",
+                        "self": true
+                    }
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": "MinusOneMinusOne",
+                "count": 2,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "212",
+        "artist": "Anthony S. Waters",
+        "flavorText": "It scours the hills for living matter, savoring even the tang of poisonous fungi.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/589f477e-fd69-4410-b9ba-1d45b25fec31.jpg?1783942721"
+    }
+}
+
+// Mudbrawler Raiders
+{
+    "name": "Mudbrawler Raiders",
+    "manaCost": "{2}{R/G}{R/G}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "This creature can't be blocked by blue creatures.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasColor",
+                            "color": "BLUE"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "213",
+        "artist": "Ron Spencer",
+        "flavorText": "To reach the ravine of the Wanderbrine River, they were told to take the shortcut \"through the mountains.\" They took the directions literally.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cbe4af47-d913-4c19-a027-501e2c78758c.jpg?1783942721"
+    }
+}
+
+// Nurturer Initiate
+{
+    "name": "Nurturer Initiate",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "Whenever a player casts a green spell, you may pay {1}. If you do, target creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "GREEN"
+                            }
+                        ]
+                    },
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever a player casts a green spell, you may pay {1}. If you do, target creature gets +1/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "artist": "Jim Pavelec",
+        "flavorText": "The elves alone preserve the few shreds of beauty left. There is no one else who cares.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/2330c78d-1655-4074-a650-27740be4cee1.jpg?1783942741"
+    }
+}
+
 // Old Ghastbark
 {
     "name": "Old Ghastbark",
@@ -111,6 +2139,1661 @@
         "WHITE",
         "GREEN"
     ]
+}
+
+// Oona's Gatewarden
+{
+    "name": "Oona's Gatewarden",
+    "manaCost": "{U/B}",
+    "typeLine": "Creature — Faerie Soldier",
+    "oracleText": "Defender, flying\nWither (This deals damage to creatures in the form of -1/-1 counters.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEFENDER",
+        "FLYING",
+        "WITHER"
+    ],
+    "metadata": {
+        "collectorNumber": "173",
+        "artist": "Mike Dringenberg",
+        "flavorText": "\"So now you've seen Glen Elendra. Take a good look. It will be the last thing you'll ever see.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/972bb6e4-300c-49f5-8305-459a3ba67baa.jpg?1783942729"
+    }
+}
+
+// Oversoul of Dusk
+{
+    "name": "Oversoul of Dusk",
+    "manaCost": "{G/W}{G/W}{G/W}{G/W}{G/W}",
+    "typeLine": "Creature — Spirit Avatar",
+    "oracleText": "Protection from blue, from black, and from red",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "BLUE"
+            }
+        },
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "BLACK"
+            }
+        },
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "RED"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "234",
+        "rarity": "RARE",
+        "artist": "Scott M. Fischer",
+        "flavorText": "\"Some say she hid the sun herself, a desperate act to save it from its ultimate extinction.\"\n—*The Seer's Parables*",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/8893842f-aa3f-45f6-8139-ca775d33792b.jpg?1783942716"
+    }
+}
+
+// Parapet Watchers
+{
+    "name": "Parapet Watchers",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Kithkin Soldier",
+    "oracleText": "{W/U}: This creature gets +0/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W/U}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "artist": "Scott Altmann",
+        "flavorText": "A kithkin doun is not so much a town as a fortress, built to withstand the constantly besieging darkness. Only those most watchful and trustworthy are tasked with guarding its walls.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/499f9987-87d8-4cd3-98c4-b6976c70739e.jpg?1783942760"
+    }
+}
+
+// Pili-Pala
+{
+    "name": "Pili-Pala",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "Flying\n{2}, {Q}: Add one mana of any color. ({Q} is the untap symbol.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostUntap"
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{2}, {Q}: Add one mana of any color."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "258",
+        "artist": "Ron Spencer",
+        "flavorText": "It wasn't really expected to fly. Then again, it wasn't expected to move, either.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/4892c152-1f4a-4616-8e7f-0ca4911e621a.jpg?1783942710"
+    }
+}
+
+// Plumeveil
+{
+    "name": "Plumeveil",
+    "manaCost": "{W/U}{W/U}{W/U}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Flash\nDefender, flying",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLASH",
+        "DEFENDER",
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "145",
+        "rarity": "UNCOMMON",
+        "artist": "Nils Hamm",
+        "flavorText": "\"It was vast, a great sheet of soaring wings, and equally silent. It caught us unawares and blocked our view of the kithkin stronghold.\"\n—Grensch, merrow cutthroat",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8e8b0449-3ae5-4fee-b870-af12be5e5a64.jpg?1783942736"
+    }
+}
+
+// Pyre Charger
+{
+    "name": "Pyre Charger",
+    "manaCost": "{R}{R}",
+    "typeLine": "Creature — Elemental Warrior",
+    "oracleText": "Haste\n{R}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Zug",
+        "flavorText": "His blade was forged over coals of moaning treefolk, curved at the optimum angle for severing heads, and heated to volcanic temperatures by his touch.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de320e0d-c1e9-4b5e-84a0-057f3f162bbf.jpg?1783942746"
+    }
+}
+
+// Rage Reflection
+{
+    "name": "Rage Reflection",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Creatures you control have double strike.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOUBLE_STRIKE",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "104",
+        "rarity": "RARE",
+        "artist": "Terese Nielsen & Ron Spencer",
+        "flavorText": "Vengeance is a dish best served twice.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/275e118d-1d50-47ee-a2c9-76169ce372cf.jpg?1783942746"
+    }
+}
+
+// Rattleblaze Scarecrow
+{
+    "name": "Rattleblaze Scarecrow",
+    "manaCost": "{6}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "This creature has persist as long as you control a black creature. (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)\nThis creature has haste as long as you control a red creature.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "PERSIST",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature black"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature red"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "259",
+        "artist": "Trevor Hairsine",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b46425f-516c-42f5-8df1-79af17d02a4a.jpg?1783942710"
+    }
+}
+
+// Raven's Run Dragoon
+{
+    "name": "Raven's Run Dragoon",
+    "manaCost": "{2}{G/W}{G/W}",
+    "typeLine": "Creature — Elf Knight",
+    "oracleText": "This creature can't be blocked by black creatures.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasColor",
+                            "color": "BLACK"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "235",
+        "artist": "Daren Bader",
+        "flavorText": "\"I have a gift. The ability to sense encroaching darkness has saved many lives. And yet constantly feeling the force of so much ugliness is a terrible burden.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b868da85-9d19-4407-a0c3-fc3b2b237cda.jpg?1783942716"
+    }
+}
+
+// Reaper King
+{
+    "name": "Reaper King",
+    "manaCost": "{2/W}{2/U}{2/B}{2/R}{2/G}",
+    "typeLine": "Legendary Artifact Creature — Scarecrow",
+    "oracleText": "({2/W} can be paid with any two mana or with {W}. This card's mana value is 10.)\nOther Scarecrow creatures you control get +1/+1.\nWhenever another Scarecrow you control enters, destroy target permanent.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Scarecrow ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature Scarecrow ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "260",
+        "rarity": "RARE",
+        "artist": "Jim Murray",
+        "flavorText": "It's harvest time.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/502740bf-0bff-4358-8996-1a27e5f0343f.jpg?1783942710"
+    }
+}
+
+// Reknit
+{
+    "name": "Reknit",
+    "manaCost": "{1}{G/W}",
+    "typeLine": "Instant",
+    "oracleText": "Regenerate target permanent.",
+    "script": {
+        "spellEffect": {
+            "type": "Regenerate",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "permanent"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "\"An axe may break upon a ribbon if the ribbon's will is the stronger.\"\n—Awylla, elvish safewright",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/10bde9be-0ad8-4f42-a9a9-838bc476c7a6.jpg?1783942716"
+    }
+}
+
+// Resplendent Mentor
+{
+    "name": "Resplendent Mentor",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Kithkin Cleric",
+    "oracleText": "White creatures you control have \"{T}: You gain 1 life.\"",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                "filter": {
+                    "baseFilter": "creature white ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "UNCOMMON",
+        "artist": "Franz Vohwinkel",
+        "flavorText": "Thoughtweft gives new meaning to the phrase \"common knowledge.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/be87e59d-422c-4dd7-8867-423e784830a2.jpg?1783942766"
+    }
+}
+
+// Revelsong Horn
+{
+    "name": "Revelsong Horn",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, {T}, Tap an untapped creature you control: Target creature gets +1/+1 until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "261",
+        "rarity": "UNCOMMON",
+        "artist": "Franz Vohwinkel",
+        "flavorText": "A deflated sigh breathed into the horn emerges as an inspiring melody.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/10a4801c-fa69-47a0-bdfa-f5f110fd0976.jpg?1783942710"
+    }
+}
+
+// Roughshod Mentor
+{
+    "name": "Roughshod Mentor",
+    "manaCost": "{5}{G}",
+    "typeLine": "Creature — Giant Warrior",
+    "oracleText": "Green creatures you control have trample.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE",
+                "filter": {
+                    "baseFilter": "creature green ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "rarity": "UNCOMMON",
+        "artist": "Steven Belledin",
+        "flavorText": "He didn't hear the cries of the treefolk whose branches he snapped or of the elves caught underfoot. He had eyes only for the path ahead.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/abe77862-516f-4eb2-9a41-0c6401d02843.jpg?1783942740"
+    }
+}
+
+// Rune-Cervin Rider
+{
+    "name": "Rune-Cervin Rider",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Elf Knight",
+    "oracleText": "Flying\n{G/W}{G/W}: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G/W}{G/W}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "Things of beauty are in constant peril. The riders whisk them to safety, ahead of the encroaching darkness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d9574f6-40b3-4fe2-950c-234bc358ecf6.jpg?1783942766"
+    }
+}
+
+// Rustrazor Butcher
+{
+    "name": "Rustrazor Butcher",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "First strike\nWither (This deals damage to creatures in the form of -1/-1 counters.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "WITHER"
+    ],
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Ron Spencer",
+        "flavorText": "A Bloodwort's blade is salted with blood and peppered with rust, seasoning and slaughtering in a single swipe.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/daa0dd3e-51d1-4d75-b0f4-835992f420d6.jpg?1783942745"
+    }
+}
+
+// Safehold Duo
+{
+    "name": "Safehold Duo",
+    "manaCost": "{3}{G/W}",
+    "typeLine": "Creature — Elf Warrior Shaman",
+    "oracleText": "Whenever you cast a green spell, this creature gets +1/+1 until end of turn.\nWhenever you cast a white spell, this creature gains vigilance until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "GREEN"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "WHITE"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "artist": "Izzy",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/32b70339-9918-4f7e-9cd0-d4ce36b65997.jpg?1783942715"
+    }
+}
+
+// Safehold Elite
+{
+    "name": "Safehold Elite",
+    "manaCost": "{1}{G/W}",
+    "typeLine": "Creature — Elf Scout",
+    "oracleText": "Persist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "PERSIST"
+    ],
+    "metadata": {
+        "collectorNumber": "239",
+        "artist": "Richard Whitters",
+        "flavorText": "\"I refuse to die—not at the hands of one such as you.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/14dee5be-94fd-4b5d-9265-edd1b58c8026.jpg?1783942714"
+    }
+}
+
+// Safehold Sentry
+{
+    "name": "Safehold Sentry",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "{2}{W}, {Q}: This creature gets +0/+2 until end of turn. ({Q} is the untap symbol.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
+                        },
+                        "CostUntap"
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{2}{W}, {Q}: This creature gets +0/+2 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "artist": "William O'Connor",
+        "flavorText": "\"These bracers were worn by my father and by his mother before him. Boggart fangs have shattered on them. Cinder flames have withered at their touch. While I wear them, the safehold will not fall.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/caa8bd74-9897-4515-b1a0-50d5f1bda673.jpg?1783942764"
+    }
+}
+
+// Scar
+{
+    "name": "Scar",
+    "manaCost": "{B/R}",
+    "typeLine": "Instant",
+    "oracleText": "Put a -1/-1 counter on target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "AddCounters",
+            "counterType": "-1/-1",
+            "count": 1,
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "artist": "Pete Venters",
+        "flavorText": "\"What is a scar? A sign of courage in the face of danger? A mere trick of flesh? Or a constant reminder of agonizing pain, and the follies of war.\"\n—Illulia of Nighthearth",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b34e3f7c-468a-456c-8ed0-0cb88f6d86fc.jpg?1783942724"
+    }
+}
+
+// Scuzzback Marauders
+{
+    "name": "Scuzzback Marauders",
+    "manaCost": "{4}{R/G}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Trample\nPersist (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE",
+        "PERSIST"
+    ],
+    "metadata": {
+        "collectorNumber": "216",
+        "artist": "Pete Venters",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/6738d2b7-2773-4146-8f95-8d95b8402266.jpg?1783942720"
+    }
+}
+
+// Scuzzback Scrapper
+{
+    "name": "Scuzzback Scrapper",
+    "manaCost": "{R/G}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "WITHER"
+    ],
+    "metadata": {
+        "collectorNumber": "217",
+        "artist": "Scott Altmann",
+        "flavorText": "The Scuzzback gang scavenges rusty armor covered in barbed protrusions. No threat is more effective than the threat of infection.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8e2ed66f-75bd-43d8-90c4-cb0a5827b2f0.jpg?1783942719"
+    }
+}
+
+// Seedcradle Witch
+{
+    "name": "Seedcradle Witch",
+    "manaCost": "{G/W}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "{2}{G}{W}: Target creature gets +3/+3 until end of turn. Untap that creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            },
+                            "tap": false
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "rarity": "UNCOMMON",
+        "artist": "Steven Belledin",
+        "flavorText": "She whispered a prayer for strength, and her wishes wafted away like seeds on the wind.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a0ae8525-ce10-40bd-8980-a05fb81a0fac.jpg?1783942714"
+    }
+}
+
+// Sickle Ripper
+{
+    "name": "Sickle Ripper",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Elemental Warrior",
+    "oracleText": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "WITHER"
+    ],
+    "metadata": {
+        "collectorNumber": "77",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "His sickle was forged in the heat of another cinder's funeral pyre.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e07c4e5f-5de7-45ec-b502-0e6d7c5c359d.jpg?1783942752"
+    }
+}
+
+// Silkbind Faerie
+{
+    "name": "Silkbind Faerie",
+    "manaCost": "{2}{W/U}",
+    "typeLine": "Creature — Faerie Rogue",
+    "oracleText": "Flying\n{1}{W/U}, {Q}: Tap target creature. ({Q} is the untap symbol.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W/U}"
+                            }
+                        },
+                        "CostUntap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{1}{W/U}, {Q}: Tap target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "artist": "Matt Cavotta",
+        "flavorText": "\"The bigger they are, the more fun it is to watch them fall flat on their faces.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/12d06328-a124-40e4-a9d8-2342a881970e.jpg?1783942736"
+    }
+}
+
+// Smolder Initiate
+{
+    "name": "Smolder Initiate",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Elemental Shaman",
+    "oracleText": "Whenever a player casts a black spell, you may pay {1}. If you do, target player loses 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "BLACK"
+                            }
+                        ]
+                    },
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever a player casts a black spell, you may pay {1}. If you do, target player loses 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "artist": "Chippy",
+        "flavorText": "\"Life is a circle. Death is a vicious circle.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/16ecbed3-3a41-4823-8cd2-498daaaa0d4f.jpg?1783942752"
+    }
+}
+
+// Somnomancer
+{
+    "name": "Somnomancer",
+    "manaCost": "{1}{W/U}",
+    "typeLine": "Creature — Kithkin Wizard",
+    "oracleText": "When this creature enters, you may tap target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "When this creature enters, you may tap target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "149",
+        "artist": "Lars Grant-West",
+        "flavorText": "\"Are you tired? You look tired.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/eaf51122-fd7c-40b5-b759-65e21c28e3d6.jpg?1783942735"
+    }
+}
+
+// Sootwalkers
+{
+    "name": "Sootwalkers",
+    "manaCost": "{2}{B/R}{B/R}",
+    "typeLine": "Creature — Elemental Rogue",
+    "oracleText": "This creature can't be blocked by white creatures.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasColor",
+                            "color": "WHITE"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "196",
+        "artist": "Nils Hamm",
+        "flavorText": "\"Why allow the fires of others to burn, when ours do not? Why leave them content, while we suffer? If there is to be misery, let it be borne by all.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f36c7932-cc1e-4b1f-ae39-2f04b84bcddb.jpg?1783942724"
+    }
+}
+
+// Spectral Procession
+{
+    "name": "Spectral Procession",
+    "manaCost": "{2/W}{2/W}{2/W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create three 1/1 white Spirit creature tokens with flying.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "WHITE"
+            ],
+            "creatureTypes": [
+                "Spirit"
+            ],
+            "keywords": [
+                "FLYING"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "rarity": "UNCOMMON",
+        "artist": "Jeremy Enecio",
+        "flavorText": "\"The dead have it easy. They suffer no more. If breaking their rest helps the living, so be it.\"\n—Olka, mistmeadow witch",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e26bd0c-5ec7-4653-8e63-747157c20af1.jpg?1783942765"
+    }
+}
+
+// Tattermunge Duo
+{
+    "name": "Tattermunge Duo",
+    "manaCost": "{2}{R/G}",
+    "typeLine": "Creature — Goblin Warrior Shaman",
+    "oracleText": "Whenever you cast a red spell, this creature gets +1/+1 until end of turn.\nWhenever you cast a green spell, this creature gains forestwalk until end of turn. (It can't be blocked as long as defending player controls a Forest.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "RED"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "GREEN"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FORESTWALK",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "artist": "Jesper Ejsing",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/ac93faba-8b40-48f4-b4eb-7c8677ed07e2.jpg?1783942719"
+    }
+}
+
+// Thistledown Duo
+{
+    "name": "Thistledown Duo",
+    "manaCost": "{2}{W/U}",
+    "typeLine": "Creature — Kithkin Soldier Wizard",
+    "oracleText": "Whenever you cast a white spell, this creature gets +1/+1 until end of turn.\nWhenever you cast a blue spell, this creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "WHITE"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "BLUE"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d57ba0ce-0390-42fd-9473-2436fac53631.jpg?1783942735"
+    }
+}
+
+// Thistledown Liege
+{
+    "name": "Thistledown Liege",
+    "manaCost": "{1}{W/U}{W/U}{W/U}",
+    "typeLine": "Creature — Kithkin Knight",
+    "oracleText": "Flash\nOther white creatures you control get +1/+1.\nOther blue creatures you control get +1/+1.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature white ctrl:you",
+                    "excludeSelf": true
+                }
+            },
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature blue ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "rarity": "RARE",
+        "artist": "Adam Rex",
+        "flavorText": "The thoughtweft is his informant, and he its devoted guardian.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/20e34233-0972-4aa7-a5ab-eabed2235148.jpg?1783942735"
+    }
+}
+
+// Thornwatch Scarecrow
+{
+    "name": "Thornwatch Scarecrow",
+    "manaCost": "{6}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "This creature has wither as long as you control a green creature. (It deals damage to creatures in the form of -1/-1 counters.)\nThis creature has vigilance as long as you control a white creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "WITHER",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature green"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature white"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "265",
+        "artist": "Chuck Lukacs",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/4/3489ac0a-cbdb-43d5-be73-6cb65ae54a20.jpg?1783942708"
+    }
+}
+
+// Torpor Dust
+{
+    "name": "Torpor Dust",
+    "manaCost": "{2}{U/B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash\nEnchant creature\nEnchanted creature gets -3/-0.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": -3,
+                "toughnessBonus": 0
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "artist": "Jesper Ejsing",
+        "flavorText": "\"Some folk these days are too restless to dream the dreams we need. We need to teach them to stop and catch their breath.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/8840551f-d43a-487f-a960-9b220dec5df4.jpg?1783942728"
+    }
+}
+
+// Trip Noose
+{
+    "name": "Trip Noose",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}, {T}: Tap target creature.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "266",
+        "rarity": "UNCOMMON",
+        "artist": "Randy Gallegos",
+        "flavorText": "A taut slipknot trigger is the only thing standing between you and standing.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b2b3dd8-cedb-4577-8897-967952dd3c13.jpg?1783942709"
+    }
+}
+
+// Wanderbrine Rootcutters
+{
+    "name": "Wanderbrine Rootcutters",
+    "manaCost": "{2}{U/B}{U/B}",
+    "typeLine": "Creature — Merfolk Rogue",
+    "oracleText": "This creature can't be blocked by green creatures.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasColor",
+                            "color": "GREEN"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "artist": "Chippy",
+        "flavorText": "Most dirtwalkers only know of the vicious merrows that dwell in the shallows. They can't begin to fathom the wickedness that skulks in the Dark Meanders.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab739d64-cdcd-4f07-9854-e067c37c4f41.jpg?1783942728"
+    }
+}
+
+// Wasp Lancer
+{
+    "name": "Wasp Lancer",
+    "manaCost": "{U/B}{U/B}{U/B}",
+    "typeLine": "Creature — Faerie Soldier",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "179",
+        "rarity": "UNCOMMON",
+        "artist": "Warren Mahy",
+        "flavorText": "\"I doubt that faeries understand how short their lives are, compared to the rest of us. If they did, would they so readily charge into battle, heedless of the danger before them?\"\n—Awylla, elvish safewright",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/ac48a4ff-433b-4fd0-b0d1-43b188ee81b6.jpg?1783942728"
+    }
+}
+
+// Watchwing Scarecrow
+{
+    "name": "Watchwing Scarecrow",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "This creature has vigilance as long as you control a white creature.\nThis creature has flying as long as you control a blue creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature white"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature blue"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "268",
+        "artist": "Chuck Lukacs",
+        "flavorText": "The wings are held in place by wicker rods. The rods are held in place by pure faith.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5c7774fd-3460-46e3-9c9c-7aa70f2ff6d8.jpg?1783942708"
+    }
+}
+
+// Wildslayer Elves
+{
+    "name": "Wildslayer Elves",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "Wither (This deals damage to creatures in the form of -1/-1 counters.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "WITHER"
+    ],
+    "metadata": {
+        "collectorNumber": "133",
+        "artist": "Dave Kendall",
+        "flavorText": "Some elves battled too long in the deep shadow, their swords dipped too often in tainted flesh and poisoned blood.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/3323467c-132f-469a-90fc-9d3b0fb004aa.jpg?1783942739"
+    }
+}
+
+// Wilt-Leaf Cavaliers
+{
+    "name": "Wilt-Leaf Cavaliers",
+    "manaCost": "{G/W}{G/W}{G/W}",
+    "typeLine": "Creature — Elf Knight",
+    "oracleText": "Vigilance",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "244",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Prescott",
+        "flavorText": "Every elf in Shadowmoor is charged from birth with a terrible duty: to strike back against the ugliness and darkness, even though they are all around and seemingly without end.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b8ffe320-c88a-4eb7-a091-e128e6c1f37c.jpg?1783942714"
+    }
 }
 
 // Wilt-Leaf Liege
@@ -170,6 +3853,94 @@
     ]
 }
 
+// Windbrisk Raptor
+{
+    "name": "Windbrisk Raptor",
+    "manaCost": "{5}{W}{W}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying\nAttacking creatures you control have lifelink.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 7
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "LIFELINK",
+                "filter": {
+                    "baseFilter": "creature attacking ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "rarity": "RARE",
+        "artist": "Omar Rayyan",
+        "flavorText": "It awakened to gloom-fouled skies and responded with a righteous rage that shook the heavens.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5df7b710-d44c-4ebc-be5b-f81d697086c4.jpg?1783942764"
+    }
+}
+
+// Wingrattle Scarecrow
+{
+    "name": "Wingrattle Scarecrow",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "oracleText": "This creature has flying as long as you control a blue creature.\nThis creature has persist as long as you control a black creature. (When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature blue"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "PERSIST",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature black"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "270",
+        "artist": "Trevor Hairsine",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61c5d86e-1ce1-4386-b70f-73b24351d6ae.jpg?1783942707"
+    }
+}
+
 // Woodfall Primus
 {
     "name": "Woodfall Primus",
@@ -220,4 +3991,25 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Zealous Guardian
+{
+    "name": "Zealous Guardian",
+    "manaCost": "{W/U}",
+    "typeLine": "Creature — Kithkin Soldier",
+    "oracleText": "Flash",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "metadata": {
+        "collectorNumber": "157",
+        "artist": "Steven Belledin",
+        "flavorText": "Parapet watchers patrol the outer edges of the doun, signaling to others who wait patiently in shadow.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/9951214b-43a9-4c51-bbb4-05bac81b9866.jpg?1783942733"
+    }
 }


### PR DESCRIPTION
Implements every Assay-ready card in **Shadowmoor**, taking the set from **6/286 (2%) to 100/286 (35%)**.

## What "Assay-ready" covered here

Of SHM's 280 missing cards, 186 are `LINE_DECLINED` and **94 read `whole`**. All 94 are in this PR. Shadowmoor is a premier set that is its own earliest printing throughout, so the usual four-way split collapses to two buckets:

| Bucket | Count |
|---|---|
| New SHM canonicals | 89 |
| Basic land names (20 `basicLand(...)` art variants, #282–301) | 5 |
| Reprint-row-only | 0 |
| Canonical belongs to an earlier scaffolded set | 0 |

Plus the tail a new canonical creates: **9 `Printing(...)` rows** in the other scaffolded sets that reprint these cards — C14 ×2, ARC, PC2, AVR, SOI, M11, M15, CMD. `check-card-printing` could not see that gap before the canonicals existed.

## How the cards were authored

Each card was authored to **`assay compile`'s JSON** — the exact `CardDefinition` model Argentum Assay builds from the oracle text — rather than from the oracle text directly. Thirteen batches were fanned out by shape (keyword creatures, colour evasion, `*/*` CDAs, lords, persist, scarecrows, conspire, `{Q}`, "cast a colour" duos, pump activations, initiates, artifacts/auras, spells), each with a brief carrying authoritative Scryfall metadata, the Assay spec, and a pre-filled skeleton.

A **capability pre-flight** traced all 24 shapes in the set to their SDK type, their consuming engine file, and a copy-from card before any card was written. Nothing left the batch and no new SDK vocabulary was added.

## Two mechanics get a scenario test

Neither adds vocabulary, but both are exercised by a shipped card for the first time.

- **`BurnTrailScenarioTest`** — Shadowmoor is the first set to *print* conspire. The only prior coverage exercised the keyword **granted** by Raiding Schemes, and the two take different paths: a granted conspire lives on `SpellGrantedKeywordsComponent`, while a printed one must survive `CardBuilder` deriving `Keyword.CONSPIRE` from `keywordAbility(KeywordAbility.Conspire)` into `CardDefinition.keywords`, which is what `GrantedKeywordResolver.hasKeyword` reads. Covers the copy + retarget, the decline, and the shares-no-colour rejection.
- **`SilkbindFaerieScenarioTest`** — the first shipped use of `{Q}` (`Costs.Untap`); the branch previously had only a synthetic "Test Untapper" behind it. Worth knowing: an unpayable **composite** cost is enumerated as a greyed-out `affordable = false` action rather than dropped, so the test pins the pair that actually matters — no *affordable* activation, and `ActivateAbilityHandler` refusing the action.

## One engine gap found, not triggered here

The pre-flight surfaced this and it is worth recording: conspire's copy trigger is only built when `cardDef.script.spellEffect != null` (`CastSpellHandler`), while `CastSpellEnumerator.enumerateConspire` offers the variant for any nonland card with the keyword. **Conspire on a permanent spell would tap two creatures and produce no copy, silently.** Every conspire card in Shadowmoor is an instant or a sorcery, so nothing in this PR is affected — but Eventide's conspire creatures and *Fists of the Demigod* need that closed first, and that is `add-feature` work rather than something to smuggle in here.

## Verification

- **`just build` green.** Card snapshot re-blessed — only `SHM.json` moved.
- **`just assay-differential`: 3706 compared, 3671 confirmed, 35 divergent — zero of them in SHM.** All 35 are pre-existing cards in other sets (LRW harbingers, DRK, SPM, DOM…), untouched by this PR.
- **Every card diffed field-by-field back against Scryfall** — mana cost, type line, P/T, oracle text, rarity, collector number, artist, flavour text, image URI — with the metadata match scoped *inside* the `metadata { }` block so a token `imageUri` can't be mistaken for the card's own. **89/89 exact**, and the 20 basic land art variants likewise.
- **`just check-card-printing`** clean (exit 0) on a 15-card sample covering all 9 reprint rows and the trickier canonicals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
