### PR TITLE
Retry ready tournament pairs when an earlier match unblocks them

### DIFF
--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -1409,7 +1409,11 @@ the entire round to finish. This "eager match starting" pattern means:
 4. Other players continue waiting or playing their own matches
 
 A ready flag is state, not an event: it is set by a ready click (or the AI auto-ready pass) and
-consumed only when a match actually starts — a round ending does not clear it. That matters because a
+consumed only when a match actually starts — a round ending does not clear it. Because it doesn't, the
+round-complete path opens the next round explicitly rather than as a side effect of the AI-ready pass;
+`currentRound` is what `isRoundComplete` reads, so leaving it on a finished round makes that path fire
+again on the next result. For the same reason, only a result from the current round can close it —
+later-round matches run concurrently with it and answer for their own round. That matters because a
 pair can be refused for a reason that has nothing to do with readiness: `hasIncompleteMatchBefore`
 holds a later-round match back while either seat still owes an earlier-round game, so a pair goes from
 blocked to launchable when a *third* pair's game finishes, with no change to the ready set at all.

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -1401,10 +1401,19 @@ WAITING_FOR_PLAYERS → DECK_BUILDING → TOURNAMENT_ACTIVE → TOURNAMENT_COMPL
 rounds for N players), then matches start dynamically as players become ready — no waiting for
 the entire round to finish. This "eager match starting" pattern means:
 
-1. A player sends `ReadyForNextRound`
-2. The server checks if their next opponent is also ready
-3. If both are ready, the match starts immediately via a new `GameSession`
+1. A player sends `ReadyForNextRound` — refused while their own match is still running, since a ready
+   click means "I dismissed the game-over overlay"
+2. The server marks them ready and sweeps the *whole* ready set for launchable pairs
+   (`TournamentManager.startableMatches`)
+3. Each pair whose seats are both ready starts immediately via a new `GameSession`
 4. Other players continue waiting or playing their own matches
+
+A ready flag is state, not an event: it is set by a ready click (or the AI auto-ready pass) and
+consumed only when a match actually starts — a round ending does not clear it. That matters because a
+pair can be refused for a reason that has nothing to do with readiness: `hasIncompleteMatchBefore`
+holds a later-round match back while either seat still owes an earlier-round game, so a pair goes from
+blocked to launchable when a *third* pair's game finishes, with no change to the ready set at all.
+Every result therefore re-runs the sweep; looking only at ready *transitions* stalls the bracket.
 
 BYE handling (odd player counts), reconnection across matches, and spectating between rounds are
 all managed at this layer. The tournament system reuses the same `GameSession` and `ActionProcessor`

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -211,9 +211,6 @@ class LobbyHandler(
     fun startTournament(lobby: TournamentLobby) =
         tournamentMatchHandler.startTournament(lobby)
 
-    fun startNextTournamentRound(lobbyId: String) =
-        tournamentMatchHandler.startNextTournamentRound(lobbyId)
-
     fun handleRoundComplete(lobbyId: String) =
         tournamentMatchHandler.handleRoundComplete(lobbyId)
 
@@ -1061,7 +1058,10 @@ class LobbyHandler(
                         standings = tournament.getStandingsInfo(connectedIds),
                         nextOpponentName = nextOpponentName,
                         nextRoundHasBye = nm.isBye,
-                        isTournamentComplete = false
+                        isTournamentComplete = false,
+                        // Describes `round` above — the round this player's next match sits in, which
+                        // by definition still has that match to play.
+                        roundComplete = false
                     ))
                 }
                 // Send active matches so player can watch live games while waiting
