### PR TITLE
Add Fatespinner and Timesifter, and the two turn-structure primitives they needed

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1037,6 +1037,19 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `ExileGroupAndLink(filter, storeAs?)` — exile all matching permanents into source's linked exile pile.
 - `ExileFromTopRepeating(count, repeatCondition)` — keep exiling top cards while a condition holds.
 - `ExileLibraryUntilManaValue(manaValue)` — exile from library until mana value ≤ N.
+- `Effects.ExileTopCardContest(storeWinnerAs, players = Player.Each, storeExiledAs = "contestExiledCards")`
+  (`ExileTopCardContestEffect`) — each player exiles the top card of their library face up; the one who
+  exiled the **greatest mana value** is published as the single entry of the pipeline collection
+  `storeWinnerAs`, and ties repeat among the **tied players only** until one is alone at the top. Fully
+  deterministic — no player ever chooses anything — so it resolves in a single pass with no decision or
+  continuation. **Open by design**: it answers "who won" and stops, so the payoff is composed off
+  `EffectTarget.PipelineTarget(storeWinnerAs)` rather than being owned by a library primitive. **The
+  contest can end with no winner** (a player with an empty library exiles nothing and so can never have
+  exiled the greatest mana value; if no contender can exile at all the tie stands), so gate the payoff on
+  `Conditions.CompareAmounts(DynamicAmount.DistinctEntitiesInCollections(listOf(storeWinnerAs)), GTE,
+  Fixed(1))` — an unresolved `PipelineTarget` otherwise falls back to the ability's controller. Every card
+  exiled, in every round, stays in exile and is published under `storeExiledAs`. Used by **Timesifter**
+  (`ExileTopCardContest` then a gated `TakeExtraTurn` on the winner).
 
 ### Return / placement
 
