### PR TITLE
Add Yarus, Roar of the Old Gods and Officious Interrogation (+ 3 engine gaps, 1 live bug fix)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3167,7 +3167,16 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
   aggregations ("creatures your opponents control").
 - `Player.ActivePlayerFirst` — all players in APNAP order.
 - `Player.TargetPlayer` / `Player.TargetOpponent` — the bound player target (resolved from the
-  chosen targets, never from turn order).
+  chosen targets, never from turn order). Both resolve to a **single** player, so on a spell that
+  targets several they silently read only the first — reach for `EachTargetedPlayer` there.
+- `Player.EachTargetedPlayer` — **every** player among the chosen targets: "those players" after
+  "choose any number of target players" (Officious Interrogation). Counting primitives sum over the
+  resolved list, which is what makes "the total number of creatures those players control" a single
+  `DynamicAmount.Count(Player.EachTargetedPlayer, Zone.BATTLEFIELD, Creature)` rather than a
+  per-target loop. Targets that have become illegal are already gone from the resolution context, so
+  they contribute nothing (CR 608.2b). Like `Each` / `EachOpponent` / `OwnersOfLinkedExile` it is a
+  *list-only* reference: the single-player resolver returns null for it deliberately, so a
+  `ForEach`-over-players reads it through its own arm.
 - `Player.DefendingPlayer` — CR 802.2a: the player the ability's source is attacking, read from
   the source's attack assignment (a creature attacking a planeswalker defends against its
   controller); falls back to the trigger's damaged player as last-known information for "deals
@@ -4209,7 +4218,15 @@ work for abilities-on-stack (which carry no `CardComponent`).
   source-relative "paired **with this creature**" — the affected set of a soulbond payoff — use
   `GroupFilter.soulbondPair()` (`Scope.SoulbondPair`) instead; a plain predicate can't express it,
   because group-static projection has no per-recipient source.
-- `IsFaceDown` — currently face-down.
+- `IsFaceDown` / `IsFaceUp` — currently face-down (CR 708). On a **zone-change trigger** off the
+  battlefield both read last-known information (`EntitySnapshot.wasFaceDown`) rather than the live
+  `FaceDownComponent`: a card put into a graveyard is turned face up (CR 708.4) and the battlefield
+  entity is gone by trigger-gating time, so "whenever a face-down creature you control dies" (Yarus,
+  Roar of the Old Gods) is only answerable from the snapshot (CR 608.2h). Note that a `faceDown()`
+  filter already *implies* creature — every face-down permanent is a 2/2 (CR 708.2) — so adding a
+  `Creature` card predicate alongside it on a dies trigger **narrows** it wrongly: the zone-change
+  path evaluates card predicates against the printed type line, which for a cloaked or manifested
+  land card is not a creature.
 - `HasCounter(type)` — has at least one counter of `type`.
 - `IsEquipped` (filter builder `equipped()`) — has at least one Equipment attached.
 - `IsEnchanted` (filter builder `enchanted()`) — has at least one **Aura** attached, i.e. the MTG
@@ -4699,7 +4716,7 @@ Named sugar for the common cases; reach for the factories for any other combinat
 - `DealsDamage` — source deals any damage (SELF binding).
 - `DealsCombatDamageToPlayer` — source deals combat damage to a player (SELF binding).
 - `DealsCombatDamageToCreature` — source deals combat damage to a creature (SELF binding).
-- `OneOrMoreDealCombatDamageToPlayerEvent(sourceFilter = Creature)` — **offensive combat-damage batch trigger** (ANY binding, via `TriggerSpec(OneOrMoreDealCombatDamageToPlayerEvent(sourceFilter = …), TriggerBinding.ANY)`): "whenever one or more [matching creatures] you control deal combat damage to a player" (Kastral, the Windcrested: `Creature.withSubtype("Bird")`; Vaan, Street Thief: `Creature.withAnySubtype("Scout", "Pirate", "Rogue")`). The `sourceFilter`'s "you control" is implied by the observer — don't add `youControl()`. Fires **once per damaged player** (a batch per recipient): multiple matching creatures hitting the same player still fire a single trigger, but two players each dealt damage fire it twice. `Player.TriggeringPlayer` resolves to the damaged player, so effects can reference "that player" (e.g. exile the top card of *that player's* library); `triggeringEntityId` is an arbitrary matching source for that player (batch triggers don't dispatch per source).
+- `OneOrMoreDealCombatDamageToPlayerEvent(sourceFilter = Creature)` — **offensive combat-damage batch trigger** (ANY binding, via `TriggerSpec(OneOrMoreDealCombatDamageToPlayerEvent(sourceFilter = …), TriggerBinding.ANY)`): "whenever one or more [matching creatures] you control deal combat damage to a player" (Kastral, the Windcrested: `Creature.withSubtype("Bird")`; Vaan, Street Thief: `Creature.withAnySubtype("Scout", "Pirate", "Rogue")`). The `sourceFilter`'s "you control" is implied by the observer — don't add `youControl()`. Fires **once per damaged player** (a batch per recipient): multiple matching creatures hitting the same player still fire a single trigger, but two players each dealt damage fire it twice. `Player.TriggeringPlayer` resolves to the damaged player, so effects can reference "that player" (e.g. exile the top card of *that player's* library); `triggeringEntityId` is an arbitrary matching source for that player (batch triggers don't dispatch per source). **Face-down attackers count**: a face-down permanent is a creature (CR 708.2), so it satisfies an unfiltered "creatures you control" batch trigger, and the filtered forms are decided by `PredicateEvaluator`'s face-down masking alone (subtypes, colors, mana value and **name** all read as absent) — which is why Yarus, Roar of the Old Gods can filter *to* `Creature.faceDown()` while Kastral's `Bird` filter still excludes one.
 - `OneOrMoreCreaturesDealCombatDamageToYou(filter = Creature)` — **defensive combat-damage batch trigger** (ANY binding): "whenever one or more creatures deal combat damage to *you*" (Witch-king of Angmar). Fires at most once per combat-damage batch regardless of how many creatures connected with the trigger's controller (the damaged player), unlike per-source `dealsDamage(recipient = You, …)` which fires once per connecting creature. The triggering entity is an arbitrary matching damager. Pair with the `dealtCombatDamageToSourceControllerThisTurn()` filter for "...each opponent sacrifices a creature that dealt combat damage to you this turn".
 - `TakesDamage` — source is dealt damage by any source (SELF binding).
 - `YouAreDealtDamage` — "whenever **you're** dealt damage" (ANY binding, `DealsDamageEvent(recipient = You)` with no source filter): the *player*-recipient sibling of `TakesDamage`, firing for **every** source — a creature in combat, a burn spell, an artifact. Fires once per damage instance; read the amount with `DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)` for "put that many counters" payoffs (Sun Droplet), and the triggering entity is the damage source.
