### PR TITLE
Fix Deep-Cavern Bat exiling a card forever when it is killed in response to its trigger

### DIFF
--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DeepCavernBat.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DeepCavernBat.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.lci.cards
 
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
@@ -11,6 +12,7 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.LookAtTargetHandEffect
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
@@ -32,6 +34,13 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * The exile-until-leaves linkage is wired via `MoveCollectionEffect.linkToSource`
  * (storing chosen IDs in the bat's `LinkedExileComponent`) and
  * `Effects.ReturnLinkedExileToHand()` on the LeavesBattlefield trigger.
+ *
+ * The exile half is gated on the bat still being on the battlefield. "…until this creature leaves
+ * the battlefield" is a duration, so a bat that is already gone when the trigger resolves has no
+ * duration left to exile for: you still look at the hand, but you exile nothing (the 2023-11-10
+ * ruling below). Without the gate the card was exiled by a dead bat and never came back, because
+ * the LeavesBattlefield trigger that returns the linked pile had already resolved. The gate also
+ * keeps the "you may exile" prompt from being offered for a bat that can no longer hold anything.
  */
 val DeepCavernBat = card("Deep-Cavern Bat") {
     manaCost = "{1}{B}"
@@ -51,24 +60,31 @@ val DeepCavernBat = card("Deep-Cavern Bat") {
         effect = Effects.Composite(
             listOf(
                 LookAtTargetHandEffect(opponent),
-                GatherCardsEffect(
-                    source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
-                    storeAs = "opponentHand"
-                ),
-                SelectFromCollectionEffect(
-                    from = "opponentHand",
-                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
-                    chooser = Chooser.Controller,
-                    filter = GameObjectFilter.Nonland,
-                    storeSelected = "exiledCard",
-                    prompt = "You may exile a nonland card from target opponent's hand",
-                    showAllCards = true,
-                    alwaysPrompt = true
-                ),
-                MoveCollectionEffect(
-                    from = "exiledCard",
-                    destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0)),
-                    linkToSource = true
+                ConditionalEffect(
+                    condition = Conditions.SourceInZone(Zone.BATTLEFIELD),
+                    effect = Effects.Composite(
+                        listOf(
+                            GatherCardsEffect(
+                                source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                                storeAs = "opponentHand"
+                            ),
+                            SelectFromCollectionEffect(
+                                from = "opponentHand",
+                                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                                chooser = Chooser.Controller,
+                                filter = GameObjectFilter.Nonland,
+                                storeSelected = "exiledCard",
+                                prompt = "You may exile a nonland card from target opponent's hand",
+                                showAllCards = true,
+                                alwaysPrompt = true
+                            ),
+                            MoveCollectionEffect(
+                                from = "exiledCard",
+                                destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0)),
+                                linkToSource = true
+                            )
+                        )
+                    )
                 )
             )
         )

