### PR TITLE
Add Duplicant and Quicksilver Elemental (Mirrodin)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6601,15 +6601,42 @@ staticAbility {
   gainer. The dynamic, copy-from-other-permanents sibling of `GrantActivatedAbility`. Mana abilities
   are excluded unless `includeManaAbilities = true`. (Sharkey, Tyrant of the Shire — "Sharkey has all
   activated abilities of lands your opponents control except mana abilities")
-- `SpendAnyManaTypeForActivatedAbilities(filter)` — mana of any type can be spent to pay the mana
-  portion of the activated-ability costs of permanents matching `filter` (a `GroupFilter`; use
-  `GroupFilter.source()` for "this permanent's abilities"). Relaxes colored/hybrid/Phyrexian/colorless
-  pips to generic per CR 118.14 / 609.4b; non-mana cost components are untouched. Honored by both
-  affordability checks and the mana solver. `filter` is matched against the permanent whose ability
-  is being activated, so a battlefield filter scopes the permission to a class of permanents —
-  `GroupFilter.AllCreaturesYouControl` for "spend mana as though it were mana of any color to activate
-  abilities of creatures you control" (Agatha's Soul Cauldron). (Sharkey, Tyrant of the Shire — "Mana
-  of any type can be spent to activate Sharkey's abilities" → `GroupFilter.source()`.)
+- `SpendAnyManaTypeForActivatedAbilities(filter, substituteColor = null)` — relaxes the mana portion
+  of the activated-ability costs of permanents matching `filter` (a `GroupFilter`; use
+  `GroupFilter.source()` for "this permanent's abilities") per CR 118.14 / 609.4b. Non-mana cost
+  components are untouched, and both affordability checks and the mana solver honor it through the
+  single `relaxAbilityCostColorsIfAny` seam. `filter` is matched against the permanent whose ability
+  is being activated, so a battlefield filter scopes the permission to a class of permanents.
+  **Two strengths, chosen by `substituteColor`:**
+    - `null` (default) — "**mana of any type can be spent**": colored/hybrid/Phyrexian/colorless pips
+      all become generic. (Sharkey, Tyrant of the Shire → `GroupFilter.source()`; Agatha's Soul
+      Cauldron → `GroupFilter.AllCreaturesYouControl`.)
+    - a `Color` — "**you may spend [color] mana as though it were mana of any color**": only that
+      color gains the substitution, and only for *colored* requirements. Lowered by rewriting each
+      foreign colored pip into a hybrid with the substitute (`ManaCost.relaxColorsTo`), reusing the
+      existing hybrid payment path — so a gained `{2}{G}` still needs two generic and one mana that
+      is green **or** blue, and a red mana still can't pay it. Generic and `{C}` pips are untouched
+      (they aren't colored). (Quicksilver Elemental — "You may spend blue mana as though it were mana
+      of any color to pay the activation costs of this creature's abilities" →
+      `SpendAnyManaTypeForActivatedAbilities(GroupFilter.source(), Color.BLUE)`.)
+- `Effects.GainAllActivatedAbilitiesOf(donor, target = EffectTarget.Self, duration = EndOfTurn)` —
+  the **one-shot, resolution-time sibling** of `GainActivatedAbilitiesOfPermanents`: `target` gains
+  all activated abilities of the object `donor` names, for `duration`. Reach for it when the donor is
+  *picked as the ability resolves* (a target) rather than described by a filter the projector re-reads.
+  The set of abilities is **snapshotted on resolution** — the Havengul Lich ruling, "gains the
+  activated abilities of the card as it existed in the graveyard" — so the donor later changing,
+  gaining abilities, or leaving the battlefield does not change what the receiver has. Each gained
+  ability is granted with the **receiver** as its source (CR 113.7), which is the printed reminder
+  "(If any of the abilities use that creature's name, use this creature's name instead.)": a copied
+  `{T}` taps the receiver and a copied "deals damage equal to its power" reads the receiver's power.
+  Only abilities activatable from the battlefield are copied, **mana abilities included** (the printed
+  wording is "all activated abilities", with no "except mana abilities" clause) — they land in
+  `GameState.grantedActivatedAbilities`, which the enumerator, `ActivateAbilityHandler`, the land mana
+  inspector and the end-of-turn cleanup all already read. Repeated activations accumulate, and each
+  gained ability is re-stamped with a donor-derived `AbilityId` so two donors sharing a card definition
+  don't collapse into one (and a once-per-turn ability gained twice gets two budgets, per the ruling).
+  (Quicksilver Elemental — "{U}: This creature gains all activated abilities of target creature until
+  end of turn" → `Effects.GainAllActivatedAbilitiesOf(donor)`.)
 - `SpendAnyManaTypeForSpells(filter)` — the **spell-side sibling** of the above: the controller may
   spend mana of any type on the mana cost of spells matching `filter` (a `GameObjectFilter`), relaxing
   colored/hybrid/Phyrexian/colorless pips to generic per CR 118.14 / 609.4b. Scoped to spells cast by

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3204,6 +3204,15 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
   `Conditions.DiscardedCardMatches(filter)`) to test the discarded card's graveyard characteristics —
   the cost-referencing sibling of `EntityReference.Sacrificed` / `TappedAsCost`. Resolution-only. Used
   by Grab the Prize ("if the discarded card wasn't a land card, …").
+- `EffectTarget.LinkedExiledCard(index = 0)` — a card exiled *with* the source permanent (its
+  imprint / "exiled with this" pile, the same object `EntityReference.LinkedExiledCard` reads as a
+  value). **Dual-mode**: it resolves at resolution *and* during static-ability projection, because it
+  hangs off the source exactly like `Self`. That is what lets it gate a `ConditionalStaticAbility` on
+  the imprinted card — pair it with an `EntityMatches` (facade
+  `Conditions.LinkedExiledCardMatches(filter)`) for "as long as a card exiled with this creature is a
+  creature card, …" (Duplicant). The card is in exile, so the filter reads its printed
+  characteristics; an empty pile (imprint declined, or the card has left exile) reads false and the
+  gated static simply stops applying.
 - `EffectTarget.PlayerRef(...)` — a player slot; see the `Player` reference list below.
 
 **`Player` references** (multiplayer-safe vocabulary — there is deliberately no bare
@@ -5949,6 +5958,19 @@ staticAbility {
   **`filter` defaults to the source, not the attached creature** — unlike `ModifyStats` / `GrantKeyword`, which
   default to `attachedCreature()`. An Aura must pass `Filters.EnchantedCreature` explicitly or it silently makes
   *itself* the Knight and leaves the enchanted creature alone.
+- `HasCreatureTypesOf(source, retainedTypes = emptySet(), filter = GroupFilter.source())` — Layer 4
+  type-changing static that gives the group **the creature types of the object `source` names**,
+  replacing their own and leaving non-creature subtypes alone (CR 205.1b). `source` is an ordinary
+  `EntityReference`, so the same static reads a card exiled with this permanent
+  (`EntityReference.LinkedExiledCard()`) or anything else the evaluator can resolve; the set is
+  re-read on every projection pass, so the gainer's types track the referenced object live. Pair it
+  with `SetBasePowerToughnessDynamicStatic` fed `DynamicAmount.EntityProperty(source, Power/Toughness)`
+  for the full "has the power, toughness, and creature types of X" sentence, and gate both on
+  `Conditions.LinkedExiledCardMatches(...)` when the printed text does (Duplicant). `retainedTypes` is
+  the printed "It's still a Shapeshifter." rider — types the gainer keeps *in addition* to what it
+  copies; it is a field rather than a separate `GrantSubtype` because both would land in Layer 4 with
+  the same timestamp and the type set could silently wipe the add. When `source` resolves to nothing,
+  only `retainedTypes` remains.
 - `GrantChosenSubtype(filter, includeControlledSpells = false, includeOwnedCardsOutsideBattlefield = false)` — Layer 4
   type-changing static that adds the creature type **chosen as the source entered** (read from the source's
   `CastChoicesComponent`) to the group, in addition to their other types. Chosen-value counterpart to `GrantSubtype`,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/ManaCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/ManaCost.kt
@@ -300,6 +300,32 @@ data class ManaCost(val symbols: List<ManaSymbol>) {
     }
 
     /**
+     * Return a relaxed cost where every colored requirement of a color other than [substitute] may
+     * *also* be paid with [substitute] — the narrower "you may spend [color] mana as though it were
+     * mana of any color" relaxation (CR 609.4b), as opposed to [relaxColors]'s "mana of any type
+     * can be spent".
+     *
+     * Modelled by rewriting each `{C}`-style colored pip into a hybrid of its own color and
+     * [substitute]: `{G}` becomes `{G/U}` for Quicksilver Elemental's blue substitution, which is
+     * exactly "pay this with green or with blue" and needs no new payment path — the solver and
+     * affordability checks already understand hybrids (CR 118.7e).
+     *
+     * Deliberately narrower than [relaxColors] in three places, because the printed wording is:
+     * generic and `{C}` requirements are untouched (they are not *colored*), and hybrid/Phyrexian
+     * pips are left alone — each already offers a choice, and no printed card turns on widening one.
+     */
+    fun relaxColorsTo(substitute: Color): ManaCost {
+        if (symbols.none { it is ManaSymbol.Colored && it.color != substitute }) return this
+        return ManaCost(
+            symbols.map { symbol ->
+                if (symbol is ManaSymbol.Colored && symbol.color != substitute)
+                    ManaSymbol.Hybrid(symbol.color, substitute)
+                else symbol
+            }
+        )
+    }
+
+    /**
      * Return a relaxed cost where every colored, hybrid, phyrexian, and colorless requirement
      * is converted into generic mana — suitable for "mana of any type can be spent" effects
      * (e.g. Taster of Wares, Cruelclaw's Heist).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -2150,6 +2150,26 @@ object Conditions {
         EntityMatches(EffectTarget.DiscardedAsCost(index), filter)
 
     /**
+     * If the card exiled *with* this permanent — its imprint / "exiled with this" pile — matches
+     * [filter]. The card is in exile, so the filter is checked against its printed characteristics.
+     *
+     * **Dual-mode**: it answers the same at resolution and during static-ability projection, so it
+     * is the gate for a [com.wingedsheep.sdk.scripting.ConditionalStaticAbility] whose payoff reads
+     * the imprinted card — Duplicant's "as long as a card exiled with this creature is a creature
+     * card, this creature has the power, toughness, and creature types of it".
+     *
+     * False when nothing is exiled at [index]: the imprint was declined, or the card has since left
+     * exile. A gated static therefore stops applying on its own, with no card-level bookkeeping.
+     *
+     * @param index Which exiled card to test (defaults to the first/only one — Imprint exiles one).
+     */
+    fun LinkedExiledCardMatches(
+        filter: com.wingedsheep.sdk.scripting.GameObjectFilter,
+        index: Int = 0
+    ): ConditionInterface =
+        EntityMatches(EffectTarget.LinkedExiledCard(index), filter)
+
+    /**
      * If the spell that triggered this ability is the first spell matching [filter] you've cast
      * this turn. True iff the triggering spell matches [filter] and no second matching spell has
      * been cast yet. Composed from [TriggeringSpellMatches] + the [YouCastSpellsThisTurn] count

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1654,6 +1654,24 @@ object Effects {
     ): Effect = GrantStaticAbilityEffect(ability, target, duration)
 
     /**
+     * "[target] gains all activated abilities of [donor] until end of turn" — Quicksilver Elemental.
+     *
+     * The abilities are **snapshotted as this resolves** and granted with [target] as their source
+     * (CR 113.7), so `{T}` and self-references inside a copied ability bind to the permanent that
+     * gained it. Only activated abilities activatable from the battlefield are copied, mana
+     * abilities included. Use the static
+     * [com.wingedsheep.sdk.scripting.GainActivatedAbilitiesOfPermanents] instead when the donors are
+     * a *filter* re-read continuously (Sharkey, Marvin) rather than a target picked on resolution.
+     */
+    fun GainAllActivatedAbilitiesOf(
+        donor: EffectTarget,
+        target: EffectTarget = EffectTarget.Self,
+        duration: Duration = Duration.EndOfTurn
+    ): Effect = com.wingedsheep.sdk.scripting.effects.GainAllActivatedAbilitiesOfEffect(
+        donor = donor, target = target, duration = duration
+    )
+
+    /**
      * Grant a replacement effect to a target for a duration — the runtime sibling of a printed
      * [com.wingedsheep.sdk.scripting.ReplacementEffect]. Anchored to [target] (defaults to the
      * resolving source); the grant's controller is the target's controller. Currently honored by

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -793,25 +793,43 @@ data class GainActivatedAbilitiesOfPermanents(
 }
 
 /**
- * Mana of any type can be spent to activate the activated abilities of permanents matching
- * [filter] (CR 118.14 / 609.4b — colored, hybrid, Phyrexian, and colorless requirements in the
- * ability's cost may be paid with mana of any color or colorless).
+ * The mana requirements in the activated-ability costs of permanents matching [filter] are relaxed
+ * (CR 118.14 / 609.4b). Two printed strengths, chosen by [substituteColor]:
  *
- * Models Sharkey, Tyrant of the Shire ("Mana of any type can be spent to activate Sharkey's
- * abilities") with `filter = GroupFilter.source()`. The relaxation is applied to the mana
- * portion of the ability's cost only — non-mana cost components (tap, sacrifice, …) are
- * untouched — and is honored by both affordability checks and the mana solver at payment time.
+ *  - `substituteColor = null` — **"mana of any type can be spent"**: every colored, hybrid,
+ *    Phyrexian and colorless requirement may be paid with any mana at all. Sharkey, Tyrant of the
+ *    Shire ("Mana of any type can be spent to activate Sharkey's abilities") and Agatha's Soul
+ *    Cauldron, both with `filter = GroupFilter.source()` / a battlefield filter.
+ *  - a color — **"you may spend [color] mana as though it were mana of any color"**: only that one
+ *    color gains the substitution, and only for *colored* requirements. Quicksilver Elemental
+ *    ("You may spend blue mana as though it were mana of any color to pay the activation costs of
+ *    this creature's abilities") with `filter = GroupFilter.source(), substituteColor = Color.BLUE`.
+ *    Lowered by rewriting each foreign colored pip into a hybrid with the substitute
+ *    ([com.wingedsheep.sdk.core.ManaCost.relaxColorsTo]), so it reuses the existing hybrid payment
+ *    path rather than adding a second one. Generic and `{C}` requirements are untouched — they are
+ *    not colored.
  *
- * @property filter Which permanents' activated-ability mana costs may be paid with any mana
- *   type (use [GroupFilter.source] for "this permanent's abilities").
+ * Either way the relaxation applies to the mana portion of the ability's cost only — non-mana
+ * components (tap, sacrifice, …) are untouched — and is honored by both affordability checks and
+ * the mana solver at payment time, through the single `relaxAbilityCostColorsIfAny` seam.
+ *
+ * @property filter Which permanents' activated-ability mana costs are relaxed (use
+ *   [GroupFilter.source] for "this permanent's abilities").
+ * @property substituteColor When set, only mana of this color may be spent as though it were mana
+ *   of any color. Null (the default) is the stronger "mana of any type can be spent".
  */
 @SerialName("SpendAnyManaTypeForActivatedAbilities")
 @Serializable
 data class SpendAnyManaTypeForActivatedAbilities(
-    val filter: GroupFilter
+    val filter: GroupFilter,
+    val substituteColor: com.wingedsheep.sdk.core.Color? = null
 ) : StaticAbility {
     override val description: String =
-        "Mana of any type can be spent to activate ${filter.description}'s abilities"
+        if (substituteColor == null)
+            "Mana of any type can be spent to activate ${filter.description}'s abilities"
+        else
+            "You may spend ${substituteColor.name.lowercase()} mana as though it were mana of any " +
+                "color to pay the activation costs of ${filter.description}'s abilities"
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
         val newFilter = filter.applyTextReplacement(replacer)
         return if (newFilter !== filter) copy(filter = newFilter) else this

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TypeStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TypeStaticAbilities.kt
@@ -103,6 +103,54 @@ data class IsAllCreatureTypes(
 }
 
 /**
+ * The permanents matching [filter] **have the creature types of the object [source] names**,
+ * replacing their own (CR 205.1b) while keeping every non-creature subtype.
+ *
+ * The type half of the "copy some characteristics of another object" family: [source] is an
+ * ordinary [com.wingedsheep.sdk.scripting.values.EntityReference], so the same static reads a card
+ * exiled with this permanent (`LinkedExiledCard()` — Duplicant), the source itself, or any other
+ * reference the evaluator can resolve. Pair it with
+ * [SetBasePowerToughnessDynamicStatic] fed `DynamicAmount.EntityProperty(source, Power/Toughness)`
+ * for the full "has the power, toughness, and creature types of X" sentence.
+ *
+ * This is a Layer 4 (TYPE) continuous effect, re-read on every projection pass — so the gainer's
+ * types track the referenced object live (Duplicant's ruling: "constantly updated if the exiled
+ * card's power and/or toughness change" applies to its types too). When [source] resolves to
+ * nothing, or the object it names has no creature types, only [retainedTypes] remains.
+ *
+ * [retainedTypes] is the printed "It's still a Shapeshifter." rider — types the gainer keeps
+ * *in addition* to the ones it copies. It exists as a field rather than a separate
+ * [GrantSubtype] static because both would land in Layer 4 with the same timestamp, and a
+ * `SetCreatureSubtypes` applied after an `AddSubtype` would silently wipe it.
+ *
+ * @property source The object whose creature types are copied.
+ * @property retainedTypes Creature types the gainer keeps regardless of what it copies.
+ * @property filter Which permanents gain the types (defaults to the source permanent itself).
+ */
+@SerialName("HasCreatureTypesOf")
+@Serializable
+data class HasCreatureTypesOf(
+    val source: com.wingedsheep.sdk.scripting.values.EntityReference,
+    val retainedTypes: Set<String> = emptySet(),
+    val filter: GroupFilter = GroupFilter.source()
+) : StaticAbility {
+    override val description: String = buildString {
+        append("${filter.description} has the creature types of ${source.description}")
+        if (retainedTypes.isNotEmpty()) {
+            append(". It's still ")
+            append(retainedTypes.sorted().joinToString(" and ") { "a $it" })
+        }
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        val newRetained = retainedTypes.map { replacer.replaceCreatureType(it) }.toSet()
+        return if (newFilter !== filter || newRetained != retainedTypes)
+            copy(filter = newFilter, retainedTypes = newRetained) else this
+    }
+}
+
+/**
  * Adds a card type (e.g., "CREATURE") to the target permanent, in addition to its other types.
  * Used for Spacecraft Station mechanic: "It's an artifact creature at 7+."
  *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/EntityMatchesCondition.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/EntityMatchesCondition.kt
@@ -38,6 +38,11 @@ import kotlinx.serialization.Serializable
  * - [EffectTarget.DiscardedAsCost] — a card discarded to pay this spell's additional discard cost;
  *   **resolution-only**, matched against that card's graveyard characteristics (CR 608.2), where it
  *   lives by the time the spell resolves (Grab the Prize, via `Conditions.DiscardedCardMatches`).
+ * - [EffectTarget.LinkedExiledCard] — a card exiled with the source (its imprint / "exiled with
+ *   this" pile); **dual-mode**, matched against that card's printed characteristics in exile. This
+ *   is what lets a [com.wingedsheep.sdk.scripting.ConditionalStaticAbility] be gated on the
+ *   imprinted card ("as long as a card exiled with this creature is a creature card" — Duplicant,
+ *   via `Conditions.LinkedExiledCardMatches`).
  *
  * Deliberately **not**: a player check (use `Conditions.TargetIsPlayer`) nor a numeric/tracker
  * check (use `Compare` over a `DynamicAmount`). Entity roles other than those listed above are
@@ -63,6 +68,8 @@ data class EntityMatches(
             "if it's ${filter.description.ifEmpty { "a matching" }} spell"
         is EffectTarget.DiscardedAsCost ->
             "if the discarded card is ${filter.description}"
+        is EffectTarget.LinkedExiledCard ->
+            "as long as the exiled card is ${filter.description}"
         else -> "if ${entity.description} matches ${filter.description}"
     }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/KeywordAndAbilityEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/KeywordAndAbilityEffects.kt
@@ -159,6 +159,53 @@ data class GrantActivatedAbilityEffect(
 }
 
 /**
+ * The permanent [target] names **gains all activated abilities of the object [donor] names**, for
+ * [duration].
+ *
+ * The one-shot, resolution-time sibling of
+ * [com.wingedsheep.sdk.scripting.GainActivatedAbilitiesOfPermanents] (a static that re-reads its
+ * donor set every projection) and of [GrantActivatedAbilityEffect] (which grants one *authored*
+ * ability). Here the donor is picked at resolution — usually a target — so the abilities can't be
+ * written into the card:
+ *  - Quicksilver Elemental: `{U}: This creature gains all activated abilities of target creature
+ *    until end of turn.` → `GainAllActivatedAbilitiesOfEffect(donor = ContextTarget(0))`.
+ *  - Grell Philosopher / Havengul Lich are the same shape with a different donor and receiver.
+ *
+ * **The set of abilities is snapshotted when this resolves**, per the Havengul Lich ruling
+ * ("gains the activated abilities of the card *as it existed in the graveyard*"): the donor
+ * changing, leaving the battlefield, or gaining abilities afterwards does not change what the
+ * receiver has. That is the difference from the static sibling, and the reason this is an effect
+ * rather than a `GrantStaticAbility` carrying one.
+ *
+ * Each gained ability is granted with the **receiver** as its source (CR 113.7), so `{T}`,
+ * `SacrificeSelf` and "this creature" inside a copied ability bind to the permanent that gained it
+ * — the printed reminder "(If any of the abilities use that creature's name, use this creature's
+ * name instead.)".
+ *
+ * It grants only *activated* abilities — never triggered, static, or keyword abilities (unless the
+ * keyword is itself modelled as an activated ability), and only those activatable from the
+ * battlefield. Mana abilities **are** included: the printed wording is "all activated abilities",
+ * with no "except mana abilities" clause.
+ *
+ * @property donor The object whose activated abilities are copied.
+ * @property target The permanent that gains them (defaults to the source itself).
+ * @property duration How long the gain lasts.
+ */
+@SerialName("GainAllActivatedAbilitiesOf")
+@Serializable
+data class GainAllActivatedAbilitiesOfEffect(
+    val donor: EffectTarget,
+    val target: EffectTarget = EffectTarget.Self,
+    val duration: Duration = Duration.EndOfTurn
+) : Effect, SelfReferentialDescription {
+    override val descriptionTemplate: String = buildString {
+        append("${target.selfNounToken} gains all activated abilities of ${donor.description}")
+        if (duration.description.isNotEmpty()) append(" ${duration.description}")
+    }
+    override val description: String get() = defaultResolvedDescription
+}
+
+/**
  * Grant Harmonize (CR 702.180) to a target instant or sorcery card in a graveyard.
  * "Target instant or sorcery card in your graveyard gains harmonize until end of turn. Its
  * harmonize cost is equal to its mana cost." — Songcrafter Mage.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/EffectTarget.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/EffectTarget.kt
@@ -264,6 +264,33 @@ sealed interface EffectTarget {
     }
 
     /**
+     * LINKED EXILED CARD: a card exiled *with* the source permanent — its `LinkedExileComponent`,
+     * the pile every imprint / "exiled with this" mechanic writes. This is the [EffectTarget] role
+     * counterpart of [com.wingedsheep.sdk.scripting.values.EntityReference.LinkedExiledCard], which
+     * is the *value-read* spelling of the same object (`EntityProperty(LinkedExiledCard(), Power)`).
+     *
+     * **Dual-mode** — resolvable at resolution *and* during static-ability projection, because it
+     * is anchored to the source permanent exactly like [Self] and needs no resolution context. That
+     * is what makes it usable as the entity of an
+     * [com.wingedsheep.sdk.scripting.conditions.EntityMatches] gating a
+     * [com.wingedsheep.sdk.scripting.ConditionalStaticAbility] — Duplicant's "as long as a card
+     * exiled with this creature is a creature card", built via
+     * `Conditions.LinkedExiledCardMatches(filter)`.
+     *
+     * Resolves to nothing when the source has no linked-exile pile (the imprint was declined, or
+     * the card has since left exile), so a condition over it reads false and the gated static
+     * simply stops applying.
+     *
+     * @property index Which exiled card to reference. Imprint exiles exactly one card, so this is a
+     *   completeness parameter rather than something Mirrodin's cards need.
+     */
+    @SerialName("LinkedExiledCard")
+    @Serializable
+    data class LinkedExiledCard(val index: Int = 0) : EffectTarget {
+        override val description: String = "the exiled card"
+    }
+
+    /**
      * CONTROLLER OF DAMAGE SOURCE: the controller of the source dealing the damage
      * currently being processed. Only meaningful inside a damage replacement
      * (e.g. [com.wingedsheep.sdk.scripting.RedirectDamage]); resolved by the damage

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -1168,6 +1168,7 @@ object CardLinter {
         "ContextTarget",
         "TriggeringEntity",
         "DiscardedAsCost",
+        "LinkedExiledCard",
     )
 
     /** Records this node's dataflow accesses and target references (not its children). */

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Duplicant.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Duplicant.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.HasCreatureTypesOf
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessDynamicStatic
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Duplicant — Mirrodin #165
+ * {6} · Artifact Creature — Shapeshifter · Rare · 2/4
+ *
+ * Imprint — When this creature enters, you may exile target nontoken creature.
+ * As long as a card exiled with this creature is a creature card, this creature has the power,
+ * toughness, and creature types of the last creature card exiled with it. It's still a Shapeshifter.
+ *
+ * Modelling notes:
+ * - The two halves are a *linked* pair (CR 607): `Effects.ExileLinkedToSource` writes the pile and
+ *   both statics read it through [EntityReference.LinkedExiledCard]. The exiled *card* is what is
+ *   read — not the permanent that was exiled — so a creature that dies out of exile, or an imprint
+ *   the controller declined, simply leaves Duplicant a printed 2/4 Shapeshifter.
+ * - "As long as a card exiled with this creature is a creature card" is the gate, not a card-level
+ *   flag: `Conditions.LinkedExiledCardMatches(Filters.Creature)` is dual-mode, so the projector
+ *   re-asks it every pass and both halves switch on and off together.
+ * - Two statics rather than one because the sentence spans two Rule 613 layers: the creature types
+ *   are Layer 4 ([HasCreatureTypesOf]) and the P/T is Layer 7b
+ *   ([SetBasePowerToughnessDynamicStatic] fed `EntityProperty(LinkedExiledCard, Power/Toughness)`).
+ *   Both are dynamic, which is what the ruling "Duplicant's power and toughness are constantly
+ *   updated if the exiled card's power and/or toughness change" requires — a snapshot taken at ETB
+ *   would be wrong.
+ * - Setting *base* P/T is also what makes the second ruling fall out for free: counters and other
+ *   P/T modifiers still apply on top, because Layer 7b runs before 7c/7d.
+ * - `retainedTypes = {"Shapeshifter"}` is the printed "It's still a Shapeshifter." rider. It rides
+ *   on the type static rather than a separate `GrantSubtype`, which would land in the same layer
+ *   with the same timestamp and could be wiped by the type set.
+ */
+val Duplicant = card("Duplicant") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Shapeshifter"
+    power = 2
+    toughness = 4
+    oracleText = "Imprint — When this creature enters, you may exile target nontoken creature.\n" +
+        "As long as a card exiled with this creature is a creature card, this creature has the " +
+        "power, toughness, and creature types of the last creature card exiled with it. It's " +
+        "still a Shapeshifter."
+
+    // "Imprint — When this creature enters, you may exile target nontoken creature."
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val exiled = target(
+            "target nontoken creature",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.nontoken()))
+        )
+        effect = Effects.ExileLinkedToSource(exiled)
+        description = "Imprint — When this creature enters, you may exile target nontoken creature."
+    }
+
+    // "... this creature has the ... creature types of the last creature card exiled with it.
+    //  It's still a Shapeshifter."
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = HasCreatureTypesOf(
+                source = EntityReference.LinkedExiledCard(),
+                retainedTypes = setOf("Shapeshifter")
+            ),
+            condition = Conditions.LinkedExiledCardMatches(Filters.Creature)
+        )
+    }
+
+    // "... this creature has the power, toughness ... of the last creature card exiled with it."
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = SetBasePowerToughnessDynamicStatic(
+                power = DynamicAmount.EntityProperty(
+                    EntityReference.LinkedExiledCard(),
+                    EntityNumericProperty.Power
+                ),
+                toughness = DynamicAmount.EntityProperty(
+                    EntityReference.LinkedExiledCard(),
+                    EntityNumericProperty.Toughness
+                )
+            ),
+            condition = Conditions.LinkedExiledCardMatches(Filters.Creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "165"
+        artist = "Thomas M. Baxa"
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d48a96f2-738f-433f-bfae-fbf378832a3b.jpg?1783944522"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/QuicksilverElemental.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/QuicksilverElemental.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.SpendAnyManaTypeForActivatedAbilities
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Quicksilver Elemental — Mirrodin #47
+ * {3}{U}{U} · Creature — Elemental · Rare · 3/4
+ *
+ * {U}: This creature gains all activated abilities of target creature until end of turn.
+ * (If any of the abilities use that creature's name, use this creature's name instead.)
+ * You may spend blue mana as though it were mana of any color to pay the activation costs of
+ * this creature's abilities.
+ *
+ * Modelling notes:
+ * - The first ability is [Effects.GainAllActivatedAbilitiesOf] with the target as the donor and the
+ *   default `EffectTarget.Self` as the receiver. The set of abilities is snapshotted as the ability
+ *   resolves, so the target later gaining abilities or leaving the battlefield changes nothing —
+ *   the reading the Havengul Lich ruling pins for this wording. That is also why it is an effect
+ *   rather than the continuously re-read static `GainActivatedAbilitiesOfPermanents` (Sharkey,
+ *   Marvin).
+ * - Each gained ability is granted with Quicksilver Elemental as its source (CR 113.7), which *is*
+ *   the parenthetical reminder: a copied "Sacrifice a creature: Nantuko Husk gets +2/+2" sacrifices
+ *   to, and pumps, the Elemental.
+ * - "You can activate the ability more than once, collecting abilities from multiple creatures (or
+ *   the same creature more than once)" falls out of the grants simply accumulating, and the
+ *   executor's donor-derived ability ids keep two donors that share a card definition from
+ *   collapsing into one gained ability.
+ * - The second ability is the *narrow* arm of [SpendAnyManaTypeForActivatedAbilities]: only blue
+ *   mana is substitutable, and only for colored requirements ("as though it were mana of any
+ *   **color**"), so a gained `{2}{G}` ability still needs two generic from anywhere and one mana
+ *   that is green or blue. `GroupFilter.source()` scopes it to "this creature's abilities", which
+ *   covers the gained ones because a granted ability's source is the permanent that has it.
+ */
+val QuicksilverElemental = card("Quicksilver Elemental") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental"
+    power = 3
+    toughness = 4
+    oracleText = "{U}: This creature gains all activated abilities of target creature until end of " +
+        "turn. (If any of the abilities use that creature's name, use this creature's name " +
+        "instead.)\n" +
+        "You may spend blue mana as though it were mana of any color to pay the activation costs " +
+        "of this creature's abilities."
+
+    // "{U}: This creature gains all activated abilities of target creature until end of turn."
+    activatedAbility {
+        cost = Costs.Mana("{U}")
+        val donor = target("target creature", Targets.Creature)
+        effect = Effects.GainAllActivatedAbilitiesOf(donor)
+        description = "{U}: This creature gains all activated abilities of target creature until end of turn."
+    }
+
+    // "You may spend blue mana as though it were mana of any color to pay the activation costs of
+    //  this creature's abilities."
+    staticAbility {
+        ability = SpendAnyManaTypeForActivatedAbilities(
+            filter = GroupFilter.source(),
+            substituteColor = Color.BLUE
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "47"
+        artist = "Tony Szczudlo"
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/2905f6ac-d054-454b-8e1a-9c32db13a581.jpg?1783944552"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DuplicantScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DuplicantScenarioTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.Bonesplitter
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.Duplicant
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.MarchOfTheMachines
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Duplicant (MRD #165) — "Imprint — When this creature enters, you may exile target nontoken
+ * creature. As long as a card exiled with this creature is a creature card, this creature has the
+ * power, toughness, and creature types of the last creature card exiled with it. It's still a
+ * Shapeshifter."
+ *
+ * Both halves of the second sentence are dynamic reads of the linked-exile pile, so what these
+ * tests pin is that the gate and the two layers agree:
+ *  - an imprinted creature card replaces Duplicant's P/T (Layer 7b) *and* its creature types
+ *    (Layer 4), while Shapeshifter survives;
+ *  - the P/T is a *base* set, so counters still apply on top (the printed ruling);
+ *  - declining the imprint leaves the printed 2/4 Shapeshifter — the dynamic read fails closed;
+ *  - the gate reads the exiled **card**, not the permanent that was exiled: a noncreature artifact
+ *    animated by March of the Machines is a legal target, but the card in exile is not a creature
+ *    card, so neither half applies.
+ */
+class DuplicantScenarioTest : FunSpec({
+
+    val allTestCards = TestCards.all
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(allTestCards + Duplicant + MarchOfTheMachines + Bonesplitter)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /**
+     * Cast Duplicant from hand so the imprint trigger fires, choose [victim] as its target (when
+     * given the choice) and answer the "you may" with [accept]. Returns Duplicant on the
+     * battlefield. Both decisions are handled by whichever arrives first — an optional trigger that
+     * also targets asks for consent and for the target in an order the harness shouldn't assume.
+     */
+    fun GameTestDriver.castDuplicant(victim: EntityId, accept: Boolean): EntityId {
+        val inHand = putCardInHand(player1, "Duplicant")
+        giveColorlessMana(player1, 6)
+        castSpell(player1, inHand).error shouldBe null
+
+        repeat(12) {
+            when (state.pendingDecision) {
+                null -> bothPass()
+                is ChooseTargetsDecision ->
+                    submitTargetSelection(player1, listOf(victim)).error shouldBe null
+                is YesNoDecision -> submitYesNo(player1, accept).error shouldBe null
+                else -> error("unexpected decision ${state.pendingDecision}")
+            }
+        }
+        return findPermanent(player1, "Duplicant")!!
+    }
+
+    test("an imprinted creature card lends Duplicant its power, toughness, and creature types") {
+        val d = driver()
+        val courser = d.putCreatureOnBattlefield(d.player2, "Centaur Courser") // 3/3 Centaur Warrior
+        val duplicant = d.castDuplicant(courser, accept = true)
+
+        withClue("the Courser was exiled with Duplicant") {
+            d.getExileCardNames(d.player2) shouldBe listOf("Centaur Courser")
+        }
+        withClue("Layer 7b: base P/T comes from the exiled card, not the printed 2/4") {
+            d.state.projectedState.getPower(duplicant) shouldBe 3
+            d.state.projectedState.getToughness(duplicant) shouldBe 3
+        }
+        withClue("Layer 4: the exiled card's creature types replace Duplicant's, and it's still a Shapeshifter") {
+            d.state.projectedState.getSubtypes(duplicant) shouldBe setOf("Centaur", "Warrior", "Shapeshifter")
+        }
+    }
+
+    test("the copied P/T is a base set, so counters still apply on top of it") {
+        val d = driver()
+        val courser = d.putCreatureOnBattlefield(d.player2, "Centaur Courser")
+        val duplicant = d.castDuplicant(courser, accept = true)
+        d.addComponent(duplicant, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+
+        withClue("3/3 from the exiled card in Layer 7b, +1/+1 from the counter in Layer 7d") {
+            d.state.projectedState.getPower(duplicant) shouldBe 4
+            d.state.projectedState.getToughness(duplicant) shouldBe 4
+        }
+    }
+
+    test("declining the imprint leaves the printed 2/4 Shapeshifter") {
+        val d = driver()
+        val courser = d.putCreatureOnBattlefield(d.player2, "Centaur Courser")
+        val duplicant = d.castDuplicant(courser, accept = false)
+
+        withClue("nothing was exiled") {
+            d.getExileCardNames(d.player2) shouldBe emptyList()
+        }
+        withClue("an empty pile means the gate is false and neither half applies") {
+            d.state.projectedState.getPower(duplicant) shouldBe 2
+            d.state.projectedState.getToughness(duplicant) shouldBe 4
+            d.state.projectedState.getSubtypes(duplicant) shouldBe setOf("Shapeshifter")
+        }
+    }
+
+    test("an animated noncreature artifact is a legal target, but its card isn't a creature card") {
+        val d = driver()
+        d.putPermanentOnBattlefield(d.player2, "March of the Machines")
+        val bonesplitter = d.putPermanentOnBattlefield(d.player2, "Bonesplitter")
+
+        withClue("March makes the Equipment a creature, so Duplicant can target it") {
+            d.state.projectedState.isCreature(bonesplitter) shouldBe true
+        }
+
+        val duplicant = d.castDuplicant(bonesplitter, accept = true)
+
+        withClue("it really was exiled") {
+            d.getExileCardNames(d.player2) shouldBe listOf("Bonesplitter")
+        }
+        withClue(
+            "\"as long as a card exiled with this creature is a creature card\" reads the card in " +
+                "exile, where March's animation no longer reaches — so Duplicant stays a 2/4 Shapeshifter"
+        ) {
+            d.state.projectedState.getPower(duplicant) shouldBe 2
+            d.state.projectedState.getToughness(duplicant) shouldBe 4
+            d.state.projectedState.getSubtypes(duplicant) shouldBe setOf("Shapeshifter")
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/QuicksilverElementalScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/QuicksilverElementalScenarioTest.kt
@@ -1,0 +1,169 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.QuicksilverElemental
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.SpikeshotGoblin
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Quicksilver Elemental (MRD #47) — "{U}: This creature gains all activated abilities of target
+ * creature until end of turn. You may spend blue mana as though it were mana of any color to pay
+ * the activation costs of this creature's abilities."
+ *
+ * What the rulings actually require, and what each test pins:
+ *  - "The granted abilities effectively use 'this permanent'" — a gained `{R}, {T}: deals damage
+ *    equal to its power` taps the *Elemental* and deals the *Elemental's* 3, not the Goblin's 1.
+ *  - The gain is snapshotted on resolution (the Havengul Lich wording), so the donor dying
+ *    afterwards doesn't take the ability back.
+ *  - Mana abilities count as activated abilities, so a gained "{T}: Add {G}" really produces mana.
+ *  - "You can activate the ability more than once, collecting abilities from multiple creatures" —
+ *    grants accumulate rather than replace.
+ *  - The blue substitution is "as though it were mana of any **color**", *not* "mana of any type":
+ *    blue pays a gained `{R}`, and green does not.
+ *  - "Until end of turn" — the grants are gone next turn.
+ */
+class QuicksilverElementalScenarioTest : FunSpec({
+
+    val gainAbility = QuicksilverElemental.activatedAbilities.single().id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + QuicksilverElemental + SpikeshotGoblin)
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** The Elemental on the battlefield, ready to use `{T}` abilities. */
+    fun GameTestDriver.elemental(): EntityId =
+        putCreatureOnBattlefield(player1, "Quicksilver Elemental").also { removeSummoningSickness(it) }
+
+    /** Pay {U} and resolve "gains all activated abilities of [donor]". */
+    fun GameTestDriver.gainAbilitiesOf(elemental: EntityId, donor: EntityId) {
+        giveMana(player1, Color.BLUE, 1)
+        submit(
+            ActivateAbility(player1, elemental, gainAbility, targets = listOf(ChosenTarget.Permanent(donor)))
+        ).error shouldBe null
+        bothPass()
+    }
+
+    /** The ids of the activated abilities currently granted to [entityId]. */
+    fun GameTestDriver.gainedAbilityIds(entityId: EntityId): List<AbilityId> =
+        state.grantedActivatedAbilities.filter { it.entityId == entityId }.map { it.ability.id }
+
+    test("a gained ability binds to the Elemental: it taps the Elemental and uses the Elemental's power") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        val elemental = d.elemental()
+        val goblin = d.putCreatureOnBattlefield(d.player2, "Spikeshot Goblin") // 1/2, {R}, {T}
+        d.gainAbilitiesOf(elemental, goblin)
+
+        val gained = d.gainedAbilityIds(elemental).single()
+        withClue("the gain is offered as a legal action, not just accepted by the handler — the " +
+            "client and the AI only ever see what the enumerator produces") {
+            d.giveMana(d.player1, Color.RED, 1)
+            d.legalActions(d.player1)
+                .map { it.action }
+                .filterIsInstance<ActivateAbility>()
+                .any { it.sourceId == elemental && it.abilityId == gained } shouldBe true
+        }
+        d.submit(
+            ActivateAbility(d.player1, elemental, gained, targets = listOf(ChosenTarget.Player(opponent)))
+        ).error shouldBe null
+        d.bothPass()
+
+        withClue("\"deals damage equal to its power\" is the Elemental's 3, not the Goblin's 1") {
+            d.getLifeTotal(opponent) shouldBe 17
+        }
+        withClue("the {T} in the copied cost taps the permanent that gained it") {
+            d.isTapped(elemental) shouldBe true
+            d.isTapped(goblin) shouldBe false
+        }
+    }
+
+    test("blue mana pays a gained {R}, but green mana does not") {
+        val d = driver()
+        val opponent = d.getOpponent(d.player1)
+        val elemental = d.elemental()
+        val goblin = d.putCreatureOnBattlefield(d.player2, "Spikeshot Goblin")
+        d.gainAbilitiesOf(elemental, goblin)
+        val gained = d.gainedAbilityIds(elemental).single()
+
+        withClue("green can't pay a gained {R}: the relaxation widens colors via blue, not to generic") {
+            d.giveMana(d.player1, Color.GREEN, 1)
+            d.submit(
+                ActivateAbility(d.player1, elemental, gained, targets = listOf(ChosenTarget.Player(opponent)))
+            ).error shouldNotBe null
+            d.stackSize shouldBe 0
+        }
+
+        withClue("blue does, because \"you may spend blue mana as though it were mana of any color\"") {
+            d.giveMana(d.player1, Color.BLUE, 1)
+            d.submit(
+                ActivateAbility(d.player1, elemental, gained, targets = listOf(ChosenTarget.Player(opponent)))
+            ).error shouldBe null
+            d.bothPass()
+            d.getLifeTotal(opponent) shouldBe 17
+        }
+    }
+
+    test("the gain is snapshotted: the donor dying afterwards doesn't take the ability back") {
+        val d = driver()
+        val elemental = d.elemental()
+        val goblin = d.putCreatureOnBattlefield(d.player2, "Spikeshot Goblin")
+        d.gainAbilitiesOf(elemental, goblin)
+        d.gainedAbilityIds(elemental).size shouldBe 1
+
+        d.moveToGraveyard(goblin)
+
+        withClue("\"gains the activated abilities of the card as it existed\" — the grant is a snapshot") {
+            d.gainedAbilityIds(elemental).size shouldBe 1
+        }
+    }
+
+    test("a gained mana ability really produces mana") {
+        val d = driver()
+        val elemental = d.elemental()
+        val elves = d.putCreatureOnBattlefield(d.player1, "Llanowar Elves") // {T}: Add {G}
+        d.gainAbilitiesOf(elemental, elves)
+
+        val gained = d.gainedAbilityIds(elemental).single()
+        d.submit(ActivateAbility(d.player1, elemental, gained)).error shouldBe null
+
+        withClue("mana abilities are activated abilities, so \"all activated abilities\" includes them") {
+            d.state.getEntity(d.player1)?.get<ManaPoolComponent>()?.green shouldBe 1
+            d.isTapped(elemental) shouldBe true
+        }
+    }
+
+    test("activating twice collects from both creatures, and everything expires at end of turn") {
+        val d = driver()
+        val elemental = d.elemental()
+        val goblin = d.putCreatureOnBattlefield(d.player2, "Spikeshot Goblin")
+        val elves = d.putCreatureOnBattlefield(d.player1, "Llanowar Elves")
+        d.gainAbilitiesOf(elemental, goblin)
+        d.gainAbilitiesOf(elemental, elves)
+
+        withClue("grants accumulate — \"you can activate the ability more than once\"") {
+            d.gainedAbilityIds(elemental).size shouldBe 2
+            d.gainedAbilityIds(elemental).distinct().size shouldBe 2
+        }
+
+        d.passPriorityUntil(Step.UPKEEP)
+        withClue("until end of turn") {
+            d.gainedAbilityIds(elemental) shouldBe emptyList()
+        }
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/DuplicantReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/DuplicantReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Duplicant reprint in Archenemy. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Mirrodin (`mrd`) — earliest real printing; this file contributes only
+ * presentation data.
+ */
+val DuplicantReprint = Printing(
+    oracleId = "ea86abfa-6cab-4ef0-8463-34136fc25b59",
+    name = "Duplicant",
+    setCode = "ARC",
+    collectorNumber = "106",
+    scryfallId = "653fa830-5cd0-4798-94be-e7644f462c26",
+    artist = "Thomas M. Baxa",
+    imageUri = "https://cards.scryfall.io/normal/front/6/5/653fa830-5cd0-4798-94be-e7644f462c26.jpg?1783941892",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -10363,6 +10363,68 @@
     ]
 }
 
+// Quicksilver Elemental
+{
+    "name": "Quicksilver Elemental",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "{U}: This creature gains all activated abilities of target creature until end of turn. (If any of the abilities use that creature's name, use this creature's name instead.)\nYou may spend blue mana as though it were mana of any color to pay the activation costs of this creature's abilities.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
+                },
+                "effect": {
+                    "type": "GainAllActivatedAbilitiesOf",
+                    "donor": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "{U}: This creature gains all activated abilities of target creature until end of turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "SpendAnyManaTypeForActivatedAbilities",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "substituteColor": "BLUE"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "47",
+        "rarity": "RARE",
+        "artist": "Tony Szczudlo",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/2905f6ac-d054-454b-8e1a-9c32db13a581.jpg?1783944552"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Quicksilver Fountain
 {
     "name": "Quicksilver Fountain",

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -2881,6 +2881,95 @@
     "colorIdentityOverride": []
 }
 
+// Duplicant
+{
+    "name": "Duplicant",
+    "manaCost": "{6}",
+    "typeLine": "Artifact Creature — Shapeshifter",
+    "oracleText": "Imprint — When this creature enters, you may exile target nontoken creature.\nAs long as a card exiled with this creature is a creature card, this creature has the power, toughness, and creature types of the last creature card exiled with it. It's still a Shapeshifter.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target nontoken creature"
+                        },
+                        "destination": "Exile",
+                        "linkToSource": true
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature nontoken"
+                    },
+                    "id": "target nontoken creature"
+                },
+                "descriptionOverride": "Imprint — When this creature enters, you may exile target nontoken creature."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "HasCreatureTypesOf",
+                    "source": "LinkedExiledCard",
+                    "retainedTypes": [
+                        "Shapeshifter"
+                    ]
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "LinkedExiledCard",
+                    "filter": "creature"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "SetBasePowerToughnessDynamicStatic",
+                    "power": {
+                        "type": "EntityProperty",
+                        "entity": "LinkedExiledCard",
+                        "numericProperty": "Power"
+                    },
+                    "toughness": {
+                        "type": "EntityProperty",
+                        "entity": "LinkedExiledCard",
+                        "numericProperty": "Toughness"
+                    }
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "LinkedExiledCard",
+                    "filter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "RARE",
+        "artist": "Thomas M. Baxa",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d48a96f2-738f-433f-bfae-fbf378832a3b.jpg?1783944522"
+    },
+    "colorIdentityOverride": []
+}
+
 // Duskworker
 {
     "name": "Duskworker",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
@@ -116,6 +116,13 @@ internal fun BridgeBuilder.damageLifeAndCards() {
     // Goblin Piledriver / Shaleskin Bruiser) all realise as a ModifyStatsEffect.
     effects("AdjustPT", "AdjustPTX", "AdjustPTForEach", tag = "ModifyStats")
     effect("AddAbility", "GrantKeyword")
+    // "gains all activated abilities of [that permanent]" — the layer effect that copies another
+    // object's activated abilities wholesale rather than granting an authored one. Quicksilver
+    // Elemental, Grell Philosopher, Havengul Lich. Renders to GainAllActivatedAbilitiesOf, which
+    // snapshots the donor's abilities as the ability resolves. Capability-only: each card wraps it in
+    // its own activated/triggered envelope, so the emitter declines -> SCAFFOLD.
+    effect("AddAbilityFromPermanentHasable", "GainAllActivatedAbilitiesOf",
+        "gain all activated abilities of another object (Quicksilver Elemental)")
 
     // "becomes a copy of [target permanent]" (CR 707) — the _LayerEffect inside a copy continuous
     // effect. Oko, the Ringleader's combat-begin "Oko becomes a copy of up to one target creature you

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.handlers
 
 import com.wingedsheep.engine.handlers.ConditionEvaluationContext.Projection
 import com.wingedsheep.engine.handlers.ConditionEvaluationContext.Resolution
+import com.wingedsheep.engine.handlers.effects.linkedexile.LinkedExileLookup
 import com.wingedsheep.engine.state.CastSpellRecord
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
@@ -829,7 +830,39 @@ class ConditionEvaluator(
             (ctx as? Resolution)?.let {
                 evaluateDiscardedCardFilterMatch(state, condition.filter, entity.index, it.effectContext)
             } ?: false
+        is EffectTarget.LinkedExiledCard ->
+            evaluateLinkedExiledCardFilterMatch(state, condition.filter, entity.index, ctx)
         else -> false
+    }
+
+    /**
+     * Match the [index]-th card exiled with the source ([EffectTarget.LinkedExiledCard]) against
+     * [filter]. **Dual-mode**: the pile hangs off the source permanent, so this answers identically
+     * at resolution and during static-ability projection — which is what lets a
+     * `ConditionalStaticAbility` be gated on the imprinted card (Duplicant's "as long as a card
+     * exiled with this creature is a creature card").
+     *
+     * The card is in exile, so it has no projection entry and `matches` falls through to its
+     * printed `CardComponent` characteristics — the right read for "is a creature card". Returns
+     * false when the pile is empty at that index (imprint declined, or the card has left exile),
+     * via [LinkedExileLookup]'s still-in-exile guard.
+     */
+    private fun evaluateLinkedExiledCardFilterMatch(
+        state: GameState,
+        filter: GameObjectFilter,
+        index: Int,
+        ctx: ConditionEvaluationContext
+    ): Boolean {
+        val sourceId = ctx.sourceId ?: return false
+        val exiledId = LinkedExileLookup.exiledCard(state, sourceId, index) ?: return false
+        val predicateContext = when (ctx) {
+            is Resolution -> PredicateContext.fromEffectContext(ctx.effectContext)
+            is Projection -> ctx.controllerId?.let { PredicateContext(controllerId = it, sourceId = sourceId) }
+                ?: PredicateContext(controllerId = sourceId, sourceId = sourceId)
+        }
+        return PredicateEvaluator().matches(
+            state, ctx.projectedStateFor(state), exiledId, filter, predicateContext
+        )
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.ExecutorModule
+import com.wingedsheep.engine.handlers.effects.permanent.abilities.GainAllActivatedAbilitiesOfExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.abilities.GrantActivatedAbilityExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.abilities.GrantActivatedAbilityToGroupExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.abilities.GrantEmbalmExecutor
@@ -209,6 +210,7 @@ class PermanentExecutors(
         SetBaseStatsExecutor(amountEvaluator),
         // abilities
         GrantActivatedAbilityExecutor(),
+        GainAllActivatedAbilitiesOfExecutor(cardRegistry),
         GrantActivatedAbilityToGroupExecutor(),
         GrantEmbalmExecutor(),
         GrantFlashbackExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/abilities/GainAllActivatedAbilitiesOfExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/abilities/GainAllActivatedAbilitiesOfExecutor.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.handlers.effects.permanent.abilities
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.event.GrantedActivatedAbility
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.effects.GainAllActivatedAbilitiesOfEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [GainAllActivatedAbilitiesOfEffect].
+ * "This creature gains all activated abilities of target creature until end of turn"
+ * (Quicksilver Elemental).
+ *
+ * Reads the donor's printed activated abilities **once, here**, and writes one
+ * [GrantedActivatedAbility] per ability onto the receiver. Snapshotting at resolution is the
+ * printed behaviour, per the Havengul Lich ruling ("gains the activated abilities of the card as it
+ * existed in the graveyard"): the donor leaving, changing, or gaining abilities afterwards doesn't
+ * change what the receiver has. That is what separates this from the continuously re-read static
+ * [com.wingedsheep.sdk.scripting.GainActivatedAbilitiesOfPermanents] (Sharkey, Marvin).
+ *
+ * `GameState.grantedActivatedAbilities` is the right store rather than a granted
+ * `GrantActivatedAbility` static, because it is the one every read site already consults: the
+ * activated-ability enumerator, `ActivateAbilityHandler`, `LandManaColorInspector` (so a gained
+ * mana ability really produces mana), and `CleanupPhaseManager` / `EndedDurationExpiryCheck` for
+ * the duration.
+ *
+ * Two details that are load-bearing:
+ *  - The grant is keyed to the **receiver**, so a copied ability's `{T}`, `SacrificeSelf` and
+ *    "this creature" bind to the permanent that gained it (CR 113.7) — the printed reminder text
+ *    "(If any of the abilities use that creature's name, use this creature's name instead.)".
+ *  - Each gained ability is re-stamped with a donor-derived [AbilityId]. Two donors sharing a card
+ *    definition otherwise carry the *same* printed id, and the enumerator's `distinctBy { id }`
+ *    would collapse them into one; the re-stamp also gives each its own once-per-turn budget, which
+ *    is the printed ruling ("If you make two copies of an ability that can be activated once a
+ *    turn, you can activate each of them once a turn"). Same technique, same reason, as
+ *    `CastPermissionUtils.donorCardsActivatedAbilities`'s `oncePerTurnEach` re-stamp.
+ *
+ * Only *activated* abilities activatable from the battlefield are copied — never triggered, static,
+ * or keyword abilities — matching `getGainedAbilitiesOfPermanents`. Mana abilities are included:
+ * the printed wording is "all activated abilities", with no "except mana abilities" clause.
+ */
+class GainAllActivatedAbilitiesOfExecutor(
+    private val cardRegistry: CardRegistry
+) : EffectExecutor<GainAllActivatedAbilitiesOfEffect> {
+
+    override val effectType: KClass<GainAllActivatedAbilitiesOfEffect> =
+        GainAllActivatedAbilitiesOfEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: GainAllActivatedAbilitiesOfEffect,
+        context: EffectContext
+    ): EffectResult {
+        val receiverId = context.resolveTarget(effect.target)
+            ?: return EffectResult.error(state, "No valid recipient for the ability gain")
+        if (!state.getBattlefield().contains(receiverId)) {
+            return EffectResult.error(state, "The recipient is not on the battlefield")
+        }
+
+        // The donor may have left the battlefield between announcement and resolution. That is not
+        // an error — the ability just gains nothing (CR 608.2b: an effect does as much as it can).
+        val donorId = context.resolveTarget(effect.donor)
+        val donorEntity = donorId?.let { state.getEntity(it) }
+        val donorCard = donorEntity?.get<CardComponent>()
+        val donorDef = donorCard?.let { cardRegistry.getCard(it.cardDefinitionId) }
+            ?: return EffectResult.success(state)
+        val donorClassLevel = donorEntity.get<ClassLevelComponent>()?.currentLevel
+
+        val gained = donorDef.script.effectiveActivatedAbilities(donorClassLevel)
+            .filter { it.activateFromZone == Zone.BATTLEFIELD }
+            .map { ability ->
+                GrantedActivatedAbility(
+                    entityId = receiverId,
+                    ability = ability.copy(
+                        id = AbilityId("gained_${donorId.value}_${ability.id.value}")
+                    ),
+                    duration = effect.duration,
+                    sourceId = context.sourceId
+                )
+            }
+        if (gained.isEmpty()) return EffectResult.success(state)
+
+        return EffectResult.success(
+            state.copy(grantedActivatedAbilities = state.grantedActivatedAbilities + gained)
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -1418,13 +1418,18 @@ class CastPermissionUtils(
     }
 
     /**
-     * True when a [com.wingedsheep.sdk.scripting.SpendAnyManaTypeForActivatedAbilities] static on
-     * the battlefield applies to [sourceId] — i.e. mana of any type may be spent to pay the mana
-     * portion of [sourceId]'s activated-ability costs (Sharkey, Tyrant of the Shire). Callers
-     * relax the colored/colorless requirements of the ability's mana cost via
-     * [com.wingedsheep.sdk.core.ManaCost.relaxColors] when this returns true (CR 118.14 / 609.4b).
+     * Every [com.wingedsheep.sdk.scripting.SpendAnyManaTypeForActivatedAbilities] static on the
+     * battlefield that applies to [sourceId] — i.e. that relaxes the mana portion of [sourceId]'s
+     * activated-ability costs (CR 118.14 / 609.4b). The list, rather than a boolean, because the
+     * static has two strengths: `substituteColor == null` is Sharkey's "mana of any type can be
+     * spent", and a color is Quicksilver Elemental's narrower "you may spend blue mana as though it
+     * were mana of any color". [relaxAbilityCostColorsIfAny] picks the strongest that applies.
      */
-    fun canSpendAnyManaTypeForAbilities(state: GameState, sourceId: EntityId): Boolean {
+    fun spendRelaxationsForAbilities(
+        state: GameState,
+        sourceId: EntityId
+    ): List<com.wingedsheep.sdk.scripting.SpendAnyManaTypeForActivatedAbilities> {
+        val result = mutableListOf<com.wingedsheep.sdk.scripting.SpendAnyManaTypeForActivatedAbilities>()
         val projected = state.projectedState
         for (granterId in state.getBattlefield()) {
             val granter = state.getEntity(granterId) ?: continue
@@ -1450,32 +1455,43 @@ class CastPermissionUtils(
                         )
                     }
                 }
-                if (applies) return true
+                if (applies) result.add(any)
             }
         }
-        return false
+        return result
     }
 
     /**
      * If [sourceId] is under a [com.wingedsheep.sdk.scripting.SpendAnyManaTypeForActivatedAbilities]
-     * static, return [cost] with the colored/hybrid/Phyrexian/colorless requirements of its mana
-     * portion relaxed to generic ("mana of any type"); otherwise return [cost] unchanged. Non-mana
-     * cost components (tap, sacrifice, …) are left intact.
+     * static, return [cost] with the mana portion relaxed accordingly; otherwise return [cost]
+     * unchanged. Non-mana cost components (tap, sacrifice, …) are left intact.
+     *
+     * When several statics apply, the strongest wins: one "mana of any type" static relaxes
+     * everything to generic ([com.wingedsheep.sdk.core.ManaCost.relaxColors]) and there is nothing a
+     * single-color substitution could add on top. Otherwise each substitute color is applied in turn
+     * ([com.wingedsheep.sdk.core.ManaCost.relaxColorsTo]), which composes correctly because each
+     * pass only widens colored pips into hybrids.
      */
     fun relaxAbilityCostColorsIfAny(
         state: GameState,
         sourceId: EntityId,
         cost: AbilityCost
     ): AbilityCost {
-        if (!canSpendAnyManaTypeForAbilities(state, sourceId)) return cost
+        val relaxations = spendRelaxationsForAbilities(state, sourceId)
+        if (relaxations.isEmpty()) return cost
+        val anyType = relaxations.any { it.substituteColor == null }
+        val substitutes = relaxations.mapNotNull { it.substituteColor }.distinct()
+        fun relax(mana: com.wingedsheep.sdk.core.ManaCost): com.wingedsheep.sdk.core.ManaCost =
+            if (anyType) mana.relaxColors()
+            else substitutes.fold(mana) { acc, color -> acc.relaxColorsTo(color) }
         return when (cost) {
             is AbilityCost.Atom -> {
                 val mana = cost.manaCostOrNull ?: return cost
-                AbilityCost.Atom(CostAtom.Mana(mana.relaxColors()))
+                AbilityCost.Atom(CostAtom.Mana(relax(mana)))
             }
             is AbilityCost.Composite -> AbilityCost.Composite(cost.costs.map { sub ->
                 val mana = sub.manaCostOrNull
-                if (mana != null) AbilityCost.Atom(CostAtom.Mana(mana.relaxColors())) else sub
+                if (mana != null) AbilityCost.Atom(CostAtom.Mana(relax(mana))) else sub
             })
             else -> cost
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
@@ -189,6 +189,43 @@ internal class EffectApplicator(
                     values.subtypes.addAll(mod.subtypes)
                     values.types.addAll(mod.subtypes)
                 }
+                is Modification.SetCreatureSubtypesFrom -> {
+                    // "Has the creature types of [that object]" (Duplicant). Same replace-only-the-
+                    // creature-types semantics as SetCreatureSubtypes above (CR 205.1b — non-creature
+                    // subtypes are untouched), but the set is read from the referenced object on every
+                    // projection pass instead of being baked in at conversion time.
+                    //
+                    // The reference is resolved against a bare EffectContext rooted at the *effect's*
+                    // source, which is all LinkedExiledCard needs — see ProjectionScopedAmounts for
+                    // why the context-scoped references can't be used here. The referenced card is in
+                    // exile and has no projection entry, so its printed creature types are the right
+                    // (and only) read.
+                    val creatureTypes = com.wingedsheep.sdk.core.Subtype.ALL_CREATURE_TYPES.toSet()
+                    val controllerId = projectedValues[effect.sourceId]?.controllerId
+                        ?: state.getEntity(effect.sourceId)?.get<ControllerComponent>()?.playerId
+                        ?: effect.controllerId
+                    val donorId = controllerId?.let {
+                        com.wingedsheep.engine.handlers.effects.TargetResolutionUtils.resolveEntityReference(
+                            mod.source,
+                            EffectContext(
+                                sourceId = effect.sourceId,
+                                controllerId = it,
+                                affectedEntityId = entityId
+                            ),
+                            state
+                        )
+                    }
+                    val donorTypes = donorId
+                        ?.let { state.getEntity(it)?.get<CardComponent>() }
+                        ?.typeLine?.subtypes.orEmpty()
+                        .map { it.value }
+                        .filter { it in creatureTypes }
+                    val newTypes = donorTypes.toSet() + mod.retainedTypes
+                    values.subtypes.removeAll { it in creatureTypes }
+                    values.types.removeAll { it in creatureTypes }
+                    values.subtypes.addAll(newTypes)
+                    values.types.addAll(newTypes)
+                }
                 is Modification.SetBasicLandTypes -> {
                     val basicLandTypes = com.wingedsheep.sdk.core.Subtype.ALL_BASIC_LAND_TYPES
                     values.subtypes.removeAll { it in basicLandTypes }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectSorter.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectSorter.kt
@@ -90,6 +90,7 @@ internal class EffectSorter {
             effectB.modification is Modification.SetCardTypes ||
             effectB.modification is Modification.SetAllSubtypes ||
             effectB.modification is Modification.SetCreatureSubtypes ||
+            effectB.modification is Modification.SetCreatureSubtypesFrom ||
             effectB.modification is Modification.AddSubtype) {
             return effectA.affectedEntities.any { it in effectB.affectedEntities }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
@@ -372,6 +372,25 @@ sealed interface Modification {
     }
 
     /**
+     * Replace all creature subtypes with **the creature types of the object [source] names**,
+     * plus [retainedTypes]. The dynamic sibling of [SetCreatureSubtypes]: the set is resolved
+     * against live state on every projection pass rather than baked in at conversion time, so a
+     * "has the creature types of X" static (Duplicant) tracks X. Lowered from
+     * [com.wingedsheep.sdk.scripting.HasCreatureTypesOf].
+     *
+     * When [source] resolves to nothing, only [retainedTypes] is applied — the gainer keeps the
+     * types its own card names it should keep and loses the rest, which is the correct reading of
+     * "has the creature types of [something that isn't there]".
+     */
+    @Serializable
+    data class SetCreatureSubtypesFrom(
+        val source: com.wingedsheep.sdk.scripting.values.EntityReference,
+        val retainedTypes: Set<String> = emptySet()
+    ) : Modification {
+        override val layer get() = Layer.TYPE
+    }
+
+    /**
      * Replace all basic land subtypes with the given set (Rule 305.7).
      * Used by "is an Island" effects that change a land's basic land types.
      * Removes existing basic land subtypes (Plains, Island, Swamp, Mountain, Forest)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -874,6 +874,15 @@ class StaticAbilityHandler(
                     affectsFilter = convertGroupFilter(ability.filter)
                 )
             }
+            is com.wingedsheep.sdk.scripting.HasCreatureTypesOf -> {
+                // "has the creature types of [that object]" — Layer 4 (TYPE). The referenced object
+                // is resolved on every projection pass by the applicator, not here, so the gainer's
+                // types track it live (Duplicant).
+                ContinuousEffectData(
+                    modification = Modification.SetCreatureSubtypesFrom(ability.source, ability.retainedTypes),
+                    affectsFilter = convertGroupFilter(ability.filter)
+                )
+            }
             is SetBaseToughnessForCreatureGroup -> {
                 ContinuousEffectData(
                     modification = Modification.SetToughness(ability.toughness),


### PR DESCRIPTION
Mirrodin's last six cards are all engine-blocked; these are the two cheapest. MRD goes **285 → 287/291**.

Four small primitives, one commit per card + its primitives. `AGENTS.md`'s house rule is one PR per new primitive — bundling a batch of primitive-needing cards into one PR is the shape you've chosen twice before, so it's what I did here rather than re-asking.

## Duplicant

> Imprint — When this creature enters, you may exile target nontoken creature.
> As long as a card exiled with this creature is a creature card, this creature has the power, toughness, and creature types of the last creature card exiled with it. It's still a Shapeshifter.

Two new words, one in each vocabulary the sentence spans:

- **`EffectTarget.LinkedExiledCard(index)`** — the *role* spelling of the imprint pile that `EntityReference.LinkedExiledCard` already read as a value. Supported in `EntityMatches` (facade `Conditions.LinkedExiledCardMatches`) as a **dual-mode** entity: it hangs off the source like `Self`, so the projector can ask it, which is what lets a `ConditionalStaticAbility` be gated on the imprinted card. Added to `CardLinter.supportedEntityMatchesRoles` — the gate that stops a role the evaluator doesn't dispatch from reading as a silent `false`.
- **`HasCreatureTypesOf(source, retainedTypes, filter)`** — a Layer 4 static giving the group the creature types of the object an `EntityReference` names, lowered to a new `Modification.SetCreatureSubtypesFrom`: the dynamic sibling of `SetCreatureSubtypes`, resolved by `EffectApplicator` on every projection pass rather than baked in at conversion time, so the types track the referenced object live. `retainedTypes` carries the printed "It's still a Shapeshifter." on the *same* static, because a separate `GrantSubtype` would land in the same layer with the same timestamp and could be wiped by the type set.

The power/toughness half needed **nothing new**: `SetBasePowerToughnessDynamicStatic` fed `EntityProperty(LinkedExiledCard(), Power/Toughness)` already works, because `LinkedExiledCard` is deliberately absent from `ProjectionScopedAmounts`' context-scoped deny list and the P/T resolver falls back to base stats for a card in exile. Setting *base* P/T is also what makes the printed ruling that counters still apply fall out for free.

Test cases: both layers, the counter interaction, the declined imprint, and the reason the gate exists — a noncreature artifact animated by March of the Machines is a legal target, but the card that lands in exile is not a creature card, so neither half applies.

## Quicksilver Elemental

> {U}: This creature gains all activated abilities of target creature until end of turn.
> You may spend blue mana as though it were mana of any color to pay the activation costs of this creature's abilities.

- **`Effects.GainAllActivatedAbilitiesOf(donor, target, duration)`** — the one-shot, resolution-time sibling of the `GainActivatedAbilitiesOfPermanents` static, for when the donor is picked *as the ability resolves* rather than described by a filter. The executor snapshots the donor's printed activated abilities into `GameState.grantedActivatedAbilities` — the store the activated-ability enumerator, `ActivateAbilityHandler`, `ManaAbilityEnumerator` and the end-of-turn cleanup all already read, so the gained abilities reach the client and the AI, a gained mana ability really produces mana, and the duration needs no new bookkeeping.

  Snapshotting is the printed behaviour, not a shortcut: the **Havengul Lich ruling** ("gains the activated abilities of the card *as it existed in the graveyard*") is what separates this wording from the continuously re-read static. Each gained ability is re-stamped with a donor-derived `AbilityId`, same technique and same reason as `donorCardsActivatedAbilities` — two donors sharing a card definition carry one printed id and would otherwise collapse under the enumerator's dedup.
- **`SpendAnyManaTypeForActivatedAbilities` gained a `substituteColor` axis.** The static previously modelled only Sharkey's "mana of any type can be spent"; "spend **blue** mana as though it were mana of any **color**" is strictly narrower, and relaxing to generic would have let a red mana pay a gained `{G}`. Lowered by rewriting each foreign colored pip into a hybrid with the substitute (`ManaCost.relaxColorsTo`), so it rides the existing hybrid payment path instead of adding a second one — no new mana path, and `relaxAbilityCostColorsIfAny` stays the single seam all three callers go through. `null` keeps the old behaviour, so Sharkey and Agatha's Soul Cauldron are untouched.

Test cases: the gained ability binding to the Elemental (its `{T}` taps the Elemental; "damage equal to its power" reads the Elemental's 3, not the Goblin's 1), the ability being *enumerated* and not merely accepted by the handler, the snapshot surviving the donor's death, mana abilities counting, grants accumulating across activations and expiring at end of turn, and blue paying a gained `{R}` where green does not.

## Also here

- `docs/card-sdk-language-reference.md` updated for all four additions.
- **mtgish bridge**: `AddAbilityFromPermanentHasable -> GainAllActivatedAbilitiesOf`, which flips Quicksilver Elemental's probe from BLOCKED to COVERABLE-NOW and scores the capability for Grell Philosopher and Havengul Lich too. Duplicant's remaining `[??]` tags are `_StaticLayerEffect` values; `Registry.loadEffectSerialNames` only scans the *effects* package, so a static ability can't be validated there today — left alone rather than registered as a claim the registry would report as MISSING. Widening the registry to statics would reclassify cards corpus-wide and belongs in its own change.
- A `Printing(...)` row for Duplicant in Archenemy (`just check-card-printing` flagged it). It landed in the second commit rather than the first — noting it so the split isn't confusing.

**No client work needed.** Duplicant's type line and P/T already render from projected state (`ClientStateTransformer` reads `projectedValues.subtypes` / P/T), and Quicksilver's gained abilities are surfaced by the enumerator like any other granted ability, which the test asserts directly.

## Verification

- `just build` — green (includes `:mtg-sets:test`: snapshots, `FacadeBoundaryTest`, `CardLintTest`)
- `just test-rules` — green (engine tests + every card scenario)
- `just check-card-printing` — clean for both cards
- MRD snapshot diff is exactly the two new card trees, nothing else moved

🤖 Generated with [Claude Code](https://claude.com/claude-code)