@@ -1968,6 +1981,23 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `Effects.FlipCoins(count, storeHeadsAs = "heads")` (`FlipCoinsEffect`) — flip `count` coins and store the number of heads under `storeHeadsAs` in the pipeline (`storedNumbers`) so a later sub-effect in the same composite can scale off it via `DynamicAmount.VariableReference`. The general "flip N coins, count heads" primitive (CR 705); unlike `FlipCoinEffect` (branch on win/lose) and `FlipTwoCoinsEffect` (branch on combined outcome) it only tallies. Each flip emits a `CoinFlipEvent`. **Ral Zarek, Guest Lecturer**'s ultimate composes `FlipCoins(5, "heads")` then `SkipNextTurn(target, count = VariableReference("heads"))`.
 - `Effects.FlipCoinsUntilLoss(storeWinsAs = "wins")` (`FlipCoinsUntilLossEffect`) — `FlipCoins`'s open-ended sibling: flip one coin at a time until the flipper *loses* a flip or answers "stop flipping", then store how many flips they won under `storeWinsAs`. The run length is discovered rather than given, and the order within an iteration is flip → check → ask, so the stop question only ever follows a *won* flip ("after each flip, you choose whether to continue flipping"). Losing the first flip stores 0, and since an unread pipeline number reads as 0, a card gating payoffs on "if you win one or more flips" needs no separate "this has no effect" branch — that sentence *is* the absence of every payoff. Deliberately **not** a `RepeatWhile` over `FlipCoinEffect`: a repeat condition is asked unconditionally after each body (so it can't stop *because* a flip was lost) and the repeat loop restarts each iteration from the pristine pre-loop context (so a running tally couldn't survive the prompt). The tally rides `FlipCoinsUntilLossContinuation` instead and is published once, when the run ends. Unlike `FlipCoins`, where the whole batch is one flip event, each coin here is its own flip — so a "the first time you flip one or more coins each turn" replacement (Edgar, King of Figaro) covers only the first coin. Bounded by `GameLimits.MAX_COIN_FLIPS_PER_EFFECT` as a backstop against a forced-win static plus an always-continue automated answer. **Fiery Gambit** composes `FlipCoinsUntilLoss("fieryGambitWins")` with three cumulative `Gate.WhenCondition(Compare(VariableReference("fieryGambitWins"), GTE, Fixed(n)))` tiers.
 - `Effects.SkipNextDrawStep(target = Controller)` (`SkipNextDrawStepEffect`) — target skips their next draw step. Adds a one-shot `SkipDrawStepComponent` marker consumed by `DrawPhaseManager.performDrawStep` (Elfhame Sanctuary's "you skip your draw step this turn").
+- `Effects.SkipStepOrPhaseThisTurn(part, target)` (`SkipStepOrPhaseThisTurnEffect`, `part` = `TurnPart.DRAW_STEP` |
+  `MAIN_PHASE` | `COMBAT_PHASE`) — the target skips **every** instance of that part of the turn for the rest of
+  this turn. The **duration** is what separates it from the one-shot `SkipNextDrawStep` / `SkipCombatPhases`
+  markers above, which are consumed by the first occurrence: this one stands until end-of-turn cleanup drops
+  its `SkippedTurnPartsComponent`, so a second main phase or an additional combat phase created later in the
+  turn is skipped too. `TurnPart` is the granularity printed cards use — one value covers both main phases
+  (CR 505.1: the precombat and postcombat main phases are individually and collectively "the main phase") and
+  one covers all five combat steps. The skip is read in `TurnManager.advanceStepFromEndedStep` *before* the
+  step's `StepChangedEvent` is built, which is what makes it faithful to CR 500.11 / 614.10 — the step is
+  proceeded past as though it didn't exist, so no player receives priority in it and no "at the beginning of
+  ..." ability triggers for it (that event is what `PassPriorityHandler` feeds to `detectPhaseStepTriggers`).
+  Skipping the postcombat main phase still runs the deferred end-of-combat bookkeeping that phase owns, or
+  creatures would stay in combat for the rest of the turn, and the additional-phase queue
+  (`AdditionalPhasesComponent`, drained on a separate path) consults the same marker — so an Aggravated
+  Assault combat phase created later in the turn is discarded rather than sailing through while the natural
+  one is skipped. Per CR 614.10 a step already under way can no longer be skipped. Used by **Fatespinner**, whose upkeep trigger routes a three-option `ChooseAction` to
+  `Player.TriggeringPlayer` and applies the chosen part to that same player.
 - `Effects.HijackNextTurn(target)` / `Effects.HijackNextCombatPhase(target)` (`HijackNextTurnEffect(target, scope)`, `scope` = `HijackScope.NextTurn` | `NextCombatPhase`) — Mindslaver-style: you make all decisions for the target player during their next whole turn, or during their next combat phase only. Moves *input authority* only (resource/permanent/spell ownership stays with the affected player); reuses `PlayerTurnHijackedComponent` + `GameState.actorFor`, so hand visibility and legal-action routing follow automatically. A scheduled hijack waits through skipped turns/combat phases and engages on the next one the player actually takes. Turn scope engages at turn start and clears at end-of-turn cleanup (**The Dominion Bracelet**); combat scope engages at beginning of combat and clears when that one combat phase ends — extra combat phases are not controlled (**Secret of Bloodbending**, whose optional waterbend upgrades combat→turn via `ConditionalEffect(Conditions.WaterbendWasPaid, HijackNextTurn, elseEffect = HijackNextCombatPhase)`).
 - `GrantCantBeBlockedByChosenColorEffect(target, duration)` — unblockable except by chosen color.
 - `Effects.GrantCantBeBlockedExceptBy(target, blockerFilter, duration = EndOfTurn)` (`GrantCantBeBlockedExceptByEffect`) —

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/TurnPart.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/TurnPart.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.sdk.core
+
+/**
+ * A named part of a turn as *printed cards talk about it* — the granularity a card uses when it
+ * offers a player a choice between "draw step, main phase, or combat phase" (Fatespinner).
+ *
+ * Deliberately coarser than [Step] and finer than [Phase]: one entry covers every [Step] that
+ * belongs to it, which is what makes "skip each instance of the chosen step or phase this turn"
+ * expressible as a single value. [MAIN_PHASE] covers both the precombat and the postcombat main
+ * phase (CR 505.1 — they are individually and collectively the main phase), and [COMBAT_PHASE]
+ * covers all five combat steps *and* any additional combat phase created that turn.
+ */
+enum class TurnPart(val displayName: String) {
+    /** The draw step (CR 504). */
+    DRAW_STEP("draw step"),
+
+    /** Both main phases (CR 505.1). */
+    MAIN_PHASE("main phase"),
+
+    /** Every step of every combat phase this turn (CR 506). */
+    COMBAT_PHASE("combat phase");
+
+    /** True when [step] belongs to this part of the turn. */
+    fun covers(step: Step): Boolean = when (this) {
+        DRAW_STEP -> step == Step.DRAW
+        MAIN_PHASE -> step.isMainPhase
+        COMBAT_PHASE -> step.phase == Phase.COMBAT
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -4248,6 +4248,35 @@ object Effects {
         SkipNextDrawStepEffect(target)
 
     /**
+     * The target player skips **every** instance of [part] for the rest of this turn — the
+     * until-end-of-turn sibling of the one-shot [SkipNextDrawStep] / `SkipCombatPhases` markers.
+     * A skipped step or phase is proceeded past as though it didn't exist (CR 500.11 / 614.10): no
+     * priority in it, and no "at the beginning of ..." trigger for it. Used by Fatespinner.
+     */
+    fun SkipStepOrPhaseThisTurn(
+        part: com.wingedsheep.sdk.core.TurnPart,
+        target: EffectTarget = EffectTarget.PlayerRef(com.wingedsheep.sdk.scripting.references.Player.TargetPlayer)
+    ): Effect = com.wingedsheep.sdk.scripting.effects.SkipStepOrPhaseThisTurnEffect(part, target)
+
+    /**
+     * Each player exiles the top card of their library; the player who exiled the greatest mana
+     * value is published as the single entry of the pipeline collection [storeWinnerAs], with ties
+     * repeating among the tied players only. Open by design — compose the payoff off
+     * `EffectTarget.PipelineTarget(storeWinnerAs)`, and gate it on the collection being non-empty
+     * because the contest can end with no winner. Used by Timesifter.
+     */
+    fun ExileTopCardContest(
+        storeWinnerAs: String,
+        players: com.wingedsheep.sdk.scripting.references.Player =
+            com.wingedsheep.sdk.scripting.references.Player.Each,
+        storeExiledAs: String = "contestExiledCards"
+    ): Effect = com.wingedsheep.sdk.scripting.effects.ExileTopCardContestEffect(
+        players = players,
+        storeWinnerAs = storeWinnerAs,
+        storeExiledAs = storeExiledAs
+    )
+
+    /**
      * Controller controls the target player during that player's next **turn**
      * (Mindslaver-style). Used by The Dominion Bracelet.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LibraryEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LibraryEffects.kt
@@ -236,6 +236,43 @@ data class ExileFromTopRepeatingEffect(
 }
 
 /**
+ * Each player in [players] exiles the top card of their library face up; the one who exiled the
+ * card with the **greatest mana value** wins, and their player entity id is published as the only
+ * member of the pipeline collection [storeWinnerAs]. Ties repeat: the tied players — and only they
+ * — exile another card each, until one of them is alone at the top (Timesifter).
+ *
+ * Deliberately *open* rather than owning the payoff. The effect answers "who won" and stops; the
+ * card composes the reward itself off [storeWinnerAs] through
+ * [com.wingedsheep.sdk.scripting.targets.EffectTarget.PipelineTarget], which keeps "take an extra
+ * turn", "draws a card", or anything else out of a library primitive.
+ *
+ * **There may be no winner**, and the collection is then empty: a player whose library is empty
+ * exiles nothing and so can never have exiled the greatest mana value, and if no contender can
+ * exile at all the contest ends undecided. Guard the payoff on the collection being non-empty
+ * (`Conditions.Compare(DynamicAmount.DistinctEntitiesInCollections(listOf(name)), GTE, Fixed(1))`)
+ * — an unguarded `PipelineTarget` falls back to the ability's controller.
+ *
+ * Every card exiled by the contest — losers' and winner's alike, from every round — stays in exile
+ * and is published under [storeExiledAs] for a card that wants to name them.
+ *
+ * Terminates: a round that exiles nothing ends the contest, so every further round shrinks at least
+ * one library.
+ */
+@SerialName("ExileTopCardContest")
+@Serializable
+data class ExileTopCardContestEffect(
+    val players: Player = Player.Each,
+    val storeWinnerAs: String,
+    val storeExiledAs: String = "contestExiledCards"
+) : Effect {
+    override val description: String =
+        "${players.description.replaceFirstChar { it.uppercase() }} exiles the top card of their " +
+            "library. The player who exiled the card with the greatest mana value wins; if two or " +
+            "more players' cards are tied for greatest, the tied players repeat this process until " +
+            "the tie is broken"
+}
+
+/**
  * For each matching player, exile cards from the top of their library until
  * the total mana value of cards exiled this way for that player reaches at
  * least [threshold]. All exiled card entity IDs (across every matched player)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.sdk.scripting.effects
 
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.TurnPart
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.TriggeredAbility
 import com.wingedsheep.sdk.scripting.events.SourceFilter
@@ -66,6 +67,34 @@ data class SkipNextDrawStepEffect(
     override val description: String = when (target) {
         EffectTarget.Controller -> "You skip your next draw step"
         else -> "${target.description.replaceFirstChar { it.uppercase() }} skips their next draw step"
+    }
+}
+
+/**
+ * The target player skips **every** instance of [part] for the rest of this turn — Fatespinner's
+ * "the player skips each instance of the chosen step or phase this turn".
+ *
+ * The duration is what separates this from the "skip your *next* X" family
+ * ([SkipNextDrawStepEffect], [SkipCombatPhasesEffect]): those are one-shot markers consumed by the
+ * first occurrence, this one stands until end of turn, so a second main phase or an additional
+ * combat phase created later in the turn is skipped too. [TurnPart] is the granularity printed
+ * cards use, so "main phase" is one value covering both main phases (CR 505.1) and "combat phase"
+ * is one value covering all five combat steps.
+ *
+ * Skipping is faithful to CR 500.11 / 614.10 — the engine proceeds past the step or phase as though
+ * it didn't exist, so no player receives priority in it and no "at the beginning of ..." ability
+ * triggers for it. Per CR 614.10 a step already under way can no longer be skipped; applying this
+ * during a player's upkeep (Fatespinner's trigger) reaches everything after the upkeep.
+ */
+@SerialName("SkipStepOrPhaseThisTurn")
+@Serializable
+data class SkipStepOrPhaseThisTurnEffect(
+    val part: TurnPart,
+    val target: EffectTarget = EffectTarget.PlayerRef(Player.TargetPlayer)
+) : Effect {
+    override val description: String = when (target) {
+        EffectTarget.Controller -> "You skip each ${part.displayName} this turn"
+        else -> "${target.description.replaceFirstChar { it.uppercase() }} skips each ${part.displayName} this turn"
     }
 }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -583,6 +583,10 @@ object CardLinter {
         put("FilterCollection" to "storeMatching", write(Space.COLLECTION))
         put("FilterCollection" to "storeNonMatching", write(Space.COLLECTION))
         put("ExileLibraryUntilManaValue" to "storeAs", write(Space.COLLECTION))
+        // The contest publishes the winning *player* as a one-entry collection and every card it
+        // exiled, in every round, as another.
+        put("ExileTopCardContest" to "storeWinnerAs", write(Space.COLLECTION))
+        put("ExileTopCardContest" to "storeExiledAs", write(Space.COLLECTION))
         put("Discover" to "storeDiscoveredAs", write(Space.COLLECTION))
         put("CopyCardIntoCollection" to "storeAs", write(Space.COLLECTION))
         put("CopyCollectionIntoCollection" to "storeAs", write(Space.COLLECTION))

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Fatespinner.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Fatespinner.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.TurnPart
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.EffectChoice
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fatespinner — Mirrodin #36 (canonical printing)
+ * {1}{U}{U} · Creature — Human Wizard · Rare · 1/2
+ *
+ * At the beginning of each opponent's upkeep, that player chooses draw step, main phase, or
+ * combat phase. The player skips each instance of the chosen step or phase this turn.
+ *
+ * Modelling notes:
+ * - **The opponent chooses, and the opponent is skipped.** Both halves are
+ *   [Player.TriggeringPlayer] — the player whose upkeep it is. `ChooseActionEffect` already routes
+ *   its decision to whatever `player` resolves to, so nothing new was needed for the routing; a
+ *   step trigger stores the active player in the context's *entity* slot, which
+ *   `TargetResolutionUtils` already falls back to.
+ * - **"Each instance ... this turn" is a duration, not a count**, which is why this uses
+ *   [Effects.SkipStepOrPhaseThisTurn] rather than the one-shot `SkipNextDrawStep` /
+ *   `SkipCombatPhases` markers. Choosing "main phase" skips *both* main phases (CR 505.1 — the
+ *   precombat and postcombat main phases are individually and collectively the main phase), and
+ *   choosing "combat phase" also swallows an additional combat phase created later that turn.
+ * - The trigger resolves during the upkeep, so nothing it names has started yet and all three
+ *   options are live (CR 614.10 — a step already under way can no longer be skipped).
+ * - The choice is mandatory and always has three feasible options, so the decision is always
+ *   presented; there is no "choose nothing" branch.
+ */
+val Fatespinner = card("Fatespinner") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 2
+    oracleText = "At the beginning of each opponent's upkeep, that player chooses draw step, " +
+        "main phase, or combat phase. The player skips each instance of the chosen step or " +
+        "phase this turn."
+
+    triggeredAbility {
+        trigger = Triggers.EachOpponentUpkeep
+        effect = Effects.ChooseAction(
+            player = EffectTarget.PlayerRef(Player.TriggeringPlayer),
+            choices = listOf(
+                EffectChoice(
+                    label = "Draw step",
+                    effect = Effects.SkipStepOrPhaseThisTurn(
+                        TurnPart.DRAW_STEP,
+                        EffectTarget.PlayerRef(Player.TriggeringPlayer)
+                    )
+                ),
+                EffectChoice(
+                    label = "Main phase",
+                    effect = Effects.SkipStepOrPhaseThisTurn(
+                        TurnPart.MAIN_PHASE,
+                        EffectTarget.PlayerRef(Player.TriggeringPlayer)
+                    )
+                ),
+                EffectChoice(
+                    label = "Combat phase",
+                    effect = Effects.SkipStepOrPhaseThisTurn(
+                        TurnPart.COMBAT_PHASE,
+                        EffectTarget.PlayerRef(Player.TriggeringPlayer)
+                    )
+                )
+            )
+        )
+        description = "At the beginning of each opponent's upkeep, that player chooses draw " +
+            "step, main phase, or combat phase. The player skips each instance of the chosen " +
+            "step or phase this turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "36"
+        artist = "rk post"
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/5780f4e0-dcfb-4d1f-8ae1-762b98970abb.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Timesifter.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Timesifter.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/** Pipeline slot holding the single player who won the contest, or nothing if it ended undecided. */
+private const val WINNER = "timesifterWinner"
+
+/**
+ * Timesifter — Mirrodin #262 (canonical printing)
+ * {5} · Artifact · Rare
+ *
+ * At the beginning of each upkeep, each player exiles the top card of their library. The player
+ * who exiled the card with the greatest mana value takes an extra turn after this one. If two or
+ * more players' cards are tied for greatest, the tied players repeat this process until the tie is
+ * broken.
+ *
+ * Modelling notes:
+ * - The whole first sentence plus the tie rule is one primitive,
+ *   [Effects.ExileTopCardContest] — the rounds are fully deterministic (no player ever chooses
+ *   anything), so it resolves in a single pass with no decision or continuation.
+ * - **The primitive is open**: it publishes the winning player into [WINNER] and stops, and the
+ *   payoff is composed here off `EffectTarget.PipelineTarget`. That keeps "take an extra turn" out
+ *   of a library primitive, and is what lets the next card that ranks exiled top cards reuse it.
+ * - **The contest can end with nobody winning**, so the extra turn is gated on [WINNER] actually
+ *   holding a player: a player with an empty library exiles nothing and therefore can't have
+ *   exiled the greatest mana value, and if no contender can exile at all the tie stands unbroken.
+ *   Without the gate an unresolved `PipelineTarget` falls back to the ability's controller, which
+ *   would hand Timesifter's own controller a free turn every time the table decked out.
+ * - `Triggers.EachUpkeep` fires on **every** player's upkeep, not just its controller's — the card
+ *   is symmetrical, and in a two-player game that is two contests per turn cycle.
+ * - Cards exiled by the contest stay in exile face up; nothing here returns them.
+ */
+val Timesifter = card("Timesifter") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "At the beginning of each upkeep, each player exiles the top card of their " +
+        "library. The player who exiled the card with the greatest mana value takes an extra " +
+        "turn after this one. If two or more players' cards are tied for greatest, the tied " +
+        "players repeat this process until the tie is broken."
+
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        effect = Effects.Composite(
+            Effects.ExileTopCardContest(storeWinnerAs = WINNER),
+            ConditionalEffect(
+                condition = Conditions.CompareAmounts(
+                    DynamicAmount.DistinctEntitiesInCollections(listOf(WINNER)),
+                    ComparisonOperator.GTE,
+                    DynamicAmount.Fixed(1)
+                ),
+                effect = Effects.TakeExtraTurn(target = EffectTarget.PipelineTarget(WINNER))
+            )
+        )
+        description = "At the beginning of each upkeep, each player exiles the top card of their " +
+            "library. The player who exiled the card with the greatest mana value takes an extra " +
+            "turn after this one. If two or more players' cards are tied for greatest, the tied " +
+            "players repeat this process until the tie is broken."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "262"
+        artist = "Dany Orizio"
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/561cab0e-8874-4534-bf79-0c1488a9f0a5.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FatespinnerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FatespinnerScenarioTest.kt
@@ -1,0 +1,198 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.player.AdditionalPhasesComponent
+import com.wingedsheep.engine.state.components.player.ExtraPhaseKind
+import com.wingedsheep.engine.state.components.player.QueuedPhase
+import com.wingedsheep.engine.state.components.player.SkippedTurnPartsComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.Fatespinner
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Fatespinner (MRD #36) — "At the beginning of each opponent's upkeep, that player chooses draw
+ * step, main phase, or combat phase. The player skips each instance of the chosen step or phase
+ * this turn."
+ *
+ * Two claims worth pinning, because both are invisible if you only assert the end state:
+ *
+ *  - **The opponent chooses, and the opponent is skipped.** The trigger belongs to Fatespinner's
+ *    controller but the decision is routed to the player whose upkeep it is, and the skip lands on
+ *    that same player. Asserting only "a step got skipped" can't tell a correct routing from one
+ *    that asked the wrong player.
+ *  - **A skipped step is proceeded past as though it didn't exist** (CR 500.11 / 614.10) — the
+ *    engine must not merely no-op inside it. These tests assert on the *step sequence the game
+ *    actually walks*, so a draw step that happens but draws nothing would fail.
+ *
+ * The "main phase" case additionally proves the duration: "each instance ... this turn" means both
+ * main phases (CR 505.1), not just the next one.
+ */
+class FatespinnerScenarioTest : FunSpec({
+
+    // Hoisted out of the test bodies: `TestCards.all` forces a ClassGraph scan of the whole corpus,
+    // and paying that inside a test puts it under the per-test timeout.
+    val cards = TestCards.all + Fatespinner
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(cards)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /**
+     * Pass priority until a decision is raised, without `passPriorityUntil`'s auto-resolve — which
+     * would answer Fatespinner's own prompt before the test could inspect who it went to.
+     */
+    fun GameTestDriver.passUntilDecision(maxPasses: Int = 60) {
+        repeat(maxPasses) {
+            if (state.pendingDecision != null) return
+            state.priorityPlayerId?.let { passPriority(it) }
+        }
+        error("no decision was raised within $maxPasses passes (step ${state.step})")
+    }
+
+    /** Pass priority until the game leaves the current step, and report the step it landed on. */
+    fun GameTestDriver.passUntilStepChanges(maxPasses: Int = 40): Step {
+        val from = state.step
+        repeat(maxPasses) {
+            if (state.step != from) return state.step
+            val holder = state.priorityPlayerId ?: error("nobody holds priority in ${state.step}")
+            passPriority(holder)
+        }
+        error("the game never advanced past $from")
+    }
+
+    /** Every distinct step the game walks through on the way to [target], inclusive. */
+    fun GameTestDriver.stepsUntil(target: Step, maxPasses: Int = 80): List<Step> {
+        val seen = mutableListOf(state.step)
+        repeat(maxPasses) {
+            if (state.step == target) return seen
+            val next = passUntilStepChanges()
+            if (seen.lastOrNull() != next) seen.add(next)
+        }
+        error("never reached $target; walked $seen")
+    }
+
+    /**
+     * Roll into the opponent's upkeep and answer Fatespinner's prompt with the named option,
+     * asserting on the way that the prompt was put to the opponent rather than to its controller.
+     */
+    fun GameTestDriver.chooseAtOpponentUpkeep(option: String) {
+        passUntilDecision()
+        val decision = state.pendingDecision
+        decision shouldNotBe null
+        withClue("\"that player chooses\" — the prompt goes to the player whose upkeep it is, not to Fatespinner's controller") {
+            decision!!.playerId shouldBe player2
+        }
+        val choice = decision as ChooseOptionDecision
+        withClue("all three printed options are offered") {
+            choice.options shouldBe listOf("Draw step", "Main phase", "Combat phase")
+        }
+        // Answering completes the ability's resolution — the prompt was raised mid-resolution,
+        // so the chosen skip is applied as the continuation resumes.
+        submitDecision(player2, OptionChosenResponse(choice.id, choice.options.indexOf(option)))
+            .error shouldBe null
+        state.pendingDecision shouldBe null
+    }
+
+    test("choosing the draw step skips it outright — the step never happens and no card is drawn") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player1, "Fatespinner")
+
+        d.chooseAtOpponentUpkeep("Draw step")
+        val handBefore = d.getHandSize(d.player2)
+
+        withClue("the upkeep hands off straight to the precombat main phase — the draw step is proceeded past as though it didn't exist (CR 500.11)") {
+            d.passUntilStepChanges() shouldBe Step.PRECOMBAT_MAIN
+        }
+        withClue("and so the active player drew nothing") {
+            d.getHandSize(d.player2) shouldBe handBefore
+        }
+    }
+
+    test("choosing the main phase skips BOTH main phases — 'each instance ... this turn'") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player1, "Fatespinner")
+
+        d.chooseAtOpponentUpkeep("Main phase")
+
+        withClue("the draw step is untouched — only the chosen part is skipped") {
+            d.passUntilStepChanges() shouldBe Step.DRAW
+        }
+        withClue("the precombat main phase is skipped: the draw step hands off to the combat phase") {
+            d.passUntilStepChanges() shouldBe Step.BEGIN_COMBAT
+        }
+
+        val rest = d.stepsUntil(Step.END)
+        withClue("and the postcombat main phase is skipped too — CR 505.1 makes both of them 'the main phase', so 'each instance this turn' covers the second one. Walked: $rest") {
+            rest shouldNotContain Step.POSTCOMBAT_MAIN
+        }
+    }
+
+    test("choosing the combat phase skips every step of it") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player1, "Fatespinner")
+
+        d.chooseAtOpponentUpkeep("Combat phase")
+
+        d.passUntilStepChanges() shouldBe Step.DRAW
+        d.passUntilStepChanges() shouldBe Step.PRECOMBAT_MAIN
+        withClue("all five combat steps are skipped in one go — the precombat main phase hands off to the postcombat main phase") {
+            d.passUntilStepChanges() shouldBe Step.POSTCOMBAT_MAIN
+        }
+    }
+
+    test("an ADDITIONAL combat phase created later in the turn is skipped too") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player1, "Fatespinner")
+
+        d.chooseAtOpponentUpkeep("Combat phase")
+        // Aggravated Assault / Aurelia queue an extra combat phase during the turn; the queue is
+        // what the TurnManager drains after the postcombat main phase. Seeding it directly keeps
+        // this test about the skip rather than about paying for the card that creates the phase.
+        d.addComponent(
+            d.player2,
+            AdditionalPhasesComponent(listOf(QueuedPhase(ExtraPhaseKind.COMBAT)))
+        )
+
+        d.passUntilStepChanges() shouldBe Step.DRAW
+        d.passUntilStepChanges() shouldBe Step.PRECOMBAT_MAIN
+        withClue("the natural combat phase is skipped") {
+            d.passUntilStepChanges() shouldBe Step.POSTCOMBAT_MAIN
+        }
+        withClue("\"each instance ... this turn\" reaches the queued extra combat phase as well — it is drained and discarded, not entered") {
+            d.passUntilStepChanges() shouldBe Step.END
+        }
+    }
+
+    test("the skip is turn-scoped — the marker is gone once the turn ends") {
+        val d = driver()
+        d.putCreatureOnBattlefield(d.player1, "Fatespinner")
+
+        d.chooseAtOpponentUpkeep("Combat phase")
+        withClue("the choice is recorded on the choosing player, not on Fatespinner's controller") {
+            d.state.getEntity(d.player2)?.get<SkippedTurnPartsComponent>() shouldNotBe null
+            d.state.getEntity(d.player1)?.get<SkippedTurnPartsComponent>() shouldBe null
+        }
+
+        // Walk out of player 2's turn and into player 1's upkeep; cleanup drops the marker on the
+        // way. Fatespinner does not trigger on its own controller's upkeep, so nothing re-adds it.
+        d.stepsUntil(Step.END)
+        d.passPriorityUntil(Step.UPKEEP)
+        d.state.activePlayerId shouldBe d.player1
+
+        withClue("\"this turn\" — the marker does not survive into the next turn") {
+            d.state.getEntity(d.player2)?.get<SkippedTurnPartsComponent>() shouldBe null
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TimesifterScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TimesifterScenarioTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.player.SkipNextTurnComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.Timesifter
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Timesifter (MRD #262) — "At the beginning of each upkeep, each player exiles the top card of
+ * their library. The player who exiled the card with the greatest mana value takes an extra turn
+ * after this one. If two or more players' cards are tied for greatest, the tied players repeat
+ * this process until the tie is broken."
+ *
+ * The engine models "take an extra turn" as every *other* player skipping their next turn
+ * (`SkipNextTurnComponent`), so that component is what these tests read to identify the winner —
+ * asserting on the exiled cards alone would pass even if the extra turn went to the wrong player.
+ *
+ * Three things are worth pinning beyond the happy path, because each is a way the contest can go
+ * subtly wrong: the tie must repeat among the **tied players only** (not the whole table, and not
+ * once more for everyone), a player with an empty library exiles nothing and therefore **can't
+ * win**, and a contest nobody can contest must end with **no winner at all** rather than defaulting
+ * to Timesifter's controller — which is exactly what an unguarded pipeline target would do.
+ */
+class TimesifterScenarioTest : FunSpec({
+
+    // Hoisted out of the test bodies: `TestCards.all` forces a ClassGraph scan of the whole corpus,
+    // and paying that inside a test puts it under the per-test timeout.
+    val cards = TestCards.all + Timesifter
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(cards)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** Stack a player's library top-down: `stackLibrary(p, "A", "B")` exiles A first, then B. */
+    fun GameTestDriver.stackLibrary(playerId: EntityId, vararg topDown: String) {
+        topDown.reversed().forEach { putCardOnTopOfLibrary(playerId, it) }
+    }
+
+    fun GameTestDriver.emptyLibrary(playerId: EntityId) {
+        replaceState(state.copy(zones = state.zones + (ZoneKey(playerId, Zone.LIBRARY) to emptyList())))
+    }
+
+    fun GameTestDriver.skippedTurns(playerId: EntityId): Int =
+        state.getEntity(playerId)?.get<SkipNextTurnComponent>()?.turns ?: 0
+
+    /** Roll into the opponent's upkeep and let the (choice-free) contest resolve. */
+    fun GameTestDriver.runContestAtNextUpkeep() = passPriorityUntil(Step.DRAW)
+
+    test("the player who exiled the greatest mana value takes the extra turn") {
+        val d = driver()
+        d.putPermanentOnBattlefield(d.player1, "Timesifter")
+        d.stackLibrary(d.player1, "Bonesplitter")  // {1}
+        d.stackLibrary(d.player2, "Alpha Myr")     // {2}
+
+        d.runContestAtNextUpkeep()
+
+        withClue("each player exiled exactly the top card of their library") {
+            d.getExileCardNames(d.player1) shouldContainExactly listOf("Bonesplitter")
+            d.getExileCardNames(d.player2) shouldContainExactly listOf("Alpha Myr")
+        }
+        withClue("{2} beats {1}, so player 2 takes the extra turn — modelled as everyone else skipping theirs") {
+            d.skippedTurns(d.player1) shouldBe 1
+            d.skippedTurns(d.player2) shouldBe 0
+        }
+    }
+
+    test("a tie repeats the process for the tied players until it is broken") {
+        val d = driver()
+        d.putPermanentOnBattlefield(d.player1, "Timesifter")
+        // Round 1 ties at {2}; round 2 breaks it {4} to {1}.
+        d.stackLibrary(d.player1, "Alpha Myr", "Bonesplitter")  // {2} then {1}
+        d.stackLibrary(d.player2, "Alpha Myr", "Duskworker")    // {2} then {4}
+
+        d.runContestAtNextUpkeep()
+
+        withClue("the tied round is repeated, so a second card leaves each library — in order") {
+            d.getExileCardNames(d.player1) shouldContainExactly listOf("Alpha Myr", "Bonesplitter")
+            d.getExileCardNames(d.player2) shouldContainExactly listOf("Alpha Myr", "Duskworker")
+        }
+        withClue("the second round decides it: {4} over {1}") {
+            d.skippedTurns(d.player1) shouldBe 1
+            d.skippedTurns(d.player2) shouldBe 0
+        }
+    }
+
+    test("a player with an empty library exiles nothing and so cannot win the contest") {
+        val d = driver()
+        d.putPermanentOnBattlefield(d.player1, "Timesifter")
+        d.emptyLibrary(d.player1)
+        d.stackLibrary(d.player2, "Ornithopter")   // {0} — the lowest possible mana value
+
+        d.runContestAtNextUpkeep()
+
+        withClue("nothing to exile from an empty library") {
+            d.getExileCardNames(d.player1) shouldContainExactly emptyList()
+            d.getExileCardNames(d.player2) shouldContainExactly listOf("Ornithopter")
+        }
+        withClue("a {0} card still beats exiling nothing at all — the player who exiled no card can't be the one who exiled the greatest mana value") {
+            d.skippedTurns(d.player1) shouldBe 1
+            d.skippedTurns(d.player2) shouldBe 0
+        }
+    }
+
+    test("with no card exiled at all the contest ends undecided — nobody takes an extra turn") {
+        val d = driver()
+        val timesifter = d.putPermanentOnBattlefield(d.player1, "Timesifter")
+        timesifter shouldNotBe null
+        d.emptyLibrary(d.player1)
+        d.emptyLibrary(d.player2)
+
+        d.runContestAtNextUpkeep()
+
+        withClue("no winner means no extra turn — in particular it must NOT fall back to Timesifter's controller") {
+            d.skippedTurns(d.player1) shouldBe 0
+            d.skippedTurns(d.player2) shouldBe 0
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -3320,6 +3320,83 @@
     "colorIdentityOverride": []
 }
 
+// Fatespinner
+{
+    "name": "Fatespinner",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "At the beginning of each opponent's upkeep, that player chooses draw step, main phase, or combat phase. The player skips each instance of the chosen step or phase this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ChooseAction",
+                    "choices": [
+                        {
+                            "label": "Draw step",
+                            "effect": {
+                                "type": "SkipStepOrPhaseThisTurn",
+                                "part": "DRAW_STEP",
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "TriggeringPlayer"
+                                }
+                            }
+                        },
+                        {
+                            "label": "Main phase",
+                            "effect": {
+                                "type": "SkipStepOrPhaseThisTurn",
+                                "part": "MAIN_PHASE",
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "TriggeringPlayer"
+                                }
+                            }
+                        },
+                        {
+                            "label": "Combat phase",
+                            "effect": {
+                                "type": "SkipStepOrPhaseThisTurn",
+                                "part": "COMBAT_PHASE",
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "TriggeringPlayer"
+                                }
+                            }
+                        }
+                    ],
+                    "player": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                },
+                "descriptionOverride": "At the beginning of each opponent's upkeep, that player chooses draw step, main phase, or combat phase. The player skips each instance of the chosen step or phase this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "RARE",
+        "artist": "rk post",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/5780f4e0-dcfb-4d1f-8ae1-762b98970abb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Fiery Gambit
 {
     "name": "Fiery Gambit",
@@ -13926,6 +14003,71 @@
     "colorIdentityOverride": [
         "BLUE"
     ]
+}
+
+// Timesifter
+{
+    "name": "Timesifter",
+    "manaCost": "{5}",
+    "typeLine": "Artifact",
+    "oracleText": "At the beginning of each upkeep, each player exiles the top card of their library. The player who exiled the card with the greatest mana value takes an extra turn after this one. If two or more players' cards are tied for greatest, the tied players repeat this process until the tie is broken.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ExileTopCardContest",
+                            "storeWinnerAs": "timesifterWinner"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "DistinctEntitiesInCollections",
+                                        "collections": [
+                                            "timesifterWinner"
+                                        ]
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "TakeExtraTurn",
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "timesifterWinner"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "At the beginning of each upkeep, each player exiles the top card of their library. The player who exiled the card with the greatest mana value takes an extra turn after this one. If two or more players' cards are tied for greatest, the tied players repeat this process until the tie is broken."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "262",
+        "rarity": "RARE",
+        "artist": "Dany Orizio",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/561cab0e-8874-4534-bf79-0c1488a9f0a5.jpg"
+    },
+    "colorIdentityOverride": []
 }
 
 // Titanium Golem

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -84,6 +84,7 @@ import com.wingedsheep.engine.state.components.player.PlayerHexproofComponent
 import com.wingedsheep.engine.state.components.player.PlayerShroudComponent
 import com.wingedsheep.engine.state.components.player.SpellsCantBeCounteredComponent
 import com.wingedsheep.engine.state.components.player.PlayerTurnHijackedComponent
+import com.wingedsheep.engine.state.components.player.SkippedTurnPartsComponent
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
@@ -627,6 +628,12 @@ class CleanupPhaseManager(
                 }
                 if (result.has<InAdditionalEndStepComponent>()) {
                     result = result.without<InAdditionalEndStepComponent>()
+                }
+                // "Skips each instance of the chosen step or phase this turn" (Fatespinner) is
+                // turn-scoped, so the marker is dropped here rather than being consumed by the
+                // first occurrence it skips.
+                if (result.has<SkippedTurnPartsComponent>()) {
+                    result = result.without<SkippedTurnPartsComponent>()
                 }
                 // Drop a Mindslaver-style hijack at end of the controlled turn (ACTIVE state).
                 // Scheduled hijacks (SCHEDULED) survive cleanup so they fire on the player's

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -542,6 +542,7 @@ val engineSerializersModule = SerializersModule {
         subclass(PlayerTurnsTakenComponent::class)
         subclass(SkipCombatPhasesComponent::class)
         subclass(SkipDrawStepComponent::class)
+        subclass(SkippedTurnPartsComponent::class)
         subclass(SkipUntapComponent::class)
         subclass(PlayerLostComponent::class)
         subclass(PlayerLeftGameComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -32,6 +32,7 @@ import com.wingedsheep.engine.state.components.player.PlayerLostComponent
 import com.wingedsheep.engine.state.components.player.PlayerTurnHijackedComponent
 import com.wingedsheep.engine.state.components.player.PlayerTurnsTakenComponent
 import com.wingedsheep.engine.state.components.player.SkipCombatPhasesComponent
+import com.wingedsheep.engine.state.components.player.SkippedTurnPartsComponent
 import com.wingedsheep.engine.state.components.player.SkipNextTurnComponent
 import com.wingedsheep.engine.state.components.player.EndTheTurnRequestedComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
@@ -234,43 +235,63 @@ class TurnManager(
      * player gets priority in the new phase.
      */
     private fun drainAdditionalPhase(state: GameState, activePlayer: EntityId): ExecutionResult? {
-        val component = state.getEntity(activePlayer)?.get<AdditionalPhasesComponent>() ?: return null
-        val next = component.phases.firstOrNull() ?: return null
-        val remaining = component.phases.drop(1)
+        var current = state
+        // True once an entry has been drained *and skipped*: the queue has been mutated, so the
+        // caller's own `state` is stale and returning null (its "nothing drained" signal) would
+        // silently lose the consumption.
+        var skippedAnEntry = false
 
-        var redirectedState = if (remaining.isEmpty()) {
-            state.updateEntity(activePlayer) { it.without<AdditionalPhasesComponent>() }
-        } else {
-            state.updateEntity(activePlayer) { it.with(AdditionalPhasesComponent(remaining)) }
-        }
+        while (true) {
+            val queued = current.getEntity(activePlayer)
+                ?.get<AdditionalPhasesComponent>()?.phases.orEmpty()
+            val next = queued.firstOrNull()
+                ?: return if (skippedAnEntry) advanceStepFromEndedStep(current) else null
+            val remaining = queued.drop(1)
 
-        val (step, phase) = when (next.kind) {
-            ExtraPhaseKind.COMBAT -> {
+            var redirectedState = if (remaining.isEmpty()) {
+                current.updateEntity(activePlayer) { it.without<AdditionalPhasesComponent>() }
+            } else {
+                current.updateEntity(activePlayer) { it.with(AdditionalPhasesComponent(remaining)) }
+            }
+
+            val (step, phase) = when (next.kind) {
+                ExtraPhaseKind.COMBAT -> Step.BEGIN_COMBAT to Phase.COMBAT
+                ExtraPhaseKind.MAIN -> Step.POSTCOMBAT_MAIN to Phase.POSTCOMBAT_MAIN
+            }
+
+            // CR 500.11 — an inserted phase whose kind the active player is skipping every
+            // instance of this turn (Fatespinner) is proceeded past as though it didn't exist.
+            // The queue entry is still consumed: the phase *was* created, it just never happens,
+            // and the next queued entry takes its place. Without this the natural combat phase
+            // would be skipped while an Aggravated Assault combat phase sailed through.
+            if (skipsTurnPart(current, step, activePlayer)) {
+                current = redirectedState
+                skippedAnEntry = true
+                continue
+            }
+
+            redirectedState = when (next.kind) {
                 // Copy the entry's attacker restriction onto the marker so the declare-attackers
                 // legality check (AdditionalCombatPhaseAttackerRule) can enforce it for the
                 // duration of this inserted phase. `null` yields an ordinary unrestricted combat.
-                redirectedState = redirectedState
-                    .updateEntity(activePlayer) {
-                        it.with(InAdditionalCombatPhaseComponent(next.attackerRestriction))
-                    }
-                Step.BEGIN_COMBAT to Phase.COMBAT
+                ExtraPhaseKind.COMBAT -> redirectedState.updateEntity(activePlayer) {
+                    it.with(InAdditionalCombatPhaseComponent(next.attackerRestriction))
+                }
+                ExtraPhaseKind.MAIN -> redirectedState.updateEntity(activePlayer) {
+                    it.without<InAdditionalCombatPhaseComponent>()
+                }
             }
-            ExtraPhaseKind.MAIN -> {
-                redirectedState = redirectedState
-                    .updateEntity(activePlayer) { it.without<InAdditionalCombatPhaseComponent>() }
-                Step.POSTCOMBAT_MAIN to Phase.POSTCOMBAT_MAIN
-            }
+
+            redirectedState = redirectedState
+                .copy(step = step, phase = phase, priorityPassedBy = emptySet())
+                .withPriority(activePlayer)
+
+            val events = mutableListOf<GameEvent>(
+                PhaseChangedEvent(phase),
+                StepChangedEvent(step)
+            )
+            return ExecutionResult.success(redirectedState, events)
         }
-
-        redirectedState = redirectedState
-            .copy(step = step, phase = phase, priorityPassedBy = emptySet())
-            .withPriority(activePlayer)
-
-        val events = mutableListOf<GameEvent>(
-            PhaseChangedEvent(phase),
-            StepChangedEvent(step)
-        )
-        return ExecutionResult.success(redirectedState, events)
     }
 
     /**
@@ -283,6 +304,19 @@ class TurnManager(
         // end-of-turn cleanup performs — applying the Upwelling / Ozai / Last Agni Kai statics.
         // Firebending (END_OF_COMBAT) mana is preserved and handled by CombatManager.endCombat.
         advanceStepFromEndedStep(cleanupPhaseManager.emptyManaPools(state))
+
+    /**
+     * True when [step] belongs to a part of the turn [playerId] is skipping every instance of this
+     * turn (`SkippedTurnPartsComponent`, written by `SkipStepOrPhaseThisTurnEffect`).
+     *
+     * One [com.wingedsheep.sdk.core.TurnPart] can cover several steps, which is the point: naming
+     * `COMBAT_PHASE` skips all five combat steps one after another as this is consulted per step,
+     * and `MAIN_PHASE` skips both main phases (CR 505.1).
+     */
+    private fun skipsTurnPart(state: GameState, step: Step, playerId: EntityId): Boolean {
+        val parts = state.getEntity(playerId)?.get<SkippedTurnPartsComponent>()?.parts ?: return false
+        return parts.any { it.covers(step) }
+    }
 
     private fun advanceStepFromEndedStep(incomingState: GameState): ExecutionResult {
         val currentStep = incomingState.step
@@ -441,6 +475,34 @@ class TurnManager(
         }
 
         val nextStep = currentStep.next()
+
+        // CR 500.11 / 614.10 — to skip a step or phase is to proceed past it as though it didn't
+        // exist. That has to happen *here*, before the StepChangedEvent below is built: that event
+        // is what `PassPriorityHandler` feeds to `detectPhaseStepTriggers`, so emitting it for a
+        // skipped step would fire "at the beginning of ..." abilities for a step that never
+        // happened, and the withPriority calls in the `when` would open a priority window in it.
+        // The marker is turn-scoped (Fatespinner skips *each* instance this turn), so it is not
+        // consumed here — end-of-turn cleanup drops it.
+        if (skipsTurnPart(state, nextStep, activePlayer)) {
+            var skipped = state.copy(
+                step = nextStep,
+                phase = nextStep.phase,
+                priorityPassedBy = emptySet()
+            )
+            val skipEvents = mutableListOf<GameEvent>()
+            // The postcombat main phase owns the deferred end-of-combat bookkeeping (see the
+            // POSTCOMBAT_MAIN branch below), so skipping the phase must still run it or creatures
+            // stay in combat for the rest of the turn.
+            if (nextStep == Step.POSTCOMBAT_MAIN) {
+                val endCombatResult = combatManager.endCombat(skipped)
+                if (!endCombatResult.isSuccess) return endCombatResult
+                skipped = endCombatResult.newState
+                skipEvents.addAll(endCombatResult.events)
+            }
+            val onward = advanceStep(skipped)
+            return onward.copy(events = skipEvents + onward.events)
+        }
+
         val nextPhase = nextStep.phase
 
         var newState = state.copy(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardContestExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/ExileTopCardContestExecutor.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.handlers.effects.library
+
+import com.wingedsheep.engine.core.CardsRevealedEvent
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.ExileTopCardContestEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [ExileTopCardContestEffect].
+ *
+ * Runs the contest to completion — there are no player choices in it, so it never pauses. Each
+ * round every remaining contender exiles the top card of their library face up (the cards stay in
+ * exile); the greatest mana value wins. A tie narrows the field to the tied players and the round
+ * repeats, which is what Timesifter's "the tied players repeat this process until the tie is
+ * broken" asks for.
+ *
+ * Two ways the contest ends without a winner, both leaving [ExileTopCardContestEffect.storeWinnerAs]
+ * empty rather than picking arbitrarily: nobody is in the contest at all, and no contender could
+ * exile a card (every remaining library is empty). A player with an empty library exiles nothing
+ * and therefore can't be the player who exiled the greatest mana value — so a round in which only
+ * one contender can still exile resolves in that player's favour.
+ *
+ * Termination: a round either exiles at least one card — shrinking a library — or ends the contest,
+ * so the loop is bounded by the total number of cards in the contenders' libraries.
+ */
+class ExileTopCardContestExecutor : EffectExecutor<ExileTopCardContestEffect> {
+
+    override val effectType: KClass<ExileTopCardContestEffect> = ExileTopCardContestEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: ExileTopCardContestEffect,
+        context: EffectContext
+    ): EffectResult {
+        var currentState = state
+        val events = mutableListOf<EngineGameEvent>()
+        val allExiled = mutableListOf<EntityId>()
+        var winner: EntityId? = null
+
+        var contenders = context.resolvePlayerTargets(
+            com.wingedsheep.sdk.scripting.targets.EffectTarget.PlayerRef(effect.players),
+            currentState
+        )
+
+        while (contenders.isNotEmpty()) {
+            // Mana value of the card each contender exiled this round; a contender whose library is
+            // empty exiles nothing and simply doesn't appear.
+            val exiledThisRound = mutableMapOf<EntityId, Int>()
+
+            for (playerId in contenders) {
+                val topCardId = currentState.getZone(ZoneKey(playerId, Zone.LIBRARY)).firstOrNull() ?: continue
+                val card = currentState.getEntity(topCardId)?.get<CardComponent>()
+                val moveResult = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                    .moveCardToZone(currentState, topCardId, Zone.EXILE)
+                if (!moveResult.isSuccess) continue
+                currentState = moveResult.state
+                events.addAll(moveResult.events)
+                allExiled.add(topCardId)
+                exiledThisRound[playerId] = card?.manaValue ?: 0
+                events.add(
+                    CardsRevealedEvent(
+                        revealingPlayerId = playerId,
+                        cardIds = listOf(topCardId),
+                        cardNames = listOf(card?.name ?: "Unknown"),
+                        imageUris = listOf(card?.imageUri),
+                        source = context.sourceId?.let { currentState.getEntity(it)?.get<CardComponent>()?.name }
+                    )
+                )
+            }
+
+            if (exiledThisRound.isEmpty()) break
+
+            val greatest = exiledThisRound.values.max()
+            val tied = exiledThisRound.filterValues { it == greatest }.keys.toList()
+            if (tied.size == 1) {
+                winner = tied.single()
+                break
+            }
+            contenders = tied
+        }
+
+        return EffectResult.success(currentState, events).copy(
+            updatedCollections = mapOf(
+                effect.storeWinnerAs to listOfNotNull(winner),
+                effect.storeExiledAs to allExiled.toList()
+            )
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
@@ -73,6 +73,7 @@ class LibraryExecutors(
         RevealCollectionExecutor(),
         ExileFromTopRepeatingExecutor(),
         ExileLibraryUntilManaValueExecutor(),
+        ExileTopCardContestExecutor(),
         CascadeExecutor(),
         DiscoverExecutor(recursion),
         CastFromCollectionWithoutPayingCostExecutor(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
@@ -81,6 +81,7 @@ class PlayerExecutors(
         SetDayNightExecutor(cardRegistry),
         SkipCombatPhasesExecutor(),
         SkipNextDrawStepExecutor(),
+        SkipStepOrPhaseThisTurnExecutor(),
         SkipNextTurnExecutor(),
         SkipUntapExecutor(),
         TakeExtraTurnExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/SkipStepOrPhaseThisTurnExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/SkipStepOrPhaseThisTurnExecutor.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.engine.handlers.effects.player
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.SkippedTurnPartsComponent
+import com.wingedsheep.sdk.scripting.effects.SkipStepOrPhaseThisTurnEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [SkipStepOrPhaseThisTurnEffect].
+ *
+ * Adds the chosen [com.wingedsheep.sdk.core.TurnPart] to the target player's
+ * [SkippedTurnPartsComponent], which `TurnManager.advanceStepFromEndedStep` consults before it
+ * enters each step. The set is additive, so two sources naming different parts in the same turn
+ * both stick, and end-of-turn cleanup drops the whole component.
+ */
+class SkipStepOrPhaseThisTurnExecutor : EffectExecutor<SkipStepOrPhaseThisTurnEffect> {
+
+    override val effectType: KClass<SkipStepOrPhaseThisTurnEffect> = SkipStepOrPhaseThisTurnEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: SkipStepOrPhaseThisTurnEffect,
+        context: EffectContext
+    ): EffectResult {
+        val targetPlayerId = context.resolvePlayerTarget(effect.target, state)
+            ?: return EffectResult.error(state, "Cannot resolve player for SkipStepOrPhaseThisTurnEffect")
+
+        val newState = state.updateEntity(targetPlayerId) { container ->
+            val existing = container.get<SkippedTurnPartsComponent>()?.parts ?: emptySet()
+            container.with(SkippedTurnPartsComponent(existing + effect.part))
+        }
+
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.sdk.core.BendType
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.TurnPart
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.effects.HijackScope
 import com.wingedsheep.sdk.scripting.effects.ManaExpiry
@@ -514,6 +515,20 @@ data class SkipUntapComponent(
     val affectsCreatures: Boolean = true,
     val affectsLands: Boolean = true
 ) : Component
+
+/**
+ * The parts of the *current* turn this player skips every instance of — Fatespinner's "the player
+ * skips each instance of the chosen step or phase this turn".
+ *
+ * Unlike the one-shot [SkipCombatPhasesComponent] / [SkipDrawStepComponent] markers, this is not
+ * consumed by the first occurrence: it stands until end-of-turn cleanup removes it, so a second
+ * main phase or an additional combat phase created later in the turn is skipped too.
+ * `TurnManager.advanceStepFromEndedStep` reads it *before* emitting the step's `StepChangedEvent`,
+ * which is what makes the skip faithful to CR 500.11 — no priority, and no "at the beginning of"
+ * trigger for a step that never happened.
+ */
+@Serializable
+data class SkippedTurnPartsComponent(val parts: Set<TurnPart>) : Component
 
 /**
  * Marker component indicating that a player should skip their next draw step.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -2187,6 +2187,19 @@ class ClientStateTransformer(
             )
         }
 
+        // Turn-scoped step/phase skips (Fatespinner). One badge per chosen part, so a player who
+        // has been hit by two of them sees both.
+        container.get<SkippedTurnPartsComponent>()?.parts?.forEach { part ->
+            effects.add(
+                ClientPlayerEffect(
+                    effectId = "skip_turn_part_${part.name.lowercase()}",
+                    name = "Skip ${part.displayName.replaceFirstChar { it.uppercase() }}",
+                    description = "You skip each ${part.displayName} this turn",
+                    icon = "shield-off"
+                )
+            )
+        }
+
         // Check for SkipUntapComponent (Exhaustion effect)
         val skipUntap = container.get<SkipUntapComponent>()
         if (skipUntap != null) {


### PR DESCRIPTION
Two more cards off Mirrodin's tail: **285/291**. Every remaining MRD card is engine-blocked, so this is
two cards rather than a handful — each needed exactly one new primitive, which is what made them the
cheapest two of the eight left.

## Why these two

Triaged all eight against the SDK before starting. Soul Foundry needs a dynamic generic mana cost
(`{X}` = a linked exiled card's mana value), which touches all three mana paths — enumeration,
validation, payment. Quicksilver Elemental needs two unrelated primitives, Spellweaver Helix and Shared
Fate one each plus a second feature, and Duplicant needs a new Layer-4 modification. Fatespinner and
Timesifter need one primitive apiece.

## `SkipStepOrPhaseThisTurnEffect(part, target)` — Fatespinner

"Skips **each instance** of the chosen step or phase this turn." The **duration** is what separates it
from the existing one-shot `SkipNextDrawStep` / `SkipCombatPhases` markers, which are consumed by the
first occurrence; this one stands until end-of-turn cleanup drops its `SkippedTurnPartsComponent`.
`TurnPart` is the granularity printed cards use — one value covers both main phases (CR 505.1: they are
individually and collectively "the main phase") and one covers all five combat steps.

The skip is read in `TurnManager.advanceStepFromEndedStep` **before** the step's `StepChangedEvent` is
built. That is what makes it faithful to CR 500.11 / 614.10 — the step is proceeded past as though it
didn't exist, so no player receives priority in it and no "at the beginning of …" ability triggers for
it, because that event is exactly what `PassPriorityHandler` feeds to `detectPhaseStepTriggers`. Two
things fall out of doing it there:

- skipping the postcombat main phase still has to run the **deferred end-of-combat bookkeeping** that
  phase owns, or creatures stay in combat for the rest of the turn;
- the additional-phase queue drains on **its own path**, so `drainAdditionalPhase` had to consult the
  same marker — otherwise an Aggravated Assault combat phase would sail through while the natural one
  was skipped. There is a test for exactly that.

The decision routing needed nothing new: `ChooseActionEffect` already routes to whatever its `player`
resolves to, and a step trigger stores the active player in the context's *entity* slot, which
`TargetResolutionUtils` already falls back to.

## `ExileTopCardContestEffect(players, storeWinnerAs, storeExiledAs)` — Timesifter

Each player exiles the top card of their library, greatest mana value wins, **ties repeat among the tied
players only**. Fully deterministic — no player ever chooses anything — so it resolves in a single pass
with no decision or continuation.

Deliberately **open**: it publishes the winning player as a one-entry pipeline collection and stops,
leaving the payoff to the card. That keeps "take an extra turn" out of a library primitive. The contest
can legitimately end with **no winner** (a player with an empty library exiles nothing and so can never
have exiled the greatest mana value), so the collection is left empty rather than arbitrarily filled and
the card gates on it — an unguarded `PipelineTarget` falls back to the ability's controller, which would
hand Timesifter's own controller a free turn every time the table decked out.

## Tests

Nine scenario tests across the two cards. They assert on **the step sequence the game actually walks**
and on **the deciding player**, not just the end state — a draw step that happened but drew nothing, or a
prompt answered by the wrong player, would otherwise pass. Covered: each of Fatespinner's three options,
both main phases skipped by one choice, an inserted extra combat phase skipped too, the marker not
surviving the turn; and for Timesifter the greatest-mana-value win, a tie repeating, an empty library
losing to a `{0}` card, and a contest nobody can enter producing no extra turn at all.

## Verification

`just test` green on the full suite (twice — once before and once after the extra-phase fix). Card
snapshot re-blessed: **+2 cards, zero deletions**, so no shared SDK behaviour shifted.
`just check-card-printing` clean for both — MRD is the earliest real printing of each.

## Notes

- **Commits are split primitives-then-cards rather than one-per-card.** The two facades land in one
  contiguous inserted block in `Effects.kt`, which `git add -p` cannot split, and the repo bans the
  edit-out-and-back workaround. Each of the two commits compiles on its own.
- **Step 8b (mtgish emitter) does not apply.** Probing the IR shows it drops Fatespinner's skip clause
  entirely — no `Skip…` verb appears at all — and expresses Timesifter as a generic repeatable block
  (`SetRepeatablePlayers`). Neither feature introduces an SDK effect that maps to an mtgish IR tag, so
  there is nothing to register; mapping the generic `ChooseAnAction` verb would make the emitter claim
  Fatespinner while silently dropping its payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
