### PR TITLE
Apply death replacements to creatures dying in the same SBA batch

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -10704,8 +10704,12 @@ The priority groups are (CR 616.1a–f):
   appliesTo)` — like `RedirectZoneChange` but also runs `additionalEffect` when the replacement fires.
   The additional effect is applied through a small executor whitelist (not the full pipeline) —
   `TakeExtraTurnEffect` (Ugin's Nexus), `AddCountersEffect` on the redirected card (Darigaaz
-  Reincarnated), and `GainLifeEffect` (fixed amount, gained by the replacement source's controller;
-  emits `LifeChangedEvent` so life-gain triggers fire). `selfOnly = true` restricts it to the source
+  Reincarnated), `GainLifeEffect` (fixed amount, gained by the replacement source's controller;
+  emits `LifeChangedEvent` so life-gain triggers fire), and `CreateTokenEffect` (Head of the Hunt's
+  "When you do, create a 2/2 green Wolf creature token" — minted for the replacement source's
+  controller through the real `CreateTokenExecutor`, so the token gets the minting set's art, its
+  keywords and static abilities, and the enters-the-battlefield events ETB triggers read).
+  `selfOnly = true` restricts it to the source
   permanent itself; `linkToSource = true` (exile destination only) adds the redirected card to the
   source's `LinkedExileComponent` exactly like `RedirectZoneChange.linkToSource`. The Darkness Crystal's
   "If a nontoken creature an opponent controls would die, instead exile it and you gain 2 life" is

--- a/manual-scenarios/cards/h/head-of-the-hunt.json
+++ b/manual-scenarios/cards/h/head-of-the-hunt.json
@@ -1,0 +1,56 @@
+{
+  "player1Name": "Player 1",
+  "player2Name": "Player 2",
+  "player1": {
+    "lifeTotal": 20,
+    "battlefield": [
+      {
+        "name": "Head of the Hunt"
+      }
+    ],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "battlefield": [
+      {
+        "name": "Castle Ardenvale"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Llanowar Elves"
+      },
+      {
+        "name": "Llanowar Elves"
+      },
+      {
+        "name": "Llanowar Elves"
+      }
+    ],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "mode": "SELF"
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ValgavothTerrorEaterScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ValgavothTerrorEaterScenarioTest.kt
@@ -70,6 +70,41 @@ class ValgavothTerrorEaterScenarioTest : FunSpec({
         linkedExileOf(driver, valgavoth) shouldContain victim
     }
 
+    test("a creature that trades with Valgavoth is still exiled, but is not linked to the dead Valgavoth") {
+        // CR 704.3 performs every applicable state-based action simultaneously as a single event,
+        // and a replacement applies as that event is about to happen (CR 614.1) — so Valgavoth
+        // still shields a creature dying alongside it. A deathtouch attacker that Valgavoth blocks
+        // is the cheap way to kill a 9/9 in the same combat-damage check that kills the attacker
+        // (it has to block rather than be blocked: Valgavoth flies, so a ground Rat can't block it).
+        //
+        // The *link* is a separate question. A permanent that has left the battlefield has had its
+        // LinkedExileComponent stripped, and re-attaching one would strand a stale exile list on a
+        // card in the graveyard that nothing cleans up — `removeFromLinkedExiles` only walks the
+        // battlefield. Coming back is a new object with no memory of its previous existence
+        // (CR 400.7), so the exile must not stay castable off a Valgavoth that died with it.
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val valgavoth = driver.putCreatureOnBattlefield(defender, "Valgavoth, Terror Eater")
+        val rat = driver.putCreatureOnBattlefield(attacker, "Deathtouch Rat") // 1/1 deathtouch
+        driver.removeSummoningSickness(rat)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(rat), defender).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(defender, mapOf(valgavoth to listOf(rat))).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.END_COMBAT)
+
+        // Deathtouch kills the 9/9 (CR 704.5h) while its 9 damage kills the 1/1 (CR 704.5g).
+        driver.getGraveyard(defender) shouldContain valgavoth
+        driver.getGraveyard(attacker) shouldNotContain rat
+        driver.getExile(attacker) shouldContain rat
+        linkedExileOf(driver, valgavoth) shouldNotContain rat
+    }
+
     test("your own creature dying is unaffected (only an opponent's graveyard)") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)

--- a/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HeadOfTheHuntScenarioTest.kt
+++ b/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HeadOfTheHuntScenarioTest.kt
@@ -1,0 +1,246 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Head of the Hunt (The Hobbit #75):
+ *   {2}{B}{B} Creature — Wolf, 4/3
+ *   Flash
+ *   If a creature an opponent controls would die, exile it instead. When you do, create a
+ *   2/2 green Wolf creature token.
+ *
+ * The interesting case is the *trade*: Head of the Hunt dying in the same combat-damage event as
+ * the creatures it is meant to exile. CR 704.3 performs every applicable state-based action
+ * simultaneously as a single event, and a replacement effect applies as that event is about to
+ * happen (CR 614.1) — so the shield is still on the battlefield and still applies. The engine
+ * moves the dying creatures one at a time, so before the pass-start snapshot went into
+ * [com.wingedsheep.engine.mechanics.sba.SbaZoneMovementHelper] this came down to battlefield
+ * iteration order: Head of the Hunt happened to move first and the creatures it had blocked went
+ * to the graveyard untouched.
+ */
+class HeadOfTheHuntScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Head of the Hunt") {
+
+            test("a creature that trades with Head of the Hunt in combat is still exiled, and still mints a Wolf") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Head of the Hunt", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Centaur Courser", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val hunt = game.findPermanent("Head of the Hunt")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+                val opponentId = game.player2Id
+
+                // 4/3 attacker into a 3/3 blocker: both are dealt lethal damage and are destroyed
+                // by the same state-based-action check.
+                game.declareAttackers(mapOf("Head of the Hunt" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Centaur Courser" to listOf("Head of the Hunt")))
+                    .error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.state.pendingDecision != null) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("Head of the Hunt itself dies normally — it shields opponents, not you") {
+                    game.state.getGraveyard(game.player1Id) shouldContain hunt
+                }
+                withClue("The blocker it traded with is exiled, not put into the graveyard") {
+                    game.state.getGraveyard(opponentId) shouldNotContain courser
+                    game.state.getExile(opponentId) shouldContain courser
+                }
+                withClue("The reflexive 'when you do' mints a Wolf for Head of the Hunt's controller") {
+                    game.findAllPermanents("Wolf Token").size shouldBe 1
+                }
+            }
+
+            test("an opponent's creature killed while Head of the Hunt survives is exiled and mints a Wolf") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Head of the Hunt", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val opponentId = game.player2Id
+
+                game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("The bolted creature is exiled instead of dying") {
+                    game.state.getGraveyard(opponentId) shouldNotContain bears
+                    game.state.getExile(opponentId) shouldContain bears
+                }
+                withClue("The rider mints one 2/2 green Wolf") {
+                    val wolves = game.findAllPermanents("Wolf Token")
+                    wolves.size shouldBe 1
+                    projector.getProjectedPower(game.state, wolves.single()) shouldBe 2
+                    projector.getProjectedToughness(game.state, wolves.single()) shouldBe 2
+                }
+            }
+
+
+            test("every creature dying alongside it is exiled — two blockers, two Wolves") {
+                // The reported bug was three creatures dying at once to one shield. With a single
+                // blocker a fix that repaired only the first redirect in a batch would still pass.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Head of the Hunt", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val hunt = game.findPermanent("Head of the Hunt")!!
+                val bears = game.findAllPermanents("Grizzly Bears")
+                bears.size shouldBe 2
+                val opponentId = game.player2Id
+
+                // 4 power split as lethal-in-order kills both 2/2s; 4 damage back kills the 4/3.
+                // All three die to the same state-based-action check.
+                game.declareAttackers(mapOf("Head of the Hunt" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.execute(
+                    DeclareBlockers(opponentId, bears.associateWith { listOf(hunt) })
+                ).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.state.pendingDecision != null) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("Head of the Hunt traded with both blockers") {
+                    game.state.getGraveyard(game.player1Id) shouldContain hunt
+                }
+                withClue("Both blockers are exiled, neither reaches the graveyard") {
+                    bears.forEach { bear ->
+                        game.state.getGraveyard(opponentId) shouldNotContain bear
+                        game.state.getExile(opponentId) shouldContain bear
+                    }
+                }
+                withClue("One Wolf per creature actually redirected") {
+                    game.findAllPermanents("Wolf Token").size shouldBe 2
+                }
+            }
+
+            test("an opponent's token is exiled too — the filter is deliberately not nontoken") {
+                // HeadOfTheHunt.kt documents that the filter is *not* nontoken(): an opponent's
+                // token still "would die", so it is exiled instead (and then ceases to exist as a
+                // state-based action) and still pays off the Wolf. The reported game was tokens.
+                //
+                // The opponent makes the tokens and then kills one of their own, which keeps the
+                // whole test inside the turn where they plainly hold priority — a token minted this
+                // turn has summoning sickness and cannot attack, and Head of the Hunt's filter only
+                // cares who *controls* the dying creature, not who killed it.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Head of the Hunt", summoningSickness = false)
+                    .withLandsOnBattlefield(2, "Mountain", 3)
+                    .withCardInHand(2, "Dragon Fodder")
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Dragon Fodder").error shouldBe null
+                game.resolveStack()
+                val goblins = game.findAllPermanents("Goblin Token")
+                withClue("Dragon Fodder made two 1/1 Goblin tokens for the opponent") {
+                    goblins.size shouldBe 2
+                }
+
+                game.castSpell(2, "Lightning Bolt", targetId = goblins.first()).error shouldBe null
+                game.resolveStack()
+
+                withClue("The bolted token was redirected to exile, minting a Wolf") {
+                    game.findAllPermanents("Wolf Token").size shouldBe 1
+                }
+                withClue("The other token is untouched") {
+                    game.findAllPermanents("Goblin Token").size shouldBe 1
+                }
+            }
+
+            test("a shield dying to zero toughness still shields the creatures dying with it") {
+                // ZeroToughnessCheck takes the same pass-start snapshot as LethalDamageCheck.
+                // Languish (-4/-4 to all creatures) puts the 4/3 at 0/-1 and the 2/2 at -2/-2, so
+                // both are put into their owners' graveyards by one CR 704.5f check — the shield
+                // among them.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Head of the Hunt", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInHand(1, "Languish")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hunt = game.findPermanent("Head of the Hunt")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val opponentId = game.player2Id
+
+                game.castSpell(1, "Languish").error shouldBe null
+                game.resolveStack()
+
+                withClue("Head of the Hunt died to zero toughness alongside the creature it shields") {
+                    game.state.getGraveyard(game.player1Id) shouldContain hunt
+                }
+                withClue("The opponent's creature is exiled, not put into the graveyard") {
+                    game.state.getGraveyard(opponentId) shouldNotContain bears
+                    game.state.getExile(opponentId) shouldContain bears
+                }
+                withClue("And still mints its Wolf") {
+                    game.findAllPermanents("Wolf Token").size shouldBe 1
+                }
+            }
+
+            test("your own dying creature is untouched — the shield only covers opponents") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Head of the Hunt", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("Your own creature dies to the graveyard as normal") {
+                    game.state.getGraveyard(game.player1Id) shouldContain bears
+                }
+                withClue("No Wolf is minted") {
+                    game.findAllPermanents("Wolf Token").size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/EngineServices.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/EngineServices.kt
@@ -58,6 +58,15 @@ class EngineServices(
         // does. The handler is stateless beyond the registry, so a singleton is sufficient.
         ZoneTransitionService.staticAbilityHandler = StaticAbilityHandler(cardRegistry)
         ZoneTransitionService.cardRegistry = cardRegistry
+        // A zone-change replacement's "…instead. When you do, create a token" rider (Head of the
+        // Hunt) mints through the same executor an ability would, so the token gets the minting
+        // set's art and its static abilities rather than the bare generic fallback.
+        com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.tokenExecutor =
+            com.wingedsheep.engine.handlers.effects.token.CreateTokenExecutor(
+                staticAbilityHandler = StaticAbilityHandler(cardRegistry),
+                cardRegistry = cardRegistry,
+                tokenArtRegistry = tokenArtRegistry
+            )
     }
     /**
      * The one replacement-effect processor for this game. Declared before anything that

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -77,6 +77,11 @@ import com.wingedsheep.sdk.scripting.predicates.evaluateWith
  * @param additionalEffect An optional effect to execute when the redirect applies
  *        (e.g., TakeExtraTurnEffect from Ugin's Nexus)
  * @param effectControllerId The controller of the replacement effect source
+ * @param effectSourceId The permanent that hosts the replacement effect. Passed to
+ *        [ZoneMovementUtils.applyReplacementAdditionalEffect] as the rider's source so a created
+ *        token resolves the minting set's art (Head of the Hunt's Wolf), exactly as it would if
+ *        the rider had resolved as an ability. May already be off the battlefield by then — the
+ *        replacement applied while it was still there (CR 704.3).
  * @param linkSourceId When non-null (and [destinationZone] is [Zone.EXILE]), the redirected
  *        card should be linked to this source permanent's `LinkedExileComponent` after the move
  *        — set by a [RedirectZoneChange] with `linkToSource = true` (Valgavoth, Terror Eater).
@@ -91,6 +96,7 @@ data class ZoneChangeRedirectResult(
     val destinationZone: Zone,
     val additionalEffect: com.wingedsheep.sdk.scripting.effects.Effect? = null,
     val effectControllerId: EntityId? = null,
+    val effectSourceId: EntityId? = null,
     val linkSourceId: EntityId? = null,
     val shuffleIntoLibrary: Boolean = false,
     val reveal: Boolean = false
@@ -106,6 +112,19 @@ data class ZoneChangeRedirectResult(
 object ZoneMovementUtils {
 
     private val predicateEvaluator = PredicateEvaluator()
+
+    /**
+     * Token executor used by [applyReplacementAdditionalEffect] for a replacement's
+     * "…instead. When you do, create a token" rider (Head of the Hunt).
+     *
+     * Wired by [com.wingedsheep.engine.core.EngineServices] so the rider mints through the same
+     * executor an ability would, with the card and token-art registries attached — mirroring
+     * `ZoneTransitionService.cardRegistry`. The default stand-in keeps this object usable
+     * unwired (unit tests, gym rollouts); tokens then fall back to the engine-wide generic art
+     * for their creature type.
+     */
+    var tokenExecutor: com.wingedsheep.engine.handlers.effects.token.CreateTokenExecutor =
+        com.wingedsheep.engine.handlers.effects.token.CreateTokenExecutor()
 
     /**
      * Destinations that the commander zone-change replacement can intercept (CR 903.9).
@@ -658,11 +677,27 @@ object ZoneMovementUtils {
             null
         }
 
+    /**
+     * Resolve the destination of a zone change after replacement effects.
+     *
+     * @param battlefieldSourceState The state whose battlefield is scanned for permanents that
+     *        host a zone-change replacement ([ReplacementEffectSourceComponent]). Defaults to
+     *        [state] and should stay that way for every event that happens on its own. It differs
+     *        only for state-based actions: CR 704.3 performs all applicable SBAs *simultaneously
+     *        as a single event*, so a shield permanent that is itself being destroyed in that same
+     *        batch still shields the others (CR 614.1 — replacement effects apply as the event
+     *        happens, and it hasn't happened yet). SBA callers therefore pass the state as it
+     *        stood when the check pass began; without it, whichever creature the battlefield
+     *        happened to iterate first would silently decide the outcome. The moving object's own
+     *        replacements (finality counter, madness, commander, self-redirect) are still read off
+     *        [state] — those travel with the card, not with a battlefield source.
+     */
     fun checkZoneChangeRedirect(
         state: GameState,
         entityId: EntityId,
         fromZone: Zone?,
-        toZone: Zone
+        toZone: Zone,
+        battlefieldSourceState: GameState = state
     ): ZoneChangeRedirectResult {
         val container = state.getEntity(entityId) ?: return ZoneChangeRedirectResult(toZone)
 
@@ -734,8 +769,8 @@ object ZoneMovementUtils {
             }
         }
 
-        for (permanentId in state.getBattlefield()) {
-            val permContainer = state.getEntity(permanentId) ?: continue
+        for (permanentId in battlefieldSourceState.getBattlefield()) {
+            val permContainer = battlefieldSourceState.getEntity(permanentId) ?: continue
             val replacementComponent = permContainer.get<ReplacementEffectSourceComponent>() ?: continue
             val sourceControllerId = permContainer.get<ControllerComponent>()?.playerId ?: continue
 
@@ -788,6 +823,7 @@ object ZoneMovementUtils {
                             effect.newDestination,
                             effect.additionalEffect,
                             sourceControllerId,
+                            effectSourceId = permanentId,
                             linkSourceId = linkSource
                         )
                     }
@@ -890,11 +926,23 @@ object ZoneMovementUtils {
      *
      * @param entityId The entity that was redirected (for effects that target it, like adding counters)
      */
+    /**
+     * Execute the rider a zone-change replacement carries — the "When you do, …" half of
+     * "…exile it instead. When you do, create a 2/2 green Wolf creature token".
+     *
+     * @param controllerId Controller of the replacement's source; the rider's "you".
+     * @param entityId The card that was redirected, for riders that act on it (Darigaaz's egg
+     *   counters).
+     * @param sourceId The permanent hosting the replacement, used as the rider's source. Only
+     *   token art reads it today; it may already have left the battlefield (CR 704.3), which is
+     *   fine — nothing here requires the source to still be there.
+     */
     fun applyReplacementAdditionalEffect(
         state: GameState,
         effect: com.wingedsheep.sdk.scripting.effects.Effect,
         controllerId: EntityId?,
-        entityId: EntityId? = null
+        entityId: EntityId? = null,
+        sourceId: EntityId? = null
     ): Pair<GameState, List<EngineGameEvent>> {
         if (effect is com.wingedsheep.sdk.scripting.effects.TakeExtraTurnEffect) {
             // Check if extra turns are prevented by any permanent on the battlefield
@@ -935,6 +983,21 @@ object ZoneMovementUtils {
                 ?: return state to emptyList()
             val (newState, event) = DamageUtils.gainLife(state, cid, amount)
             return newState to listOfNotNull(event)
+        }
+        if (effect is com.wingedsheep.sdk.scripting.effects.CreateTokenEffect) {
+            // Head of the Hunt. Delegated to the real executor rather than open-coded: that is
+            // what gives the token the minting set's art, its keywords and static abilities, and
+            // the enters-the-battlefield events that ETB triggers read. Its controller is the
+            // replacement's controller — the rider's "you" — so a token minted while an opponent's
+            // creature is redirected still lands on the shield controller's side.
+            val cid = controllerId ?: return state to emptyList()
+            val result = tokenExecutor.execute(
+                state,
+                effect,
+                com.wingedsheep.engine.handlers.EffectContext(sourceId = sourceId, controllerId = cid)
+            )
+            if (result.error != null) return state to emptyList()
+            return result.state to result.events
         }
         return state to emptyList()
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -883,7 +883,8 @@ object ZoneTransitionService {
         // 9. Apply redirect additional effects if any
         if (redirectResult.additionalEffect != null) {
             val (updatedState, extraEvents) = ZoneMovementUtils.applyReplacementAdditionalEffect(
-                newState, redirectResult.additionalEffect, redirectResult.effectControllerId, entityId
+                newState, redirectResult.additionalEffect, redirectResult.effectControllerId, entityId,
+                sourceId = redirectResult.effectSourceId
             )
             newState = updatedState
             events.addAll(extraEvents)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/StateBasedActionChecker.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/StateBasedActionChecker.kt
@@ -95,7 +95,10 @@ class StateBasedActionChecker(
         val events = mutableListOf<GameEvent>()
 
         for (check in registry.allChecks()) {
-            val result = check.check(newState)
+            // `state` is the pass-start snapshot: everything this pass performs is one
+            // simultaneous event (CR 704.3), so a check that must see the battlefield as it
+            // stood before the batch started gets it rather than reconstructing it.
+            val result = check.check(newState, state)
 
             if (result.isPaused) {
                 // Return paused with events accumulated so far + this check's events

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaZoneMovementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaZoneMovementHelper.kt
@@ -37,12 +37,23 @@ object SbaZoneMovementHelper {
      * Move a creature to graveyard via SBA (zero toughness, lethal damage).
      * Emits both CreatureDestroyedEvent and ZoneChangeEvent.
      * Respects ExileOnDeath, zone change redirects, and ExileControllerGraveyardOnDeath.
+     *
+     * @param passStartState The state as it stood when the SBA check pass began, before any
+     *        creature in this batch was moved. CR 704.3 performs all applicable state-based
+     *        actions simultaneously as a single event, so a permanent hosting a "would die →
+     *        exile it instead" replacement (Head of the Hunt, The Darkness Crystal, Valgavoth)
+     *        still shields the creatures dying alongside it — it is on the battlefield right up
+     *        until the event happens (CR 614.1). Callers move creatures one at a time through a
+     *        progressively mutated state, so the replacement lookup must read this snapshot
+     *        instead; otherwise battlefield iteration order decides whether the shield applies.
+     *        Defaults to [state] for callers outside a batch.
      */
     fun putCreatureInGraveyard(
         state: GameState,
         entityId: EntityId,
         cardComponent: CardComponent,
-        reason: String
+        reason: String,
+        passStartState: GameState = state
     ): ExecutionResult {
         val container = state.getEntity(entityId) ?: return ExecutionResult.success(state)
         val controllerId = container.get<ControllerComponent>()?.playerId
@@ -56,9 +67,11 @@ object SbaZoneMovementHelper {
         }
         val exileInstead = exileOnDeathIndex != -1
 
-        // Check for RedirectZoneChange replacement effects
+        // Check for RedirectZoneChange replacement effects. Battlefield-sourced shields are read
+        // off the pass-start snapshot so a shield dying in the same SBA batch still applies.
         val redirectResult = ZoneMovementUtils.checkZoneChangeRedirect(
-            state, entityId, Zone.BATTLEFIELD, Zone.GRAVEYARD
+            state, entityId, Zone.BATTLEFIELD, Zone.GRAVEYARD,
+            battlefieldSourceState = passStartState
         )
         val destinationZone = if (exileInstead) Zone.EXILE else redirectResult.destinationZone
 
@@ -148,7 +161,17 @@ object SbaZoneMovementHelper {
 
         // Link the exiled card to a RedirectZoneChange(linkToSource) source (Valgavoth) — the
         // move above ran with skipZoneChangeRedirect=true, so the link is applied here.
-        if (!exileInstead && destinationZone == Zone.EXILE && redirectResult.linkSourceId != null) {
+        //
+        // Only while the source is still on the battlefield *after* this move. Since the
+        // replacement is now looked up in the pass-start snapshot, the source may itself have died
+        // in this same SBA batch — the shield still applies (CR 704.3), but a permanent that left
+        // has had its LinkedExileComponent stripped, and writing one back would leave a stale exile
+        // list on a card in the graveyard that nothing cleans up (removeFromLinkedExiles only walks
+        // the battlefield). Returning to the battlefield makes it a new object with no memory of
+        // what the old one exiled (CR 400.7), so the link must not survive the source's death.
+        if (!exileInstead && destinationZone == Zone.EXILE && redirectResult.linkSourceId != null &&
+            redirectResult.linkSourceId in newState.getBattlefield()
+        ) {
             newState = ZoneMovementUtils.linkExiledToSource(newState, entityId, redirectResult.linkSourceId)
         }
 
@@ -156,7 +179,8 @@ object SbaZoneMovementHelper {
         // counters, The Darkness Crystal's "you gain 2 life").
         if (redirectResult.additionalEffect != null) {
             val (updatedState, extraEvents) = ZoneMovementUtils.applyReplacementAdditionalEffect(
-                newState, redirectResult.additionalEffect, redirectResult.effectControllerId, entityId
+                newState, redirectResult.additionalEffect, redirectResult.effectControllerId, entityId,
+                sourceId = redirectResult.effectSourceId
             )
             newState = updatedState
             events.addAll(extraEvents)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/StateBasedActionCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/StateBasedActionCheck.kt
@@ -18,6 +18,17 @@ interface StateBasedActionCheck {
 
     /** Check and apply this SBA. Returns success with events if changes were made. */
     fun check(state: GameState): ExecutionResult
+
+    /**
+     * Check and apply this SBA, told what the game looked like when the pass began.
+     *
+     * CR 704.3 performs every applicable state-based action *simultaneously as a single event*,
+     * but the checks here run in [SbaOrder] sequence and each moves permanents one at a time.
+     * A check that needs to see the battlefield as it stood before any of that batch left —
+     * a "would die → exile it instead" shield that is itself dying, say — overrides this and
+     * reads [passStartState]. Everything else keeps the single-argument form.
+     */
+    fun check(state: GameState, passStartState: GameState): ExecutionResult = check(state)
 }
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/creature/LethalDamageCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/creature/LethalDamageCheck.kt
@@ -20,7 +20,9 @@ class LethalDamageCheck : StateBasedActionCheck {
     override val name = "704.5g/h Lethal Damage"
     override val order = SbaOrder.LETHAL_DAMAGE
 
-    override fun check(state: GameState): ExecutionResult {
+    override fun check(state: GameState): ExecutionResult = check(state, state)
+
+    override fun check(state: GameState, passStartState: GameState): ExecutionResult {
         var newState = state
         val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
         // CR 704.3: state-based actions are checked, then all applicable ones are performed
@@ -75,8 +77,14 @@ class LethalDamageCheck : StateBasedActionCheck {
                     continue
                 }
 
+                // `passStartState` — not `newState` — decides which battlefield permanents can
+                // replace this death. Everything this SBA pass performs is one simultaneous event
+                // (CR 704.3), so a "would die → exile it instead" shield dying in the same batch
+                // still shields the rest (CR 614.1). Reading the mutated state instead would let
+                // battlefield iteration order decide it: a Head of the Hunt that traded with the
+                // creatures it was meant to exile happened to be moved first, so they died.
                 val result = SbaZoneMovementHelper.putCreatureInGraveyard(
-                    newState, entityId, cardComponent, "lethal damage"
+                    newState, entityId, cardComponent, "lethal damage", passStartState
                 )
                 newState = result.newState
                 events.addAll(result.events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/creature/ZeroToughnessCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/creature/ZeroToughnessCheck.kt
@@ -14,7 +14,9 @@ class ZeroToughnessCheck : StateBasedActionCheck {
     override val name = "704.5f Zero Toughness"
     override val order = SbaOrder.ZERO_TOUGHNESS
 
-    override fun check(state: GameState): ExecutionResult {
+    override fun check(state: GameState): ExecutionResult = check(state, state)
+
+    override fun check(state: GameState, passStartState: GameState): ExecutionResult {
         var newState = state
         val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
         val projected = state.projectedState
@@ -28,8 +30,10 @@ class ZeroToughnessCheck : StateBasedActionCheck {
             val effectiveToughness = projected.getToughness(entityId) ?: 0
 
             if (effectiveToughness <= 0) {
+                // Same simultaneity rule as LethalDamageCheck: battlefield-sourced death
+                // replacements are read off the pass-start state (CR 704.3 / 614.1).
                 val result = SbaZoneMovementHelper.putCreatureInGraveyard(
-                    newState, entityId, cardComponent, "zero toughness"
+                    newState, entityId, cardComponent, "zero toughness", passStartState
                 )
                 newState = result.newState
                 events.addAll(result.events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2264,7 +2264,8 @@ class StackResolver(
 
                 pausedRedirect.additionalEffect?.let { extra ->
                     val (updatedState, extraEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.applyReplacementAdditionalEffect(
-                        pausedState, extra, pausedRedirect.effectControllerId, spellId
+                        pausedState, extra, pausedRedirect.effectControllerId, spellId,
+                        sourceId = pausedRedirect.effectSourceId
                     )
                     pausedState = updatedState
                     pausedCounterEvents.addAll(extraEvents)
@@ -2446,7 +2447,8 @@ class StackResolver(
 
         redirect.additionalEffect?.let { extra ->
             val (updatedState, extraEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.applyReplacementAdditionalEffect(
-                newState, extra, redirect.effectControllerId, spellId
+                newState, extra, redirect.effectControllerId, spellId,
+                sourceId = redirect.effectSourceId
             )
             newState = updatedState
             events.addAll(extraEvents)


### PR DESCRIPTION
# Apply death replacements to creatures dying in the same SBA batch

Reported from a live game: Head of the Hunt (The Hobbit #75) attacked, was blocked by three Human
Citizen tokens, and traded with them. All three tokens went to the graveyard and no Wolf appeared —
the card did nothing at all.

> Head of the Hunt — {2}{B}{B} Creature — Wolf, 4/3
> Flash
> If a creature an opponent controls would die, exile it instead. When you do, create a 2/2 green
> Wolf creature token.

Expected: all three tokens exiled instead of dying, and three 2/2 green Wolf tokens created.

There were two independent bugs behind that, and the first was masking the second.

## 1. Replacement effects and simultaneous state-based actions

CR 704.3 checks for state-based actions and then "performs all applicable state-based actions
**simultaneously as a single event**". CR 614.1 has replacement effects "apply continuously as
events happen — they aren't locked in ahead of time … They act like 'shields' around whatever
they're affecting." Combat damage is dealt simultaneously, so the 4/3 and the three tokens are all
destroyed by one SBA check, and Head of the Hunt is still on the battlefield right up until that
event happens. Its shield covers the creatures dying alongside it.

`LethalDamageCheck` already understood the *determination* half of this — it deliberately reads a
single projection taken before any creature moves, with a comment explaining that re-projecting off
the progressively-mutated state would make the outcome depend on battlefield iteration order. But
the destruction itself still ran one creature at a time through that mutated state, and
`ZoneMovementUtils.checkZoneChangeRedirect` scanned *that* battlefield for permanents hosting a
zone-change replacement. So iteration order silently decided the result: Head of the Hunt happened
to be moved first, its `ReplacementEffectSourceComponent` left the battlefield with it, and the
three tokens were then processed with no shield in sight.

The fix mirrors what the projection already does:

- `StateBasedActionChecker.checkOnce` passes each check the state as the pass began. This is a new
  defaulted overload on `StateBasedActionCheck`, so the other ~20 checks are untouched.
- `LethalDamageCheck` and `ZeroToughnessCheck` forward it to
  `SbaZoneMovementHelper.putCreatureInGraveyard`. Covering both means a shield dying to zero
  toughness in the same pass also still applies — the two checks are adjacent in `SbaOrder` and are
  one event as far as CR 704.3 is concerned.
- `checkZoneChangeRedirect` gains a `battlefieldSourceState` parameter, defaulting to `state` and
  used **only** for the loop that scans the battlefield for replacement sources.

The moving object's *own* replacements — finality counter, madness, commander divert, the
`SelfZoneRedirectComponent` self-redirect — deliberately keep reading live `state`. Those travel
with the card, not with a battlefield source, so freezing them would be wrong rather than merely
unnecessary.

## 2. The `CreateTokenEffect` rider was a silent no-op

`RedirectZoneChangeWithEffect` applies its rider through a small whitelist in
`applyReplacementAdditionalEffect` rather than the full effect pipeline. That whitelist held
`TakeExtraTurnEffect` (Ugin's Nexus), `AddCountersEffect` (Darigaaz Reincarnated) and
`GainLifeEffect` (The Darkness Crystal). `CreateTokenEffect` fell through to
`return state to emptyList()`.

So Head of the Hunt would never have minted a Wolf in *any* situation — not just the trade, but a
plain removal spell on an opponent's creature too. Fixing only bug 1 would have produced a correct
exile and still no token.

Rather than open-code a token mint, the rider now delegates to the real `CreateTokenExecutor`,
wired in `EngineServices` alongside the existing `ZoneTransitionService.cardRegistry` static wiring.
That matters for more than tidiness: The Hobbit registers its own Wolf art (`thob #9 — the Wolf of
Chief Warg's Company and Head of the Hunt`), and only the executor consults `TokenArtRegistry`. It
also gets the token its keywords, static abilities, and the enters-the-battlefield events ETB
triggers read. `ZoneChangeRedirectResult` carries a new `effectSourceId` so the executor has a
source to resolve that art against.