--- a/mtg-sets/2023/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DeepCavernBatScenarioTest.kt
+++ b/mtg-sets/2023/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DeepCavernBatScenarioTest.kt
@@ -1,0 +1,156 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Deep-Cavern Bat (LCI #102) — {1}{B} Creature — Bat, 1/1, flying, lifelink.
+ *
+ * "When this creature enters, look at target opponent's hand. You may exile a nonland card from it
+ *  until this creature leaves the battlefield."
+ *
+ * The exile half is a linked pipeline exile; the LTB trigger returns the linked pile to its owner's
+ * hand. These tests pin both halves — in particular that killing the bat gives the card back to the
+ * opponent who owned it.
+ */
+class DeepCavernBatScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Deep-Cavern Bat") {
+
+            test("ETB exiles a chosen nonland card; killing the bat returns it to its owner's hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Deep-Cavern Bat")
+                    .withCardInHand(1, "Murder")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withCardInHand(2, "Hill Giant")
+                    .withCardInHand(2, "Forest")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Deep-Cavern Bat")
+                game.resolveStack()
+                game.selectTargets(listOf(game.player2Id))
+                game.resolveStack()
+
+                val giantId = game.findCardsInHand(2, "Hill Giant").first()
+                game.selectCards(listOf(giantId))
+
+                withClue("the chosen nonland card is exiled") {
+                    game.isInHand(2, "Hill Giant") shouldBe false
+                    game.state.getExile(game.player2Id).any { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Hill Giant"
+                    } shouldBe true
+                }
+                withClue("the land stays in the opponent's hand") {
+                    game.isInHand(2, "Forest") shouldBe true
+                }
+
+                val batId = game.findPermanent("Deep-Cavern Bat")!!
+                val linked = game.state.getEntity(batId)?.get<LinkedExileComponent>()
+                linked shouldNotBe null
+                linked!!.exiledIds shouldHaveSize 1
+                linked.exiledIds.first() shouldBe giantId
+
+                game.castSpell(1, "Murder", batId).error shouldBe null
+                game.resolveStack()
+
+                withClue("the bat died") {
+                    game.isOnBattlefield("Deep-Cavern Bat") shouldBe false
+                    game.isInGraveyard(1, "Deep-Cavern Bat") shouldBe true
+                }
+                withClue("the exiled card goes back to its OWNER's hand") {
+                    game.isInHand(2, "Hill Giant") shouldBe true
+                    game.isInHand(1, "Hill Giant") shouldBe false
+                    game.state.getExile(game.player2Id) shouldHaveSize 0
+                }
+            }
+
+            test("dying in combat on a later turn still returns the exiled card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Deep-Cavern Bat")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(2, "Hill Giant")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Deep-Cavern Bat")
+                game.resolveStack()
+                game.selectTargets(listOf(game.player2Id))
+                game.resolveStack()
+                val giantId = game.findCardsInHand(2, "Hill Giant").first()
+                game.selectCards(listOf(giantId))
+                game.isInHand(2, "Hill Giant") shouldBe false
+
+                // Hand the turn over; the opponent attacks and the 1/1 bat blocks the 2/2 Bears.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 1)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Deep-Cavern Bat" to listOf("Grizzly Bears"))).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                game.resolveStack()
+
+                withClue("the bat died in combat") {
+                    game.isOnBattlefield("Deep-Cavern Bat") shouldBe false
+                    game.isInGraveyard(1, "Deep-Cavern Bat") shouldBe true
+                }
+                withClue("the exiled card goes back to its OWNER's hand") {
+                    game.isInHand(2, "Hill Giant") shouldBe true
+                    game.state.getExile(game.player2Id) shouldHaveSize 0
+                }
+            }
+
+            test("killed with its ETB trigger still on the stack, nothing is exiled") {
+                val game = scenario()
+                    .withPlayers("Player1", "Opponent")
+                    .withCardInHand(1, "Deep-Cavern Bat")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInHand(2, "Murder")
+                    .withCardInHand(2, "Hill Giant")
+                    .withLandsOnBattlefield(2, "Swamp", 3)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Deep-Cavern Bat")
+                game.passPriority()
+                game.passPriority() // the bat resolves; its ETB trigger goes on the stack
+                val batId = game.findPermanent("Deep-Cavern Bat")!!
+
+                // The opponent kills the bat while its ETB trigger is still on the stack.
+                game.passPriority()
+                game.castSpell(2, "Murder", batId).error shouldBe null
+                game.resolveStack()
+
+                withClue("the bat died before its trigger resolved") {
+                    game.isOnBattlefield("Deep-Cavern Bat") shouldBe false
+                    game.isInGraveyard(1, "Deep-Cavern Bat") shouldBe true
+                }
+                withClue("the trigger still looks at the hand, but exiles nothing (LCI ruling 2023-11-10)") {
+                    game.state.pendingDecision shouldBe null
+                    game.isInHand(2, "Hill Giant") shouldBe true
+                    game.state.getExile(game.player2Id) shouldHaveSize 0
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -4958,45 +4958,62 @@
                             }
                         },
                         {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Hand",
-                                "player": {
-                                    "type": "ContextPlayer",
-                                    "index": 0
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "SourceInZone",
+                                    "zones": [
+                                        "Battlefield"
+                                    ]
                                 }
                             },