@@ -6243,7 +6260,13 @@ staticAbility {
   permanent exists; a stack-spell target reduction shows at full cost during enumeration and locks
   in once targets are announced), `IncreaseGeneric(amount)`,
   `IncreaseColored(symbols)` (colored tax — adds colored pips, e.g. the Invasion Leeches'
-  "White spells you cast cost {W} more"), `IncreaseGenericPerOtherSpellThisTurn(amountPerSpell)`,
+  "White spells you cast cost {W} more"),
+  `IncreaseColoredPerUnit(symbols, countSource)` (the exact tax mirror of `ReduceColoredPerUnit`:
+  appends one copy of `symbols` per unit of `countSource`. Unlike the reduction side there is no
+  overflow question — added pips always land. Officious Interrogation's "This spell costs {W}{U}
+  more to cast for each target beyond the first" is
+  `SelfCast` + `IncreaseColoredPerUnit("{W}{U}", ChosenTargetsBeyondTheFirst)`),
+  `IncreaseGenericPerOtherSpellThisTurn(amountPerSpell)`,
   `IncreaseGenericIfAnyTargetMatches(amount, filter)` (target-gated tax — "{N} more if it targets
   a Dragon", Dragon's Prey; the increase analogue of the `FixedIfAnyTargetMatches` reduction;
   applies only once a matching target is chosen, so affordability enumeration treats it as not
@@ -6276,6 +6299,16 @@ staticAbility {
   so nine creature cards shave only {1}; the counting sibling of `CardsInGraveyardMatchingFilter`,
   which totals cards. Same aggregation as `Conditions.Delirium` over the same zone, capped by the
   number of card types — {9} for Emrakul), `FixedIfAnyTargetMatches`,
+  `ChosenTargetsBeyondTheFirst` (the count of the spell's chosen targets minus one — "for each
+  target beyond the first". Only meaningful on a `SelfCast` modifier, since only that path is priced
+  with the caster's own chosen targets; before targets are chosen it reads 0, which is also the right
+  answer for affordability enumeration because one target is the cheapest legal cast. Pair with
+  `IncreaseColoredPerUnit` for a colored tax or `IncreaseGenericBy` for a generic one. Note that a
+  per-target *increase* survives a free cast: "without paying its mana cost" and alternative costs
+  waive the mana cost, not the increases applied to the total cost (CR 601.2f), which
+  Officious Interrogation's 2024-02-02 ruling states outright — the cast pipeline adds
+  `CostCalculator.selfPerTargetTax` on top of exactly those branches. The life-cost sibling for the
+  same wording is `AdditionalCost.PayLifePerTarget`, Phyrexian Purge),
   `FixedIfCreatureDiedThisTurn(amount)` (the morbid discount — "costs {N} less to cast if a creature
   died this turn", Dreaded Bat-Cloud. Reads the same per-player `CreaturesDiedThisTurnComponent`
   tallies as `Conditions.CreatureDiedThisTurn`, summed across the table, so an opponent's creature

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -62,6 +62,8 @@ data class ModifySpellCost(
             is CostModification.IncreaseGenericBy ->
                 "cost {X} more to cast, where X is ${fromCasterPerspective(modification.source.description)}"
             is CostModification.IncreaseColored -> "cost ${modification.symbols} more to cast"
+            is CostModification.IncreaseColoredPerUnit ->
+                "cost ${modification.symbols} more to cast for each ${modification.countSource.description}"
             is CostModification.IncreaseGenericPerOtherSpellThisTurn ->
                 "cost {${modification.amountPerSpell}} more to cast for each other spell that player has cast this turn"
             is CostModification.IncreaseGenericIfAnyTargetMatches ->
@@ -361,6 +363,24 @@ sealed interface CostModification {
     data class IncreaseColored(val symbols: String) : CostModification
 
     /**
+     * Add [symbols] to the cost once per unit of [countSource] — the tax mirror of
+     * [ReduceColoredPerUnit], reading the same [CostReductionSource] vocabulary.
+     *
+     * Used for Officious Interrogation ("This spell costs {W}{U} more to cast for each target
+     * beyond the first") as
+     * `IncreaseColoredPerUnit("{W}{U}", CostReductionSource.ChosenTargetsBeyondTheFirst)`.
+     *
+     * Unlike the reduction side there is no overflow question: added symbols always land, so a
+     * count of N simply appends N copies of [symbols].
+     */
+    @SerialName("IncreaseColoredPerUnit")
+    @Serializable
+    data class IncreaseColoredPerUnit(
+        val symbols: String,
+        val countSource: CostReductionSource,
+    ) : CostModification
+
+    /**
      * Damping-Sphere-style scaling tax: increase by `amountPerSpell` for each spell
      * the casting player has already cast this turn.
      */
@@ -584,6 +604,25 @@ sealed interface CostReductionSource {
         val filter: GameObjectFilter
     ) : CostReductionSource {
         override val description: String = "$amount if it targets ${filter.description}"
+    }
+
+    /**
+     * The number of targets the spell has beyond the first — "for each target beyond the first"
+     * (Officious Interrogation, and the classic Phyrexian Purge / Fireball wording). Counts the
+     * spell's chosen targets, so it is 0 for a single-target cast and never negative.
+     *
+     * Only meaningful on a **self**-cast modifier ([SpellCostTarget.SelfCast]): "beyond the first"
+     * is a property of the spell being cast, and only the self path is priced with the caster's own
+     * chosen targets. Before targets are chosen (affordability enumeration) it reads 0, which is
+     * correct — one target is the cheapest legal cast, so the base cost is the true minimum.
+     *
+     * Pair with [CostModification.IncreaseColoredPerUnit] for a colored per-target tax and with
+     * [CostModification.IncreaseGenericBy] for a generic one.
+     */
+    @SerialName("ChosenTargetsBeyondTheFirst")
+    @Serializable
+    data object ChosenTargetsBeyondTheFirst : CostReductionSource {
+        override val description: String = "each target beyond the first"
     }
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
@@ -99,6 +99,23 @@ sealed interface Player {
         override val description: String = "target player"
     }
 
+    /**
+     * **Every** player among the spell or ability's chosen targets — "those players" after
+     * "choose any number of target players" (Officious Interrogation). The plural sibling of
+     * [TargetPlayer], which resolves to a single targeted player and so silently reads only the
+     * first when a spell targets several.
+     *
+     * Counting primitives sum over the resolved list, which is what makes "the total number of
+     * creatures those players control" one [DynamicAmount] instead of a per-target loop. A target
+     * that has become illegal by resolution is already gone from the context's target list, so it
+     * contributes nothing — exactly what Officious Interrogation's 2024-02-02 ruling requires.
+     */
+    @SerialName("EachTargetedPlayer")
+    @Serializable
+    data object EachTargetedPlayer : Player {
+        override val description: String = "those players"
+    }
+
     /** A targeted opponent (resolved at effect execution) */
     @SerialName("TargetOpponent")
     @Serializable
@@ -281,6 +298,7 @@ sealed interface Player {
             DefendingPlayer -> "defending player's"
             TargetOpponent -> "target opponent's"
             TargetPlayer -> "target player's"
+            EachTargetedPlayer -> "those players'"
             Each -> "each player's"
             ActivePlayerFirst -> "each player's"
             EachOpponent -> "each opponent's"

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/OfficiousInterrogation.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/OfficiousInterrogation.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Officious Interrogation — Murders at Karlov Manor #222
+ * {W}{U} · Instant
+ *
+ * This spell costs {W}{U} more to cast for each target beyond the first.
+ * Choose any number of target players. Investigate X times, where X is the total number of
+ * creatures those players control.
+ *
+ * **Three things had to exist first, and each is the general form, not a special case.**
+ *
+ * *The tax.* A per-*mode* mana increase already existed (escalate,
+ * `ModalEffect.additionalManaCostPerExtraMode`); a per-*target* one did not. Rather than build a
+ * second parallel rail through enumeration, validation and payment, this rides the
+ * [ModifySpellCost] / [SpellCostTarget.SelfCast] static that already prices a spell against its own
+ * chosen targets — the same machinery behind Dragon's Prey ("costs {2} more if it targets a
+ * Dragon"). Two additions: [CostReductionSource.ChosenTargetsBeyondTheFirst], a count source, and
+ * [CostModification.IncreaseColoredPerUnit], the exact tax mirror of the long-standing
+ * `ReduceColoredPerUnit`. Phyrexian Purge's "3 life more for each target" is the life-side sibling
+ * that already worked (`AdditionalCost.PayLifePerTarget`); this is the mana side.
+ *
+ * *The plural target reference.* "Those players" is not [Player.TargetPlayer] — that resolves to a
+ * *single* targeted player, so on a spell targeting four it would have counted one player's
+ * creatures and quietly under-investigated. [Player.EachTargetedPlayer] resolves to all of them,
+ * and `DynamicAmount.Count` sums over the resolved list, which is what makes "the total number of
+ * creatures those players control" one amount rather than a per-target loop. It also gets the
+ * 2024-02-02 ruling right for free: a target that has become illegal is already gone from the
+ * resolution context, so its creatures aren't counted.
+ *
+ * *A free cast still owes the tax.* "Costs {W}{U} more" is a cost *increase*, and an alternative
+ * cost or a "without paying its mana cost" permission waives the mana cost, not the increases
+ * applied to the total cost (CR 601.2f) — the card's own ruling says so outright. The ordinary cast
+ * path prices this inside `CostCalculator.calculateEffectiveCost`, which those branches never
+ * reach, so `CostCalculator.selfPerTargetTax` is added on top of them in both the validate and the
+ * execute half of the cast pipeline.
+ *
+ * `unlimited = true` is the right target shape for "any number of target players" — not
+ * `count = <n>, optional = true`, which caps at a magic number, and not a `dynamicMaxCount`, which
+ * is for "X target …". Zero targets is a legal (if inadvisable) cast, and the mana value stays 2
+ * however many targets are chosen, because the increase is applied to the *total cost* and never to
+ * the printed one.
+ */
+val OfficiousInterrogation = card("Officious Interrogation") {
+    manaCost = "{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Instant"
+    oracleText = "This spell costs {W}{U} more to cast for each target beyond the first.\n" +
+        "Choose any number of target players. Investigate X times, where X is the total number " +
+        "of creatures those players control. (To investigate, create a Clue token. It's an " +
+        "artifact with \"{2}, Sacrifice this token: Draw a card.\")"
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.IncreaseColoredPerUnit(
+                symbols = "{W}{U}",
+                countSource = CostReductionSource.ChosenTargetsBeyondTheFirst
+            )
+        )
+    }
+
+    spell {
+        target("targets", TargetPlayer(unlimited = true))
+        effect = Effects.Investigate(
+            count = DynamicAmount.Count(
+                player = Player.EachTargetedPlayer,
+                zone = Zone.BATTLEFIELD,
+                filter = GameObjectFilter.Creature
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "222"
+        artist = "Borja Pindado"
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a433ca4c-82d0-4e49-bc8e-98e18dd174e9.jpg?1783912842"
+
+        ruling(
+            "2024-02-02",
+            "Any target players that are no longer legal targets by the time Officious " +
+                "Interrogation resolves won't have their creatures counted when determining how " +
+                "many tokens you create."
+        )
+        ruling(
+            "2024-02-02",
+            "You choose how many targets Officious Interrogation has and what those targets are " +
+                "as you cast it. You can't choose the same target more than once. It's legal to " +
+                "cast Officious Interrogation with no targets, although this particular option " +
+                "should be placed under some serious scrutiny."
+        )
+        ruling(
+            "2024-02-02",
+            "Officious Interrogation's mana value doesn't change no matter how many targets it has."
+        )
+        ruling(
+            "2024-02-02",
+            "If a spell or ability allows you to cast Officious Interrogation without paying its " +
+                "mana cost, you must still pay the additional cost for any targets beyond the " +
+                "first."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/YarusRoarOfTheOldGods.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/YarusRoarOfTheOldGods.kt
@@ -1,0 +1,158 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.OneOrMoreDealCombatDamageToPlayerEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.conditions.EntityMatches
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.TurnFaceUpEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Yarus, Roar of the Old Gods — Murders at Karlov Manor #245
+ * {2}{R}{G} · Legendary Creature — Centaur Druid · 4/4
+ *
+ * Other creatures you control have haste.
+ * Whenever one or more face-down creatures you control deal combat damage to a player, draw a card.
+ * Whenever a face-down creature you control dies, return it to the battlefield face down under its
+ * owner's control if it's a permanent card, then turn it face up.
+ *
+ * **Both trigger halves needed engine work, and one of them was a live bug.**
+ *
+ * *The damage half.* `TriggerDetector.detectCombatDamageBatchTriggers` used to skip any source
+ * carrying a `FaceDownComponent` outright, in both the offensive and the defensive variant. That
+ * guard pre-dated `PredicateEvaluator`'s face-down masking and had become strictly harmful: a
+ * face-down permanent *is* a creature (CR 708.2), so it should satisfy an unfiltered
+ * "creatures you control" batch trigger, and the filtered ones are already decided by the evaluator,
+ * which hides subtypes, colors, mana value — and now name — behind `isFaceDown`. Removing it fixed
+ * this card *and* Kastral, the Windcrested and friends, which quietly under-triggered whenever a
+ * morphed or disguised creature connected.
+ *
+ * *The death half.* `EntitySnapshot` never captured face-down-ness, so `StatePredicate.IsFaceDown`
+ * had no last-known arm and this trigger could never match: a card put into a graveyard is turned
+ * face up (CR 708.4) and the battlefield entity is gone by trigger-gating time, so the live
+ * `FaceDownComponent` the projected path reads no longer exists. `EntitySnapshot.wasFaceDown` plus
+ * an `IsFaceDown`/`IsFaceUp` arm in `matchesStatePredicateForZoneChangeTrigger` is the LKI channel
+ * (CR 608.2h), sitting alongside `wasSuspected` / `wasAttacking` / `wasEnchanted`.
+ *
+ * **The dies filter carries no `Creature` card predicate on purpose.** Every face-down permanent is
+ * a 2/2 creature whatever card is under it, so `faceDown()` already implies "creature" — while
+ * spelling `GameObjectFilter.Creature` would *narrow* the trigger wrongly: the zone-change path
+ * evaluates card predicates against the **printed** type line, so a cloaked or manifested *land*
+ * card dying would fail `IsCreature` even though a face-down land is exactly the case this ability
+ * exists to handle.
+ *
+ * **"If it's a permanent card" is checked against the graveyard card, not last-known info.** By
+ * resolution "it" is a face-up card in the graveyard, and `EntityMatches` on a non-battlefield
+ * entity falls back to base `CardComponent` data — so `Permanent` reads the real printed types. An
+ * LKI card-type condition would be wrong here: the last-known type line of *any* face-down
+ * permanent is Creature, so an instant card cloaked onto the battlefield would sail through the
+ * gate and then be stranded on the battlefield.
+ *
+ * The return is deliberately two steps, matching the oracle order. `FaceDownMode.HIDDEN` is the
+ * right mode for the intermediate state: the card is not being disguised or cloaked, so it gets no
+ * ward {2} and no turn-up procedure of its own (2024-02-02 ruling) — `TurnFaceUpEffect` then flips
+ * it without a cost. Going face down and back up rather than straight to the battlefield face up is
+ * what makes a disguise creature's "when this is turned face up" trigger fire on the way back.
+ *
+ * `fromZone = Zone.GRAVEYARD` is the "left the graveyard first" gate: a card that has already moved
+ * on by the time this resolves stays where it is (2024-02-02 ruling) rather than being dragged back
+ * from wherever it went.
+ */
+val YarusRoarOfTheOldGods = card("Yarus, Roar of the Old Gods") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Creature — Centaur Druid"
+    power = 4
+    toughness = 4
+    oracleText = "Other creatures you control have haste.\n" +
+        "Whenever one or more face-down creatures you control deal combat damage to a player, " +
+        "draw a card.\n" +
+        "Whenever a face-down creature you control dies, return it to the battlefield face down " +
+        "under its owner's control if it's a permanent card, then turn it face up."
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.HASTE,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl()).other()
+        )
+    }
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            OneOrMoreDealCombatDamageToPlayerEvent(
+                sourceFilter = GameObjectFilter.Creature.faceDown()
+            ),
+            TriggerBinding.ANY
+        )
+        effect = Effects.DrawCards(1)
+        description = "Whenever one or more face-down creatures you control deal combat damage " +
+            "to a player, draw a card."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Any.youControl().faceDown(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = ConditionalEffect(
+            condition = EntityMatches(EffectTarget.TriggeringEntity, GameObjectFilter.Permanent),
+            effect = Effects.Move(
+                target = EffectTarget.TriggeringEntity,
+                destination = Zone.BATTLEFIELD,
+                fromZone = Zone.GRAVEYARD,
+                faceDown = FaceDownMode.HIDDEN
+            ) then TurnFaceUpEffect(EffectTarget.TriggeringEntity)
+        )
+        description = "Whenever a face-down creature you control dies, return it to the " +
+            "battlefield face down under its owner's control if it's a permanent card, then turn " +
+            "it face up."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "245"
+        artist = "Dmitry Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/326845a7-7502-4dc3-8f3e-867d6c84e931.jpg?1783912832"
+
+        ruling(
+            "2024-02-02",
+            "Normally, combat damage is dealt all at the same time. In that case, Yarus, Roar of " +
+                "the Old Gods's last ability triggers once for each player that face-down " +
+                "creatures you control dealt combat damage to, regardless of how many creatures " +
+                "were dealing that damage. If any of those face-down creatures have double strike " +
+                "or first strike, the ability will trigger once for each player dealt damage in " +
+                "each combat damage step."
+        )
+        ruling(
+            "2024-02-02",
+            "If Yarus, Roar of the Old Gods dies at the same time as one or more face-down " +
+                "creatures you control, its last ability triggers for each of those creatures."
+        )
+        ruling(
+            "2024-02-02",
+            "If a face-down creature dies but the permanent card it becomes in the graveyard " +
+                "leaves the graveyard before Yarus, Roar of the Old Gods's last ability resolves, " +
+                "it will not return to the battlefield."
+        )
+        ruling(
+            "2024-02-02",
+            "If a permanent card that would be returned to the battlefield face down by Yarus, " +
+                "Roar of the Old Gods's last ability can't be turned face up for some reason, " +
+                "it'll still be returned to the battlefield, but it will stay face down. In that " +
+                "case, it will be a 2/2 creature with no name, mana cost, or creature types. " +
+                "Since it isn't disguised or cloaked, it won't have ward {2}."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/YarusRoarOfTheOldGods.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/YarusRoarOfTheOldGods.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.mtg.sets.definitions.mkm.cards
 
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
@@ -11,7 +12,6 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantKeyword
 import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.TriggerSpec
-import com.wingedsheep.sdk.scripting.conditions.EntityMatches
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
 import com.wingedsheep.sdk.scripting.effects.TurnFaceUpEffect
@@ -107,7 +107,10 @@ val YarusRoarOfTheOldGods = card("Yarus, Roar of the Old Gods") {
             binding = TriggerBinding.ANY
         )
         effect = ConditionalEffect(
-            condition = EntityMatches(EffectTarget.TriggeringEntity, GameObjectFilter.Permanent),
+            condition = Conditions.EntityMatches(
+                EffectTarget.TriggeringEntity,
+                GameObjectFilter.Permanent
+            ),
             effect = Effects.Move(
                 target = EffectTarget.TriggeringEntity,
                 destination = Zone.BATTLEFIELD,

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/OfficiousInterrogationScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/OfficiousInterrogationScenarioTest.kt
@@ -1,0 +1,170 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Officious Interrogation (MKM #222) — {W}{U} Instant.
+ *
+ * "This spell costs {W}{U} more to cast for each target beyond the first.
+ *  Choose any number of target players. Investigate X times, where X is the total number of
+ *  creatures those players control."
+ *
+ * Two engine additions carry this card, and each has a way of failing silently that these tests are
+ * built to catch:
+ *
+ *  - **the per-target tax** (`CostModification.IncreaseColoredPerUnit` over
+ *    `CostReductionSource.ChosenTargetsBeyondTheFirst`). A tax that never applied would look exactly
+ *    like a working card in a test that only checks the Clue count, so the price is pinned from both
+ *    sides: two targets must be *rejected* on one-target mana, and accepted on two-target mana.
+ *  - **the plural target reference** (`Player.EachTargetedPlayer`). `Player.TargetPlayer` resolves to
+ *    a *single* targeted player, so a card written with it would still make Clues — just the wrong
+ *    number. The asymmetric board (one creature vs two) is what tells the two apart: the total is 3,
+ *    which is neither player's own count.
+ *
+ * The client contract is checked too — the enumerated action must advertise the *one-target minimum*
+ * as its `manaCostString` plus the increment as `manaCostPerExtraTarget`, because that pair is what
+ * lets the web client defer its mana-source step past targeting instead of under-tapping.
+ */
+class OfficiousInterrogationScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Officious Interrogation") {
+
+            /** Cast it from player 1's hand at [targetPlayerIds], with no manual payment plan. */
+            fun TestGame.interrogate(targetPlayerIds: List<EntityId> = emptyList()) = execute(
+                CastSpell(
+                    playerId = player1Id,
+                    cardId = state.getHand(player1Id).first { id ->
+                        state.getEntity(id)?.get<CardComponent>()?.name == "Officious Interrogation"
+                    },
+                    targets = targetPlayerIds.map { ChosenTarget.Player(it) }
+                )
+            )
+
+            test("one target costs the printed {W}{U} and counts that player's creatures") {
+                val game = scenario()
+                    .withPlayers("Detective", "Suspect")
+                    .withCardInHand(1, "Officious Interrogation")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Savannah Lions")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.interrogate(listOf(game.player2Id))
+                withClue("a single target owes nothing extra: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("two creatures under the one target → two Clues") {
+                    game.findPermanents("Clue").size shouldBe 2
+                }
+            }
+
+            test("two targets are rejected on one-target mana") {
+                val game = scenario()
+                    .withPlayers("Detective", "Suspect")
+                    .withCardInHand(1, "Officious Interrogation")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.interrogate(listOf(game.player1Id, game.player2Id))
+                withClue("the second target owes another {W}{U}, which this board can't pay") {
+                    cast.error.shouldNotBeNull()
+                }
+                withClue("a rejected cast leaves the spell in hand") {
+                    game.handSize(1) shouldBe 1
+                }
+            }
+
+            test("two targets on two-target mana investigate for the combined total") {
+                val game = scenario()
+                    .withPlayers("Detective", "Suspect")
+                    .withCardInHand(1, "Officious Interrogation")
+                    // Asymmetric on purpose: 1 + 2 = 3 is neither player's own count, so a
+                    // single-player reference could not produce it.
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Savannah Lions")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.interrogate(listOf(game.player1Id, game.player2Id))
+                withClue("{W}{U}{W}{U} is payable here: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("the total across BOTH targeted players, not either one alone") {
+                    game.findPermanents("Clue").size shouldBe 3
+                }
+                withClue("the Clues belong to the caster, not the targeted players") {
+                    game.findPermanents("Clue").all { clue ->
+                        game.state.projectedState.getController(clue) == game.player1Id
+                    } shouldBe true
+                }
+            }
+
+            test("no targets is a legal cast that investigates zero times") {
+                val game = scenario()
+                    .withPlayers("Detective", "Suspect")
+                    .withCardInHand(1, "Officious Interrogation")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.interrogate()
+                withClue("\"any number of target players\" includes none: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("nobody targeted, nothing counted") {
+                    game.findPermanents("Clue").size shouldBe 0
+                }
+            }
+
+            test("the enumerated action advertises the one-target minimum plus the increment") {
+                val game = scenario()
+                    .withPlayers("Detective", "Suspect")
+                    .withCardInHand(1, "Officious Interrogation")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val action = game.getLegalActions(1)
+                    .firstOrNull { it.description.contains("Officious Interrogation") }
+                action.shouldNotBeNull()
+
+                withClue("enumeration prices it with no targets, i.e. the cheapest legal cast") {
+                    action.manaCostString shouldBe "{W}{U}"
+                }
+                withClue("the client needs the increment to price its own mana-source step") {
+                    action.manaCostPerExtraTarget shouldBe "{W}{U}"
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/YarusRoarOfTheOldGodsScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/YarusRoarOfTheOldGodsScenarioTest.kt
@@ -1,0 +1,299 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.NightdrinkerMoroii
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.YarusRoarOfTheOldGods
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Yarus, Roar of the Old Gods — "Other creatures you control have haste. Whenever one or more
+ * face-down creatures you control deal combat damage to a player, draw a card. Whenever a face-down
+ * creature you control dies, return it to the battlefield face down under its owner's control if
+ * it's a permanent card, then turn it face up."
+ *
+ * Both trigger halves rest on engine changes made for this card, and the tests are aimed at those:
+ *
+ * - the **damage** half needed the blanket `FaceDownComponent` skip removed from
+ *   `TriggerDetector.detectCombatDamageBatchTriggers`. The batching contract is what the removal
+ *   must not disturb, so there is a two-attacker test: one draw, not two. And because that guard
+ *   was the only thing keeping a face-down creature out of a *name*-filtered batch trigger, a
+ *   control card proves the replacement — `PredicateEvaluator`'s face-down masking — actually holds.
+ * - the **death** half needed `EntitySnapshot.wasFaceDown`, because a card put into a graveyard is
+ *   turned face up (CR 708.4) and the battlefield entity is gone by trigger-gating time. Without
+ *   that channel the trigger simply never matched.
+ *
+ * The face-up control tests are the other half of each: a hard-cast creature connecting must draw
+ * nothing, and a face-up creature dying must stay dead.
+ */
+class YarusRoarOfTheOldGodsScenarioTest : FunSpec({
+
+    // A vanilla 2/2 with no morph or disguise — stands in for a *cloaked* or *manifested* permanent
+    // (a card put face down by an effect, not cast face down). It is the honest test subject for the
+    // dies trigger: the card underneath needs no face-down mechanic of its own for Yarus to bring
+    // it back.
+    val plainBear = card("Plain Test Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        // 4/1 on purpose: face down it is a 2/2 (CR 708.2), so power alone tells "came back face
+        // up" apart from "came back still face down".
+        power = 4
+        toughness = 1
+    }
+
+    // A plain 2/2 blocker, defined here rather than borrowed from the corpus so the combat maths in
+    // these tests can't drift with someone else's card.
+    val testBlocker = card("Test Blocker") {
+        manaCost = "{1}{W}"
+        typeLine = "Creature — Wall"
+        power = 2
+        toughness = 2
+    }
+
+    // A creature whose printed name is what a name-filtered batch trigger would look for. Used to
+    // prove that removing the face-down guard did NOT open name-filtered triggers to face-down
+    // creatures: a face-down permanent has no name (CR 708.2a).
+    val namedHitter = card("Named Test Hitter") {
+        manaCost = "{1}{R}"
+        typeLine = "Creature — Goblin"
+        power = 2
+        toughness = 2
+    }
+
+    val allCards = TestCards.all +
+        listOf(YarusRoarOfTheOldGods, NightdrinkerMoroii, plainBear, testBlocker, namedHitter)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(allCards)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        return driver
+    }
+
+    /**
+     * Put [cardName] onto the battlefield face down under [mode], deriving its turn-up data the way
+     * a real face-down entry does. Mirrors `DisguiseKeywordScenarioTest.putFaceDown`.
+     */
+    fun GameTestDriver.putFaceDown(
+        playerId: EntityId,
+        cardName: String,
+        mode: FaceDownMode = FaceDownMode.CLOAK
+    ): EntityId {
+        val id = putCreatureOnBattlefield(playerId, cardName)
+        val cardDef = cardRegistry.requireCard(cardName)
+        replaceState(
+            state.updateEntity(id) { container ->
+                var c = container.with(FaceDownComponent).with(FaceDownModeComponent(mode))
+                FaceDownTurnUp.dataFor(cardDef, cardName, mode)?.let { c = c.with(it) }
+                c
+            }
+        )
+        removeSummoningSickness(id)
+        return id
+    }
+
+    context("other creatures you control have haste") {
+
+        test("a creature that entered this turn can attack alongside Yarus") {
+            val driver = createDriver()
+            val player = driver.activePlayer!!
+            val opponent = driver.getOpponent(player)
+
+            driver.putCreatureOnBattlefield(player, "Yarus, Roar of the Old Gods")
+            // Deliberately NOT removeSummoningSickness — haste is what has to let this attack.
+            val bear = driver.putCreatureOnBattlefield(player, "Plain Test Bear")
+
+            driver.state.projectedState.hasKeyword(bear, Keyword.HASTE) shouldBe true
+
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+            withClue("the granted haste lets a freshly-entered creature attack") {
+                driver.declareAttackers(player, listOf(bear), opponent).isSuccess shouldBe true
+            }
+        }
+    }
+
+    context("whenever one or more face-down creatures you control deal combat damage to a player") {
+
+        test("a face-down attacker connecting draws a card") {
+            val driver = createDriver()
+            val player = driver.activePlayer!!
+            val opponent = driver.getOpponent(player)
+
+            driver.putCreatureOnBattlefield(player, "Yarus, Roar of the Old Gods")
+            val hidden = driver.putFaceDown(player, "Plain Test Bear")
+
+            val handBefore = driver.getHandSize(player)
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+            driver.declareAttackers(player, listOf(hidden), opponent).isSuccess shouldBe true
+            driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+            driver.declareNoBlockers(opponent)
+            driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+            withClue("the face-down 2/2 got through") {
+                driver.getLifeTotal(opponent) shouldBe 18
+            }
+            withClue("the batch trigger fired once — this is the removed FaceDownComponent guard") {
+                driver.getHandSize(player) shouldBe handBefore + 1
+            }
+        }
+
+        test("two face-down attackers hitting the same player still draw only one card") {
+            val driver = createDriver()
+            val player = driver.activePlayer!!
+            val opponent = driver.getOpponent(player)
+
+            driver.putCreatureOnBattlefield(player, "Yarus, Roar of the Old Gods")
+            val first = driver.putFaceDown(player, "Plain Test Bear")
+            val second = driver.putFaceDown(player, "Nightdrinker Moroii", FaceDownMode.DISGUISE)
+
+            val handBefore = driver.getHandSize(player)
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+            driver.declareAttackers(player, listOf(first, second), opponent).isSuccess shouldBe true
+            driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+            driver.declareNoBlockers(opponent)
+            driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+            withClue("both 2/2s connected") {
+                driver.getLifeTotal(opponent) shouldBe 16
+            }
+            withClue("\"one or more\" batches per damaged player, so exactly one draw") {
+                driver.getHandSize(player) shouldBe handBefore + 1
+            }
+        }
+
+        test("a face-up attacker connecting draws nothing") {
+            val driver = createDriver()
+            val player = driver.activePlayer!!
+            val opponent = driver.getOpponent(player)
+
+            driver.putCreatureOnBattlefield(player, "Yarus, Roar of the Old Gods")
+            val bear = driver.putCreatureOnBattlefield(player, "Plain Test Bear")
+            driver.removeSummoningSickness(bear)
+
+            val handBefore = driver.getHandSize(player)
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+            driver.declareAttackers(player, listOf(bear), opponent).isSuccess shouldBe true
+            driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+            driver.declareNoBlockers(opponent)
+            driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+            withClue("face up it hits for its printed 4, not the 2 it would while hidden") {
+                driver.getLifeTotal(opponent) shouldBe 16
+            }
+            withClue("the trigger is filtered to face-down creatures") {
+                driver.getHandSize(player) shouldBe handBefore
+            }
+        }
+
+        test("a name-filtered batch trigger still ignores a face-down creature") {
+            // The control for the guard removal: with the blanket FaceDownComponent skip gone, a
+            // face-down source is excluded from a name-filtered trigger only because
+            // PredicateEvaluator masks `NameEquals` behind isFaceDown (CR 708.2a). If that masking
+            // regressed, this would fire.
+            val watcher = card("Name Watcher") {
+                manaCost = "{2}{W}"
+                typeLine = "Creature — Human Soldier"
+                power = 1
+                toughness = 3
+                triggeredAbility {
+                    trigger = com.wingedsheep.sdk.scripting.TriggerSpec(
+                        com.wingedsheep.sdk.scripting.EventPattern.OneOrMoreDealCombatDamageToPlayerEvent(
+                            sourceFilter = com.wingedsheep.sdk.scripting.GameObjectFilter.Creature
+                                .named("Named Test Hitter")
+                        ),
+                        com.wingedsheep.sdk.scripting.TriggerBinding.ANY
+                    )
+                    effect = com.wingedsheep.sdk.dsl.Effects.DrawCards(1)
+                    description = "Whenever one or more creatures named Named Test Hitter you " +
+                        "control deal combat damage to a player, draw a card."
+                }
+            }
+            val driver = GameTestDriver()
+            driver.registerCards(allCards + watcher)
+            driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+            val player = driver.activePlayer!!
+            val opponent = driver.getOpponent(player)
+
+            driver.putCreatureOnBattlefield(player, "Name Watcher")
+            val hidden = driver.putFaceDown(player, "Named Test Hitter")
+
+            val handBefore = driver.getHandSize(player)
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+            driver.declareAttackers(player, listOf(hidden), opponent).isSuccess shouldBe true
+            driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+            driver.declareNoBlockers(opponent)
+            driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+            driver.getLifeTotal(opponent) shouldBe 18
+            withClue("face down, it has no name, so the name-filtered trigger must not fire") {
+                driver.getHandSize(player) shouldBe handBefore
+            }
+        }
+    }
+
+    context("whenever a face-down creature you control dies") {
+
+        test("a face-down creature that dies comes back face up") {
+            val driver = createDriver()
+            val player = driver.activePlayer!!
+            val opponent = driver.getOpponent(player)
+
+            driver.putCreatureOnBattlefield(player, "Yarus, Roar of the Old Gods")
+            val hidden = driver.putFaceDown(player, "Plain Test Bear")
+
+            // Kill it in combat: a 2/2 face-down attacker into a 3/3 blocker.
+            val blocker = driver.putCreatureOnBattlefield(opponent, "Test Blocker")
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+            driver.declareAttackers(player, listOf(hidden), opponent).isSuccess shouldBe true
+            driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+            driver.declareBlockers(opponent, mapOf(blocker to listOf(hidden)))
+            driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+            val returned = driver.findPermanent(player, "Plain Test Bear")
+            withClue("wasFaceDown LKI is what lets this trigger match at all") {
+                returned.shouldNotBeNull()
+            }
+            withClue("it was returned face down and then turned face up") {
+                driver.state.getEntity(returned!!)?.has<FaceDownComponent>() shouldBe false
+            }
+            withClue("back as its real 4/1 self, not the 2/2 it was while hidden") {
+                driver.state.projectedState.getPower(returned!!) shouldBe 4
+            }
+        }
+
+        test("a face-up creature that dies is not returned") {
+            val driver = createDriver()
+            val player = driver.activePlayer!!
+            val opponent = driver.getOpponent(player)
+
+            driver.putCreatureOnBattlefield(player, "Yarus, Roar of the Old Gods")
+            val bear = driver.putCreatureOnBattlefield(player, "Plain Test Bear")
+            driver.removeSummoningSickness(bear)
+
+            val blocker = driver.putCreatureOnBattlefield(opponent, "Test Blocker")
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+            driver.declareAttackers(player, listOf(bear), opponent).isSuccess shouldBe true
+            driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+            driver.declareBlockers(opponent, mapOf(blocker to listOf(bear)))
+            driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+            withClue("the trigger is filtered to face-down creatures") {
+                driver.findPermanent(player, "Plain Test Bear") shouldBe null
+                driver.getGraveyardCardNames(player) shouldContain "Plain Test Bear"
+            }
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -14660,6 +14660,72 @@
     ]
 }
 
+// Officious Interrogation
+{
+    "name": "Officious Interrogation",
+    "manaCost": "{W}{U}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {W}{U} more to cast for each target beyond the first.\nChoose any number of target players. Investigate X times, where X is the total number of creatures those players control. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "CreatePredefinedToken",
+            "tokenType": "Clue",
+            "dynamicCount": {
+                "type": "Count",
+                "player": "EachTargetedPlayer",
+                "zone": "Battlefield",
+                "filter": "creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "unlimited": true,
+                "id": "targets"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "IncreaseColoredPerUnit",
+                    "symbols": "{W}{U}",
+                    "countSource": "ChosenTargetsBeyondTheFirst"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "rarity": "RARE",
+        "artist": "Borja Pindado",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a433ca4c-82d0-4e49-bc8e-98e18dd174e9.jpg?1783912842",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any target players that are no longer legal targets by the time Officious Interrogation resolves won't have their creatures counted when determining how many tokens you create."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "You choose how many targets Officious Interrogation has and what those targets are as you cast it. You can't choose the same target more than once. It's legal to cast Officious Interrogation with no targets, although this particular option should be placed under some serious scrutiny."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Officious Interrogation's mana value doesn't change no matter how many targets it has."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a spell or ability allows you to cast Officious Interrogation without paying its mana cost, you must still pay the additional cost for any targets beyond the first."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // On the Job
 {
     "name": "On the Job",
@@ -21338,5 +21404,113 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Yarus, Roar of the Old Gods
+{
+    "name": "Yarus, Roar of the Old Gods",
+    "manaCost": "{2}{R}{G}",
+    "typeLine": "Legendary Creature — Centaur Druid",
+    "oracleText": "Other creatures you control have haste.\nWhenever one or more face-down creatures you control deal combat damage to a player, draw a card.\nWhenever a face-down creature you control dies, return it to the battlefield face down under its owner's control if it's a permanent card, then turn it face up.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "OneOrMoreDealCombatDamageToPlayerEvent",
+                    "sourceFilter": "creature facedown"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever one or more face-down creatures you control deal combat damage to a player, draw a card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "facedown ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": "TriggeringEntity",
+                            "filter": "permanent"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": "TriggeringEntity",
+                                "destination": "Battlefield",
+                                "fromZone": "Graveyard",
+                                "faceDown": "HIDDEN"
+                            },
+                            {
+                                "type": "TurnFaceUp",
+                                "target": "TriggeringEntity"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Whenever a face-down creature you control dies, return it to the battlefield face down under its owner's control if it's a permanent card, then turn it face up."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE",
+                "filter": {
+                    "baseFilter": "creature ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "245",
+        "rarity": "RARE",
+        "artist": "Dmitry Burmak",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/326845a7-7502-4dc3-8f3e-867d6c84e931.jpg?1783912832",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Normally, combat damage is dealt all at the same time. In that case, Yarus, Roar of the Old Gods's last ability triggers once for each player that face-down creatures you control dealt combat damage to, regardless of how many creatures were dealing that damage. If any of those face-down creatures have double strike or first strike, the ability will trigger once for each player dealt damage in each combat damage step."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If Yarus, Roar of the Old Gods dies at the same time as one or more face-down creatures you control, its last ability triggers for each of those creatures."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a face-down creature dies but the permanent card it becomes in the graveyard leaves the graveyard before Yarus, Roar of the Old Gods's last ability resolves, it will not return to the battlefield."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a permanent card that would be returned to the battlefield face down by Yarus, Roar of the Old Gods's last ability can't be turned face up for some reason, it'll still be returned to the battlefield, but it will stay face down. In that case, it will be a 2/2 creature with no name, mana cost, or creature types. Since it isn't disguised or cloaked, it won't have ward {2}."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
     ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -2662,6 +2662,15 @@ class TriggerDetector(
      * Detect "whenever one or more [creatures] you control deal combat damage to a player"
      * batching triggers. Groups all combat damage-to-player events and fires matching
      * triggers at most once per observer, regardless of how many creatures connected.
+     *
+     * A **face-down** attacker counts. It is a creature (a 2/2 with no name, no subtypes, no
+     * colors and mana value 0 — CR 708.2), so it satisfies an unfiltered "creatures you control"
+     * batch trigger, and the filtered variants are decided by [predicateEvaluator] alone: that
+     * evaluator masks every printed characteristic behind `isFaceDown`, name included, so a
+     * "Bird you control"-style filter still excludes it without a separate guard here. This used
+     * to carry a blanket `FaceDownComponent` skip, which pre-dated the masking and silently made
+     * unfiltered batch triggers (Kastral, the Windcrested; Yarus, Roar of the Old Gods) miss
+     * whenever a morphed, manifested, disguised or cloaked creature connected.
      */
     private fun detectCombatDamageBatchTriggers(
         state: GameState,
@@ -2700,7 +2709,6 @@ class TriggerDetector(
                         val sourceContainer = state.getEntity(info.sourceId) ?: return@firstOrNull false
                         sourceContainer.get<CardComponent>() ?: return@firstOrNull false
                         if (!projected.isCreature(info.sourceId)) return@firstOrNull false
-                        if (sourceContainer.has<FaceDownComponent>()) return@firstOrNull false
                         predicateEvaluator.matches(
                             state, projected, info.sourceId, trigger.sourceFilter,
                             PredicateContext(controllerId = controllerId, sourceId = entry.entityId)
@@ -2734,7 +2742,6 @@ class TriggerDetector(
                     val sourceContainer = state.getEntity(info.sourceId) ?: return@filter false
                     sourceContainer.get<CardComponent>() ?: return@filter false
                     if (!projected.isCreature(info.sourceId)) return@filter false
-                    if (sourceContainer.has<FaceDownComponent>()) return@filter false
 
                     predicateEvaluator.matches(
                         state,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -2071,6 +2071,19 @@ class TriggerMatcher(
                 isModified(state, event.entityId)
             }
         }
+        // Face down (CR 708) on a permanent that has left the battlefield reads last-known
+        // information: a card put into a graveyard is turned face up (CR 708.4) and the
+        // battlefield entity is gone by gating time, so the live `FaceDownComponent` the
+        // projected path would read no longer exists. "Whenever a face-down creature you control
+        // dies" (Yarus, Roar of the Old Gods) is only answerable from the snapshot (CR 608.2h).
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsFaceDown -> {
+            if (event.fromZone == Zone.BATTLEFIELD) event.lastKnown?.wasFaceDown == true
+            else matchesStatePredicateForTrigger(predicate, state, event.entityId)
+        }
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsFaceUp -> {
+            if (event.fromZone == Zone.BATTLEFIELD) event.lastKnown?.wasFaceDown == false
+            else matchesStatePredicateForTrigger(predicate, state, event.entityId)
+        }
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEquipped -> {
             if (event.fromZone == Zone.BATTLEFIELD) event.lastKnown?.wasEquipped == true
             else hasAttachmentOfKind(state, event.entityId, equipment = true)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -1162,6 +1162,13 @@ class DynamicAmountEvaluator(
             is Player.TargetOpponent, is Player.TargetPlayer -> listOfNotNull(
                 TargetResolutionUtils.resolvePlayerRef(player, context, state)
             )
+            // "those players" — every player among the chosen targets, so counting primitives sum
+            // across all of them ("the total number of creatures those players control"). Targets
+            // that became illegal are already absent from `context.targets`, so they drop out.
+            is Player.EachTargetedPlayer -> context.targets
+                .filterIsInstance<com.wingedsheep.engine.state.components.stack.ChosenTarget.Player>()
+                .map { it.playerId }
+                .distinct()
             is Player.Each -> state.activePlayers
             is Player.Any -> state.activePlayers
             is Player.ContextPlayer -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -486,7 +486,12 @@ class PredicateEvaluator {
             }
 
             // Name predicates
-            is CardPredicate.NameEquals -> card.name == predicate.name
+            // A face-down permanent has no name (CR 708.2a), so it matches no name predicate —
+            // the same masking the subtype/color/mana-value arms above apply. Load-bearing for the
+            // batch combat-damage detector, which relies on this evaluator alone to keep a
+            // face-down creature out of a name-filtered trigger.
+            is CardPredicate.NameEquals ->
+                projectedValues?.isFaceDown != true && card.name == predicate.name
 
             // CR 709 + Central Elevator ruling: a Room card may be found only if none of its
             // door names matches an *unlocked* door name of a Room the searcher controls. A Room
@@ -926,7 +931,8 @@ class PredicateEvaluator {
             // Context-relative predicates (pipeline variable references)
             is CardPredicate.NameEqualsChosen -> {
                 val chosenName = context?.chosenValues?.get(predicate.variableName) ?: return false
-                card.name.equals(chosenName, ignoreCase = true)
+                // Nameless while face down (CR 708.2a) — see [CardPredicate.NameEquals] above.
+                projectedValues?.isFaceDown != true && card.name.equals(chosenName, ignoreCase = true)
             }
 
             // Source-component name reference: the name durably chosen by the source permanent as it

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1113,6 +1113,18 @@ class CastSpellHandler(
             }
         }
 
+        // "This spell costs {W}{U} more to cast for each target beyond the first" (Officious
+        // Interrogation). Charged outside every `playForFree` / alternative-cost branch above,
+        // because a cost *increase* is not part of the cost those branches waive or replace
+        // (CR 601.2f) — the card's own ruling spells it out: a free cast still owes the tax for
+        // targets beyond the first. `calculateEffectiveCost` already applied it on the ordinary
+        // path, so only the branches that bypassed it are topped up here.
+        if (cardDef != null && (playForFree || action.useAlternativeCost || action.castFaceDown)) {
+            effectiveCost = effectiveCost + costCalculator.selfPerTargetTax(
+                cardDef, action.targets.map { it.toEntityId() }
+            )
+        }
+
         // Fold in the "… or pay {N}" alternative mana for every or-pay cost whose non-mana leg the
         // caster declined (validation side; execute() applies the same rule to the cost it charges).
         if (cardDef != null && !playForFree) {
@@ -2447,6 +2459,15 @@ class CastSpellHandler(
             if (kickerManaCost != null) {
                 effectiveCost = ManaCost(effectiveCost.symbols + kickerManaCost.symbols)
             }
+        }
+
+        // Per-target self tax — mirrors validate()'s branch, same CR 601.2f reasoning: the
+        // free-cast / alternative-cost / face-down branches above never called
+        // `calculateEffectiveCost`, so they owe it here.
+        if (cardDef != null && (playForFreeInExecute || action.useAlternativeCost || action.castFaceDown)) {
+            effectiveCost = effectiveCost + costCalculator.selfPerTargetTax(
+                cardDef, action.targets.map { it.toEntityId() }
+            )
         }
 
         // Apply per-mode additional mana cost (e.g., Feed the Cycle "pay {B}" mode).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -184,9 +184,12 @@ object TargetResolutionUtils {
             Player.ControllerOfTargetingSource -> context.targetingSourceEntityId
                 ?.let { stackObjectController(state, it) ?: controllerOf(state, it) }
             // Multi-player / list-only references have no single resolution here.
-            // OwnersOfLinkedExile is resolved by ForEachExecutor.resolvePlayers (a player loop).
+            // OwnersOfLinkedExile is resolved by ForEachExecutor.resolvePlayers (a player loop);
+            // EachTargetedPlayer by DynamicAmountEvaluator.resolveUnifiedPlayerIds. Collapsing
+            // either to its first player is exactly the bug they exist to avoid, so neither gets a
+            // single-player arm.
             Player.Each, Player.EachOpponent, Player.ActivePlayerFirst,
-            Player.OwnersOfLinkedExile -> null
+            Player.EachTargetedPlayer, Player.OwnersOfLinkedExile -> null
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -192,6 +192,7 @@ object ZoneTransitionService {
         // CastChoicesComponent is stripped so dies/leaves triggers reading CastX still see it
         // as last-known information (CR 603.10a).
         var lastKnownCastX: Int? = null
+        var lastKnownWasFaceDown = false
 
         if (leavingBattlefield) {
             val countersComponent = container.get<CountersComponent>()
@@ -239,6 +240,12 @@ object ZoneTransitionService {
                     ?.sources ?: emptySet()
             lastKnownCastX = container
                 .get<com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent>()?.x
+            // A card is turned face up as it leaves the battlefield for a graveyard (CR 708.4), and
+            // the battlefield entity is gone by trigger-gating time either way, so "whenever a
+            // face-down creature you control dies" (Yarus, Roar of the Old Gods) has to read this
+            // as last-known information (CR 608.2h).
+            lastKnownWasFaceDown = container
+                .has<com.wingedsheep.engine.state.components.identity.FaceDownComponent>()
         }
 
         // 3. Check zone change redirect (unless skipped)
@@ -326,6 +333,7 @@ object ZoneTransitionService {
                 wasToken = lastKnownWasToken,
                 damageDealtByPlayers = lastKnownDamageDealtByPlayers,
                 damageSources = lastKnownDamageSources,
+                wasFaceDown = lastKnownWasFaceDown,
             )
         } else null
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
@@ -250,6 +250,13 @@ class ForEachExecutor(
             Player.TargetOpponent, Player.TargetPlayer -> listOfNotNull(
                 TargetResolutionUtils.resolvePlayerRef(player, context, state)
             )
+            // "those players" — iterate every player among the chosen targets. Needs its own arm:
+            // the `else` below routes through the single-player resolver, which deliberately
+            // returns null for plural references, so a ForEach over them would silently do nothing.
+            Player.EachTargetedPlayer -> context.targets
+                .filterIsInstance<com.wingedsheep.engine.state.components.stack.ChosenTarget.Player>()
+                .map { it.playerId }
+                .distinct()
             // Single-player references (e.g. ControllerOf a targeted permanent — Unwanted
             // Remake's "its controller manifests dread") resolve to exactly that player. An
             // unresolved reference means there is nobody to iterate, not "every player": that

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
@@ -86,6 +86,18 @@ data class LegalAction(
 
     // Costs
     val manaCostString: String? = null,
+    /**
+     * The mana this spell adds to its own cost for each target beyond the first — "This spell
+     * costs {W}{U} more to cast for each target beyond the first" (Officious Interrogation) sends
+     * `"{W}{U}"`. Null for every spell that does not tax itself per target.
+     *
+     * When set, [manaCostString] is the *one-target minimum*, not the final price: the real cost
+     * is settled by targeting. The client must therefore run its targeting phase **before** any
+     * manual mana-source phase (the same way an X cost forces `xSelection` first) and scale the
+     * cost it charges there by the number of targets picked. Under auto-tap none of this shows —
+     * the server prices the submitted targets itself and solves.
+     */
+    val manaCostPerExtraTarget: String? = null,
     val hasXCost: Boolean = false,
     val maxAffordableX: Int? = null,
     val minX: Int = 0,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -34,6 +34,8 @@ import com.wingedsheep.sdk.scripting.AdditionalCost
 import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.ChoiceSlot
 import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
 import com.wingedsheep.sdk.dsl.giftKeyword
 import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
 import com.wingedsheep.sdk.scripting.effects.Mode
@@ -740,6 +742,15 @@ class CastSpellEnumerator : ActionEnumerator {
             // Always include mana cost string for cast actions
             val manaCostString = effectiveCost.toString()
 
+            // "This spell costs {W}{U} more to cast for each target beyond the first" (Officious
+            // Interrogation): `effectiveCost` above is priced with no targets chosen, so it is the
+            // one-target minimum. Flag it so the client settles targeting before offering a manual
+            // mana-source pick — the same reason an X cost forces its `xSelection` phase first.
+            val manaCostPerExtraTarget = cardDef?.script?.staticAbilities
+                ?.filterIsInstance<ModifySpellCost>()
+                ?.filter { it.target == SpellCostTarget.SelfCast }
+                ?.firstNotNullOfOrNull { context.costCalculator.perExtraTargetCost(it.modification) }
+
             // Compute auto-tap preview for UI highlighting (skipped in ACTIONS_ONLY mode).
             //
             // The solver runs against the worst-case *remaining* cost the player can be
@@ -1257,6 +1268,7 @@ class CastSpellEnumerator : ActionEnumerator {
                                 delveCards = delveCards,
                                 minDelveNeeded = minDelveNeeded,
                                 manaCostString = manaCostString,
+                                manaCostPerExtraTarget = manaCostPerExtraTarget,
                                 requiresDamageDistribution = requiresDamageDistribution,
                                 totalDamageToDistribute = totalDamageToDistribute,
                                 minDamagePerTarget = minDamagePerTarget,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -404,6 +404,13 @@ class CostCalculator(
                     .filterIsInstance<ManaSymbol.Colored>()
                     .forEach(addColoredIncrease)
             }
+            is CostModification.IncreaseColoredPerUnit -> {
+                val units =
+                    evaluateReduction(state, modification.countSource, casterId, chosenTargets, abilitySourceId)
+                val coloredSymbols = ManaCost.parse(modification.symbols).symbols
+                    .filterIsInstance<ManaSymbol.Colored>()
+                repeat(units) { coloredSymbols.forEach(addColoredIncrease) }
+            }
             is CostModification.IncreaseGenericPerOtherSpellThisTurn -> {
                 val spellsCast = state.playerSpellsCastThisTurn[casterId] ?: 0
                 addGenericIncrease(spellsCast * modification.amountPerSpell)
@@ -469,6 +476,11 @@ class CostCalculator(
                 else if (anyTargetMatchesFilter(state, playerId, chosenTargets, source.filter)) source.amount
                 else 0
             }
+            // "for each target beyond the first" — 0 while targets are still unchosen, which is
+            // also the right answer for affordability enumeration (one target is the cheapest
+            // legal cast, so the unmodified cost is the true minimum).
+            CostReductionSource.ChosenTargetsBeyondTheFirst ->
+                (chosenTargets.size - 1).coerceAtLeast(0)
             is CostReductionSource.FixedIfCreatureAttackingYou -> {
                 if (isAnyCreatureAttacking(state, playerId)) source.amount else 0
             }
@@ -803,6 +815,47 @@ class CostCalculator(
     private fun sourceFromModification(modification: CostModification): CostReductionSource? = when (modification) {
         is CostModification.ReduceGenericBy -> modification.source
         is CostModification.ReduceColoredPerUnit -> modification.countSource
+        else -> null
+    }
+
+    /**
+     * The per-target tax this card levies on its own cast — the mana owed for
+     * [chosenTargets] beyond the first by every self-cast [ModifySpellCost] whose count source is
+     * [CostReductionSource.ChosenTargetsBeyondTheFirst]. [ManaCost.ZERO] for cards that have none.
+     *
+     * Split out from [calculateEffectiveCost] because it must be charged **even on a free cast**:
+     * "without paying its mana cost" waives the mana cost, not the increases applied to the total
+     * cost (CR 601.2f), and Officious Interrogation's 2024-02-02 ruling says so in as many words —
+     * "you must still pay the additional cost for any targets beyond the first". The free-cast
+     * branches never reach [calculateEffectiveCost] at all, so the cast pipeline adds this on top.
+     */
+    fun selfPerTargetTax(cardDef: CardDefinition, chosenTargets: List<EntityId>): ManaCost {
+        val extraTargets = (chosenTargets.size - 1).coerceAtLeast(0)
+        if (extraTargets == 0) return ManaCost.ZERO
+        var tax = ManaCost.ZERO
+        for (ability in cardDef.script.staticAbilities) {
+            if (ability !is ModifySpellCost) continue
+            if (ability.target != SpellCostTarget.SelfCast) continue
+            val perTarget = perExtraTargetCost(ability.modification) ?: continue
+            repeat(extraTargets) { tax = tax + ManaCost.parse(perTarget) }
+        }
+        return tax
+    }
+
+    /**
+     * The mana [modification] adds for each target the spell has beyond the first, as a cost
+     * string (`"{W}{U}"`, `"{1}"`), or null if it does not price the spell's own chosen targets.
+     *
+     * The enumerator sends this to the client so the mana-source picker can charge the real price
+     * once targets are chosen — the advertised `manaCostString` is priced with no targets and is
+     * therefore only the one-target minimum.
+     */
+    fun perExtraTargetCost(modification: CostModification): String? = when {
+        modification is CostModification.IncreaseColoredPerUnit &&
+            modification.countSource == CostReductionSource.ChosenTargetsBeyondTheFirst ->
+            modification.symbols
+        modification is CostModification.IncreaseGenericBy &&
+            modification.source == CostReductionSource.ChosenTargetsBeyondTheFirst -> "{1}"
         else -> null
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
@@ -164,6 +164,17 @@ data class EntitySnapshot(
     val damageSources: Set<DamageSourceLki> = emptySet(),
     /** The cast-time {X} carried by `CastChoicesComponent`, so dies/leaves triggers read `DynamicAmount.CastX`. */
     val castX: Int? = null,
+    /**
+     * True if this permanent was face down (CR 708) when it left the battlefield.
+     *
+     * Frozen because a card put into a graveyard is always turned face up (CR 708.4), so by the
+     * time a dies trigger is gated the `FaceDownComponent` is gone along with the battlefield
+     * entity — "whenever a face-down creature you control dies" (Yarus, Roar of the Old Gods) can
+     * only be answered from last-known information (CR 608.2h). Backs the last-known leg of
+     * [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsFaceDown] / `IsFaceUp`, the same
+     * way [wasSuspected] does for the suspected designation.
+     */
+    val wasFaceDown: Boolean = false,
 ) : EntityView {
     companion object {
         /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
@@ -130,6 +130,7 @@ class LegalActionEnricher(
             hasHarmonize = action.hasHarmonize,
             validHarmonizeCreatures = action.harmonizeCreatures?.map { it.toDto() },
             manaCostString = action.manaCostString,
+            manaCostPerExtraTarget = action.manaCostPerExtraTarget,
             minimumManaCostString = minimumManaCostString(action),
             requiresDamageDistribution = action.requiresDamageDistribution,
             totalDamageToDistribute = action.totalDamageToDistribute,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
@@ -123,6 +123,13 @@ data class LegalActionInfo(
     val validHarmonizeCreatures: List<HarmonizeCreatureInfo>? = null,
     val manaCostString: String? = null,
     /**
+     * Mana added to this spell's cost per target beyond the first, so [manaCostString] above is
+     * only the one-target minimum and the real price is settled by targeting. Mirrors
+     * [com.wingedsheep.engine.legalactions.LegalAction.manaCostPerExtraTarget]; the client uses it
+     * to run targeting before a manual mana-source pick, and to price that pick.
+     */
+    val manaCostPerExtraTarget: String? = null,
+    /**
      * The cheapest [manaCostString] can end up being once the alternative payments this action
      * already offers are used to the maximum — convoke taps (CR 702.51a), delve exiles (CR 702.66a),
      * waterbend taps, a harmonize tap. Null when nothing can move the cost.

--- a/web-client/src/store/slices/ui/pipelinePhases.test.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.test.ts
@@ -277,3 +277,40 @@ describe('enterPhase — sum-gated graveyard exile costs', () => {
     })
   })
 })
+
+describe('computePhases — per-target mana tax (Officious Interrogation)', () => {
+  /**
+   * `manaCostString` on a per-target-taxed spell is only the one-target minimum, so picking mana
+   * sources before targeting would always under-tap and the server would reject the cast. The
+   * targeting phase therefore has to come first, exactly as an X cost puts `xSelection` first.
+   */
+  function interrogation(over: Record<string, unknown> = {}): LegalActionInfo {
+    return castAction({
+      actionType: 'CastSpell',
+      manaCostString: '{W}{U}',
+      requiresTargets: true,
+      validTargets: ['p1', 'p2'],
+      availableManaSources: [{ entityId: 'plains1' }, { entityId: 'island1' }],
+      ...over,
+    })
+  }
+
+  it('defers the manaSource phase past targeting when the cost scales with targets', () => {
+    const phases = computePhases(interrogation({ manaCostPerExtraTarget: '{W}{U}' }), {
+      autoTapEnabled: false,
+    })
+    expect(phases).toEqual([{ type: 'targeting' }, { type: 'manaSource' }])
+  })
+
+  it('keeps manaSource before targeting for an ordinary spell', () => {
+    const phases = computePhases(interrogation(), { autoTapEnabled: false })
+    expect(phases).toEqual([{ type: 'manaSource' }, { type: 'targeting' }])
+  })
+
+  it('runs no manaSource phase at all under auto-tap — the server prices the targets', () => {
+    const phases = computePhases(interrogation({ manaCostPerExtraTarget: '{W}{U}' }), {
+      autoTapEnabled: true,
+    })
+    expect(phases).toEqual([{ type: 'targeting' }])
+  })
+})

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -195,10 +195,16 @@ export function computePhases(actionInfo: LegalActionInfo, options?: ComputePhas
     (p) => p.type === 'delve' || p.type === 'convoke',
   )
   const hasPhyrexianMana = (actionInfo.manaCostString ?? '').includes('/P}')
-  if (
+  //    A spell that taxes itself per target ("costs {W}{U} more for each target beyond the first")
+  //    advertises only its one-target minimum, so picking sources before targeting would always
+  //    under-tap and the server would reject the cast. Defer the manaSource step past targeting,
+  //    exactly as an X cost puts `xSelection` before it. Under auto-tap neither phase runs and the
+  //    server prices the submitted targets itself, so this only bites manual tappers.
+  const manaAfterTargeting = actionInfo.manaCostPerExtraTarget != null
+  const needsManaSource =
     ((actionInfo.availableManaSources?.length ?? 0) > 0 || hasPhyrexianMana) &&
     (hasAlternativePaymentPhase || hasPhyrexianMana || !options?.autoTapEnabled)
-  ) {
+  if (needsManaSource && !manaAfterTargeting) {
     phases.push({ type: 'manaSource' })
   }
 
@@ -247,6 +253,12 @@ export function computePhases(actionInfo: LegalActionInfo, options?: ComputePhas
   // 6. Targeting
   if (actionInfo.requiresTargets && actionInfo.validTargets && actionInfo.validTargets.length > 0) {
     phases.push({ type: 'targeting' })
+  }
+
+  // 6b. The deferred manaSource step for a per-target-taxed spell (see phase 4): now that the
+  //     targets are chosen, the price the player taps for is the real one.
+  if (needsManaSource && manaAfterTargeting) {
+    phases.push({ type: 'manaSource' })
   }
 
   // 7. Mana color choice (abilities only, after cost)

--- a/web-client/src/store/slices/ui/selectionSlice.ts
+++ b/web-client/src/store/slices/ui/selectionSlice.ts
@@ -582,6 +582,7 @@ export const createSelectionSlice: SliceCreator<SelectionSlice> = (set, get) => 
     // sources to also cover xValue * (number of {X} symbols).
     const action = actionInfo.action as {
       xValue?: number
+      targets?: readonly unknown[]
       alternativePayment?: { harmonizeCreature?: EntityId | null }
       additionalCostPayment?: { sacrificedPermanents?: readonly EntityId[] }
     }
@@ -594,7 +595,17 @@ export const createSelectionSlice: SliceCreator<SelectionSlice> = (set, get) => 
     const emergeCost = emergeSacrifice
       ? actionInfo.additionalCostInfo?.costAfterSacrifice?.[emergeSacrifice]
       : undefined
-    const manaCost = emergeCost ?? actionInfo.manaCostString ?? ''
+    // "This spell costs {W}{U} more to cast for each target beyond the first" (Officious
+    // Interrogation): the server advertises the one-target minimum, because it prices the cost
+    // before any target exists. `computePhases` puts targeting ahead of this step precisely so the
+    // tax is knowable here — append one copy of the increment per target beyond the first. Same
+    // shape as the emerge/harmonize adjustments around it: the server owns the rule, the client
+    // only applies the choice the player has since made.
+    const perExtraTarget = actionInfo.manaCostPerExtraTarget
+    const extraTargets = Math.max(0, (action.targets?.length ?? 0) - 1)
+    const targetTax =
+      perExtraTarget && extraTargets > 0 ? perExtraTarget.repeat(extraTargets) : ''
+    const manaCost = (emergeCost ?? actionInfo.manaCostString ?? '') + targetTax
     const xSymbolCount = Math.max(1, (manaCost.match(/\{X\}/g)?.length ?? 0))
 
     // Harmonize creature-tap (chosen in the prior `harmonize` phase) reduces the

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -920,6 +920,17 @@ export interface LegalActionInfo {
    * and waterbend are generic-only, harmonize taps one creature.
    */
   readonly minimumManaCostString?: string
+  /**
+   * Mana this spell adds to its own cost per target beyond the first — Officious Interrogation
+   * ("This spell costs {W}{U} more to cast for each target beyond the first") sends `'{W}{U}'`.
+   * Absent for every spell that doesn't tax itself per target.
+   *
+   * When set, `manaCostString` is only the one-target minimum, so targeting has to be settled
+   * before the player can sensibly pick mana sources by hand: `computePhases` orders `targeting`
+   * ahead of `manaSource`, and `startManaSelection` scales the cost it charges by the targets
+   * actually picked.
+   */
+  readonly manaCostPerExtraTarget?: string
   /** Whether this spell requires damage distribution at cast time (for DividedDamageEffect) */
   readonly requiresDamageDistribution?: boolean
   /** Total damage to distribute for DividedDamageEffect spells */


### PR DESCRIPTION
MKM's last 11 cards all need engine work — none is composable. These two were the cheapest to unblock, and one of the features fixes a **live bug in already-shipped cards**.

MKM goes **265/276 → 267/276**.

## Engine features (done first, as they had to be)

### 1. Face-down creatures now count for combat-damage batch triggers — *bug fix*

`TriggerDetector.detectCombatDamageBatchTriggers` skipped any source carrying a `FaceDownComponent`, in **both** the offensive and defensive variant. That guard pre-dated `PredicateEvaluator`'s face-down masking and had become strictly harmful: a face-down permanent *is* a creature (CR 708.2), so it should satisfy an unfiltered "creatures you control" batch trigger, and the filtered forms are already decided by the evaluator.

**Independent of this PR's cards, that means unfiltered "whenever one or more creatures you control deal combat damage to a player" under-triggered whenever a morphed, manifested, disguised or cloaked creature connected** — Kastral, the Windcrested and Vaan, Street Thief among them.

Removing it needed one companion fix: `CardPredicate.NameEquals` (and `NameEqualsChosen`) were **not** face-down-masked, so a nameless permanent matched a name filter. Now masked, per CR 708.2a. A control test pins this: a name-filtered batch trigger must still ignore a face-down creature.

### 2. Face-down last-known information for zone-change triggers

`EntitySnapshot` never captured face-down-ness, so `StatePredicate.IsFaceDown` had no LKI arm and "whenever a face-down creature you control dies" could **never** match — a card put into a graveyard is turned face up (CR 708.4) and the battlefield entity is gone by trigger-gating time, so the live `FaceDownComponent` the projected path reads no longer exists.

Adds `EntitySnapshot.wasFaceDown` (captured in `ZoneTransitionService`) plus `IsFaceDown` / `IsFaceUp` arms in `matchesStatePredicateForZoneChangeTrigger` — the same LKI channel (CR 608.2h) that already backs `wasSuspected` / `wasAttacking` / `wasEnchanted`.

### 3. Per-target mana cost increase

A per-*mode* mana increase existed (escalate, `ModalEffect.additionalManaCostPerExtraMode`); a per-*target* one did not. Rather than build a second parallel rail through enumeration/validation/payment, this rides the `ModifySpellCost` / `SpellCostTarget.SelfCast` static that already prices a spell against its own chosen targets (the machinery behind Dragon's Prey). Two additions, both mirrors of things that already existed:

- `CostReductionSource.ChosenTargetsBeyondTheFirst` — a count source. Reads 0 before targets are chosen, which is also correct for affordability enumeration: one target is the cheapest legal cast.
- `CostModification.IncreaseColoredPerUnit` — the exact tax mirror of the long-standing `ReduceColoredPerUnit`.

The life-side sibling for the same wording already worked (`AdditionalCost.PayLifePerTarget`, Phyrexian Purge); this is the mana side.

**A free cast still owes the tax.** "Costs {W}{U} more" is a cost *increase*, and an alternative cost or a "without paying its mana cost" permission waives the mana cost, not the increases applied to the total cost (CR 601.2f) — the card's 2024-02-02 ruling says so outright. The ordinary path prices this inside `CostCalculator.calculateEffectiveCost`, which those branches never reach, so `CostCalculator.selfPerTargetTax` is added on top of them in both the validate and execute halves of the cast pipeline.

**Client.** `LegalAction.manaCostPerExtraTarget` carries the increment through to `LegalActionInfo`. `computePhases` defers a manual `manaSource` phase past `targeting` when it is set (the same reason an X cost forces `xSelection` first), and `startManaSelection` scales the cost it charges by the targets picked — the same shape as the emerge/harmonize re-pricing already sitting next to it. Under auto-tap (the default) neither phase runs and the server prices the submitted targets itself, so none of this is visible there.

### 4. `Player.EachTargetedPlayer` — "those players"

`Player.TargetPlayer` resolves to a **single** targeted player, so a plural reference written with it silently reads only the first. The new reference resolves to every player among the chosen targets, and counting primitives sum over the resolved list — which makes "the total number of creatures those players control" one `DynamicAmount` rather than a per-target loop. It also gets the illegal-target ruling right for free: a target gone from the resolution context contributes nothing. Like `Each` / `EachOpponent` / `OwnersOfLinkedExile` it is list-only; the single-player resolver returns null for it deliberately, and `ForEachExecutor` gets its own arm so a `ForEach` over it isn't a silent no-op.

## Cards

**Yarus, Roar of the Old Gods** — needs (1) and (2). Two judgement calls worth flagging in review:

- Its dies filter deliberately carries **no `Creature` card predicate**. `faceDown()` already implies creature — every face-down permanent is a 2/2 — while spelling `GameObjectFilter.Creature` would *narrow* the trigger wrongly: the zone-change path evaluates card predicates against the **printed** type line, so a cloaked or manifested *land* card dying would fail `IsCreature`, which is exactly the case the ability exists to handle.
- "If it's a permanent card" is checked against the **graveyard card** (`EntityMatches` on a non-battlefield entity falls back to base `CardComponent` data), not last-known info — whose type line for *any* face-down permanent is Creature, so an instant cloaked onto the battlefield would sail through the gate and strand itself.

The return is two steps matching the oracle order, with `FaceDownMode.HIDDEN` for the intermediate state: not disguised or cloaked, so no ward {2} and no turn-up procedure of its own (2024-02-02 ruling).

**Officious Interrogation** — needs (3) and (4).

## Verification

- `just test-rules` — engine tests plus **every** card scenario: green.
- 7 new Yarus scenario tests, 5 new Officious Interrogation ones, 3 new client `computePhases` tests.
- Full `web-client` vitest suite (590 tests) and `tsc --noEmit`: green.
- `just check-card-printing` for both cards: canonical in MKM, reprint rows present.
- MKM card snapshot re-blessed — the diff is only these two cards.
- `docs/card-sdk-language-reference.md` updated in the same change (cost modifications, cost reduction sources, `Player` references, `IsFaceDown`, and the batch-trigger entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