## 3. A guard the first fix made necessary

Reaching a shield that has already left the battlefield has one consequence worth calling out.
`RedirectZoneChange(linkToSource = true)` — Valgavoth, Terror Eater — tethers each card it exiles to
the source's `LinkedExileComponent`, so the source can later cast them. That link is applied *after*
the move, and the source may now be a permanent that died in the same batch. A permanent that leaves
the battlefield has had its `LinkedExileComponent` stripped, so writing one back would strand a
stale exile list on a card sitting in the graveyard that nothing cleans up (`removeFromLinkedExiles`
only walks the battlefield). If that card returned to the battlefield it would be a new object with
no memory of its previous existence (CR 400.7), yet would arrive carrying the old object's exiles.

So the link is now guarded on the source still being on the battlefield after the move. The
redirect itself is unaffected — an opponent's creature trading with Valgavoth is still exiled rather
than dying; it just isn't castable off a Valgavoth that died with it, which is the rules-correct
outcome. Before this branch the situation could not arise, because a shield that had left the
battlefield was never found in the first place.

## No new SDK vocabulary

Nothing was added to the card SDK. Head of the Hunt's existing definition is unchanged — it already
composed `RedirectZoneChangeWithEffect` correctly, and both bugs were in the engine behind it.
`docs/card-sdk-language-reference.md` is updated because it documents that rider whitelist by name,
and the list was now wrong.