-                            "storeAs": "opponentHand"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "opponentHand",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                }
-                            },
-                            "filter": "nonland",
-                            "storeSelected": "exiledCard",
-                            "prompt": "You may exile a nonland card from target opponent's hand",
-                            "showAllCards": true,
-                            "alwaysPrompt": true
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "exiledCard",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Exile",
-                                "player": {
-                                    "type": "ContextPlayer",
-                                    "index": 0
-                                }
-                            },
-                            "linkToSource": true
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand",
+                                            "player": {
+                                                "type": "ContextPlayer",
+                                                "index": 0
+                                            }
+                                        },
+                                        "storeAs": "opponentHand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "opponentHand",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "filter": "nonland",
+                                        "storeSelected": "exiledCard",
+                                        "prompt": "You may exile a nonland card from target opponent's hand",
+                                        "showAllCards": true,
+                                        "alwaysPrompt": true
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "exiledCard",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Exile",
+                                            "player": {
+                                                "type": "ContextPlayer",
+                                                "index": 0
+                                            }
+                                        },
+                                        "linkToSource": true
+                                    }
+                                ]
+                            }
                         }
                     ]
                 },


### PR DESCRIPTION
## The bug

Killing Deep-Cavern Bat did not give the card back to its owner — reported from a live game.

The exile half of *"When this creature enters, look at target opponent's hand. You may exile a nonland card from it until this creature leaves the battlefield"* ran with no check that the bat was still on the battlefield. Kill the bat while its ETB trigger is still on the stack (the ordinary way to play against it) and the trigger still exiled a card and wrote the link onto an entity that had already left. The `LeavesBattlefield` trigger that returns the linked pile had already resolved by then, so nothing ever returned the card: it was exiled **permanently**.

Killing the bat *after* the exile always worked; both of those paths are now pinned by tests too.

## The fix

`…until this creature leaves the battlefield` is a duration, so a bat that is already gone has none left to exile for: you still look at the hand, but you exile nothing. That is exactly the card's own ruling, which was already quoted in the file:

> **2023-11-10** — If Deep-Cavern Bat leaves the battlefield before its last ability resolves, you'll still look at the target opponent's hand, but you won't exile any cards from it.

The gather → select → move tail is now wrapped in `ConditionalEffect(Conditions.SourceInZone(Zone.BATTLEFIELD), …)`. Side benefit: the "you may exile a nonland card" prompt is no longer offered for a bat that can no longer hold anything.

`interveningIf` would have been wrong — the ability has no printed "if", and the "look at target opponent's hand" half still happens.

## Why the gate is in the card and not in `MoveCollectionExecutor`

`MoveCollectionEffect.linkToSource` looks like the natural place for a `sourceId !in state.getBattlefield()` guard (that is what `ExileUntilLeavesExecutor` does), but the flag carries two meanings the executor cannot tell apart:

- **duration** — "exile it *until this leaves the battlefield*" (Deep-Cavern Bat). Must not exile at all if the source is gone.
- **bookkeeping** — "exile that card" permanently, where the link only records *which* card for a later trigger (Severance Priest's LTB token, Spell Queller's "the owner may cast it"). Exiling with the source already gone is **correct** for these.

An executor-level gate would have broken the second group. Deep-Cavern Bat is the only pipeline `linkToSource` card whose oracle text spells the duration out; the rest either use `Effects.ExileUntilLeaves` (gated in its executor already) or exile permanently.

## Tests

New `DeepCavernBatScenarioTest` — one file, one card, three paths:

1. ETB exiles a chosen nonland card; removal kills the bat → card returns to its **owner's** hand.
2. The bat dies blocking a turn later → card still returns.
3. The bat is killed with its ETB trigger still on the stack → hand is looked at, nothing is exiled. **This one fails without the fix** (the Hill Giant lands in exile and stays there).

## Verification

- `just test-class DeepCavernBatScenarioTest` — 3/3 pass.
- `:mtg-sets:test` green (lint, facade boundary, snapshots).
- LCI card snapshot re-blessed; the diff is confined to this ability.
- `just assay-differential --set LCI` — 34/34 confirmed, 0 divergences.
- Oracle text and the ruling re-verified against Scryfall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)