@@ -1069,10 +1069,9 @@ class LobbyHandler(
                 // Send ready status
                 val readyPlayerIds = lobby.getReadyPlayerIds()
                 if (readyPlayerIds.isNotEmpty()) {
+                    // A snapshot for the reconnecting player, not news about them — hence no playerId.
                     sender.send(session, ServerMessage.PlayerReadyForRound(
                         lobbyId = lobby.lobbyId,
-                        playerId = identity.playerId.value,
-                        playerName = identity.playerName,
                         readyPlayerIds = readyPlayerIds.map { it.value },
                         totalConnectedPlayers = connectedIds.size
                     ))
@@ -1096,7 +1095,10 @@ class LobbyHandler(
                         standings = tournament.getStandingsInfo(connectedIds),
                         nextOpponentName = nextOpponentName,
                         nextRoundHasBye = nm.isBye,
-                        isTournamentComplete = false
+                        isTournamentComplete = false,
+                        // Without this the reconnecting player is told their finished round is still
+                        // running, and the overlay names the round they already played.
+                        roundComplete = currentRound.isComplete
                     ))
                     // Send active matches so player can watch live games while waiting
                     val spectatingGameId = identity.currentSpectatingGameId
@@ -1127,10 +1129,9 @@ class LobbyHandler(
                 // Send ready status
                 val readyPlayerIds = lobby.getReadyPlayerIds()
                 if (readyPlayerIds.isNotEmpty()) {
+                    // A snapshot for the reconnecting player, not news about them — hence no playerId.
                     sender.send(session, ServerMessage.PlayerReadyForRound(
                         lobbyId = lobby.lobbyId,
-                        playerId = identity.playerId.value,
-                        playerName = identity.playerName,
                         readyPlayerIds = readyPlayerIds.map { it.value },
                         totalConnectedPlayers = connectedIds.size
                     ))

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
@@ -88,33 +88,9 @@ class TournamentMatchHandler(
                 return
             }
 
-            while (true) {
-                val needsPrepare = tournament.currentRound == null ||
-                        tournament.currentRound?.isComplete == true
-                if (!needsPrepare) break
-
-                val round = tournament.startNextRound()
-                if (round == null) {
-                    completeTournament(lobbyId)
-                    return
-                }
-
-                for (match in round.matches) {
-                    if (match.isBye && match.isComplete) {
-                        val byePlayerState = lobby.players[match.player1Id]
-                        val byeWs = byePlayerState?.identity?.webSocketSession
-                        if (byeWs != null && byeWs.isOpen) {
-                            ctx.sender.send(byeWs, ServerMessage.TournamentBye(
-                                lobbyId = lobbyId,
-                                round = round.roundNumber
-                            ))
-                            spectatingHandler.sendActiveMatchesToPlayer(byePlayerState.identity, byeWs)
-                        }
-                    }
-                }
-
-                ctx.lobbyRepository.saveTournament(lobbyId, tournament)
-                logger.info("Prepared round ${round.roundNumber} for tournament $lobbyId")
+            if (!prepareRoundsIfNeeded(lobby, tournament)) {
+                completeTournament(lobbyId)
+                return
             }
 
             val wasNewlyReady = lobby.markPlayerReady(identity.playerId)
@@ -153,7 +129,15 @@ class TournamentMatchHandler(
             // next round when the current one is done, which would make `isRoundComplete()` report on
             // the fresh round and swallow this round's `RoundComplete` broadcast entirely. The
             // round-complete path readies the AI itself, so either branch ends with a start sweep.
-            if (tournament.isRoundComplete()) {
+            //
+            // Only a result *from* the current round can close it. Matches from later rounds run
+            // concurrently with it (eager starting), and letting one of those answer for the current
+            // round would re-report a round already closed — announcing stale results and clearing
+            // every player's game-session pointer, including seats mid-game.
+            val resultRound = tournament.getRoundForMatch(gameSessionId)
+            val closesCurrentRound = resultRound != null &&
+                    resultRound.roundNumber == tournament.currentRound?.roundNumber
+            if (closesCurrentRound && tournament.isRoundComplete()) {
                 doHandleRoundComplete(lobbyId)
             } else {
                 val lobby = ctx.lobbyRepository.findLobbyById(lobbyId)
@@ -180,6 +164,13 @@ class TournamentMatchHandler(
             tournament.recordAbandon(playerId)
             ctx.lobbyRepository.saveTournament(lobbyId, tournament)
 
+            // Drop the departed player's ready flag. Nothing else clears it now that a round boundary
+            // doesn't, and a leaver left in the set inflates the lobby's "n/m ready" for good.
+            ctx.lobbyRepository.findLobbyById(lobbyId)?.let { lobby ->
+                lobby.clearPlayerReady(playerId)
+                ctx.lobbyRepository.saveLobby(lobby)
+            }
+
             // Freeze the standings as they stand after the forfeit; the row keeps these if it later
             // flips to ABANDONED on teardown.
             recordTournamentProgress(lobbyId)
@@ -188,6 +179,16 @@ class TournamentMatchHandler(
 
             if (tournament.isRoundComplete()) {
                 doHandleRoundComplete(lobbyId)
+            } else {
+                // A forfeit completes every match the abandoner had left, in every round — the same
+                // "an earlier game finished" event a real result is, so the pairs it frees need the
+                // same sweep, or they wait on an unrelated result to come along.
+                val lobby = ctx.lobbyRepository.findLobbyById(lobbyId)
+                if (lobby != null) {
+                    startReadyMatches(lobby, tournament)
+                    broadcastReadyStatus(lobby)
+                    ctx.lobbyRepository.saveLobby(lobby)
+                }
             }
         }
     }
@@ -351,6 +352,12 @@ class TournamentMatchHandler(
         }
 
         if (!tournament.isComplete) {
+            // Open the next round now the closing one has been reported. This used to happen as a side
+            // effect of `autoReadyAiPlayers` — reachable only because the ready-clearing above made its
+            // AI guard true — so it has to be explicit here, and it has to come after the broadcast:
+            // the messages above describe the round that just ended.
+            prepareRoundsIfNeeded(lobby, tournament)
+
             // Ready the AI for the next round, but not the human: they must click "Ready for Next
             // Round" after dismissing the game-over overlay, so the next game can't start underneath it.
             autoReadyAiPlayers(lobby, tournament, autoReadyHumansVsAi = false)
@@ -406,11 +413,44 @@ class TournamentMatchHandler(
                 nextOpponentName = nextOpponentName,
                 nextRoundHasBye = hasBye,
                 isTournamentComplete = tournament.isComplete,
-                currentRoundComplete = completedRound.isComplete
+                roundComplete = completedRound.isComplete
             ))
         }
 
         ctx.lobbyRepository.saveTournament(lobbyId, tournament)
+    }
+
+    /**
+     * Advance the bracket until the current round is one that still has games to play, announcing the
+     * BYEs each newly opened round auto-completes.
+     *
+     * Returns false when the schedule ran out — the caller finishes the tournament.
+     *
+     * `currentRound` is what `isRoundComplete`, spectating and the next-opponent fields all read, so
+     * advancing is not bookkeeping: leave it pointing at a finished round and the round-complete path
+     * fires again on the next result. Loops because an all-BYE round is complete the moment it opens.
+     */
+    private fun prepareRoundsIfNeeded(lobby: TournamentLobby, tournament: TournamentManager): Boolean {
+        while (tournament.currentRound.let { it == null || it.isComplete }) {
+            val round = tournament.startNextRound() ?: return false
+
+            for (match in round.matches) {
+                if (!match.isBye || !match.isComplete) continue
+                val byePlayerState = lobby.players[match.player1Id] ?: continue
+                val byeWs = byePlayerState.identity.webSocketSession
+                if (byeWs != null && byeWs.isOpen) {
+                    ctx.sender.send(byeWs, ServerMessage.TournamentBye(
+                        lobbyId = lobby.lobbyId,
+                        round = round.roundNumber
+                    ))
+                    spectatingHandler.sendActiveMatchesToPlayer(byePlayerState.identity, byeWs)
+                }
+            }
+
+            ctx.lobbyRepository.saveTournament(lobby.lobbyId, tournament)
+            logger.info("Prepared round ${round.roundNumber} for tournament ${lobby.lobbyId}")
+        }
+        return true
     }
 
     /**
@@ -711,56 +751,13 @@ class TournamentMatchHandler(
 
         val readyPlayerIds = lobby.getReadyPlayerIds()
         if (readyPlayerIds.isNotEmpty()) {
+            // A snapshot for this one player, not news about them — hence no playerId.
             ctx.sender.send(ws, ServerMessage.PlayerReadyForRound(
                 lobbyId = lobby.lobbyId,
-                playerId = identity.playerId.value,
-                playerName = identity.playerName,
                 readyPlayerIds = readyPlayerIds.map { it.value },
                 totalConnectedPlayers = connectedIds.size
             ))
         }
-    }
-
-    fun tryStartMatchAfterDeckSubmit(
-        lobby: TournamentLobby,
-        tournament: TournamentManager,
-        identity: PlayerIdentity
-    ) {
-        if (tournament.currentRound == null) {
-            val round = tournament.startNextRound()
-            if (round == null) {
-                completeTournament(lobby.lobbyId)
-                return
-            }
-            logger.info("Prepared round ${round.roundNumber} for tournament ${lobby.lobbyId}")
-        }
-
-        val (round, match) = tournament.getNextMatchForPlayer(identity.playerId) ?: return
-
-        if (match.isBye) {
-            match.isComplete = true
-            val ws = identity.webSocketSession
-            if (ws != null && ws.isOpen) {
-                ctx.sender.send(ws, ServerMessage.TournamentBye(
-                    lobbyId = lobby.lobbyId,
-                    round = round.roundNumber
-                ))
-                spectatingHandler.sendActiveMatchesToPlayer(identity, ws)
-            }
-            ctx.lobbyRepository.saveTournament(lobby.lobbyId, tournament)
-            return
-        }
-
-        if (match.gameSessionId != null) return
-
-        val opponentId = if (match.player1Id == identity.playerId) match.player2Id else match.player1Id
-        if (opponentId == null) return
-
-        val opponentState = lobby.players[opponentId] ?: return
-        if (!opponentState.hasSubmittedDeck) return
-
-        logger.info("Both players submitted decks, starting match: ${identity.playerName} vs ${opponentState.identity.playerName}")
-        startSingleMatch(lobby, tournament, round, match)
     }
 
     fun startTournament(lobby: TournamentLobby) {
@@ -804,47 +801,6 @@ class TournamentMatchHandler(
         }
     }
 
-    fun startNextTournamentRound(lobbyId: String) {
-        val lobby = ctx.lobbyRepository.findLobbyById(lobbyId) ?: return
-        val tournament = ctx.lobbyRepository.findTournamentById(lobbyId) ?: return
-
-        if (tournament.currentRound?.isComplete != false) {
-            val round = tournament.startNextRound()
-            if (round == null) {
-                completeTournament(lobbyId)
-                return
-            }
-            lobby.clearReadyState()
-            ctx.lobbyRepository.saveLobby(lobby)
-            ctx.lobbyRepository.saveTournament(lobbyId, tournament)
-        }
-
-        val round = tournament.currentRound ?: return
-        logger.info("Starting round ${round.roundNumber} for tournament $lobbyId")
-
-        for (match in tournament.getCurrentRoundGameMatches()) {
-            if (match.gameSessionId == null) {
-                startSingleMatch(lobby, tournament, round, match)
-            }
-        }
-        ctx.lobbyRepository.saveTournament(lobbyId, tournament)
-
-        for (match in round.matches) {
-            if (match.isBye) {
-                val playerState = lobby.players[match.player1Id]
-                val identity = playerState?.identity
-                val ws = identity?.webSocketSession
-                if (identity != null && ws != null && ws.isOpen) {
-                    ctx.sender.send(ws, ServerMessage.TournamentBye(
-                        lobbyId = lobbyId,
-                        round = round.roundNumber
-                    ))
-                    spectatingHandler.sendActiveMatchesToPlayer(identity, ws)
-                }
-            }
-        }
-    }
-
     /**
      * @param autoReadyHumansVsAi when true, a human whose next opponent is AI is auto-readied (and the
      *   match started) so a solo-vs-AI tournament doesn't require a manual ready click to begin. This is
@@ -867,29 +823,15 @@ class TournamentMatchHandler(
             aiGameManager.isAiPlayer(playerId) && ps.hasSubmittedDeck && playerId !in lobby.getReadyPlayerIds()
         }
 
-        if (hasAiPlayersToReady) {
-            // Ensure the round is initialized so matches can be found and started
-            if (lobby.allDecksSubmitted() && (tournament.currentRound == null || tournament.currentRound?.isComplete == true)) {
-                val round = tournament.startNextRound()
-                if (round != null) {
-                    for (match in round.matches) {
-                        if (match.isBye && match.isComplete) {
-                            val byePlayerState = lobby.players[match.player1Id]
-                            val byeWs = byePlayerState?.identity?.webSocketSession
-                            if (byeWs != null && byeWs.isOpen) {
-                                ctx.sender.send(byeWs, ServerMessage.TournamentBye(
-                                    lobbyId = lobby.lobbyId,
-                                    round = round.roundNumber
-                                ))
-                                spectatingHandler.sendActiveMatchesToPlayer(byePlayerState.identity, byeWs)
-                            }
-                        }
-                    }
-                    ctx.lobbyRepository.saveTournament(lobby.lobbyId, tournament)
-                    logger.info("Prepared round ${round.roundNumber} for tournament ${lobby.lobbyId}")
-                }
-            }
+        // Open a round once everyone has a deck, so there are matches to find: the first one, or the
+        // one an extra rotation just appended past a finished bracket. Deliberately outside the
+        // `hasAiPlayersToReady` guard, which was only ever true here because `doHandleRoundComplete`
+        // had just wiped the ready set — it doesn't, now, and the advance can't hang off that.
+        if (lobby.allDecksSubmitted()) {
+            prepareRoundsIfNeeded(lobby, tournament)
+        }
 
+        if (hasAiPlayersToReady) {
             for ((playerId, playerState) in lobby.players) {
                 if (!aiGameManager.isAiPlayer(playerId)) continue
                 if (!playerState.hasSubmittedDeck) continue

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
@@ -67,8 +67,27 @@ class TournamentMatchHandler(
             return
         }
 
+        // Read the epoch before queueing on the lock. If the ready set is wiped while we wait — the
+        // tournament being resumed for extra rounds is the live case — this request was aimed at a
+        // bracket that no longer exists, and honouring it would ready the player for a round they
+        // haven't seen. A round *completing* no longer clears readies, so it no longer lands here.
+        val epochBeforeLock = lobby.readyEpoch
+
         val lock = ctx.roundLocks.computeIfAbsent(lobbyId) { Any() }
         synchronized(lock) {
+            if (lobby.readyEpoch != epochBeforeLock) return
+
+            // A ready click means "I dismissed the game-over overlay and want the next game". A player
+            // whose match is still running can't have done that, so this is a duplicate or a click that
+            // raced their own match starting. Banking it would consent to the *following* match while
+            // they are mid-game, and the sweep would launch that game the moment this one ends.
+            if (tournament.hasActiveMatch(identity.playerId)) {
+                logger.debug(
+                    "Ignoring ready from ${identity.playerName} in tournament $lobbyId: match still in progress"
+                )
+                return
+            }
+
             while (true) {
                 val needsPrepare = tournament.currentRound == null ||
                         tournament.currentRound?.isComplete == true
@@ -108,7 +127,8 @@ class TournamentMatchHandler(
             broadcastReadyStatus(lobby, identity)
             ctx.lobbyRepository.saveLobby(lobby)
 
-            tryStartMatchForPlayer(lobby, tournament, identity)
+            resolveByesForPlayer(lobby, tournament, identity)
+            startReadyMatches(lobby, tournament)
         }
     }
 
@@ -129,17 +149,27 @@ class TournamentMatchHandler(
             recordTournamentProgress(lobbyId)
             spectatingHandler.broadcastActiveMatchesToWaitingPlayers(lobbyId)
 
-            val lobby = ctx.lobbyRepository.findLobbyById(lobbyId)
-            if (lobby != null) {
-                // Ready the AI, but not the human: they must click "Ready for Next Round" after
-                // dismissing the game-over overlay, so the next game can't start underneath it.
-                autoReadyAiPlayers(lobby, tournament, autoReadyHumansVsAi = false)
-                ctx.lobbyRepository.saveLobby(lobby)
-            }
-
+            // Test round completion *before* touching ready state: `autoReadyAiPlayers` prepares the
+            // next round when the current one is done, which would make `isRoundComplete()` report on
+            // the fresh round and swallow this round's `RoundComplete` broadcast entirely. The
+            // round-complete path readies the AI itself, so either branch ends with a start sweep.
             if (tournament.isRoundComplete()) {
                 doHandleRoundComplete(lobbyId)
+            } else {
+                val lobby = ctx.lobbyRepository.findLobbyById(lobbyId)
+                if (lobby != null) {
+                    // Ready the AI, but not the human: they must click "Ready for Next Round" after
+                    // dismissing the game-over overlay, so the next game can't start underneath it.
+                    // The sweep inside also retries pairs this result just unblocked.
+                    autoReadyAiPlayers(lobby, tournament, autoReadyHumansVsAi = false)
+                    ctx.lobbyRepository.saveLobby(lobby)
+                }
             }
+
+            // `MatchComplete` / `RoundComplete` make the client drop its ready list, and the readies
+            // that survive a round boundary would otherwise vanish from the lobby's counter. Re-state
+            // the authoritative set once everything above has settled.
+            ctx.lobbyRepository.findLobbyById(lobbyId)?.let { broadcastReadyStatus(it) }
         }
     }
 
@@ -262,7 +292,11 @@ class TournamentMatchHandler(
 
         logger.info("Round ${round.roundNumber} complete for tournament $lobbyId")
 
-        lobby.clearReadyState()
+        // Deliberately NOT clearing ready state here. A ready flag is consumed the moment the player's
+        // match starts, so whoever is still ready at a round boundary never had it consumed: an early
+        // finisher who dismissed the game-over overlay and clicked Ready while the round was finishing,
+        // a player who sat out a BYE, or an AI. Wiping them discarded a deliberate Ready action and
+        // forced a second click; none of them has a game-over overlay a new game could start under.
 
         val connectedIds = lobby.players.values
             .filter { it.identity.isConnected }
@@ -371,21 +405,27 @@ class TournamentMatchHandler(
                 standings = tournament.getStandingsInfo(connectedIds),
                 nextOpponentName = nextOpponentName,
                 nextRoundHasBye = hasBye,
-                isTournamentComplete = tournament.isComplete
+                isTournamentComplete = tournament.isComplete,
+                currentRoundComplete = completedRound.isComplete
             ))
         }
 
         ctx.lobbyRepository.saveTournament(lobbyId, tournament)
     }
 
-    fun tryStartMatchForPlayer(
+    /**
+     * Complete and announce every BYE sitting between this player and their next real match. A bye
+     * has no opponent to wait for, so it resolves the moment the player is ready for it.
+     */
+    fun resolveByesForPlayer(
         lobby: TournamentLobby,
         tournament: TournamentManager,
         identity: PlayerIdentity
     ) {
-        val (round, match) = tournament.getNextMatchForPlayer(identity.playerId) ?: return
+        while (true) {
+            val (round, match) = tournament.getNextMatchForPlayer(identity.playerId) ?: return
+            if (!match.isBye) return
 
-        if (match.isBye) {
             match.isComplete = true
             val ws = identity.webSocketSession
             if (ws != null && ws.isOpen) {
@@ -396,25 +436,36 @@ class TournamentMatchHandler(
                 spectatingHandler.sendActiveMatchesToPlayer(identity, ws)
             }
             ctx.lobbyRepository.saveTournament(lobby.lobbyId, tournament)
-            tryStartMatchForPlayer(lobby, tournament, identity)
-            return
         }
+    }
 
-        val opponentId = if (match.player1Id == identity.playerId) match.player2Id else match.player1Id
-        if (opponentId == null) return
-
-        if (opponentId !in lobby.getReadyPlayerIds()) return
-
-        if (tournament.hasIncompleteMatchBefore(identity.playerId, round.roundNumber)) return
-        if (tournament.hasIncompleteMatchBefore(opponentId, round.roundNumber)) return
-
-        logger.info("Both players ready, starting match: ${identity.playerName} vs ${lobby.players[opponentId]?.identity?.playerName}")
-        val started = startSingleMatch(lobby, tournament, round, match)
-
-        if (started) {
-            lobby.clearPlayerReady(identity.playerId)
-            lobby.clearPlayerReady(opponentId)
+    /**
+     * Launch every match both of whose seats are ready — see [TournamentManager.startableMatches].
+     *
+     * This is a sweep over the whole ready set, not a lookup for one player, because a ready flag is
+     * consumed only when a match actually starts: a pair refused by the earlier-round guard stays
+     * ready, and `markPlayerReady` will never transition false→true for them a second time. Nothing
+     * else would ever reconsider them, so every caller that changes the ready set *or* completes a
+     * match runs this pass.
+     */
+    fun startReadyMatches(lobby: TournamentLobby, tournament: TournamentManager) {
+        var startedAny = false
+        for ((round, match) in tournament.startableMatches(lobby.getReadyPlayerIds())) {
+            val player2Id = match.player2Id ?: continue
+            logger.info(
+                "Both players ready, starting round ${round.roundNumber} match: " +
+                    "${lobby.players[match.player1Id]?.identity?.playerName} vs " +
+                    "${lobby.players[player2Id]?.identity?.playerName}"
+            )
+            if (startSingleMatch(lobby, tournament, round, match)) {
+                lobby.clearPlayerReady(match.player1Id)
+                lobby.clearPlayerReady(player2Id)
+                startedAny = true
+            }
         }
+        // The starts above consumed ready flags; push the new authoritative set so the lobby's
+        // "n/m ready" counter doesn't keep counting players who are already in a game.
+        if (startedAny) broadcastReadyStatus(lobby)
     }
 
     fun startSingleMatch(
@@ -808,76 +859,90 @@ class TournamentMatchHandler(
     }
 
     private fun autoReadyAiPlayersLocked(lobby: TournamentLobby, tournament: TournamentManager, autoReadyHumansVsAi: Boolean) {
-        // Check if there are any AI players with submitted decks to ready up
+        // Any AI seat with a submitted deck that isn't ready yet. When every AI is already ready there
+        // is nothing to mark — but that must NOT short-circuit the [startReadyMatches] sweep at the
+        // bottom: a pair blocked by an earlier-round game stays ready, and re-examining the whole ready
+        // set is the only thing that starts it once the blocker lands.
         val hasAiPlayersToReady = lobby.players.any { (playerId, ps) ->
             aiGameManager.isAiPlayer(playerId) && ps.hasSubmittedDeck && playerId !in lobby.getReadyPlayerIds()
         }
-        if (!hasAiPlayersToReady) return
 
-        // Ensure the round is initialized so matches can be found and started
-        if (lobby.allDecksSubmitted() && (tournament.currentRound == null || tournament.currentRound?.isComplete == true)) {
-            val round = tournament.startNextRound()
-            if (round != null) {
-                for (match in round.matches) {
-                    if (match.isBye && match.isComplete) {
-                        val byePlayerState = lobby.players[match.player1Id]
-                        val byeWs = byePlayerState?.identity?.webSocketSession
-                        if (byeWs != null && byeWs.isOpen) {
-                            ctx.sender.send(byeWs, ServerMessage.TournamentBye(
-                                lobbyId = lobby.lobbyId,
-                                round = round.roundNumber
-                            ))
-                            spectatingHandler.sendActiveMatchesToPlayer(byePlayerState.identity, byeWs)
+        if (hasAiPlayersToReady) {
+            // Ensure the round is initialized so matches can be found and started
+            if (lobby.allDecksSubmitted() && (tournament.currentRound == null || tournament.currentRound?.isComplete == true)) {
+                val round = tournament.startNextRound()
+                if (round != null) {
+                    for (match in round.matches) {
+                        if (match.isBye && match.isComplete) {
+                            val byePlayerState = lobby.players[match.player1Id]
+                            val byeWs = byePlayerState?.identity?.webSocketSession
+                            if (byeWs != null && byeWs.isOpen) {
+                                ctx.sender.send(byeWs, ServerMessage.TournamentBye(
+                                    lobbyId = lobby.lobbyId,
+                                    round = round.roundNumber
+                                ))
+                                spectatingHandler.sendActiveMatchesToPlayer(byePlayerState.identity, byeWs)
+                            }
                         }
                     }
+                    ctx.lobbyRepository.saveTournament(lobby.lobbyId, tournament)
+                    logger.info("Prepared round ${round.roundNumber} for tournament ${lobby.lobbyId}")
                 }
-                ctx.lobbyRepository.saveTournament(lobby.lobbyId, tournament)
-                logger.info("Prepared round ${round.roundNumber} for tournament ${lobby.lobbyId}")
             }
-        }
 
-        for ((playerId, playerState) in lobby.players) {
-            if (!aiGameManager.isAiPlayer(playerId)) continue
-            if (!playerState.hasSubmittedDeck) continue
+            for ((playerId, playerState) in lobby.players) {
+                if (!aiGameManager.isAiPlayer(playerId)) continue
+                if (!playerState.hasSubmittedDeck) continue
 
-            val wasNewlyReady = lobby.markPlayerReady(playerId)
-            if (wasNewlyReady) {
-                logger.info("AI ${playerState.identity.playerName} auto-ready for next round")
-                tryStartMatchForPlayer(lobby, tournament, playerState.identity)
+                if (lobby.markPlayerReady(playerId)) {
+                    logger.info("AI ${playerState.identity.playerName} auto-ready for next round")
+                    // Broadcast the AI's flip too. The human branches below do; without this the other
+                    // clients' ready indicators stay stale until something else happens to broadcast.
+                    broadcastReadyStatus(lobby, playerState.identity)
+                    resolveByesForPlayer(lobby, tournament, playerState.identity)
+                }
             }
         }
 
         // Auto-ready human players whose next opponent is AI (no reason to wait).
         // Skipped after a game/round ends: the human must dismiss the game-over overlay and click
         // "Ready for Next Round" first, otherwise the next game would start under the overlay.
-        if (!autoReadyHumansVsAi) return
-        for ((playerId, playerState) in lobby.players) {
-            if (aiGameManager.isAiPlayer(playerId)) continue
-            if (!playerState.hasSubmittedDeck) continue
-            if (playerId in lobby.getReadyPlayerIds()) continue
+        if (autoReadyHumansVsAi) {
+            for ((playerId, playerState) in lobby.players) {
+                if (aiGameManager.isAiPlayer(playerId)) continue
+                if (!playerState.hasSubmittedDeck) continue
+                if (playerId in lobby.getReadyPlayerIds()) continue
 
-            val nextMatch = tournament.getNextMatchForPlayer(playerId) ?: continue
-            val (nextRound, match) = nextMatch
-            val opponentId = if (match.player1Id == playerId) match.player2Id else match.player1Id
-            if (opponentId == null || !aiGameManager.isAiPlayer(opponentId)) continue
+                val nextMatch = tournament.getNextMatchForPlayer(playerId) ?: continue
+                val (nextRound, match) = nextMatch
+                val opponentId = if (match.player1Id == playerId) match.player2Id else match.player1Id
+                if (opponentId == null || !aiGameManager.isAiPlayer(opponentId)) continue
 
-            if (tournament.hasIncompleteMatchBefore(playerId, nextRound.roundNumber)) continue
+                if (tournament.hasIncompleteMatchBefore(playerId, nextRound.roundNumber)) continue
 
-            lobby.markPlayerReady(playerId)
-            logger.info("Auto-readied ${playerState.identity.playerName} (opponent is AI)")
-            broadcastReadyStatus(lobby, playerState.identity)
-            tryStartMatchForPlayer(lobby, tournament, playerState.identity)
+                lobby.markPlayerReady(playerId)
+                logger.info("Auto-readied ${playerState.identity.playerName} (opponent is AI)")
+                broadcastReadyStatus(lobby, playerState.identity)
+                resolveByesForPlayer(lobby, tournament, playerState.identity)
+            }
         }
+
+        startReadyMatches(lobby, tournament)
     }
 
-    fun broadcastReadyStatus(lobby: TournamentLobby, identity: PlayerIdentity) {
+    /**
+     * Push the authoritative ready set to every connected player. [identity] names the player whose
+     * flag just went up, when there is one; a plain snapshot — after match starts consumed flags —
+     * passes null and only carries the set.
+     */
+    fun broadcastReadyStatus(lobby: TournamentLobby, identity: PlayerIdentity? = null) {
         val connectedPlayers = lobby.players.values.filter { it.identity.isConnected }
         val readyPlayerIds = lobby.getReadyPlayerIds().map { it.value }
 
         val readyMessage = ServerMessage.PlayerReadyForRound(
             lobbyId = lobby.lobbyId,
-            playerId = identity.playerId.value,
-            playerName = identity.playerName,
+            playerId = identity?.playerId?.value,
+            playerName = identity?.playerName,
             readyPlayerIds = readyPlayerIds,
             totalConnectedPlayers = connectedPlayers.size
         )

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -810,11 +810,14 @@ sealed interface ServerMessage {
         /** True if the tournament is complete (no more rounds) */
         val isTournamentComplete: Boolean = false,
         /**
-         * True when every match in [round] is finished. False means this player finished early and the
-         * round is still running — the client must keep showing [round] as in progress instead of
-         * advertising the next one, and a `RoundComplete` for [round] is still to come.
+         * True when every match in [round] is finished. False means this player finished early and
+         * [round] is still running — the client must keep showing it as in progress instead of
+         * advertising the next one, and a `RoundComplete` for it is still to come.
+         *
+         * Named for [round], not for the tournament's current round: eager starting means a later
+         * round's match can finish while an earlier round is still the current one.
          */
-        val currentRoundComplete: Boolean = false,
+        val roundComplete: Boolean = false,
     ) : ServerMessage
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -809,6 +809,12 @@ sealed interface ServerMessage {
         val nextRoundHasBye: Boolean = false,
         /** True if the tournament is complete (no more rounds) */
         val isTournamentComplete: Boolean = false,
+        /**
+         * True when every match in [round] is finished. False means this player finished early and the
+         * round is still running — the client must keep showing [round] as in progress instead of
+         * advertising the next one, and a `RoundComplete` for [round] is still to come.
+         */
+        val currentRoundComplete: Boolean = false,
     ) : ServerMessage
 
     /**
@@ -819,8 +825,11 @@ sealed interface ServerMessage {
     @SerialName("playerReadyForRound")
     data class PlayerReadyForRound(
         val lobbyId: String,
-        val playerId: String,
-        val playerName: String,
+        /** The player whose ready flag just went up; null when this is a plain snapshot re-broadcast. */
+        val playerId: String? = null,
+        /** Name of [playerId]; null on a snapshot re-broadcast. */
+        val playerName: String? = null,
+        /** The authoritative ready set — clients replace their own copy with this, they don't merge. */
         val readyPlayerIds: List<String>,
         val totalConnectedPlayers: Int
     ) : ServerMessage

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/TournamentManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/TournamentManager.kt
@@ -618,6 +618,34 @@ class TournamentManager(
     }
 
     /**
+     * Every match that could be launched right now, given the set of players who are ready.
+     *
+     * A match qualifies when it has two seats (no BYE), hasn't been started or decided, both seats
+     * are ready, and neither seat still owes a game from an earlier round — see
+     * [hasIncompleteMatchBefore]. That last guard is why this query exists rather than a per-player
+     * lookup: a pair can become startable purely because somebody *else's* earlier-round match
+     * finished, with no change to the ready set, so the whole set has to be re-examined whenever a
+     * result lands.
+     *
+     * A player appears in at most one returned pair: their earliest unplayed match blocks every
+     * later one through the same guard, so the caller can start all of them in one sweep.
+     */
+    fun startableMatches(readyPlayerIds: Set<EntityId>): List<Pair<TournamentRound, TournamentMatch>> {
+        val startable = mutableListOf<Pair<TournamentRound, TournamentMatch>>()
+        for (round in rounds) {
+            for (match in round.matches) {
+                if (match.isBye || match.isComplete || match.gameSessionId != null) continue
+                val player2Id = match.player2Id ?: continue
+                if (match.player1Id !in readyPlayerIds || player2Id !in readyPlayerIds) continue
+                if (hasIncompleteMatchBefore(match.player1Id, round.roundNumber)) continue
+                if (hasIncompleteMatchBefore(player2Id, round.roundNumber)) continue
+                startable.add(round to match)
+            }
+        }
+        return startable
+    }
+
+    /**
      * Get the round containing a specific match (by gameSessionId).
      */
     fun getRoundForMatch(gameSessionId: String): TournamentRound? {

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/tournament/TournamentProgressionTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/tournament/TournamentProgressionTest.kt
@@ -110,6 +110,44 @@ class TournamentProgressionTest : FunSpec({
         startable.flatMap { (_, m) -> listOfNotNull(m.player1Id, m.player2Id) }.toSet() shouldBe everyone
     }
 
+    test("a finished round keeps answering isRoundComplete until it is advanced past") {
+        // Why the round-complete path advances the bracket itself. It used to get that for free: it
+        // cleared the ready set, which made the AI-ready pass find work, which called startNextRound.
+        // With readies surviving a round boundary that guard is false, and an un-advanced `currentRound`
+        // is not cosmetic — `isRoundComplete()` reads it, so it answers true forever.
+        val manager = tournament()
+        val round1 = manager.startNextRound()!!
+        manager.startAll(round1)
+        round1.matches.forEach { manager.reportMatchResult(it.gameSessionId!!, it.player1Id) }
+
+        manager.isRoundComplete() shouldBe true
+        manager.currentRound?.roundNumber shouldBe 1
+
+        manager.startNextRound()!!.roundNumber shouldBe 2
+        manager.isRoundComplete() shouldBe false
+    }
+
+    test("a later round's result is attributable to that round, not to the current one") {
+        // The other half: matches from later rounds run concurrently with the current round, so a
+        // result arriving while `currentRound` still points at a finished round must not be taken as
+        // closing it — that re-announces a closed round and clears every player's game-session pointer,
+        // including seats that are mid-game. `getRoundForMatch` is what tells the two apart.
+        val manager = tournament()
+        val round1 = manager.startNextRound()!!
+        manager.startAll(round1)
+        round1.matches.forEach { manager.reportMatchResult(it.gameSessionId!!, it.player1Id) }
+
+        // Round 1 is done but nothing advanced yet — exactly the window the sweep runs in.
+        val (round2, someRound2Match) = manager.getNextMatchForPlayer(human)!!
+        round2.roundNumber shouldBe 2
+        someRound2Match.gameSessionId = "r2-eager"
+        manager.reportMatchResult("r2-eager", human)
+
+        manager.currentRound?.roundNumber shouldBe 1
+        manager.getRoundForMatch("r2-eager")?.roundNumber shouldBe 2
+        manager.getRoundForMatch(round1.matches.first().gameSessionId!!)?.roundNumber shouldBe 1
+    }
+
     test("a player mid-match is distinguishable from one waiting, so a stale Ready can be refused") {
         // The handler refuses a ready click from a player whose match is still running: they can't have
         // dismissed a game-over overlay yet, and banking it would consent to the match *after* this one,

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/tournament/TournamentProgressionTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/tournament/TournamentProgressionTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.gameserver.tournament
+
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cross-round matchmaking liveness for the shape that actually stalls in production: one human and
+ * seven AI seats, where the human finishes their round-1 match long before the AI-vs-AI games around
+ * them.
+ *
+ * The mechanism behind that stall is [TournamentManager.startableMatches] versus
+ * [TournamentManager.hasIncompleteMatchBefore]: a pair can go from blocked to startable purely
+ * because a *third* pair's earlier-round game finished, with no change at all to the ready set. The
+ * handler used to look for a startable match only on a false→true ready transition, so once every AI
+ * was marked ready nothing ever re-asked and the round-2 slate sat idle — permanently, whenever the
+ * round-complete fallback was skipped because the round had already been advanced.
+ */
+class TournamentProgressionTest : FunSpec({
+
+    val human = EntityId("human")
+    val ai = (1..7).map { EntityId("ai$it") }
+    val everyone = (listOf(human) + ai).toSet()
+
+    fun tournament(): TournamentManager = TournamentManager(
+        lobbyId = "lobby-1952",
+        players = (listOf(human to "Vincent") + ai.mapIndexed { i, id -> id to "AI ${i + 1}" }),
+        gamesPerMatch = 1
+    )
+
+    fun TournamentRound.matchFor(playerId: EntityId): TournamentMatch =
+        matches.first { it.player1Id == playerId || it.player2Id == playerId }
+
+    fun TournamentMatch.opponentOf(playerId: EntityId): EntityId =
+        (if (player1Id == playerId) player2Id else player1Id)!!
+
+    // Launches a match the way the handler does: stamping a session id is what takes it out of both
+    // `startableMatches` and `getNextMatchForPlayer`.
+    fun TournamentManager.startAll(round: TournamentRound) {
+        round.matches.forEachIndexed { i, match -> match.gameSessionId = "r${round.roundNumber}-g$i" }
+    }
+
+    test("the schedule opens on round 1, not round 2") {
+        val manager = tournament()
+        val first = manager.startNextRound()!!
+        first.roundNumber shouldBe 1
+        manager.currentRound?.roundNumber shouldBe 1
+        // 8 players, no BYE: four concurrent matches per round, seven rounds of round robin.
+        first.matches.size shouldBe 4
+        first.matches.none { it.isBye } shouldBe true
+        manager.totalRounds shouldBe 7
+    }
+
+    test("a pair blocked by an earlier-round match becomes startable when that match finishes") {
+        val manager = tournament()
+        val round1 = manager.startNextRound()!!
+
+        // Everyone readies and all four round-1 matches start; starting consumes the ready flags.
+        manager.startableMatches(everyone).size shouldBe 4
+        manager.startAll(round1)
+        manager.startableMatches(everyone).shouldBeEmpty()
+
+        // The human wins early while the other three round-1 games are still running.
+        val humanRound1 = round1.matchFor(human)
+        val humansRound1Opponent = humanRound1.opponentOf(human)
+        manager.reportMatchResult(humanRound1.gameSessionId!!, human)
+        manager.isRoundComplete() shouldBe false
+
+        // Both early finishers ready up for round 2 — the human by clicking Ready after dismissing the
+        // game-over overlay, the AI through the auto-ready pass.
+        val ready = mutableSetOf(human, humansRound1Opponent)
+
+        // Their round-2 opponents are still mid-round-1, so nothing may start. That is the
+        // `hasIncompleteMatchBefore` invariant and it has to stay intact.
+        manager.startableMatches(ready).shouldBeEmpty()
+
+        // The auto-ready pass sweeps every AI, including the six still playing round 1. Still nothing
+        // may start: every candidate pair has a seat that owes a round-1 game.
+        ready += ai
+        manager.startableMatches(ready).shouldBeEmpty()
+
+        // Now the blocker lands — the human's round-2 opponent finishes their round-1 match. No ready
+        // flag changed, so a transition-triggered retry would never look again; re-examining the ready
+        // set has to find the pair.
+        val (round2, humansRound2) = manager.getNextMatchForPlayer(human)!!
+        round2.roundNumber shouldBe 2
+        val humansRound2Opponent = humansRound2.opponentOf(human)
+        manager.hasIncompleteMatchBefore(humansRound2Opponent, 2) shouldBe true
+        manager.reportMatchResult(round1.matchFor(humansRound2Opponent).gameSessionId!!, humansRound2Opponent)
+
+        manager.isRoundComplete() shouldBe false
+        manager.startableMatches(ready).map { it.second } shouldContainExactly listOf(humansRound2)
+        manager.startableMatches(ready).single().first.roundNumber shouldBe 2
+    }
+
+    test("no seat is offered two matches at once, so the whole sweep can be launched in one pass") {
+        val manager = tournament()
+        val round1 = manager.startNextRound()!!
+
+        // Every round-1 game is decided and everybody is ready. Rounds 2..7 are all unplayed, but only
+        // round 2 may start: later rounds are held back by the round-2 games nobody has played yet.
+        manager.startAll(round1)
+        round1.matches.forEach { manager.reportMatchResult(it.gameSessionId!!, it.player1Id) }
+
+        val startable = manager.startableMatches(everyone)
+        startable.map { it.first.roundNumber }.toSet() shouldBe setOf(2)
+        startable.size shouldBe 4
+        startable.flatMap { (_, m) -> listOfNotNull(m.player1Id, m.player2Id) }.toSet() shouldBe everyone
+    }
+
+    test("a player mid-match is distinguishable from one waiting, so a stale Ready can be refused") {
+        // The handler refuses a ready click from a player whose match is still running: they can't have
+        // dismissed a game-over overlay yet, and banking it would consent to the match *after* this one,
+        // which the sweep would then launch the instant this one ended.
+        val manager = tournament()
+        val round1 = manager.startNextRound()!!
+        val humanRound1 = round1.matchFor(human)
+
+        manager.hasActiveMatch(human) shouldBe false
+        manager.startAll(round1)
+        manager.hasActiveMatch(human) shouldBe true
+        manager.reportMatchResult(humanRound1.gameSessionId!!, human)
+        manager.hasActiveMatch(human) shouldBe false
+    }
+
+    test("a seat that is not ready keeps its match out of the sweep") {
+        val manager = tournament()
+        val round1 = manager.startNextRound()!!
+        val humanRound1 = round1.matchFor(human)
+        val opponent = humanRound1.opponentOf(human)
+
+        // The human hasn't dismissed the game-over overlay yet, so only their opponent is ready.
+        manager.startableMatches(setOf(opponent)).shouldBeEmpty()
+        manager.startableMatches(setOf(human)).shouldBeEmpty()
+        manager.startableMatches(setOf(human, opponent)).map { it.second } shouldContainExactly listOf(humanRound1)
+    }
+})

--- a/web-client/src/components/tournament/TournamentOverlay.tsx
+++ b/web-client/src/components/tournament/TournamentOverlay.tsx
@@ -7,6 +7,7 @@ import { ReplayViewer, type GameSummary } from '../admin/ReplayViewer'
 import type { ReplayData } from '@/replay/reconstructSnapshots.ts'
 import { useDeckLibrary, buildDraftedDeckSave, type SavedDeckEntry } from '@/store/deckLibrary'
 import { useSaveDeck } from '@/store/useSaveDeck'
+import { deriveRoundPhase } from './roundPhase'
 import styles from '../ui/GameUI.module.css'
 
 /**
@@ -103,13 +104,9 @@ export function TournamentOverlay({
   // Spectators are not in the standings list
   const isSpectator = !playerId || !tournamentState.standings.some(s => s.playerId === playerId)
 
-  // Check if we're waiting for players to ready up (before first game OR between rounds)
-  const isWaitingForReady = (
-    // Before first round (round 0)
-    tournamentState.currentRound === 0 ||
-    // Between rounds (has results, no active match)
-    (tournamentState.lastRoundResults !== null && !tournamentState.currentMatchGameSessionId)
-  ) && !tournamentState.isComplete
+  // Waiting for ready (before the first game or between matches), and — the distinction that keeps an
+  // early finisher honest — whether the round they just finished is still being played elsewhere.
+  const { isWaitingForReady, roundStillRunning, roundNumber, readyLabel } = deriveRoundPhase(tournamentState)
 
   // Check if current player is ready
   const isPlayerReady = playerId ? tournamentState.readyPlayerIds.includes(playerId) : false
@@ -155,9 +152,7 @@ export function TournamentOverlay({
   }
 
   const roundLabel = !tournamentState.isComplete
-    ? isWaitingForReady
-      ? `Round ${tournamentState.currentRound + 1} of ${tournamentState.totalRounds}`
-      : `Round ${tournamentState.currentRound} of ${tournamentState.totalRounds}`
+    ? `Round ${roundNumber} of ${tournamentState.totalRounds}`
     : null
 
   return (
@@ -233,7 +228,7 @@ export function TournamentOverlay({
                 disabled={isPlayerReady}
                 className={styles.readyButton}
               >
-                {isPlayerReady ? '✓ Ready' : 'Ready for Next Round'}
+                {isPlayerReady ? '✓ Ready' : readyLabel}
               </button>
               {tournamentState.currentRound === 0 && !isPlayerReady && (
                 <button onClick={unsubmitDeck} className={styles.editDeckButton}>
@@ -246,10 +241,13 @@ export function TournamentOverlay({
             </div>
           )}
 
-          {/* Waiting for others */}
-          {!isWaitingForReady && !tournamentState.isBye && !tournamentState.currentMatchGameSessionId && (
+          {/* Waiting for others — including the early finisher who may already be ready: the round
+              they just played is still running, so the notice belongs next to the Ready button. */}
+          {(roundStillRunning || !isWaitingForReady) && !tournamentState.isBye && !tournamentState.currentMatchGameSessionId && (
             <div className={styles.statusBoxWaiting}>
-              Waiting for other matches to complete...
+              {roundStillRunning
+                ? `Round ${roundNumber} is still being played — your next match starts as soon as it can.`
+                : 'Waiting for other matches to complete...'}
             </div>
           )}
         </div>

--- a/web-client/src/components/tournament/TournamentOverlay.tsx
+++ b/web-client/src/components/tournament/TournamentOverlay.tsx
@@ -246,7 +246,9 @@ export function TournamentOverlay({
           {(roundStillRunning || !isWaitingForReady) && !tournamentState.isBye && !tournamentState.currentMatchGameSessionId && (
             <div className={styles.statusBoxWaiting}>
               {roundStillRunning
-                ? `Round ${roundNumber} is still being played — your next match starts as soon as it can.`
+                ? isPlayerReady
+                  ? `Round ${roundNumber} is still being played — your next match starts as soon as it can.`
+                  : `Round ${roundNumber} is still being played at other tables.`
                 : 'Waiting for other matches to complete...'}
             </div>
           )}

--- a/web-client/src/components/tournament/roundPhase.test.ts
+++ b/web-client/src/components/tournament/roundPhase.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { deriveRoundPhase, type RoundPhaseInput } from './roundPhase'
+
+const base: RoundPhaseInput = {
+  currentRound: 0,
+  currentRoundComplete: false,
+  lastRoundResults: null,
+  currentMatchGameSessionId: null,
+  isComplete: false,
+}
+
+const phase = (over: Partial<RoundPhaseInput>) => deriveRoundPhase({ ...base, ...over })
+
+describe('deriveRoundPhase', () => {
+  it('offers Ready for round 1 before the tournament starts', () => {
+    const p = phase({})
+    expect(p.isWaitingForReady).toBe(true)
+    expect(p.roundStillRunning).toBe(false)
+    expect(p.roundNumber).toBe(1)
+  })
+
+  it('names the round being played while in a match', () => {
+    const p = phase({ currentRound: 2, currentMatchGameSessionId: 'g7', lastRoundResults: [] })
+    expect(p.isWaitingForReady).toBe(false)
+    expect(p.roundNumber).toBe(2)
+  })
+
+  it('keeps naming the current round when we finished early and it is still running', () => {
+    // The one-human/seven-AI case: our matchComplete populated lastRoundResults, but three AI-vs-AI
+    // tables are still playing round 1. Labelling this "Round 2" was the reported bug.
+    const p = phase({ currentRound: 1, lastRoundResults: [{}], currentRoundComplete: false })
+    expect(p.isWaitingForReady).toBe(true)
+    expect(p.roundStillRunning).toBe(true)
+    expect(p.roundNumber).toBe(1)
+    expect(p.readyLabel).toBe('Ready for Next Match')
+  })
+
+  it('advertises the next round once the round has actually completed', () => {
+    const p = phase({ currentRound: 1, lastRoundResults: [{}], currentRoundComplete: true })
+    expect(p.isWaitingForReady).toBe(true)
+    expect(p.roundStillRunning).toBe(false)
+    expect(p.roundNumber).toBe(2)
+    expect(p.readyLabel).toBe('Ready for Next Round')
+  })
+
+  it('drops out of the waiting state once a new match starts', () => {
+    // roundComplete then matchStarting: currentRoundComplete goes back to false because we are
+    // playing in the new round — and that must not resurrect the "still running" wording.
+    const p = phase({ currentRound: 2, lastRoundResults: [{}], currentMatchGameSessionId: 'g9' })
+    expect(p.isWaitingForReady).toBe(false)
+    expect(p.roundStillRunning).toBe(false)
+    expect(p.roundNumber).toBe(2)
+  })
+
+  it('stops offering Ready when the tournament is over', () => {
+    const p = phase({ currentRound: 7, lastRoundResults: [{}], currentRoundComplete: true, isComplete: true })
+    expect(p.isWaitingForReady).toBe(false)
+    expect(p.roundStillRunning).toBe(false)
+  })
+})

--- a/web-client/src/components/tournament/roundPhase.ts
+++ b/web-client/src/components/tournament/roundPhase.ts
@@ -1,0 +1,48 @@
+/**
+ * Where a tournament player stands between games: in a match, waiting out a round that's still being
+ * played at other tables, or genuinely between rounds.
+ *
+ * The distinction the overlay used to miss is the middle one. `lastRoundResults` is populated by our
+ * *own* `matchComplete`, so an early finisher looked identical to a player whose round had ended —
+ * and the header advertised `currentRound + 1` while three other tables were still playing. The
+ * server settles it with `currentRoundComplete`; this derivation is the single place that reads it.
+ *
+ * Readying early is still allowed and still meaningful: the server keeps the flag and starts the
+ * match the moment the round-boundary guards clear. Only the labelling changes.
+ */
+export interface RoundPhaseInput {
+  readonly currentRound: number
+  readonly currentRoundComplete: boolean
+  readonly lastRoundResults: readonly unknown[] | null
+  readonly currentMatchGameSessionId: string | null
+  readonly isComplete: boolean
+}
+
+export interface RoundPhase {
+  /** The player is out of a game and may click Ready — before round 1, or between matches. */
+  readonly isWaitingForReady: boolean
+  /** Other tables are still playing the round named by `roundNumber`. */
+  readonly roundStillRunning: boolean
+  /** The round the header should name: the one in progress, or the one being readied for. */
+  readonly roundNumber: number
+  /** Ready-button text — "next match" while the round runs on, "next round" once it's done. */
+  readonly readyLabel: string
+}
+
+export function deriveRoundPhase(state: RoundPhaseInput): RoundPhase {
+  const betweenMatches =
+    // Before round 1 the server hasn't sent a round number yet.
+    state.currentRound === 0 ||
+    // Our match ended (results arrived) and we haven't been put in a new one.
+    (state.lastRoundResults !== null && !state.currentMatchGameSessionId)
+  const isWaitingForReady = betweenMatches && !state.isComplete
+
+  const roundStillRunning = isWaitingForReady && state.currentRound > 0 && !state.currentRoundComplete
+
+  return {
+    isWaitingForReady,
+    roundStillRunning,
+    roundNumber: isWaitingForReady && !roundStillRunning ? state.currentRound + 1 : state.currentRound,
+    readyLabel: roundStillRunning ? 'Ready for Next Match' : 'Ready for Next Round',
+  }
+}

--- a/web-client/src/store/slices/handlers/lobbyHandlers.ts
+++ b/web-client/src/store/slices/handlers/lobbyHandlers.ts
@@ -138,6 +138,7 @@ export function createLobbyHandlers(set: SetState, get: GetState): Pick<MessageH
           readyPlayerIds: [],
           nextOpponentName: msg.nextOpponentName ?? null,
           nextRoundHasBye: msg.nextRoundHasBye ?? false,
+          currentRoundComplete: false,
         },
         // Keep deckBuildingState but ensure phase is 'submitted'
         deckBuildingState: state.deckBuildingState
@@ -158,6 +159,8 @@ export function createLobbyHandlers(set: SetState, get: GetState): Pick<MessageH
               readyPlayerIds: [],
               nextOpponentName: null,
               nextRoundHasBye: false,
+              // We're playing in this round, so it plainly isn't finished.
+              currentRoundComplete: false,
               activeMatches: [], // Clear - player is now in a game
             }
           : null,
@@ -200,6 +203,8 @@ export function createLobbyHandlers(set: SetState, get: GetState): Pick<MessageH
                 readyPlayerIds: [],
                 nextOpponentName: msg.nextOpponentName ?? null,
                 nextRoundHasBye: msg.nextRoundHasBye ?? false,
+                // This message *is* the round ending — every table in it has finished.
+                currentRoundComplete: true,
                 activeMatches: [], // Clear - round is over, no active matches
               }
             : null,
@@ -234,6 +239,9 @@ export function createLobbyHandlers(set: SetState, get: GetState): Pick<MessageH
                 readyPlayerIds: [],
                 nextOpponentName: msg.nextOpponentName ?? null,
                 nextRoundHasBye: msg.nextRoundHasBye ?? false,
+                // Only *our* match ended. The server says whether the round did — an early finisher
+                // gets false here and must keep seeing the round in progress, not the next one.
+                currentRoundComplete: msg.currentRoundComplete ?? false,
                 activeMatches: [],
               }
             : null,

--- a/web-client/src/store/slices/handlers/lobbyHandlers.ts
+++ b/web-client/src/store/slices/handlers/lobbyHandlers.ts
@@ -178,6 +178,9 @@ export function createLobbyHandlers(set: SetState, get: GetState): Pick<MessageH
               currentMatchGameSessionId: null,
               currentMatchOpponentName: null,
               isBye: true,
+              // The round we're sitting out has just opened, so it is not finished. Without this the
+              // flag stays true from the previous roundComplete and the header reads one round ahead.
+              currentRoundComplete: false,
             }
           : null,
       }))
@@ -241,7 +244,7 @@ export function createLobbyHandlers(set: SetState, get: GetState): Pick<MessageH
                 nextRoundHasBye: msg.nextRoundHasBye ?? false,
                 // Only *our* match ended. The server says whether the round did — an early finisher
                 // gets false here and must keep seeing the round in progress, not the next one.
-                currentRoundComplete: msg.currentRoundComplete ?? false,
+                currentRoundComplete: msg.roundComplete ?? false,
                 activeMatches: [],
               }
             : null,
@@ -302,6 +305,10 @@ export function createLobbyHandlers(set: SetState, get: GetState): Pick<MessageH
               readyPlayerIds: [],
               nextOpponentName: msg.nextOpponentName ?? null,
               nextRoundHasBye: msg.nextRoundHasBye ?? false,
+              // Extra rounds are appended to a bracket that had finished, so the last played round is
+              // done — and if the tournament ended without a final roundComplete, the flag could still
+              // be false here and claim that round is running.
+              currentRoundComplete: true,
             }
           : null,
       }))

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -669,6 +669,12 @@ export interface TournamentState {
   nextOpponentName: string | null
   /** True if player has a BYE in the next round */
   nextRoundHasBye: boolean
+  /**
+   * True once every match in `currentRound` is finished. While false, we are an early finisher and
+   * the round is still being played at other tables — `lastRoundResults` being populated says only
+   * that *our* match ended, so it must never be read as "the round is over".
+   */
+  currentRoundComplete: boolean
 }
 
 /**

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1676,13 +1676,22 @@ export interface MatchCompleteMessage {
   readonly nextRoundHasBye?: boolean
   /** True if the tournament is complete (no more rounds) */
   readonly isTournamentComplete?: boolean
+  /**
+   * True when every match in `round` is finished. False means we finished early and the round is
+   * still running, so the overlay must keep naming `round` instead of advertising the next one; a
+   * `roundComplete` for the same round still follows.
+   */
+  readonly currentRoundComplete?: boolean
 }
 
 export interface PlayerReadyForRoundMessage {
   readonly type: 'playerReadyForRound'
   readonly lobbyId: string
-  readonly playerId: string
-  readonly playerName: string
+  /** The player whose ready flag just went up; absent when this is a plain snapshot re-broadcast. */
+  readonly playerId?: string | null
+  /** Name of `playerId`; absent on a snapshot re-broadcast. */
+  readonly playerName?: string | null
+  /** The authoritative ready set — replace the local copy with this, never merge into it. */
   readonly readyPlayerIds: readonly string[]
   readonly totalConnectedPlayers: number
 }

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1677,11 +1677,12 @@ export interface MatchCompleteMessage {
   /** True if the tournament is complete (no more rounds) */
   readonly isTournamentComplete?: boolean
   /**
-   * True when every match in `round` is finished. False means we finished early and the round is
-   * still running, so the overlay must keep naming `round` instead of advertising the next one; a
-   * `roundComplete` for the same round still follows.
+   * True when every match in `round` is finished. False means we finished early and `round` is still
+   * running, so the overlay must keep naming it instead of advertising the next one; a `roundComplete`
+   * message for the same round still follows. Named for `round`, not for the tournament's current
+   * round — eager starting lets a later round's match finish while an earlier one is still current.
    */
-  readonly currentRoundComplete?: boolean
+  readonly roundComplete?: boolean
 }
 
 export interface PlayerReadyForRoundMessage {


### PR DESCRIPTION
Fixes #1952.

## The stall

A ready flag is consumed only when a match actually *starts*. So a pair that
`hasIncompleteMatchBefore` refused — because either seat still owed an earlier-round game — stays
ready, and `markPlayerReady` will never transition false→true for them again. `autoReadyAiPlayers`
returned early once every submitted AI was already in the ready set, and only called
`tryStartMatchForPlayer` on that transition, so nothing ever reconsidered the pair when the blocking
game finished. With one human and seven AI seats, the human's early finish left the entire round-2
slate idle.

The reporter noted a full-round fallback that recovers this. It doesn't always fire: `autoReadyAiPlayers`
ran *before* the round-completion check and prepares the next round itself, so when the last match of a
round completed with any AI unready, `isRoundComplete()` reported on the freshly-prepared round and
`RoundComplete` was never broadcast at all. No fallback, no clear, no retry — a permanent deadlock, and
also why the client only ever saw `MatchComplete` and had to guess the round phase from it.

## The fix

**One pure query owns the decision.** `TournamentManager.startableMatches(readyPlayerIds)` returns every
pair that could launch right now. `hasIncompleteMatchBefore` is untouched and still gates each one, so no
unsafe cross-round start is introduced. A seat's earliest unplayed match blocks its later ones through
that same guard, so no seat appears twice and the whole sweep can be launched in one pass.

**Every result re-runs the sweep.** `startReadyMatches` replaces the per-player lookup. This is the
substance of the fix: a pair goes from blocked to launchable because a *third* pair's game finished, with
no change to the ready set, so looking at ready transitions can't work.

**Round completion is decided before readiness is touched**, so `RoundComplete` is always broadcast.

**Round completion no longer wipes ready flags.** Whoever is still ready at a round boundary never had
theirs consumed — an early finisher who dismissed the overlay and clicked Ready, a BYE, an AI — and none
of them has a game-over overlay a new game could start under. Wiping them discarded a deliberate Ready
and forced a second click.

**A ready click is refused while the sender's own match is still running.** They can't have dismissed the
game-over overlay yet, and banking it consents to the match *after* this one — which the sweep would then
launch the instant this one ended. `SealedTournamentReconnectionTest` caught exactly this: a third
player's Ready arrived just after their own round-2 match started, and the new sweep dutifully began
round 3 the moment round 2 ended.

**Ready state is broadcast consistently.** The AI branch now broadcasts like the human one, and the
authoritative set is re-stated after every result — `MatchComplete`/`RoundComplete` make the client drop
its list, and readies that survive a round boundary would otherwise vanish from the counter.
`PlayerReadyForRound.playerId`/`playerName` are nullable for a plain snapshot.

**The overlay stops mislabelling an early finisher.** `MatchComplete` gains `currentRoundComplete`;
`lastRoundResults` only ever said *our* match ended. `deriveRoundPhase` reads the server's answer, keeps
naming the round in progress, keeps the waiting notice up beside the Ready button, and labels the button
"Ready for Next Match" while the round runs on. Readying early is still allowed and still honoured — only
the labelling changed.

Also restores the `readyEpoch` staleness check, which lost its only reader when this handler was split out
of `LobbyHandler` (the reporter flagged it as dead). `resumeTournament` for extra rounds is now its live case.

## Verification

- `TournamentProgressionTest` (new, pure and deterministic): one human + seven AI, asserts the schedule
  opens on round 1, that all four round-1 pairs start, that the pair stays blocked through the human's
  early finish *and* through the AI auto-ready sweep, and that finishing the blocker — changing no ready
  flag — makes exactly that pair startable. Plus the no-seat-twice and not-ready cases, and the
  mid-match/waiting distinction behind the stale-Ready guard.
- `roundPhase.test.ts` (new): the early-finisher label, the genuine between-rounds label, and the
  in-match and tournament-over cases.
- `just test-server` green (496 tests) — including `SealedTournamentReconnectionTest`'s full multi-round
  flow, which failed against an earlier draft of this change and passes now.
- `npm run typecheck` and the full vitest suite (590 tests) green.

Not covered: reconnecting mid-tournament still resets the client to round 0 because `TournamentStarted`
carries no round number. Pre-existing, unchanged here, and it leaves the new phase derivation behaving
exactly as today on that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