## Verification

`just test-class HeadOfTheHuntScenarioTest` — **6/6 pass**:

| Case | Why it's there |
|---|---|
| Trades in combat → exiled + Wolf | the reported bug |
| Removed while the shield survives → exiled + Wolf | isolates the `CreateTokenEffect` rider |
| Two blockers → two exiles, two Wolves | a fix repairing only the *first* redirect in a batch would pass a one-blocker test |
| An opponent's token → exiled + Wolf | the reported game was tokens, and the filter is deliberately not `nontoken()` |
| Shield dies to zero toughness (Languish) → still shields | `ZeroToughnessCheck` takes the same change and cites the same rules |
| Your own creature dies → graveyard, no Wolf | the shield only covers opponents |

`just test-class ValgavothTerrorEaterScenarioTest` — **8/8 pass**, including a new case where a
deathtouch attacker trades with Valgavoth: the attacker is still exiled (the simultaneity fix
reaching a `linkToSource` shield) but is *not* linked to the dead Valgavoth (the guard).

**Mutation check.** With the simultaneity fix reverted and everything else in place:

| Test | Fixed | Simultaneity reverted |
|---|---|---|
| Trades in combat → exiled + Wolf | PASSED | **FAILED** |
| Removed while shield survives → exiled + Wolf | PASSED | PASSED |
| Your own creature dies → graveyard, no Wolf | PASSED | PASSED |

