### PR TITLE
Add three Murders at Karlov Manor cards with the engine gaps they needed

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2436,6 +2436,18 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     count = 1, target = PlayerRef(Player.You)), Patterns.Library.searchLibrary(Creature, HAND,
     reveal = true), successCriterion = PermanentsSacrificed)` — the ability doesn't target, and an
     empty board means no sacrifice and no search.
+    `SuccessCriterion.TurnedFaceUp` gates on whether the action **actually turned a permanent face
+    up** (a `TurnFaceUpEvent`). Turning face up is not a zone move, so `Auto` can't infer it, and
+    `Always` would report success for the two cases the rules call failures: a manifested or cloaked
+    permanent represented by an instant or sorcery card is revealed and left face down (CR 701.40g /
+    701.58g), and an already-face-up permanent has nothing to turn. Use for the "Turn this face up.
+    **If you can't**, …" shape, where the fallback rides `ifYouDont` and the primary instruction stays
+    the gated action rather than being re-encoded as a condition that would have to re-derive the
+    engine's own turn-up legality. **Etrata, Deadly Fugitive** grants face-down creatures
+    "{2}{U}{B}: Turn this creature face up. If you can't, exile it, then you may cast the exiled card
+    without paying its mana cost" → `IfYouDoEffect(TurnFaceUpEffect(Self), Effects.Composite(emptyList()),
+    ifYouDont = <exile + may cast>, successCriterion = TurnedFaceUp)` — the empty `ifYouDo` is the
+    house spelling for a gate that only has a failure branch (Kellan, the Kid uses the same shape).
     `CollectionNonEmpty` gates on the action's actual pipeline collection
     (`storedCollections[name].size >= min` after the action runs) — the collections propagate onto
     the gate frame via `exposeCollectionsToNextFrame`, in both the synchronous and the
@@ -3219,6 +3231,15 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
     "this artifact" / "this land" / … ) when it renders the ability on the stack (and planeswalker
     loyalty lines). `descriptionTemplate` and `description` are computed (non-constructor)
     properties, so neither is serialized — the card snapshot is unaffected.
+  - **A face-down permanent can hold a granted ability.** CR 708.2 strips a face-down permanent of
+    every characteristic except the ones the rules that turned it face down list, so none of its
+    *card's* abilities are activatable — but an ability another effect grants it applies in Layer 6
+    to the object on the battlefield, not to the hidden card, and stays activatable. Both ability
+    enumerators and `ActivateAbilityHandler` therefore fold face-down into the same own-vs-granted
+    split they already use for "has lost all abilities" rather than skipping the permanent outright.
+    Etrata, Deadly Fugitive is the card that needs it: "Face-down creatures you control have
+    '{2}{U}{B}: Turn this creature face up. …'".
+
 - `EffectTarget.GrantingSource` — the permanent whose static ability granted the currently-resolving
   ability: the Equipment/Aura/permanent bearing the `GrantActivatedAbility` static, as the counterpart
   to `Self` (the host). Use when a granted ability names the *granting object* — e.g. Trusty

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -539,6 +539,27 @@ sealed interface SuccessCriterion {
     @SerialName("SuccessCriterion.PermanentsSacrificed")
     @Serializable
     data object PermanentsSacrificed : SuccessCriterion
+
+    /**
+     * Action succeeded iff the gated action actually *turned a permanent face up* — a
+     * `TurnFaceUpEvent` was emitted during the action. Turning face up is not a zone move, so
+     * [Auto] can't infer it, and [Always] would wrongly report success for the cases the rules
+     * single out as failures.
+     *
+     * A `TurnFaceUpEffect` deliberately produces no such event when it can't do its work:
+     * a manifested or cloaked permanent represented by an instant or sorcery card is revealed and
+     * left face down (CR 701.40g / 701.58g), and a permanent that is already face up has nothing
+     * to turn. Both are exactly the "you can't" the gate must catch.
+     *
+     * Etrata, Deadly Fugitive grants face-down creatures "{2}{U}{B}: Turn this creature face up.
+     * **If you can't**, exile it, then you may cast the exiled card without paying its mana cost."
+     * — the fallback lives in [GatedEffect.otherwise], so the primary instruction stays the gated
+     * action rather than being re-encoded as a condition that would have to re-derive the engine's
+     * own turn-up legality.
+     */
+    @SerialName("SuccessCriterion.TurnedFaceUp")
+    @Serializable
+    data object TurnedFaceUp : SuccessCriterion
 }
 
 /**

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CovetedFalcon.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CovetedFalcon.kt
@@ -1,0 +1,158 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GiveControlToTargetPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Coveted Falcon — Murders at Karlov Manor #48
+ * {1}{U}{U} · Artifact Creature — Bird · 1/4
+ *
+ * Flying
+ * Whenever this creature attacks, gain control of target permanent you own but don't control.
+ * Disguise {1}{U}
+ * When this creature is turned face up, target opponent gains control of any number of target
+ * permanents you control. Draw a card for each one they gained control of this way.
+ *
+ * A card that hands permanents out and then takes them back, so both halves are control changes
+ * read from opposite ends.
+ *
+ * **"You own but don't control" is a composed controller predicate**, not a named one:
+ * `ControllerPredicate.And(OwnedByYou, Not(ControlledByYou))`. The two axes are genuinely
+ * different — ownership is the card's immutable owner, control is projected and moves with
+ * Layer-2 effects — and `GameObjectFilter.and` deliberately rejects two *different* controller
+ * predicates rather than silently keeping one, so the intent has to be stated as one composed
+ * predicate. `Not(ControlledByYou)` rather than `ControlledByOpponent` because that is what the
+ * card prints; on the battlefield the two coincide, but the negation is the wording and doesn't
+ * depend on every other player being an opponent.
+ *
+ * **The gift is a per-permanent gate, not one bulk effect.** "Draw a card for each one they gained
+ * control of **this way**" counts control changes that actually happened, not targets chosen — a
+ * permanent that left the battlefield (or that you no longer control) between trigger and
+ * resolution is skipped, and it must not draw. So the chosen permanent targets are gathered with
+ * [CardSource.ChosenTargets] and iterated with [ForEachInCollectionEffect], and each iteration is
+ * the same [SuccessCriterion.ControlChanged] gate Stiltzkin, Moogle Merchant uses for its singular
+ * "If they do, you draw a card" — one draw per control change that really moved. The gather skips
+ * player targets by construction, so the target opponent in slot 0 is never iterated over.
+ *
+ * `unlimited = true` is the right shape for "any number of target permanents" — these *are*
+ * targets (shroud, protection and "can't be the target of" all apply, and each is locked in when
+ * the trigger goes on the stack), unlike a resolution-time "choose any number" pipeline. Choosing
+ * zero is legal, and then the trigger simply draws nothing.
+ *
+ * The turned-face-up trigger is not an enters trigger: turning a permanent face up doesn't cause
+ * enters-the-battlefield abilities to trigger (CR 708.8), so a hard-cast Falcon never gives
+ * anything away — you only get the gift-and-draw by disguising it and flipping it up.
+ */
+val CovetedFalcon = card("Coveted Falcon") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Bird"
+    oracleText = "Flying\n" +
+        "Whenever this creature attacks, gain control of target permanent you own but don't " +
+        "control.\n" +
+        "Disguise {1}{U} (You may cast this card face down for {3} as a 2/2 creature with " +
+        "ward {2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this creature is turned face up, target opponent gains control of any number of " +
+        "target permanents you control. Draw a card for each one they gained control of this way."
+    power = 1
+    toughness = 4
+    keywords(Keyword.FLYING)
+
+    disguise = "{1}{U}"
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val stolen = target(
+            "target permanent you own but don't control",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.Permanent.withControllerPredicate(
+                        ControllerPredicate.And(
+                            listOf(
+                                ControllerPredicate.OwnedByYou,
+                                ControllerPredicate.Not(ControllerPredicate.ControlledByYou),
+                            )
+                        )
+                    )
+                )
+            ),
+        )
+        effect = Effects.GainControl(stolen)
+        description = "Whenever this creature attacks, gain control of target permanent you own " +
+            "but don't control."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        val opponent = target("target opponent", TargetOpponent())
+        target(
+            "any number of target permanents you control",
+            TargetPermanent(
+                unlimited = true,
+                filter = TargetFilter(GameObjectFilter.Permanent.youControl()),
+            ),
+        )
+        effect = Effects.Composite(
+            GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "falconGifts"),
+            ForEachInCollectionEffect(
+                collection = "falconGifts",
+                effect = IfYouDoEffect(
+                    action = GiveControlToTargetPlayerEffect(
+                        permanent = EffectTarget.Self,
+                        newController = opponent,
+                    ),
+                    ifYouDo = Effects.DrawCards(1),
+                    successCriterion = SuccessCriterion.ControlChanged,
+                ),
+            ),
+        )
+        description = "When this creature is turned face up, target opponent gains control of any " +
+            "number of target permanents you control. Draw a card for each one they gained " +
+            "control of this way."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "48"
+        artist = "Madeline Boni"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc936987-d58b-4e7c-870f-379bcae77727.jpg?1783912913"
+
+        ruling("2024-02-02", "A token's owner is the player who created it.")
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to. Only a face-down permanent can " +
+                "be turned face up this way; a face-down spell cannot."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+        ruling(
+            "2024-02-02",
+            "A permanent that turns face up or face down changes characteristics but is otherwise " +
+                "the same permanent. Spells and abilities that were targeting that permanent and " +
+                "Auras and Equipment that were attached to that permanent aren't affected unless " +
+                "the new characteristics of the object change the legality of those targets or " +
+                "attachments."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/EtrataDeadlyFugitive.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/EtrataDeadlyFugitive.kt
@@ -1,0 +1,203 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.LookAudience
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.effects.TurnFaceUpEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Etrata, Deadly Fugitive — Murders at Karlov Manor #200
+ * {1}{U}{B} · Legendary Creature — Vampire Assassin · 1/4
+ *
+ * Deathtouch
+ * Face-down creatures you control have "{2}{U}{B}: Turn this creature face up. If you can't, exile
+ * it, then you may cast the exiled card without paying its mana cost."
+ * Whenever an Assassin you control deals combat damage to an opponent, cloak the top card of that
+ * player's library.
+ *
+ * The two halves are one engine: the trigger turns opponents' libraries into face-down 2/2s under
+ * your control, and the granted ability turns each of those into either a real permanent or a free
+ * spell. Etrata is an Assassin herself, so her own connection starts the loop.
+ *
+ * **"If you can't" is the gated action's failure branch, not a condition.** The granted ability's
+ * primary instruction *is* the turn-up attempt, so it rides `Gate.DoAction` with the new
+ * [SuccessCriterion.TurnedFaceUp], which reads whether a `TurnFaceUpEvent` was actually emitted.
+ * Encoding it as a "can this be turned face up?" condition instead would mean re-deriving the
+ * engine's own turn-up legality in a second place and letting the two drift. `ifYouDo` is an empty
+ * composite — the house spelling for a gate that only has a failure branch (Kellan, the Kid).
+ *
+ * The two ways it can fail, per the printed ruling: the permanent is a *cloaked or manifested
+ * instant or sorcery card*, which CR 701.58g / 701.40g say is revealed and left face down (and, the
+ * same rules add, doesn't trigger "turned face up" abilities); or an effect prohibits turning
+ * face-down creatures face up at all. A morph/disguise face-down permanent is always a creature
+ * card, so for those the ability is simply a second, more expensive turn-up price.
+ *
+ * **The grant covers every face-down creature you control**, not just the ones Etrata cloaked:
+ * `GroupFilter(Creature.youControl().faceDown())`. Your opponent's face-down creatures don't get
+ * it, and a face-down permanent that isn't a creature (there is no such thing under current rules —
+ * face-down permanents enter as 2/2 creatures) is excluded by construction. `EffectTarget.Self`
+ * inside a granted ability resolves to the *host* that received it, so both the turn-up and the
+ * exile act on the face-down creature being activated, never on Etrata.
+ *
+ * **The exiled card goes to its owner's exile and is cast by you.** A cloaked card is usually owned
+ * by the opponent whose library it came from; `MoveCollectionExecutor` routes a battlefield→exile
+ * move to the owner's exile zone regardless of the nominal destination player, and the free cast is
+ * `Chooser.Controller` — you cast a card you don't own, which is the whole point of the card.
+ *
+ * **The cloak trigger reads the damaged player, not the attacker's defending player.** An
+ * ANY-bound `dealsDamage` trigger with a `sourceFilter` binds the damaging creature as the
+ * triggering entity and the damaged player as [Player.TriggeringPlayer] — so "that player's
+ * library" is the player who actually took the damage, which matters when several Assassins connect
+ * with different opponents in the same combat damage step (each is its own trigger). The cloaked
+ * card enters the battlefield under *your* control (`underOwnersControl` left false), matching the
+ * ruling that the cards you cloaked are exiled if you leave the game.
+ */
+val EtrataDeadlyFugitive = card("Etrata, Deadly Fugitive") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Vampire Assassin"
+    oracleText = "Deathtouch\n" +
+        "Face-down creatures you control have \"{2}{U}{B}: Turn this creature face up. If you " +
+        "can't, exile it, then you may cast the exiled card without paying its mana cost.\"\n" +
+        "Whenever an Assassin you control deals combat damage to an opponent, cloak the top card " +
+        "of that player's library. (To cloak a card, put it onto the battlefield face down as a " +
+        "2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a " +
+        "creature card.)"
+    power = 1
+    toughness = 4
+    keywords(Keyword.DEATHTOUCH)
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                cost = Costs.Mana("{2}{U}{B}"),
+                effect = IfYouDoEffect(
+                    action = TurnFaceUpEffect(EffectTarget.Self),
+                    ifYouDo = Effects.Composite(emptyList()),
+                    ifYouDont = Effects.Pipeline {
+                        val thisCreature = gather(CardSource.Self)
+                        val exiled = moveTracked(
+                            thisCreature,
+                            CardDestination.ToZone(Zone.EXILE),
+                            name = "etrataExiled",
+                        )
+                        run(
+                            MayEffect(
+                                Effects.CastFromCollectionWithoutPayingCost(exiled.key),
+                                descriptionOverride = "You may cast the exiled card without " +
+                                    "paying its mana cost.",
+                            )
+                        )
+                    },
+                    successCriterion = SuccessCriterion.TurnedFaceUp,
+                    descriptionOverride = "Turn this creature face up. If you can't, exile it, " +
+                        "then you may cast the exiled card without paying its mana cost.",
+                ),
+                descriptionOverride = "Turn this creature face up. If you can't, exile it, " +
+                    "then you may cast the exiled card without paying its mana cost.",
+            ),
+            filter = GroupFilter(GameObjectFilter.Creature.youControl().faceDown()),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.Opponent,
+            sourceFilter = GameObjectFilter.Creature.withSubtype(Subtype.ASSASSIN).youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(
+                    count = DynamicAmount.Fixed(1),
+                    player = Player.TriggeringPlayer,
+                ),
+                storeAs = "etrataCloaked",
+                lookAudience = LookAudience.None,
+            ),
+            MoveCollectionEffect(
+                from = "etrataCloaked",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                faceDown = FaceDownMode.CLOAK,
+            ),
+        )
+        description = "Whenever an Assassin you control deals combat damage to an opponent, " +
+            "cloak the top card of that player's library."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "200"
+        artist = "Livia Prima"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/4410db5a-62af-43ac-979d-88a7c975f7bd.jpg?1783912850"
+
+        ruling(
+            "2024-02-02",
+            "You might be unable to turn a face-down creature face up because it's an instant or " +
+                "sorcery. Alternatively, abilities such as that of Karlov Watchdog might prevent " +
+                "you from turning face-down creatures face up altogether. In those cases, you'll " +
+                "exile that creature, and then you'll choose whether or not to cast that card " +
+                "without paying its mana cost."
+        )
+        ruling(
+            "2024-02-02",
+            "If you cast a spell \"without paying its mana cost\", you can't choose to cast it " +
+                "for any alternative costs. You can, however, pay additional costs, such as " +
+                "kicker costs. If the card has any mandatory additional costs, such as that of " +
+                "Demand Answers, those must be paid to cast the spell."
+        )
+        ruling(
+            "2024-02-02",
+            "If the spell you cast has {X} in its mana cost, you must choose 0 as the value of X " +
+                "when casting it without paying its mana cost."
+        )
+        ruling("2024-02-02", "Your opponents can't look at cards they own that you cloaked.")
+        ruling(
+            "2024-02-02",
+            "In a multiplayer game, if an opponent leaves the game, all of the cards they own " +
+                "that you cloaked leave as well. If you leave the game, the creatures you cloaked " +
+                "with Etrata, Deadly Fugitive's triggered ability are exiled."
+        )
+        ruling(
+            "2024-02-02",
+            "To cloak a card, put it onto the battlefield face down. It becomes a 2/2 face-down " +
+                "creature card with ward {2} and no name, mana cost, or creature types. It's " +
+                "colorless and has a mana value of 0. Other effects that apply to the permanent " +
+                "can still grant it any characteristics it doesn't have or change the " +
+                "characteristics it does have."
+        )
+        ruling(
+            "2024-02-02",
+            "If something tries to turn a face-down instant or sorcery card on the battlefield " +
+                "face up, reveal that card to show all players it's an instant or sorcery card. " +
+                "The permanent remains on the battlefield face down. Abilities that trigger when " +
+                "a permanent turns face up won't trigger, because even though you revealed the " +
+                "card, it never turned face up."
+        )
+    }
+}

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/LazavWearerOfFaces.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/LazavWearerOfFaces.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lazav, Wearer of Faces — Murders at Karlov Manor #216
+ * {U}{B} · Legendary Creature — Shapeshifter Detective · 2/3
+ *
+ * Whenever Lazav attacks, exile target card from a graveyard, then investigate.
+ * Whenever you sacrifice a Clue, you may have Lazav become a copy of a creature card exiled with
+ * it until end of turn.
+ *
+ * **"Exiled with it" is Lazav's own linked exile, not the Clue's.** The two abilities are a linked
+ * pair (CR 607): the first one does the exiling, the second one refers back to what it exiled, and
+ * "it" is the object both abilities are printed on. Reading "it" as the sacrificed Clue would be
+ * unsatisfiable — a Clue token never exiles anything, so that pile is always empty. So the attack
+ * trigger exiles with `linkToSource = true` (a `LinkedExileComponent` entry on Lazav) and the
+ * sacrifice trigger reads the accumulated pile back with [CardSource.FromLinkedExile]. Sacrificing
+ * a Clue is the *permission* to copy, not the pool: every card Lazav has ever exiled stays
+ * eligible, which is what makes attacking repeatedly worth doing.
+ *
+ * **The investigate is sequenced after the exile, in one resolution.** Both live in a single
+ * `Composite` so the Clue exists only if the ability resolves at all — per the printed ruling, an
+ * illegal exile target means the ability doesn't resolve and you don't investigate either.
+ *
+ * The copy half is Lazav, Familiar Stranger's shape with a different pool: gather → keep the
+ * creature cards → choose up to one → become a copy of it until end of turn, reading the copy
+ * source from exile via `sourceFromAnyZone`. `chooseUpTo(1)` *is* the printed "you may" —
+ * declining selects nothing and the [ConditionalEffect] gate leaves Lazav alone. Copying takes
+ * copiable values only (CR 707.2), so Lazav keeps his counters, his tapped-and-attacking state and
+ * any Auras, and reverts at end of turn.
+ *
+ * The pool is filtered to creature cards *before* the prompt rather than after the pick: the card
+ * says "a creature card exiled with it", so a noncreature card in the pile was never a legal
+ * choice and shouldn't be offered.
+ */
+val LazavWearerOfFaces = card("Lazav, Wearer of Faces") {
+    manaCost = "{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Shapeshifter Detective"
+    oracleText = "Whenever Lazav attacks, exile target card from a graveyard, then investigate. " +
+        "(Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\n" +
+        "Whenever you sacrifice a Clue, you may have Lazav become a copy of a creature card " +
+        "exiled with it until end of turn."
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val graveyardCard = target("target card from a graveyard", Targets.CardInGraveyard)
+        effect = Effects.Composite(
+            Effects.Move(graveyardCard, Zone.EXILE, linkToSource = true),
+            Effects.Investigate(),
+        )
+        description = "Whenever Lazav attacks, exile target card from a graveyard, then investigate."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouSacrificeA(GameObjectFilter.Artifact.withSubtype("Clue"))
+        effect = Effects.Pipeline {
+            val exiledWithLazav = gather(CardSource.FromLinkedExile())
+            val creatureCards = filter(
+                exiledWithLazav,
+                GameObjectFilter.Creature,
+                name = "lazavCreatureCards",
+            )
+            val chosen = chooseUpTo(
+                1,
+                from = creatureCards,
+                prompt = "You may have Lazav become a copy of a creature card exiled with it",
+                selectedLabel = "Become a copy",
+                name = "lazavCopySource",
+            )
+            run(
+                ConditionalEffect(
+                    condition = whenMatches(chosen),
+                    effect = Effects.EachPermanentBecomesCopyOfTarget(
+                        target = EffectTarget.PipelineTarget(chosen.key),
+                        duration = Duration.EndOfTurn,
+                        affected = EffectTarget.Self,
+                        sourceFromAnyZone = true,
+                    ),
+                )
+            )
+        }
+        description = "Whenever you sacrifice a Clue, you may have Lazav become a copy of a " +
+            "creature card exiled with it until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "216"
+        artist = "Wisnu Tan"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc264d1d-689d-41ac-b624-3fc7bb890e58.jpg?1783912843"
+
+        ruling(
+            "2024-02-02",
+            "If the target of Lazav, Wearer of Faces's first ability is illegal as the ability " +
+                "tries to resolve, it won't resolve and none of its effects will happen. You " +
+                "won't investigate."
+        )
+        ruling(
+            "2024-02-02",
+            "Some abilities trigger \"whenever you sacrifice a Clue\". Those abilities trigger " +
+                "whenever you sacrifice a Clue for any reason, not just to activate a Clue's " +
+                "activated ability."
+        )
+        ruling(
+            "2024-02-02",
+            "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact " +
+                "token. For example, you can sacrifice Wrench to pay for Alquist Proft, Master " +
+                "Sleuth's activated ability."
+        )
+        ruling(
+            "2024-02-02",
+            "You can't sacrifice a Clue to pay multiple costs. For example, you can't sacrifice a " +
+                "Clue token to activate its own ability and also to activate Alquist Proft, " +
+                "Master Sleuth's ability."
+        )
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CovetedFalconScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CovetedFalconScenarioTest.kt
@@ -1,0 +1,230 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.CovetedFalcon
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Coveted Falcon — {1}{U}{U} Artifact Creature — Bird 1/4.
+ *
+ * Two control-change abilities pointing in opposite directions. The one that needs proving is the
+ * turned-face-up trigger: "target opponent gains control of any number of target permanents you
+ * control. Draw a card for each one **they gained control of this way**" — the draw count is
+ * control changes that actually happened, not targets that were chosen.
+ */
+class CovetedFalconScenarioTest : FunSpec({
+
+    val allCards = TestCards.all + listOf(CovetedFalcon)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(allCards)
+        return driver
+    }
+
+    /** Put [cardName] onto [playerId]'s battlefield face down under disguise, as a real cast would. */
+    fun GameTestDriver.disguise(playerId: EntityId, cardName: String): EntityId {
+        val id = putCreatureOnBattlefield(playerId, cardName)
+        val cardDef = cardRegistry.requireCard(cardName)
+        replaceState(
+            state.updateEntity(id) { container ->
+                var c = container.with(FaceDownComponent)
+                    .with(FaceDownModeComponent(FaceDownMode.DISGUISE))
+                FaceDownTurnUp.dataFor(cardDef, cardName, FaceDownMode.DISGUISE)?.let { c = c.with(it) }
+                c
+            }
+        )
+        removeSummoningSickness(id)
+        return id
+    }
+
+    /**
+     * Re-own [permanent] to [newOwner] while leaving it on its current controller's battlefield —
+     * the "you own but don't control" board state the attack trigger looks for. Ownership is the
+     * card's immutable owner, so this is the only way to build it without a second control-change
+     * effect in the fixture.
+     */
+    fun GameTestDriver.reown(permanent: EntityId, newOwner: EntityId) {
+        replaceState(
+            state.updateEntity(permanent) { container ->
+                val card = container.get<CardComponent>()!!
+                container.with(OwnerComponent(newOwner)).with(card.copy(ownerId = newOwner))
+            }
+        )
+    }
+
+    context("turned face up — gifting permanents") {
+
+        test("the opponent gains control of both chosen permanents and you draw two cards") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+            val me = driver.activePlayer!!
+            val opp = driver.getOpponent(me)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val falcon = driver.disguise(me, "Coveted Falcon")
+            val gift1 = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+            val gift2 = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+            val handBefore = driver.getHand(me).size
+
+            driver.giveMana(me, Color.BLUE, 2) // disguise {1}{U}
+            driver.submit(
+                TurnFaceUp(playerId = me, sourceId = falcon, paymentStrategy = PaymentStrategy.FromPool)
+            ).error shouldBe null
+
+            // The trigger goes on the stack and asks for its two target requirements at once.
+            (driver.state.pendingDecision is ChooseTargetsDecision) shouldBe true
+            driver.submitMultiTargetSelection(
+                me,
+                mapOf(0 to listOf(opp), 1 to listOf(gift1, gift2)),
+            ).isSuccess shouldBe true
+
+            var guard = 0
+            while (driver.state.stack.isNotEmpty() && guard++ < 20) driver.bothPass()
+
+            driver.state.projectedState.getController(gift1) shouldBe opp
+            driver.state.projectedState.getController(gift2) shouldBe opp
+            driver.getHand(me).size shouldBe handBefore + 2
+        }
+
+        test("choosing zero permanents is legal and draws nothing") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+            val me = driver.activePlayer!!
+            val opp = driver.getOpponent(me)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val falcon = driver.disguise(me, "Coveted Falcon")
+            val keeper = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+            val handBefore = driver.getHand(me).size
+
+            driver.giveMana(me, Color.BLUE, 2)
+            driver.submit(
+                TurnFaceUp(playerId = me, sourceId = falcon, paymentStrategy = PaymentStrategy.FromPool)
+            ).error shouldBe null
+
+            // "any number" has a minimum of zero (`unlimited = true`), so an empty list is a legal
+            // choice for the permanent requirement even though the opponent target is mandatory.
+            driver.submitMultiTargetSelection(
+                me,
+                mapOf(0 to listOf(opp), 1 to emptyList()),
+            ).isSuccess shouldBe true
+
+            var guard = 0
+            while (driver.state.stack.isNotEmpty() && guard++ < 20) driver.bothPass()
+
+            driver.state.projectedState.getController(keeper) shouldBe me
+            driver.getHand(me).size shouldBe handBefore
+        }
+
+        test("a chosen permanent that left the battlefield draws no card") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+            val me = driver.activePlayer!!
+            val opp = driver.getOpponent(me)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val falcon = driver.disguise(me, "Coveted Falcon")
+            val survivor = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+            val doomed = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+            val handBefore = driver.getHand(me).size
+
+            driver.giveMana(me, Color.BLUE, 2)
+            driver.submit(
+                TurnFaceUp(playerId = me, sourceId = falcon, paymentStrategy = PaymentStrategy.FromPool)
+            ).error shouldBe null
+
+            driver.submitMultiTargetSelection(
+                me,
+                mapOf(0 to listOf(opp), 1 to listOf(survivor, doomed)),
+            ).isSuccess shouldBe true
+
+            // With the trigger on the stack and its targets locked in (CR 603.3d), one of them dies.
+            driver.moveToGraveyard(doomed)
+
+            var guard = 0
+            while (driver.state.stack.isNotEmpty() && guard++ < 20) driver.bothPass()
+
+            driver.state.projectedState.getController(survivor) shouldBe opp
+            // One control change actually happened, so exactly one card is drawn.
+            driver.getHand(me).size shouldBe handBefore + 1
+        }
+    }
+
+    context("attacks — taking a permanent back") {
+
+        test("gains control of a permanent you own but don't control") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+            val me = driver.activePlayer!!
+            val opp = driver.getOpponent(me)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val falcon = driver.putCreatureOnBattlefield(me, "Coveted Falcon")
+            driver.removeSummoningSickness(falcon)
+
+            // A creature on the opponent's battlefield that I own — e.g. one the Falcon gave away.
+            val mine = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+            driver.reown(mine, me)
+
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+            driver.declareAttackers(me, listOf(falcon), opp)
+
+            var guard = 0
+            while (driver.state.pendingDecision !is ChooseTargetsDecision && guard++ < 20) {
+                driver.bothPass()
+            }
+            (driver.state.pendingDecision is ChooseTargetsDecision) shouldBe true
+            driver.submitTargetSelection(me, listOf(mine)).isSuccess shouldBe true
+
+            guard = 0
+            while (driver.state.stack.isNotEmpty() && guard++ < 20) driver.bothPass()
+
+            driver.state.projectedState.getController(mine) shouldBe me
+        }
+
+        test("a permanent the opponent both owns and controls is not a legal target") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+            val me = driver.activePlayer!!
+            val opp = driver.getOpponent(me)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val falcon = driver.putCreatureOnBattlefield(me, "Coveted Falcon")
+            driver.removeSummoningSickness(falcon)
+
+            // Owned *and* controlled by the opponent — fails the `OwnedByYou` half of the predicate.
+            val theirs = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+            driver.declareAttackers(me, listOf(falcon), opp)
+
+            var guard = 0
+            while (driver.state.pendingDecision !is ChooseTargetsDecision && guard++ < 20) {
+                driver.bothPass()
+            }
+            val decision = driver.state.pendingDecision
+            if (decision is ChooseTargetsDecision) {
+                decision.legalTargets.values.flatten().contains(theirs) shouldBe false
+            }
+        }
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EtrataDeadlyFugitiveScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EtrataDeadlyFugitiveScenarioTest.kt
@@ -1,0 +1,218 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.EtrataDeadlyFugitive
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Etrata, Deadly Fugitive (MKM) — {1}{U}{B} 1/4 Legendary Creature — Vampire Assassin.
+ *
+ * The card under test for [com.wingedsheep.sdk.scripting.effects.SuccessCriterion.TurnedFaceUp]:
+ * the ability Etrata grants reads "Turn this creature face up. **If you can't**, exile it, then you
+ * may cast the exiled card without paying its mana cost", and the only honest way to know whether
+ * you could is to try. Both branches get a test, plus the cloak trigger that manufactures the
+ * face-down creatures in the first place.
+ */
+class EtrataDeadlyFugitiveScenarioTest : FunSpec({
+
+    // A creature card: cloaked, it *can* be turned face up (CR 701.58b).
+    val bear = card("Cloakable Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    // An Assassin, so its combat damage fires Etrata's trigger without Etrata herself attacking.
+    val assassin = card("Test Assassin") {
+        manaCost = "{1}{B}"
+        typeLine = "Creature — Human Assassin"
+        power = 2
+        toughness = 2
+    }
+
+    val grantedAbilityId = EtrataDeadlyFugitive.staticAbilities
+        .filterIsInstance<GrantActivatedAbility>()
+        .single()
+        .ability
+        .id
+
+    val allCards = TestCards.all + listOf(bear, assassin, EtrataDeadlyFugitive)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(allCards)
+        return driver
+    }
+
+    /** Cloak [cardName] onto [playerId]'s battlefield, deriving turn-up data the way a real entry does. */
+    fun GameTestDriver.cloak(playerId: EntityId, cardName: String): EntityId {
+        val id = putPermanentOnBattlefield(playerId, cardName)
+        val cardDef = cardRegistry.requireCard(cardName)
+        replaceState(
+            state.updateEntity(id) { container ->
+                var c = container.with(FaceDownComponent)
+                    .with(FaceDownModeComponent(FaceDownMode.CLOAK))
+                FaceDownTurnUp.dataFor(cardDef, cardName, FaceDownMode.CLOAK)?.let { c = c.with(it) }
+                c
+            }
+        )
+        removeSummoningSickness(id)
+        return id
+    }
+
+    context("the granted ability — \"turn this face up. If you can't, …\"") {
+
+        test("a cloaked creature card turns face up and is not exiled") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+            val me = driver.activePlayer!!
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            driver.putCreatureOnBattlefield(me, "Etrata, Deadly Fugitive")
+            val hidden = driver.cloak(me, "Cloakable Bear")
+
+            driver.giveMana(me, Color.BLUE, 2)
+            driver.giveMana(me, Color.BLACK, 2)
+            driver.submitSuccess(
+                ActivateAbility(playerId = me, sourceId = hidden, abilityId = grantedAbilityId)
+            )
+            var guard = 0
+            while (driver.state.stack.isNotEmpty() && guard++ < 20) driver.bothPass()
+
+            driver.state.getEntity(hidden)?.get<FaceDownComponent>() shouldBe null
+            driver.state.getEntity(hidden)?.get<CardComponent>()?.name shouldBe "Cloakable Bear"
+            driver.state.getBattlefield().contains(hidden) shouldBe true
+        }
+
+        test("a cloaked instant card can't be turned face up, so it is exiled instead") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+            val me = driver.activePlayer!!
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            driver.putCreatureOnBattlefield(me, "Etrata, Deadly Fugitive")
+            // CR 701.58g — a cloaked instant that would turn face up is revealed and stays face
+            // down, so no TurnFaceUpEvent is emitted and the gate takes the failure branch.
+            val hidden = driver.cloak(me, "Lightning Bolt")
+
+            driver.giveMana(me, Color.BLUE, 2)
+            driver.giveMana(me, Color.BLACK, 2)
+            driver.submitSuccess(
+                ActivateAbility(playerId = me, sourceId = hidden, abilityId = grantedAbilityId)
+            )
+
+            var guard = 0
+            while (guard++ < 30) {
+                if (driver.state.pendingDecision != null) {
+                    driver.autoResolveDecision()
+                } else if (driver.state.stack.isNotEmpty()) {
+                    driver.bothPass()
+                } else {
+                    break
+                }
+            }
+
+            driver.state.getBattlefield().contains(hidden) shouldBe false
+            driver.getExile(me).contains(hidden) shouldBe true
+        }
+
+        test("an opponent's face-down creature does not gain the ability") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+            val me = driver.activePlayer!!
+            val opp = driver.getOpponent(me)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            driver.putCreatureOnBattlefield(me, "Etrata, Deadly Fugitive")
+            val theirs = driver.cloak(opp, "Cloakable Bear")
+
+            // "Face-down creatures **you control**" — the grant's filter is controller-scoped.
+            driver.legalActions(opp)
+                .none { (it.action as? ActivateAbility)?.sourceId == theirs } shouldBe true
+        }
+    }
+
+    context("the cloak trigger") {
+
+        test("an Assassin's combat damage cloaks the top card of the damaged player's library") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+            val me = driver.activePlayer!!
+            val opp = driver.getOpponent(me)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            driver.putCreatureOnBattlefield(me, "Etrata, Deadly Fugitive")
+            val killer = driver.putCreatureOnBattlefield(me, "Test Assassin")
+            driver.removeSummoningSickness(killer)
+
+            val topOfTheirLibrary = driver.putCardOnTopOfLibrary(opp, "Cloakable Bear")
+
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+            driver.declareAttackers(me, listOf(killer), opp)
+            driver.declareNoBlockers(opp)
+
+            var guard = 0
+            while (guard++ < 40) {
+                if (driver.state.pendingDecision != null) {
+                    driver.autoResolveDecision()
+                } else if (driver.state.stack.isNotEmpty()) {
+                    driver.bothPass()
+                } else if (driver.state.getBattlefield().contains(topOfTheirLibrary)) {
+                    break
+                } else {
+                    driver.bothPass()
+                }
+            }
+
+            // It came off the opponent's library but is a face-down 2/2 under *my* control.
+            driver.state.getBattlefield().contains(topOfTheirLibrary) shouldBe true
+            driver.state.getEntity(topOfTheirLibrary)?.get<FaceDownComponent>().shouldNotBeNull()
+            driver.state.projectedState.getController(topOfTheirLibrary) shouldBe me
+            driver.state.getEntity(topOfTheirLibrary)
+                ?.get<FaceDownModeComponent>()?.mode shouldBe FaceDownMode.CLOAK
+        }
+
+        test("a non-Assassin's combat damage cloaks nothing") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+            val me = driver.activePlayer!!
+            val opp = driver.getOpponent(me)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            driver.putCreatureOnBattlefield(me, "Etrata, Deadly Fugitive")
+            val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+            driver.removeSummoningSickness(bears)
+
+            val topOfTheirLibrary = driver.putCardOnTopOfLibrary(opp, "Cloakable Bear")
+
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+            driver.declareAttackers(me, listOf(bears), opp)
+            driver.declareNoBlockers(opp)
+
+            var guard = 0
+            while (guard++ < 20) {
+                if (driver.state.pendingDecision != null) driver.autoResolveDecision()
+                else if (driver.state.stack.isNotEmpty()) driver.bothPass()
+                else break
+            }
+
+            driver.state.getBattlefield().contains(topOfTheirLibrary) shouldBe false
+        }
+    }
+})

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LazavWearerOfFacesScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/LazavWearerOfFacesScenarioTest.kt
@@ -1,0 +1,173 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Lazav, Wearer of Faces (MKM) — {U}{B} 2/3 Legendary Creature — Shapeshifter Detective.
+ *
+ * "Whenever Lazav attacks, exile target card from a graveyard, then investigate."
+ * "Whenever you sacrifice a Clue, you may have Lazav become a copy of a creature card exiled with
+ * it until end of turn."
+ *
+ * The pair is linked (CR 607): the attack trigger's exile is the *only* thing that stocks the pool
+ * the sacrifice trigger reads, so these tests run them in sequence rather than seeding a linked
+ * exile by hand. What they pin down is that the exile really lands on Lazav's
+ * [LinkedExileComponent], that a Clue sacrificed for any reason is the trigger, that only creature
+ * cards from that pile are offered, and that declining leaves Lazav alone.
+ */
+class LazavWearerOfFacesScenarioTest : ScenarioTestBase() {
+
+    private val clueAbilityId = PredefinedTokens.Clue.activatedAbilities.first().id
+
+    private fun clue(game: TestGame): EntityId? = game.state.getBattlefield()
+        .firstOrNull { game.state.getEntity(it)?.get<CardComponent>()?.name == "Clue" }
+
+    private fun linkedExile(game: TestGame): List<EntityId> =
+        game.state.getEntity(game.findPermanent("Lazav, Wearer of Faces")!!)
+            ?.get<LinkedExileComponent>()?.exiledIds.orEmpty()
+
+    /** Attack with Lazav, exiling [graveyardCard]; leaves the Clue on the battlefield. */
+    private fun TestGame.attackExiling(graveyardCard: EntityId) {
+        advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+        declareAttackers(mapOf("Lazav, Wearer of Faces" to 2)).error shouldBe null
+
+        val decision = getPendingDecision()
+        (decision is ChooseTargetsDecision) shouldBe true
+        submitDecision(
+            TargetsResponse((decision as ChooseTargetsDecision).id, mapOf(0 to listOf(graveyardCard)))
+        ).error shouldBe null
+        resolveStack()
+    }
+
+    init {
+        test("attacking exiles the targeted graveyard card onto Lazav's linked exile and investigates") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Lazav, Wearer of Faces")
+                .withCardInGraveyard(2, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findCardsInGraveyard(2, "Grizzly Bears").single()
+            game.attackExiling(bears)
+
+            game.isInExile(2, "Grizzly Bears") shouldBe true
+            linkedExile(game) shouldBe listOf(bears)
+            clue(game).shouldNotBeNull()
+        }
+
+        test("sacrificing the Clue lets Lazav become a copy of the exiled creature card") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Lazav, Wearer of Faces")
+                .withLandsOnBattlefield(1, "Island", 2)
+                .withCardInGraveyard(2, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findCardsInGraveyard(2, "Grizzly Bears").single()
+            game.attackExiling(bears)
+
+            val lazav = game.findPermanent("Lazav, Wearer of Faces").shouldNotBeNull()
+            val clueId = clue(game).shouldNotBeNull()
+
+            // Crack the Clue for its own draw — "for any reason" includes its own ability.
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = clueId, abilityId = clueAbilityId)
+            ).error shouldBe null
+            game.resolveStack()
+
+            // The copy trigger offers exactly the creature cards in Lazav's linked exile.
+            val selection = game.getPendingDecision()
+            (selection is SelectCardsDecision) shouldBe true
+            (selection as SelectCardsDecision).options shouldBe listOf(bears)
+
+            game.selectCards(listOf(bears)).error shouldBe null
+            game.resolveStack()
+
+            game.state.getEntity(lazav)?.get<CardComponent>()?.name shouldBe "Grizzly Bears"
+            game.state.projectedState.getPower(lazav) shouldBe 2
+            game.state.projectedState.getToughness(lazav) shouldBe 2
+        }
+
+        test("declining the choice leaves Lazav as himself") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Lazav, Wearer of Faces")
+                .withLandsOnBattlefield(1, "Island", 2)
+                .withCardInGraveyard(2, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findCardsInGraveyard(2, "Grizzly Bears").single()
+            game.attackExiling(bears)
+
+            val lazav = game.findPermanent("Lazav, Wearer of Faces").shouldNotBeNull()
+            val clueId = clue(game).shouldNotBeNull()
+
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = clueId, abilityId = clueAbilityId)
+            ).error shouldBe null
+            game.resolveStack()
+
+            // Selecting nothing is the printed "you may" declining.
+            game.skipSelection().error shouldBe null
+            game.resolveStack()
+
+            game.state.getEntity(lazav)?.get<CardComponent>()?.name shouldBe "Lazav, Wearer of Faces"
+            game.state.projectedState.getPower(lazav) shouldBe 2
+            game.state.projectedState.getToughness(lazav) shouldBe 3
+        }
+
+        test("a noncreature card in the linked exile is never offered as a copy source") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Lazav, Wearer of Faces")
+                .withLandsOnBattlefield(1, "Island", 2)
+                .withCardInGraveyard(2, "Lightning Bolt")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bolt = game.findCardsInGraveyard(2, "Lightning Bolt").single()
+            game.attackExiling(bolt)
+
+            linkedExile(game) shouldBe listOf(bolt)
+
+            val lazav = game.findPermanent("Lazav, Wearer of Faces").shouldNotBeNull()
+            val clueId = clue(game).shouldNotBeNull()
+
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = clueId, abilityId = clueAbilityId)
+            ).error shouldBe null
+            game.resolveStack()
+
+            // The creature-card filter empties the pool, so there is nothing to prompt for and
+            // Lazav is untouched — "a creature card exiled with it" had no candidate.
+            val decision = game.getPendingDecision()
+            if (decision is SelectCardsDecision) {
+                decision.options shouldNotBe listOf(bolt)
+                game.skipSelection()
+            }
+            game.resolveStack()
+
+            game.state.getEntity(lazav)?.get<CardComponent>()?.name shouldBe "Lazav, Wearer of Faces"
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -5762,6 +5762,155 @@
     ]
 }
 
+// Coveted Falcon
+{
+    "name": "Coveted Falcon",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Artifact Creature — Bird",
+    "oracleText": "Flying\nWhenever this creature attacks, gain control of target permanent you own but don't control.\nDisguise {1}{U} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, target opponent gains control of any number of target permanents you control. Draw a card for each one they gained control of this way.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{U}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "GainControl",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target permanent you own but don't control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsPermanent"
+                            ],
+                            "controllerPredicate": {
+                                "type": "ControllerAnd",
+                                "predicates": [
+                                    "OwnedByYou",
+                                    {
+                                        "type": "ControllerNot",
+                                        "predicate": "ControlledByYou"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "id": "target permanent you own but don't control"
+                },
+                "descriptionOverride": "Whenever this creature attacks, gain control of target permanent you own but don't control."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "falconGifts"
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Collection",
+                                "collection": "falconGifts"
+                            },
+                            "body": {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.DoAction",
+                                    "action": {
+                                        "type": "GiveControlToTargetPlayer",
+                                        "permanent": "Self",
+                                        "newController": {
+                                            "type": "BoundVariable",
+                                            "name": "target opponent"
+                                        }
+                                    },
+                                    "successCriterion": "SuccessCriterion.ControlChanged"
+                                },
+                                "then": {
+                                    "type": "DrawCards",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "unlimited": true,
+                        "filter": {
+                            "baseFilter": "permanent ctrl:you"
+                        },
+                        "id": "any number of target permanents you control"
+                    }
+                ],
+                "descriptionOverride": "When this creature is turned face up, target opponent gains control of any number of target permanents you control. Draw a card for each one they gained control of this way."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "rarity": "RARE",
+        "artist": "Madeline Boni",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc936987-d58b-4e7c-870f-379bcae77727.jpg?1783912913",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "A token's owner is the player who created it."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "A permanent that turns face up or face down changes characteristics but is otherwise the same permanent. Spells and abilities that were targeting that permanent and Auras and Equipment that were attached to that permanent aren't affected unless the new characteristics of the object change the legality of those targets or attachments."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Crime Novelist
 {
     "name": "Crime Novelist",
@@ -7616,6 +7765,166 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Etrata, Deadly Fugitive
+{
+    "name": "Etrata, Deadly Fugitive",
+    "manaCost": "{1}{U}{B}",
+    "typeLine": "Legendary Creature — Vampire Assassin",
+    "oracleText": "Deathtouch\nFace-down creatures you control have \"{2}{U}{B}: Turn this creature face up. If you can't, exile it, then you may cast the exiled card without paying its mana cost.\"\nWhenever an Assassin you control deals combat damage to an opponent, cloak the top card of that player's library. (To cloak a card, put it onto the battlefield face down as a 2/2 creature with ward {2}. Turn it face up any time for its mana cost if it's a creature card.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "RecipientOpponent",
+                    "sourceFilter": "creature Assassin ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "player": "TriggeringPlayer"
+                            },
+                            "storeAs": "etrataCloaked",
+                            "lookAudience": "None"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "etrataCloaked",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "faceDown": "CLOAK"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever an Assassin you control deals combat damage to an opponent, cloak the top card of that player's library."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "cost": {
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{2}{U}{B}"
+                        }
+                    },
+                    "effect": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "TurnFaceUp",
+                                "target": "Self"
+                            },
+                            "successCriterion": "SuccessCriterion.TurnedFaceUp"
+                        },
+                        "then": {
+                            "type": "Composite",
+                            "effects": []
+                        },
+                        "otherwise": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": "Self",
+                                    "storeAs": "gathered0"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "gathered0",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Exile"
+                                    },
+                                    "storeMovedAs": "etrataExiled"
+                                },
+                                {
+                                    "type": "Gated",
+                                    "gate": "Gate.MayDecide",
+                                    "then": {
+                                        "type": "CastFromCollectionWithoutPayingCost",
+                                        "from": "etrataExiled"
+                                    },
+                                    "descriptionOverride": "You may cast the exiled card without paying its mana cost."
+                                }
+                            ]
+                        },
+                        "descriptionOverride": "Turn this creature face up. If you can't, exile it, then you may cast the exiled card without paying its mana cost."
+                    },
+                    "descriptionOverride": "Turn this creature face up. If you can't, exile it, then you may cast the exiled card without paying its mana cost."
+                },
+                "filter": {
+                    "baseFilter": "creature facedown ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "200",
+        "rarity": "MYTHIC",
+        "artist": "Livia Prima",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/4410db5a-62af-43ac-979d-88a7c975f7bd.jpg?1783912850",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "You might be unable to turn a face-down creature face up because it's an instant or sorcery. Alternatively, abilities such as that of Karlov Watchdog might prevent you from turning face-down creatures face up altogether. In those cases, you'll exile that creature, and then you'll choose whether or not to cast that card without paying its mana cost."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If you cast a spell \"without paying its mana cost\", you can't choose to cast it for any alternative costs. You can, however, pay additional costs, such as kicker costs. If the card has any mandatory additional costs, such as that of Demand Answers, those must be paid to cast the spell."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If the spell you cast has {X} in its mana cost, you must choose 0 as the value of X when casting it without paying its mana cost."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Your opponents can't look at cards they own that you cloaked."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "In a multiplayer game, if an opponent leaves the game, all of the cards they own that you cloaked leave as well. If you leave the game, the creatures you cloaked with Etrata, Deadly Fugitive's triggered ability are exiled."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "To cloak a card, put it onto the battlefield face down. It becomes a 2/2 face-down creature card with ward {2} and no name, mana cost, or creature types. It's colorless and has a mana value of 0. Other effects that apply to the permanent can still grant it any characteristics it doesn't have or change the characteristics it does have."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If something tries to turn a face-down instant or sorcery card on the battlefield face up, reveal that card to show all players it's an instant or sorcery card. The permanent remains on the battlefield face down. Abilities that trigger when a permanent turns face up won't trigger, because even though you revealed the card, it never turned face up."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 
@@ -12978,6 +13287,144 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Lazav, Wearer of Faces
+{
+    "name": "Lazav, Wearer of Faces",
+    "manaCost": "{U}{B}",
+    "typeLine": "Legendary Creature — Shapeshifter Detective",
+    "oracleText": "Whenever Lazav attacks, exile target card from a graveyard, then investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\nWhenever you sacrifice a Clue, you may have Lazav become a copy of a creature card exiled with it until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target card from a graveyard"
+                            },
+                            "destination": "Exile",
+                            "linkToSource": true
+                        },
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Clue"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {},
+                        "zone": "Graveyard"
+                    },
+                    "id": "target card from a graveyard"
+                },
+                "descriptionOverride": "Whenever Lazav attacks, exile target card from a graveyard, then investigate."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "artifact Clue",
+                    "perPermanent": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "gathered0",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "creature"
+                            },
+                            "storeMatching": "lazavCreatureCards"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "lazavCreatureCards",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "lazavCopySource",
+                            "prompt": "You may have Lazav become a copy of a creature card exiled with it",
+                            "selectedLabel": "Become a copy"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "CollectionContainsMatch",
+                                    "collection": "lazavCopySource"
+                                }
+                            },
+                            "then": {
+                                "type": "EachPermanentBecomesCopyOfTarget",
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "lazavCopySource"
+                                },
+                                "duration": "EndOfTurn",
+                                "affected": "Self",
+                                "sourceFromAnyZone": true
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever you sacrifice a Clue, you may have Lazav become a copy of a creature card exiled with it until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "rarity": "RARE",
+        "artist": "Wisnu Tan",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc264d1d-689d-41ac-b624-3fc7bb890e58.jpg?1783912843",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If the target of Lazav, Wearer of Faces's first ability is illegal as the ability tries to resolve, it won't resolve and none of its effects will happen. You won't investigate."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Some abilities trigger \"whenever you sacrifice a Clue\". Those abilities trigger whenever you sacrifice a Clue for any reason, not just to activate a Clue's activated ability."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact token. For example, you can sacrifice Wrench to pay for Alquist Proft, Master Sleuth's activated ability."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "You can't sacrifice a Clue to pay multiple costs. For example, you can't sacrifice a Clue token to activate its own ability and also to activate Alquist Proft, Master Sleuth's ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -208,9 +208,20 @@ class ActivateAbilityHandler(
                 }
             }
 
-            // Face-down creatures have no abilities (Rule 708.2)
+            // A face-down permanent has no characteristics beyond those the rules that made it face
+            // down list (CR 708.2), so none of its *card's* abilities are activatable. Abilities
+            // another effect grants it are a different thing entirely — they apply in Layer 6 to the
+            // object on the battlefield, not to the hidden card — so they stay activatable
+            // (Etrata, Deadly Fugitive: "Face-down creatures you control have '{2}{U}{B}: Turn this
+            // creature face up …'"). Same own-vs-granted split as the lost-all-abilities check below.
             if (container.has<FaceDownComponent>()) {
-                return "Face-down creatures have no abilities"
+                val isOwnAbility =
+                    cardDef?.script?.effectiveActivatedAbilities(classLevel)?.any { it.id == action.abilityId } == true ||
+                        action.abilityId.value.startsWith("class_level_up_") ||
+                        IntrinsicManaAbilities.lookup(action.abilityId) != null
+                if (isOwnAbility) {
+                    return "Face-down creatures have no abilities"
+                }
             }
 
             // PreventActivatedAbilities (Cursed Totem etc.) blocks activated abilities of

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -808,7 +808,18 @@ class GatedEffectExecutor(
             is SuccessCriterion.ControlChanged -> evaluateControlChanged(priorEvents)
             is SuccessCriterion.CountersRemoved -> evaluateCountersRemoved(priorEvents)
             is SuccessCriterion.PermanentsSacrificed -> evaluatePermanentsSacrificed(priorEvents)
+            is SuccessCriterion.TurnedFaceUp -> evaluateTurnedFaceUp(priorEvents)
         }
+
+        /**
+         * Did the gated action actually turn a permanent face up? Scans the action's own events for
+         * a [TurnFaceUpEvent]. `TurnFaceUpExecutor` emits one only when the permanent really flipped:
+         * a manifested/cloaked instant or sorcery card is revealed and left face down (CR 701.40g /
+         * 701.58g, a [CardsRevealedEvent] instead), and an already-face-up permanent produces no
+         * event at all. Both are the "you can't" case Etrata, Deadly Fugitive's fallback branch needs.
+         */
+        private fun evaluateTurnedFaceUp(priorEvents: List<GameEvent>): Boolean =
+            priorEvents.any { event -> event is TurnFaceUpEvent }
 
         /**
          * Did the gated action actually sacrifice something? Scans the action's own events for a

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GiveControlToTargetPlayerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GiveControlToTargetPlayerExecutor.kt
@@ -35,6 +35,14 @@ class GiveControlToTargetPlayerExecutor : EffectExecutor<GiveControlToTargetPlay
         val targetContainer = state.getEntity(targetId)
             ?: return EffectResult.error(state, "Target permanent no longer exists")
 
+        // CR 110.2a — only a permanent has a controller, so a target that has left the battlefield
+        // between targeting and resolution simply isn't affected (CR 608.2b). Silently, and with no
+        // ControlChangedEvent: `SuccessCriterion.ControlChanged` riders ("...gains control of target
+        // permanent you control. If they do, you draw a card") read that event to decide whether the
+        // control change really happened, so emitting one here would pay out for a permanent that is
+        // sitting in a graveyard.
+        if (targetId !in state.getBattlefield()) return EffectResult.success(state)
+
         val cardComponent = targetContainer.get<CardComponent>()
             ?: return EffectResult.error(state, "Target is not a card")
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -51,8 +51,13 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
             val container = state.getEntity(entityId) ?: continue
             val cardComponent = container.get<CardComponent>() ?: continue
 
-            // Face-down creatures have no abilities (Rule 708.2)
-            if (container.has<FaceDownComponent>()) continue
+            // A face-down permanent has no characteristics beyond those the rules that made it face
+            // down list (CR 708.2), so none of its *card's* abilities are offered. Abilities another
+            // effect grants it still are — those apply in Layer 6 to the object on the battlefield,
+            // not to the hidden card (Etrata, Deadly Fugitive grants face-down creatures you control
+            // a turn-up ability). Handled below by folding face-down into the same own-vs-granted
+            // split the lost-all-abilities case uses, so this is not an early `continue`.
+            val isFaceDown = container.has<FaceDownComponent>()
 
             // Activated abilities of permanents matching a PreventActivatedAbilities filter
             // (Cursed Totem etc.) can't be activated — applies to both mana and non-mana
@@ -103,12 +108,12 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
             val classLevelComponent = container.get<ClassLevelComponent>()
             val classLevel = classLevelComponent?.currentLevel
 
-            // If entity lost all abilities, suppress its own non-mana abilities
-            val ownNonManaAbilities = if (cardDef == null || projected.hasLostAllAbilities(entityId)) emptyList()
+            // If entity lost all abilities — or is face down — suppress its own non-mana abilities
+            val ownNonManaAbilities = if (cardDef == null || isFaceDown || projected.hasLostAllAbilities(entityId)) emptyList()
             else cardDef.script.effectiveActivatedAbilities(classLevel).filter { !it.isManaAbility && it.activateFromZone == Zone.BATTLEFIELD }
 
             // Generate level-up abilities for Class enchantments
-            val levelUpAbilities = if (cardDef != null && classLevelComponent != null && !projected.hasLostAllAbilities(entityId)) {
+            val levelUpAbilities = if (cardDef != null && classLevelComponent != null && !isFaceDown && !projected.hasLostAllAbilities(entityId)) {
                 generateClassLevelUpAbilities(cardDef, classLevelComponent)
             } else emptyList()
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ManaAbilityEnumerator.kt
@@ -55,8 +55,13 @@ class ManaAbilityEnumerator : ActionEnumerator {
             val container = state.getEntity(entityId) ?: continue
             val cardComponent = container.get<CardComponent>() ?: continue
 
-            // Face-down creatures have no abilities (Rule 708.2)
-            if (container.has<FaceDownComponent>()) continue
+            // A face-down permanent has no characteristics beyond those the rules that made it
+            // face down list (CR 708.2), so none of its *card's* mana abilities are offered — but
+            // a mana ability another effect grants it applies in Layer 6 to the object on the
+            // battlefield, not to the hidden card, and stays activatable. Folded into
+            // `ownManaAbilities` below rather than skipping the permanent outright, so this
+            // enumerator and `ActivatedAbilityEnumerator` answer the same rule the same way.
+            val isFaceDown = container.has<FaceDownComponent>()
 
             // PreventActivatedAbilities (Cursed Totem etc.) blocks mana abilities too —
             // per ruling, "Cursed Totem stops players from activating mana abilities of
@@ -94,6 +99,7 @@ class ManaAbilityEnumerator : ActionEnumerator {
 
             // If no card definition (e.g., tokens) and no granted/static/intrinsic mana abilities, skip
             if (cardDef == null && grantedManaAbilities.isEmpty() && staticManaAbilities.isEmpty() && intrinsicManaAbilities.isEmpty()) continue
+            if (isFaceDown && grantedManaAbilities.isEmpty() && staticManaAbilities.isEmpty()) continue
 
             // If entity lost all abilities, only granted/static abilities remain (own abilities
             // suppressed) — this includes intrinsic basic-land-subtype abilities: a Plains hit by
@@ -103,6 +109,7 @@ class ManaAbilityEnumerator : ActionEnumerator {
             // back to the intrinsic-subtype inference.
             val classLevel = container.get<com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent>()?.currentLevel
             val ownManaAbilities = when {
+                isFaceDown -> emptyList()
                 // Blood Moon / Zhao ("nonbasic lands are Mountains"): an effect that SET this
                 // land's basic types also grants the type's intrinsic mana ability (CR 305.7),
                 // which survives the same effect's ability removal — so the land still taps for


### PR DESCRIPTION
MKM's tail is 7 cards and every one of them needs engine work, so this is a smaller handful than usual: three cards, and the three engine gaps they turned up. MKM goes **269 → 272/276**.

## Cards

- **Coveted Falcon** — {1}{U}{U} Artifact Creature — Bird 1/4, flying, disguise {1}{U}. Attacks to take back a permanent you own but don't control; turned face up, gives any number of your permanents to an opponent and draws one card per permanent that *actually* changed control. "You own but don't control" is a composed `And(OwnedByYou, Not(ControlledByYou))` controller predicate; the gift is `ChosenTargets` → `ForEachInCollection` → the `SuccessCriterion.ControlChanged` gate Stiltzkin already uses, one draw per iteration.
- **Lazav, Wearer of Faces** — {U}{B} Legendary Creature — Shapeshifter Detective 2/3. Attack trigger exiles a graveyard card with `linkToSource` and investigates; sacrificing a Clue lets Lazav copy a creature card from that linked pile until end of turn. "Exiled with it" is Lazav's own pile, not the Clue's — the two abilities are a linked pair (CR 607) and a Clue token never exiles anything. Composes existing primitives only.
- **Etrata, Deadly Fugitive** — {1}{U}{B} Legendary Creature — Vampire Assassin 1/4. Grants face-down creatures you control a turn-up-or-exile-and-cast-free ability, and cloaks the top card of an opponent's library whenever an Assassin you control connects.

## Engine changes

**`SuccessCriterion.TurnedFaceUp`** — the one piece of new SDK vocabulary. "Turn this face up. **If you can't**, …" needs to know whether the turn-up happened; it isn't a zone move, so `Auto` can't infer it and `Always` would report success for the two cases the rules call failures (CR 701.40g / 701.58g's manifested-or-cloaked instant, and an already-face-up permanent). Reads a `TurnFaceUpEvent`, the same event-scan shape as `ControlChanged` / `CountersRemoved` / `PermanentsSacrificed`. Expressed as a gated-action failure branch rather than a "can this be turned face up?" condition, so the engine's turn-up legality isn't re-derived in a second place.

**Face-down permanents can hold granted abilities.** CR 708.2 strips a face-down permanent of its *card's* abilities. Three sites read that as "no abilities at all" and skipped the permanent outright — `ActivatedAbilityEnumerator`, `ManaAbilityEnumerator`, `ActivateAbilityHandler`. An ability another effect grants applies in Layer 6 to the object on the battlefield, not to the hidden card, so it survives. All three now fold face-down into the same own-vs-granted split they already ran for "has lost all abilities". The mana enumerator is fixed alongside so the two enumerators don't disagree about the same permanent.

**A control change to a permanent that has left the battlefield is now a no-op.** `GiveControlToTargetPlayerExecutor` added a Layer-2 effect and emitted a `ControlChangedEvent` for a target sitting in a graveyard. Only a permanent has a controller (CR 110.2a) and an illegal target isn't affected (CR 608.2b). The event is what bit: `SuccessCriterion.ControlChanged` reads it, and its own KDoc names this exact case as the one it must catch — it fired anyway. **This was a live bug in Stiltzkin, Moogle Merchant**, which drew a card for a permanent that died in response; Coveted Falcon is what surfaced it.

## Not in this PR

The other four MKM cards each need a multi-feature project, not a gap: **Urgent Necropsy** (dynamic amounts inside cost atoms *plus* a client cast-phase reorder), **Aurelia's Vindicator** (X in a turn-up cost), **A Killer Among Us** (hidden-information choices), **Kaya, Spirits' Justice** (batch-exile copy + per-player targeting).

Etrata needs new vocabulary, so by the house rule it would normally get its own PR. It's kept here at the user's request for one PR, with every card and every engine change in its own commit so any one of them can be reverted alone.

## Verification

`just test` green (full suite, 4m55s) — worth running rather than a narrower gate because the ability handler and both ability enumerators are shared by everything. `just build` green. `just check-card-printing` clean for all three. The re-blessed `MKM.json` snapshot is insertions only; no unrelated card moved.

14 new scenario tests across three files, one per card:
- Coveted Falcon: gift-and-draw, choosing zero, a target that left the battlefield drawing nothing, the attack steal, and an opponent's own permanent not being a legal target.
- Lazav: the linked exile actually landing on Lazav, the Clue sacrifice offering only creature cards from that pile, declining, and a noncreature pile offering nothing.
- Etrata: both branches of "if you can't" (cloaked creature flips; cloaked instant is exiled instead), an opponent's face-down creature not gaining the ability, and the cloak trigger firing for an Assassin but not for a Bear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