The second row staying green under the mutation is the point: it isolates the two bugs, showing the
rider works on its own and that the combat failure is purely the SBA ordering issue.

`manual-scenarios/cards/h/head-of-the-hunt.json` is the hand-play repro the bug was found with —
Head of the Hunt facing Castle Ardenvale's token making — so the trade can be replayed in the dev
scenario runner rather than only in the automated tests.

**Suites.** `:rules-engine:test` plus all seven era scenario suites green on the simultaneity +
token work. The link guard that came later was re-gated on what *it* touches:
`TheDarknessCrystalScenarioTest` (the other card whose replacement carries a rider), the full 2024
and 2026 era suites (the two modules whose tests changed), and `:rules-engine:test` — all exit 0.

Two environment notes, since both could be misread as this branch's problem:

- `just test-rules` first came back with five era modules red. The JUnit XML thread dumps showed the
  test worker still inside `CardDiscovery` reflection, class-initialising the card corpus, five
  minutes in — it had never reached game logic. `test-rules` runs the era test tasks in parallel,
  and several JVMs each loading the whole corpus starved each other past `TestHangGuard`'s hard cap;
  load average hit 22, all of it this run's own workers. Gradle then aborted before scheduling 2025
  and 2026 at all. Re-run one era at a time (`just test-scenarios <era>`), all seven returned exit 0.
- Gradle reported `resourceHashesCache.bin ... is corrupt. Discarding.` in the shared
  `/workspace/.gradle` cache during one run. It self-healed and continued; no shared state was
  cleaned. Flagging it because that cache is shared with sibling containers.

**What the gate does not cover:** nothing outside `:rules-engine` and the card scenarios ran —
`:game-server`, `:ai`, `:gym*` and the web client were not exercised. The diff touches none of them,
but `StateBasedActionCheck` gained an interface member, so any implementation of that interface
outside these modules is worth a grep before merge. No E2E or self-play run was done.

Rule numbers cited here (704.3, 614.1, 400.7) were checked against
`MagicCompRules_20260808.txt` in the workspace, not from memory.

## Deliberately left out

A sweeper is `ForEachInGroup(GroupFilter(Creature), Move(Self, GRAVEYARD, byDestruction = true))` —
Wrath of God's script — which walks the effect-executor path and moves creatures one at a time
through a mutating state. That is the same ordering dependency as bug 1, so a Head of the Hunt
caught in its own Wrath still won't shield the opponent's board. Threading a snapshot through
`ForEachInGroup` is a wider change in machinery a great many cards share, and it deserves its own
branch and its own gate rather than being folded in here.
