### PR TITLE
Add coin-flip replacement with a mid-flip choice, and Krark's Thumb

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6776,6 +6776,22 @@ staticAbility {
   every coin flip the controller makes. Heads is modeled as a won flip, so this forces the win. Not a
   Rule 613 continuous effect — the coin-flip executors query it via `CoinFlipModifiers`, and a
   per-player `FlippedCoinsThisTurnComponent` (cleared at cleanup) tracks the "first each turn" gate.
+- `FlipAdditionalCoins(coinsPerFlip = 2)` — the other coin-flip replacement (CR 614.1a — an "instead" effect is a replacement effect): each coin the
+  controller would flip becomes `coinsPerFlip` real coins, all but one of which they ignore
+  (**Krark's Thumb** — "If you would flip a coin, instead flip two coins and ignore one"). Applies
+  **per coin, not per instruction**: "flip five coins" is five *pairs* with one kept from each, not
+  ten coins with any five ignored. Every coin of a batch is rolled *before* any is ignored, so the
+  flipper always chooses knowing all the results; a batch whose coins agree offers no choice and
+  raises no prompt. Instances **multiply** — two Thumbs flip four coins per flip and ignore three —
+  so `CoinFlipModifiers.coinsPerFlip` takes the product across the flipper's sources. Composing with
+  `WinCoinFlips` needs no special case: a forced win makes every coin heads, leaving nothing to
+  choose. All four flip effects (`FlipCoinEffect`, `FlipTwoCoinsEffect`, `FlipCoinsEffect`,
+  `FlipCoinsUntilLossEffect`) get their coins from the single `CoinFlipService` seam, so the
+  replacement reaches every flip in the game; the choice pauses on a `CoinFlipChoiceContinuation`,
+  which carries the flip effect and its `EffectContext` whole so the branch run afterwards keeps its
+  targets. Each coin really flipped emits a `CoinFlipEvent`, with the discarded ones carrying
+  `ignored = true` so the log and the client animation show what was flipped without reporting a win
+  nobody got. Not a Rule 613 continuous effect.
 - `RestrictSpellsCastPerTurn(maxPerTurn, eachPlayer = false)` — a per-turn cap on spells cast.
   `eachPlayer = false` (default) limits only the source's controller (Yawgmoth's Agenda: "You can't
   cast more than one spell each turn."); `eachPlayer = true` is a *global* restriction binding every

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -1090,6 +1090,48 @@ data class WinCoinFlips(
 }
 
 /**
+ * Each coin the controller would flip is replaced by [coinsPerFlip] coins, all but one of which the
+ * controller ignores — Krark's Thumb's "If you would flip a coin, instead flip two coins and ignore
+ * one" (CR 614.1a — an "instead" effect is a replacement effect; this one changes *how a flip's
+ * result is produced*, and the flip itself still
+ * happens, so a "whenever you flip a coin" ability sees exactly one flip per replaced coin).
+ *
+ * Queried by the coin-flip executors (`FlipCoinExecutor` / `FlipTwoCoinsExecutor` /
+ * `FlipCoinsExecutor` / `FlipCoinsUntilLossExecutor`) via `CoinFlipModifiers`, exactly like
+ * [WinCoinFlips]; it is not a Rule 613 continuous effect, so it maps to no layer (classified as
+ * no-op in `StaticAbilityHandler`).
+ *
+ * Three consequences of the Krark's Thumb rulings are load-bearing and are what make this a
+ * *per-coin* replacement rather than a per-flip-event one:
+ *
+ * - **It replaces each individual coin, not the instruction.** "If an effect tells you to flip two
+ *   coins, you don't flip four coins and ignore any two; you flip two coins, flip two coins, and
+ *   then ignore one flip from each pair." So a `FlipCoinsEffect(5)` under one Thumb flips ten coins
+ *   as five pairs and keeps one from each.
+ * - **All the coins are flipped before any is ignored** — "You will know the results of all
+ *   simultaneous flips before choosing which to ignore." The engine therefore flips the whole batch
+ *   up front and only then asks, so the flipper always chooses with complete information.
+ * - **Instances multiply.** A second Thumb replaces each of the first Thumb's coins in turn, so two
+ *   Thumbs flip four coins per original flip and ignore three. `CoinFlipModifiers` multiplies
+ *   [coinsPerFlip] across every source the flipper controls rather than summing them.
+ *
+ * A [WinCoinFlips] replacement that also applies makes every coin in the batch heads, which leaves
+ * the flipper nothing to choose — the engine skips the prompt whenever a batch is unanimous.
+ *
+ * @property coinsPerFlip How many coins are flipped in place of each single coin. Two is the printed
+ *   value (Krark's Thumb, and its silver-bordered twin Krark's Other Thumb); the parameter exists so
+ *   a future "flip three coins and ignore two" needs no new type. Values below two leave flips alone.
+ */
+@SerialName("FlipAdditionalCoins")
+@Serializable
+data class FlipAdditionalCoins(
+    val coinsPerFlip: Int = 2,
+) : StaticAbility {
+    override val description: String =
+        "If you would flip a coin, instead flip $coinsPerFlip coins and ignore all but one"
+}
+
+/**
  * Replaces land mana production when a land would produce two or more mana.
  * Used for Damping Sphere: "If a land is tapped for two or more mana, it produces {C} instead
  * of any other type and amount."

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/KrarksThumb.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/KrarksThumb.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.FlipAdditionalCoins
+
+/**
+ * Krark's Thumb
+ * {2}
+ * Legendary Artifact
+ *
+ * If you would flip a coin, instead flip two coins and ignore one.
+ *
+ * The engine's [FlipAdditionalCoins] coin-flip replacement (CR 614), consulted by `CoinFlipService`
+ * wherever a coin is flipped. Three of the card's rulings are what make that a *per-coin*
+ * replacement rather than a per-instruction one, and the engine follows each:
+ *
+ * - "Flip five coins" becomes five *pairs* with one kept from each — not ten coins with any five
+ *   ignored.
+ * - All the coins of a batch are flipped before any is ignored, so the flipper chooses knowing every
+ *   result.
+ * - A second Thumb replaces each of the first one's coins in turn: four coins per flip, three
+ *   ignored.
+ */
+val KrarksThumb = card("Krark's Thumb") {
+    manaCost = "{2}"
+    typeLine = "Legendary Artifact"
+    oracleText = "If you would flip a coin, instead flip two coins and ignore one."
+
+    staticAbility {
+        ability = FlipAdditionalCoins(coinsPerFlip = 2)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "190"
+        artist = "Ron Spencer"
+        flavorText = "\"I can think of one goblin it ain't so lucky for.\"\n—Slobad, goblin tinkerer"
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/78a5d49a-747e-4ec8-a20a-ca917c315774.jpg?1783944517"
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/KrarksThumbScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/KrarksThumbScenarioTest.kt
@@ -1,0 +1,203 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CoinFlipEvent
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.FieryGambit
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.KrarksThumb
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.GameRng
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Krark's Thumb (MRD #190) — "If you would flip a coin, instead flip two coins and ignore one."
+ *
+ * Exercised against Fiery Gambit, its own set-mate, because that card is the hardest thing in the
+ * game for this replacement to interact with: its run has **two** questions per coin once the Thumb
+ * is out — "which of these two coins do you keep?" and then "flip another coin?" — and the won-flip
+ * tally has to survive both. A tally that were carried in the pipeline rather than in the frames
+ * would come back wrong exactly here.
+ *
+ * The Thumb's own contract is checked at the same time: two coins are really flipped for every one
+ * the Gambit asks for, exactly one of them counts, and the flipper — not the engine — picks which.
+ *
+ * Runs are seeded so the coin sequence is fixed; each test states the batch it relies on rather
+ * than assuming one, so a change to the RNG shows up as a clear failure instead of a flake.
+ */
+class KrarksThumbScenarioTest : FunSpec({
+
+    class Board(val d: GameTestDriver, val opponent: EntityId, val bears: EntityId, val gambit: EntityId) {
+        val me: EntityId get() = d.player1
+        fun lands(): List<EntityId> = d.getLands(me)
+        fun handSize(): Int = d.getHandSize(me)
+        fun question(): YesNoDecision? = d.pendingDecision as? YesNoDecision
+
+        /** Hand size once the Gambit itself has left the hand — the baseline the draw tier moves. */
+        var handAtResolution: Int = 0
+    }
+
+    /** The Fiery Gambit board, with [thumbs] copies of Krark's Thumb already on the battlefield. */
+    fun board(seed: Long, thumbs: Int = 1): Board {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + FieryGambit + KrarksThumb)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val opponent = d.getOpponent(d.player1)
+        val bears = d.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        repeat(3) { d.putLandOnBattlefield(d.player1, "Mountain") }
+        d.getLands(d.player1).forEach { d.tapPermanent(it) }
+        repeat(thumbs) { d.putPermanentOnBattlefield(d.player1, "Krark's Thumb") }
+
+        val gambit = d.putCardInHand(d.player1, "Fiery Gambit")
+        d.giveMana(d.player1, Color.RED, 1)
+        d.giveColorlessMana(d.player1, 2)
+
+        d.replaceState(d.state.copy(rng = GameRng.seeded(seed)))
+        return Board(d, opponent, bears, gambit)
+    }
+
+    fun Board.cast(): ExecutionResult {
+        val cast = d.castSpell(me, gambit, targets = listOf(bears))
+        withClue("cast failed: ${cast.error}") { cast.isSuccess shouldBe true }
+        // Read the hand *after* the Gambit has left it, so the draw-nine tier is measured against
+        // the board the spell actually resolves on.
+        handAtResolution = handSize()
+        return d.bothPass()
+    }
+
+    /**
+     * The seed of the first run in [range] whose very first coin came up mixed — the only case in
+     * which the Thumb actually offers a choice, and therefore the only one worth driving.
+     */
+    fun seedWithAChoiceOnTheFirstFlip(range: LongRange): Long = range.first { seed ->
+        val b = board(seed)
+        b.cast()
+        b.question()?.yesText == "Keep heads"
+    }
+
+    test("the Thumb turns the Gambit's first coin into two, and asks which one to keep") {
+        val seed = seedWithAChoiceOnTheFirstFlip(1L..200L)
+        val b = board(seed)
+        val events = b.cast()
+
+        val question = b.question()
+        withClue("a mixed pair must put the choice to the flipper, not resolve itself") {
+            question?.yesText shouldBe "Keep heads"
+            question?.noText shouldBe "Keep tails"
+            question?.playerId shouldBe b.me
+        }
+        withClue("both coins were rolled before the question — the flipper chooses knowing both") {
+            question?.prompt shouldBe
+                "You flipped 1 heads and 1 tails. Ignore all but one — which result do you keep?"
+        }
+        withClue("the flips are not reported until the batch is settled") {
+            events.events.filterIsInstance<CoinFlipEvent>().size shouldBe 0
+        }
+    }
+
+    test("keeping the heads coin wins the flip, so the run continues") {
+        val seed = seedWithAChoiceOnTheFirstFlip(1L..200L)
+        val b = board(seed)
+        b.cast()
+
+        b.d.submitYesNo(b.me, true).error shouldBe null
+
+        withClue("a won flip is followed by the Gambit's own 'flip another coin?'") {
+            b.question()?.yesText shouldBe "Flip again"
+        }
+    }
+
+    test("keeping the tails coin loses the flip, which ends the run with nothing") {
+        val seed = seedWithAChoiceOnTheFirstFlip(1L..200L)
+        val b = board(seed)
+        b.cast()
+        val handBefore = b.handAtResolution
+
+        val answer = b.d.submitYesNo(b.me, false)
+        answer.error shouldBe null
+
+        withClue("a lost flip ends the run — there is no 'flip again?' to answer") {
+            b.question() shouldBe null
+        }
+        withClue("no tier fired: the Bears live, nobody lost life, nothing was drawn or untapped") {
+            b.d.findPermanent(b.opponent, "Grizzly Bears") shouldBe b.bears
+            b.d.getLifeTotal(b.opponent) shouldBe 20
+            b.handSize() shouldBe handBefore
+            b.lands().count { b.d.isTapped(it) } shouldBe 3
+        }
+        withClue("both coins are reported once the batch settles, and exactly one of them counted") {
+            val flips = answer.events.filterIsInstance<CoinFlipEvent>()
+            flips.size shouldBe 2
+            flips.count { !it.ignored } shouldBe 1
+            flips.single { !it.ignored }.won shouldBe false
+        }
+    }
+
+    test("the won-flip tally survives both of the run's pauses and pays out all three tiers") {
+        val seed = seedWithAChoiceOnTheFirstFlip(1L..200L)
+        val b = board(seed)
+        b.cast()
+        val handBefore = b.handAtResolution
+
+        // Win three flips, answering whichever question is in front of us: the Thumb's
+        // "keep heads" whenever the pair came up mixed, and the Gambit's "flip again" after each
+        // win. Both answers are `true`, so this is one loop rather than two interleaved scripts —
+        // and it is precisely the interleaving that the tally has to survive.
+        var wins = 0
+        var guard = 0
+        while (wins < 3 && guard++ < 40) {
+            val question = b.question() ?: break
+            if (question.yesText == "Flip again") wins++
+            b.d.submitYesNo(b.me, true).error shouldBe null
+        }
+        withClue("keeping heads every time must be able to win three flips") { wins shouldBe 3 }
+
+        // Stop of our own accord, so the tally is published by the "stop" path rather than a loss.
+        b.d.submitYesNo(b.me, false).error shouldBe null
+
+        withClue("three wins pays all three tiers — the tally came through both pause kinds intact") {
+            b.d.findPermanent(b.opponent, "Grizzly Bears") shouldBe null
+            b.d.getLifeTotal(b.opponent) shouldBe 14
+            b.handSize() shouldBe handBefore + 9
+            b.lands().count { b.d.isTapped(it) } shouldBe 0
+        }
+    }
+
+    test("a second Thumb flips four coins per flip and still leaves exactly one counting") {
+        // Four coins are unanimous far less often than two, so a mixed batch — and therefore a
+        // question — is the overwhelmingly common case; find one and read the batch off its prompt.
+        val seed = (1L..200L).first { s ->
+            val probe = board(s, thumbs = 2)
+            probe.cast()
+            probe.question()?.yesText == "Keep heads"
+        }
+        val b = board(seed, thumbs = 2)
+        b.cast()
+
+        val prompt = b.question()?.prompt
+        withClue("two Thumbs are four coins per flip, not three: the replacements multiply") {
+            val counts = Regex("""You flipped (\d+) heads and (\d+) tails""").find(prompt ?: "")
+            val heads = counts?.groupValues?.get(1)?.toInt() ?: 0
+            val tails = counts?.groupValues?.get(2)?.toInt() ?: 0
+            (heads + tails) shouldBe 4
+        }
+
+        val answer = b.d.submitYesNo(b.me, true)
+        answer.error shouldBe null
+        withClue("all four coins are reported, and three of them are ignored") {
+            val flips = answer.events.filterIsInstance<CoinFlipEvent>()
+            flips.size shouldBe 4
+            flips.count { !it.ignored } shouldBe 1
+            flips.single { !it.ignored }.won shouldBe true
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -5787,6 +5787,26 @@
     ]
 }
 
+// Krark's Thumb
+{
+    "name": "Krark's Thumb",
+    "manaCost": "{2}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "If you would flip a coin, instead flip two coins and ignore one.",
+    "script": {
+        "staticAbilities": [
+            "FlipAdditionalCoins"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "190",
+        "rarity": "RARE",
+        "artist": "Ron Spencer",
+        "flavorText": "\"I can think of one goblin it ain't so lucky for.\"\n—Slobad, goblin tinkerer",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/78a5d49a-747e-4ec8-a20a-ca917c315774.jpg?1783944517"
+    }
+}
+
 // Krark-Clan Grunt
 {
     "name": "Krark-Clan Grunt",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -473,6 +473,38 @@ data class FlipCoinsUntilLossContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume a coin flip after the flipper says which of the coins to keep — the pause a
+ * [com.wingedsheep.sdk.scripting.FlipAdditionalCoins] replacement (Krark's Thumb) introduces into
+ * every coin-flip executor.
+ *
+ * One frame serves all four flip effects because the *only* thing the pause interrupts is producing
+ * the results; what each effect does with them afterwards is decided from [effect] on resume. That
+ * is why [effect] and [effectContext] are carried whole rather than the four executors each getting
+ * a frame of their own: the sub-effect a [com.wingedsheep.sdk.scripting.effects.FlipCoinEffect]
+ * runs on a win needs the original context's targets, and re-deriving them field by field is how
+ * continuations lose them.
+ *
+ * A batch can owe several answers (one per coin whose replacement came up mixed), so resuming may
+ * push this same frame again — [pending] carries how far the batch got.
+ *
+ * @property effect The flip effect that was executing; decides what happens once the coins settle.
+ * @property effectContext The context that effect was running under, restored verbatim on resume.
+ * @property pending The batch part-way through being resolved (see
+ *   [com.wingedsheep.engine.handlers.effects.CoinFlipService.PendingCoinFlipChoice]).
+ * @property winsSoFar Only meaningful for
+ *   [com.wingedsheep.sdk.scripting.effects.FlipCoinsUntilLossEffect]: flips won before this one, so
+ *   the run's tally survives the extra pause exactly as it survives the "flip again?" one.
+ */
+@Serializable
+data class CoinFlipChoiceContinuation(
+    override val decisionId: String,
+    val effect: Effect,
+    val effectContext: EffectContext,
+    val pending: com.wingedsheep.engine.handlers.effects.CoinFlipService.PendingCoinFlipChoice,
+    val winsSoFar: Int = 0
+) : ContinuationFrame
+
+/**
  * Phase discriminator for RepeatWhileContinuation.
  */
 @Serializable

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -1925,10 +1925,19 @@ data class GiftGivenEvent(
 /**
  * A player flipped a coin.
  *
+ * One event per coin that was actually flipped. Under a
+ * [com.wingedsheep.sdk.scripting.FlipAdditionalCoins] replacement (Krark's Thumb) a single coin the
+ * game asked for becomes several real flips, all of which are reported — only one of them decides
+ * the outcome and the rest carry [ignored].
+ *
  * @property playerId The player who flipped the coin
  * @property won Whether the player won the flip
  * @property sourceId The entity that caused the coin flip
  * @property sourceName The name of the card/ability that caused the coin flip
+ * @property ignored True when this coin was flipped but then discarded by a "flip N coins and
+ *   ignore all but one" replacement, so its result had no effect. The flip still happened — it is
+ *   reported so the log and the animation show what was really flipped — but nothing reads its
+ *   [won] value.
  */
 @Serializable
 @SerialName("CoinFlipEvent")
@@ -1936,7 +1945,8 @@ data class CoinFlipEvent(
     val playerId: EntityId,
     val won: Boolean,
     val sourceId: EntityId,
-    val sourceName: String
+    val sourceName: String,
+    val ignored: Boolean = false
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -290,6 +290,7 @@ val engineSerializersModule = SerializersModule {
         subclass(DrawUpToContinuation::class)
         subclass(RepeatWhileContinuation::class)
         subclass(FlipCoinsUntilLossContinuation::class)
+        subclass(CoinFlipChoiceContinuation::class)
         subclass(SelectFromCollectionContinuation::class)
         subclass(MoveCollectionOrderContinuation::class)
         subclass(ChooseOptionPipelineContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
@@ -2,7 +2,14 @@ package com.wingedsheep.engine.handlers.continuations
 
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.CoinFlipService
 import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
+import com.wingedsheep.engine.handlers.effects.composite.FlipCoinExecutor
+import com.wingedsheep.engine.handlers.effects.composite.FlipTwoCoinsExecutor
+import com.wingedsheep.sdk.scripting.effects.FlipCoinEffect
+import com.wingedsheep.sdk.scripting.effects.FlipCoinsEffect
+import com.wingedsheep.sdk.scripting.effects.FlipCoinsUntilLossEffect
+import com.wingedsheep.sdk.scripting.effects.FlipTwoCoinsEffect
 import com.wingedsheep.engine.handlers.effects.permanent.counters.ProliferateExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.counters.RemoveAnyNumberOfCountersFlow
 import com.wingedsheep.engine.state.GameState
@@ -26,6 +33,7 @@ class MiscContinuationResumer(
         resumer(DrawUpToContinuation::class, ::resumeDrawUpTo),
         resumer(RepeatWhileContinuation::class, ::resumeRepeatWhile),
         resumer(FlipCoinsUntilLossContinuation::class, ::resumeFlipCoinsUntilLoss),
+        resumer(CoinFlipChoiceContinuation::class, ::resumeCoinFlipChoice),
         resumer(StormCopyTargetContinuation::class, ::resumeStormCopyTarget),
         resumer(StormCopyModalTargetContinuation::class, ::resumeStormCopyModalTarget),
         resumer(CopyEachSpellContinuation::class, ::resumeCopyEachSpell),
@@ -359,10 +367,10 @@ class MiscContinuationResumer(
 
         val result = com.wingedsheep.engine.handlers.effects.composite.FlipCoinsUntilLossExecutor.flipOnce(
             state = state,
-            flipperId = continuation.flipperId,
-            storeWinsAs = continuation.storeWinsAs,
+            effect = com.wingedsheep.sdk.scripting.effects.FlipCoinsUntilLossEffect(continuation.storeWinsAs),
+            context = com.wingedsheep.engine.handlers.effects.composite.FlipCoinsUntilLossExecutor
+                .contextFor(continuation.flipperId, continuation.sourceId),
             winsSoFar = continuation.winsSoFar,
-            sourceId = continuation.sourceId,
             cardRegistry = services.cardRegistry,
             decisionHandler = com.wingedsheep.engine.handlers.DecisionHandler(),
             priorEvents = emptyList()
@@ -376,6 +384,126 @@ class MiscContinuationResumer(
             numbers = result.updatedStoredNumbers
         )
         return checkForMore(published, result.events.toList())
+    }
+
+    /**
+     * Resume a coin flip after the flipper says which coin to keep — the pause a
+     * [com.wingedsheep.sdk.scripting.FlipAdditionalCoins] replacement (Krark's Thumb) puts inside
+     * every flip.
+     *
+     * A batch can owe more than one answer (one per coin that came up mixed), so
+     * [CoinFlipService.advanceAfterAnswer] may hand back another question; only once it reports the
+     * whole batch settled does the flip effect get to act on its results. What "act on its results"
+     * means is read off the frame's own [CoinFlipChoiceContinuation.effect], which is why all four
+     * flip effects share this one resumer.
+     */
+    private fun resumeCoinFlipChoice(
+        state: GameState,
+        continuation: CoinFlipChoiceContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is YesNoResponse) {
+            return ExecutionResult.error(state, "Expected keep-heads/keep-tails response for a coin flip")
+        }
+
+        val decisionHandler = com.wingedsheep.engine.handlers.DecisionHandler()
+        val resolution = CoinFlipService.advanceAfterAnswer(
+            state = state,
+            pending = continuation.pending,
+            keepHeads = response.choice,
+            decisionHandler = decisionHandler
+        )
+
+        // Still coins left to choose between: park the same frame again with the batch advanced.
+        if (resolution is CoinFlipService.Resolution.NeedsChoice) {
+            return ExecutionResult.paused(
+                resolution.state.pushContinuation(
+                    continuation.copy(
+                        decisionId = resolution.decision.id,
+                        pending = resolution.pending
+                    )
+                ),
+                resolution.decision,
+                resolution.events
+            )
+        }
+
+        val settled = resolution as CoinFlipService.Resolution.Resolved
+        val context = continuation.effectContext
+
+        return when (val effect = continuation.effect) {
+            is FlipCoinEffect -> {
+                val subEffect = FlipCoinExecutor.subEffectFor(effect, settled.results)
+                runSubEffect(settled.state, subEffect, context, settled.events, checkForMore)
+            }
+
+            is FlipTwoCoinsEffect -> {
+                val subEffect = FlipTwoCoinsExecutor.subEffectFor(effect, settled.results)
+                runSubEffect(settled.state, subEffect, context, settled.events, checkForMore)
+            }
+
+            is FlipCoinsEffect -> {
+                // The heads tally goes to the frame beneath, not this resumer's return value: its
+                // consumer is the sibling effect in the same composite, and that is where a pipeline
+                // number has to land to survive the stack round-trip.
+                val published = exposeCollectionsToNextFrame(
+                    settled.state,
+                    collections = emptyMap(),
+                    numbers = mapOf(effect.storeHeadsAs to settled.results.count { it })
+                )
+                checkForMore(published, settled.events)
+            }
+
+            is FlipCoinsUntilLossEffect -> {
+                val result = com.wingedsheep.engine.handlers.effects.composite.FlipCoinsUntilLossExecutor
+                    .afterFlip(
+                        state = settled.state,
+                        effect = effect,
+                        context = context,
+                        won = settled.results.firstOrNull() == true,
+                        winsSoFar = continuation.winsSoFar,
+                        decisionHandler = decisionHandler,
+                        priorEvents = settled.events
+                    )
+                if (result.isPaused) return result.toExecutionResult()
+                val published = exposeCollectionsToNextFrame(
+                    result.state,
+                    collections = emptyMap(),
+                    numbers = result.updatedStoredNumbers
+                )
+                checkForMore(published, result.events.toList())
+            }
+
+            else -> ExecutionResult.error(
+                settled.state,
+                "Coin-flip choice resumed for an effect that does not flip coins: " +
+                    effect::class.simpleName
+            )
+        }
+    }
+
+    /**
+     * Run the branch a settled flip selected, or finish with just the flip events when that branch
+     * is empty ("flip a coin. If you win the flip, …" with no losing half).
+     */
+    private fun runSubEffect(
+        state: GameState,
+        subEffect: com.wingedsheep.sdk.scripting.effects.Effect?,
+        context: EffectContext,
+        flipEvents: List<com.wingedsheep.engine.core.GameEvent>,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (subEffect == null) return checkForMore(state, flipEvents)
+        val result = effectRunner.executeRemainingEffects(state, listOf(subEffect), context)
+        if (result.isPaused) {
+            return ExecutionResult.paused(
+                result.state,
+                result.pendingDecision!!,
+                flipEvents + result.events
+            )
+        }
+        return checkForMore(result.state, flipEvents + result.events)
     }
 
     private fun resumeCopyEachSpell(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/CoinFlipModifiers.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/CoinFlipModifiers.kt
@@ -5,17 +5,25 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.player.FlippedCoinsThisTurnComponent
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.FlipAdditionalCoins
 import com.wingedsheep.sdk.scripting.WinCoinFlips
 
 /**
- * Shared application path for coin-flip result replacement (CR 705.3, "An effect may state that a
- * coin flip has a certain result and/or that a certain player wins a coin flip … ignore the actual
- * results and use the indicated results instead"). Consulted from every coin-flip emission point —
- * `FlipCoinExecutor`, `FlipTwoCoinsExecutor`, and `FlipCoinsExecutor` — so any coin flip runs
- * through the same filter.
+ * Shared application path for coin-flip replacement, consulted from [CoinFlipService] — the single
+ * place a coin is actually flipped — so every coin in the game runs through the same filter.
  *
- * Currently the only source is [WinCoinFlips] (Edgar, King of Figaro's Two-Headed Coin). "Heads" is
- * modeled as a won flip throughout the coin plumbing, so a forced win is a forced heads.
+ * Two replacements live here:
+ *
+ * - [WinCoinFlips] (Edgar, King of Figaro's Two-Headed Coin) dictates the *result* (CR 705.3, "An
+ *   effect may state that a coin flip has a certain result and/or that a certain player wins a coin
+ *   flip … ignore the actual results and use the indicated results instead"). "Heads" is modeled as
+ *   a won flip throughout the coin plumbing, so a forced win is a forced heads.
+ * - [FlipAdditionalCoins] (Krark's Thumb) dictates *how many coins are flipped* in place of each one
+ *   (CR 614.1a — an "instead" effect is a replacement effect), leaving the flipper to ignore all but
+ *   one.
+ *
+ * The two compose without interacting: a forced win makes every coin in an enlarged batch heads, so
+ * there is nothing left to ignore and the flipper is never asked.
  */
 object CoinFlipModifiers {
 
@@ -48,4 +56,24 @@ object CoinFlipModifiers {
      */
     fun markFlipped(state: GameState, playerId: EntityId): GameState =
         state.updateEntity(playerId) { it.with(FlippedCoinsThisTurnComponent) }
+
+    /**
+     * How many coins [playerId] really flips in place of each single coin — 1 when they control no
+     * [FlipAdditionalCoins] source, 2 under one Krark's Thumb, 4 under two.
+     *
+     * Instances **multiply** rather than add: a second Thumb replaces each of the coins the first
+     * one produced, so two Thumbs are "flip four coins and ignore three", not "flip three and ignore
+     * two". A [FlipAdditionalCoins.coinsPerFlip] below 2 would flip fewer coins than the game asked
+     * for, which no replacement may do, so such a value is ignored rather than shrinking the batch.
+     *
+     * Uses projected controllers so a stolen Krark's Thumb helps its current controller.
+     */
+    fun coinsPerFlip(state: GameState, cardRegistry: CardRegistry, playerId: EntityId): Int =
+        state.projectedState.getBattlefieldControlledBy(playerId).fold(1) { coins, permanentId ->
+            val card = state.getEntity(permanentId)?.get<CardComponent>() ?: return@fold coins
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: return@fold coins
+            cardDef.script.staticAbilities
+                .filterIsInstance<FlipAdditionalCoins>()
+                .fold(coins) { running, ability -> running * ability.coinsPerFlip.coerceAtLeast(1) }
+        }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/CoinFlipService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/CoinFlipService.kt
@@ -1,0 +1,244 @@
+package com.wingedsheep.engine.handlers.effects
+
+import com.wingedsheep.engine.core.CoinFlipEvent
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.handlers.DecisionHandler
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.model.EntityId
+import kotlinx.serialization.Serializable
+
+/**
+ * The single place a coin is actually flipped.
+ *
+ * Every coin-flip executor asks this service for its coins rather than calling
+ * [GameState.nextRandom] itself, so both coin-flip replacements apply uniformly wherever a flip
+ * happens: [com.wingedsheep.sdk.scripting.WinCoinFlips] (all coins come up heads, CR 705.3) and
+ * [com.wingedsheep.sdk.scripting.FlipAdditionalCoins] (each coin becomes several, all but one
+ * ignored — Krark's Thumb).
+ *
+ * "Heads" is a won flip throughout the coin plumbing, so a forced win is a forced heads.
+ *
+ * ### Why this is a two-phase API
+ *
+ * "Flip two coins and ignore one" is a *choice*, so a flip can pause mid-resolution. The service
+ * therefore returns either a [Resolution.Resolved] with one result per coin the caller asked for,
+ * or a [Resolution.NeedsChoice] carrying the decision plus the [PendingCoinFlipChoice] the caller
+ * must park in a [com.wingedsheep.engine.core.CoinFlipChoiceContinuation]. Resuming calls
+ * [advanceAfterAnswer], which either raises the next question or finishes the batch — so a caller
+ * never has to know how many prompts a flip will cost.
+ *
+ * ### What the rulings pin down
+ *
+ * - The replacement applies to **each individual coin**, not to the instruction: "flip five coins"
+ *   under one Krark's Thumb is five *pairs*, one kept from each — not ten coins with five ignored.
+ *   That is why [flip] takes a `count` and builds one batch per coin.
+ * - **Every coin is flipped before any is ignored** ("You will know the results of all simultaneous
+ *   flips before choosing which to ignore"), so [flip] rolls the whole batch up front and only then
+ *   starts asking.
+ * - A batch whose coins all agree offers nothing to choose, so no question is raised for it. That
+ *   also means a [com.wingedsheep.sdk.scripting.WinCoinFlips] replacement — which makes every coin
+ *   heads — silently costs no prompts.
+ */
+object CoinFlipService {
+
+    /**
+     * A coin-flip batch part-way through being resolved: the raw coins that were flipped for each
+     * coin the caller asked for, plus the kept result of every batch decided so far.
+     *
+     * [decided] fills [batches] from the front, so `decided.size` is both the number of finished
+     * batches and the index of the one being asked about. Rides in
+     * [com.wingedsheep.engine.core.CoinFlipChoiceContinuation] across the pause.
+     */
+    @Serializable
+    data class PendingCoinFlipChoice(
+        val batches: List<List<Boolean>>,
+        val decided: List<Boolean> = emptyList(),
+        val flipperId: EntityId,
+        val sourceId: EntityId? = null,
+        val sourceName: String = "Unknown"
+    )
+
+    /** Either a finished batch of flips, or a question the flipper still owes an answer to. */
+    sealed interface Resolution {
+
+        /**
+         * The batch is done. [results] has one entry per coin the caller asked for — `true` is
+         * heads / a won flip — and [events] reports every coin that was really flipped, with the
+         * discarded ones carrying [CoinFlipEvent.ignored].
+         */
+        data class Resolved(
+            val state: GameState,
+            val results: List<Boolean>,
+            val events: List<GameEvent>
+        ) : Resolution
+
+        /**
+         * The flipper must say which coin to keep. [events] carries the flips already settled (so
+         * they reach the log at the pause); [pending] must be stored in the caller's continuation
+         * and handed back to [advanceAfterAnswer] with the answer.
+         */
+        data class NeedsChoice(
+            val state: GameState,
+            val decision: PendingDecision,
+            val pending: PendingCoinFlipChoice,
+            val events: List<GameEvent>
+        ) : Resolution
+    }
+
+    /**
+     * Flip [count] coins for [flipperId], applying every coin-flip replacement they control.
+     *
+     * [count] is the number of coins the *game* asked for; a replacement may turn each into several
+     * real flips. A [count] of zero is a no-op and does not even mark the player as having flipped.
+     */
+    fun flip(
+        state: GameState,
+        flipperId: EntityId,
+        count: Int,
+        sourceId: EntityId?,
+        cardRegistry: CardRegistry,
+        decisionHandler: DecisionHandler
+    ): Resolution {
+        val sourceName = sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name } ?: "Unknown"
+        val wanted = count.coerceAtLeast(0)
+        if (wanted == 0) return Resolution.Resolved(state, emptyList(), emptyList())
+
+        val forced = CoinFlipModifiers.shouldForceWin(state, cardRegistry, flipperId)
+        val coinsPerFlip = CoinFlipModifiers.coinsPerFlip(state, cardRegistry, flipperId)
+
+        var current = state
+        val batches = List(wanted) {
+            List(coinsPerFlip) {
+                if (forced) {
+                    true
+                } else {
+                    val (result, advanced) = current.nextRandom { nextBoolean() }
+                    current = advanced
+                    result
+                }
+            }
+        }
+
+        // One "you flipped coins" mark per flip event, as before — the replacement multiplies the
+        // coins inside the event, it does not turn one event into several.
+        current = CoinFlipModifiers.markFlipped(current, flipperId)
+
+        return advance(
+            current,
+            PendingCoinFlipChoice(batches, emptyList(), flipperId, sourceId, sourceName),
+            emptyList(),
+            decisionHandler
+        )
+    }
+
+    /**
+     * Resume a paused batch: record [keepHeads] as the kept result of the batch that was being
+     * asked about, then carry on to the next undecided batch (or finish).
+     */
+    fun advanceAfterAnswer(
+        state: GameState,
+        pending: PendingCoinFlipChoice,
+        keepHeads: Boolean,
+        decisionHandler: DecisionHandler
+    ): Resolution {
+        val index = pending.decided.size
+        if (index >= pending.batches.size) {
+            return Resolution.Resolved(state, pending.decided, emptyList())
+        }
+        val settled = pending.copy(decided = pending.decided + keepHeads)
+        return advance(state, settled, eventsForBatch(settled, index), decisionHandler)
+    }
+
+    /**
+     * Settle every batch that needs no input, stopping at the first that does.
+     *
+     * [eventsSoFar] are flips already settled on this pass and not yet published; they ride out on
+     * whichever [Resolution] this returns.
+     */
+    private fun advance(
+        state: GameState,
+        pending: PendingCoinFlipChoice,
+        eventsSoFar: List<GameEvent>,
+        decisionHandler: DecisionHandler
+    ): Resolution {
+        var settled = pending
+        val events = eventsSoFar.toMutableList()
+
+        while (settled.decided.size < settled.batches.size) {
+            val index = settled.decided.size
+            val batch = settled.batches[index]
+
+            // Nothing to choose when the coins agree — including the trivial one-coin batch of a
+            // player with no "flip additional coins" replacement, and any batch a forced-win
+            // replacement made unanimously heads.
+            val unanimous = batch.all { it } || batch.none { it }
+            if (unanimous) {
+                settled = settled.copy(decided = settled.decided + batch.first())
+                events += eventsForBatch(settled, index)
+                continue
+            }
+
+            val decisionResult = decisionHandler.createYesNoDecision(
+                state = state,
+                playerId = settled.flipperId,
+                sourceId = settled.sourceId,
+                sourceName = settled.sourceName,
+                prompt = choicePrompt(settled, index),
+                yesText = "Keep heads",
+                noText = "Keep tails",
+                phase = DecisionPhase.RESOLUTION
+            )
+            val decision = decisionResult.pendingDecision
+                ?: return Resolution.Resolved(
+                    // Fail closed on the honest result rather than inventing a choice: without a
+                    // decision the flipper cannot pick, so the batch keeps its first coin.
+                    state,
+                    settled.decided + batch.first(),
+                    events + eventsForBatch(settled.copy(decided = settled.decided + batch.first()), index)
+                )
+
+            return Resolution.NeedsChoice(
+                decisionResult.state,
+                decision,
+                settled,
+                events + decisionResult.events
+            )
+        }
+
+        return Resolution.Resolved(state, settled.decided, events)
+    }
+
+    /**
+     * The flips of batch [index], now that its kept result is known: exactly one coin matching the
+     * kept result counts, and every other coin in the batch is reported as ignored.
+     */
+    private fun eventsForBatch(pending: PendingCoinFlipChoice, index: Int): List<GameEvent> {
+        val batch = pending.batches[index]
+        val kept = pending.decided[index]
+        val keptPosition = batch.indexOf(kept)
+        return batch.mapIndexed { position, coin ->
+            CoinFlipEvent(
+                playerId = pending.flipperId,
+                won = coin,
+                sourceId = pending.sourceId ?: pending.flipperId,
+                sourceName = pending.sourceName,
+                ignored = position != keptPosition
+            )
+        }
+    }
+
+    private fun choicePrompt(pending: PendingCoinFlipChoice, index: Int): String {
+        val batch = pending.batches[index]
+        val heads = batch.count { it }
+        val tails = batch.size - heads
+        val rolled = "You flipped $heads heads and $tails tails"
+        val which =
+            if (pending.batches.size == 1) "."
+            else " for flip ${index + 1} of ${pending.batches.size}."
+        return "$rolled$which Ignore all but one — which result do you keep?"
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CompositeExecutors.kt
@@ -36,11 +36,11 @@ class CompositeExecutors(
     private val payDynamicManaCostExecutor by lazy { PayDynamicManaCostExecutor(cardRegistry) }
     private val payManaCostRepeatedlyExecutor by lazy { PayManaCostRepeatedlyExecutor(cardRegistry, decisionHandler) }
     private val reflexiveTriggerEffectExecutor by lazy { ReflexiveTriggerEffectExecutor(effectExecutor, targetFinder, decisionHandler, cardRegistry) }
-    private val flipCoinExecutor by lazy { FlipCoinExecutor(cardRegistry, effectExecutor) }
+    private val flipCoinExecutor by lazy { FlipCoinExecutor(cardRegistry, effectExecutor, decisionHandler) }
     private val repeatWhileExecutor by lazy { RepeatWhileExecutor(effectExecutor) }
     private val conditionalOnCollectionExecutor by lazy { ConditionalOnCollectionExecutor(effectExecutor) }
-    private val flipTwoCoinsExecutor by lazy { FlipTwoCoinsExecutor(cardRegistry, effectExecutor) }
-    private val flipCoinsExecutor by lazy { FlipCoinsExecutor(cardRegistry) }
+    private val flipTwoCoinsExecutor by lazy { FlipTwoCoinsExecutor(cardRegistry, effectExecutor, decisionHandler) }
+    private val flipCoinsExecutor by lazy { FlipCoinsExecutor(cardRegistry, decisionHandler) }
     private val flipCoinsUntilLossExecutor by lazy { FlipCoinsUntilLossExecutor(cardRegistry, decisionHandler) }
     private val chooseActionEffectExecutor by lazy { ChooseActionEffectExecutor(effectExecutor) }
     private val repeatDynamicTimesExecutor by lazy { RepeatDynamicTimesExecutor(effectExecutor) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/FlipCoinExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/FlipCoinExecutor.kt
@@ -1,28 +1,33 @@
 package com.wingedsheep.engine.handlers.effects.composite
 
-import com.wingedsheep.engine.core.CoinFlipEvent
+import com.wingedsheep.engine.core.CoinFlipChoiceContinuation
 import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.EffectContext
-import com.wingedsheep.engine.handlers.effects.CoinFlipModifiers
+import com.wingedsheep.engine.handlers.effects.CoinFlipService
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.FlipCoinEffect
 import kotlin.reflect.KClass
 
 /**
- * Executor for FlipCoinEffect.
- * Flips a coin (50/50 random) and executes the appropriate sub-effect. A [CoinFlipModifiers]
- * result replacement (e.g. Edgar's Two-Headed Coin) can force the flip to a win (CR 705.3).
+ * Executor for [FlipCoinEffect].
  *
- * @param cardRegistry Used to look up coin-flip result replacements the flipping player controls.
+ * Flips one coin through [CoinFlipService] — which applies any coin-flip replacement the flipper
+ * controls — and executes the matching sub-effect. Because a
+ * [com.wingedsheep.sdk.scripting.FlipAdditionalCoins] replacement (Krark's Thumb) turns that coin
+ * into a batch the flipper must choose from, the flip can pause; the sub-effect then runs from
+ * [CoinFlipChoiceContinuation] on the resume path instead of here.
+ *
+ * @param cardRegistry Used to look up the coin-flip replacements the flipping player controls.
  * @param effectExecutor Function to execute a sub-effect (provided by registry)
  */
 class FlipCoinExecutor(
     private val cardRegistry: CardRegistry,
-    private val effectExecutor: (GameState, Effect, EffectContext) -> EffectResult
+    private val effectExecutor: (GameState, Effect, EffectContext) -> EffectResult,
+    private val decisionHandler: DecisionHandler = DecisionHandler()
 ) : EffectExecutor<FlipCoinEffect> {
 
     override val effectType: KClass<FlipCoinEffect> = FlipCoinEffect::class
@@ -32,21 +37,47 @@ class FlipCoinExecutor(
         effect: FlipCoinEffect,
         context: EffectContext
     ): EffectResult {
-        val forced = CoinFlipModifiers.shouldForceWin(state, cardRegistry, context.controllerId)
-        val (won, afterFlip) = if (forced) true to state else state.nextRandom { nextBoolean() }
-        val marked = CoinFlipModifiers.markFlipped(afterFlip, context.controllerId)
+        val resolution = CoinFlipService.flip(
+            state = state,
+            flipperId = context.controllerId,
+            count = 1,
+            sourceId = context.sourceId,
+            cardRegistry = cardRegistry,
+            decisionHandler = decisionHandler
+        )
 
-        val sourceId = context.sourceId
-        val sourceName = sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name } ?: "Unknown"
-        val event = CoinFlipEvent(context.controllerId, won, sourceId ?: context.controllerId, sourceName)
+        return when (resolution) {
+            is CoinFlipService.Resolution.NeedsChoice -> EffectResult.paused(
+                resolution.state.pushContinuation(
+                    CoinFlipChoiceContinuation(
+                        decisionId = resolution.decision.id,
+                        effect = effect,
+                        effectContext = context,
+                        pending = resolution.pending
+                    )
+                ),
+                resolution.decision,
+                resolution.events
+            )
 
-        val subEffect = if (won) effect.wonEffect else effect.lostEffect
-
-        if (subEffect == null) {
-            return EffectResult.success(marked, listOf(event))
+            is CoinFlipService.Resolution.Resolved -> {
+                val subEffect = subEffectFor(effect, resolution.results)
+                    ?: return EffectResult.success(resolution.state, resolution.events)
+                val result = effectExecutor(resolution.state, subEffect, context)
+                result.copy(events = resolution.events + result.events)
+            }
         }
+    }
 
-        val result = effectExecutor(marked, subEffect, context)
-        return result.copy(events = listOf(event) + result.events)
+    companion object {
+
+        /**
+         * Which half of [effect] the settled coin calls for, or null when that half is empty.
+         *
+         * Shared with the resume path so a flip that paused for a Krark's Thumb choice runs exactly
+         * the same branch it would have run without one.
+         */
+        fun subEffectFor(effect: FlipCoinEffect, results: List<Boolean>): Effect? =
+            if (results.firstOrNull() == true) effect.wonEffect else effect.lostEffect
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/FlipCoinsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/FlipCoinsExecutor.kt
@@ -1,34 +1,35 @@
 package com.wingedsheep.engine.handlers.effects.composite
 
-import com.wingedsheep.engine.core.CoinFlipEvent
+import com.wingedsheep.engine.core.CoinFlipChoiceContinuation
 import com.wingedsheep.engine.core.EffectResult
-import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.EffectContext
-import com.wingedsheep.engine.handlers.effects.CoinFlipModifiers
+import com.wingedsheep.engine.handlers.effects.CoinFlipService
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.FlipCoinsEffect
 import kotlin.reflect.KClass
 
 /**
  * Executor for [FlipCoinsEffect].
  *
- * Flips [FlipCoinsEffect.count] coins, emitting one [CoinFlipEvent] per flip, and publishes the
- * number that came up heads into the pipeline (`storedNumbers[storeHeadsAs]`) via
+ * Flips [FlipCoinsEffect.count] coins through [CoinFlipService] and publishes the number that came
+ * up heads into the pipeline (`storedNumbers[storeHeadsAs]`) via
  * [EffectResult.updatedStoredNumbers] so a later sub-effect in the same composite can scale off it
  * with [com.wingedsheep.sdk.scripting.values.DynamicAmount.VariableReference] — exactly how
  * [StoreNumberExecutor][com.wingedsheep.engine.handlers.effects.library.StoreNumberExecutor]
  * surfaces a value.
  *
  * "Heads" is modelled as a won flip, matching the rest of the coin-flip plumbing
- * ([FlipCoinExecutor]). A [CoinFlipModifiers] result replacement (e.g. Edgar's Two-Headed Coin)
- * forces every coin in the event to heads (CR 705.3) — all [FlipCoinsEffect.count] coins are one
- * flip event, so a first-flip-each-turn replacement covers the whole batch.
+ * ([FlipCoinExecutor]). Each of the [FlipCoinsEffect.count] coins is its own flip for replacement
+ * purposes, so a [com.wingedsheep.sdk.scripting.FlipAdditionalCoins] replacement (Krark's Thumb)
+ * turns "flip five coins" into five pairs with one kept from each, not into ten coins with any five
+ * ignored — the distinction the card's own ruling draws.
  */
 class FlipCoinsExecutor(
-    private val cardRegistry: CardRegistry
+    private val cardRegistry: CardRegistry,
+    private val decisionHandler: DecisionHandler = DecisionHandler()
 ) : EffectExecutor<FlipCoinsEffect> {
 
     override val effectType: KClass<FlipCoinsEffect> = FlipCoinsEffect::class
@@ -38,35 +39,34 @@ class FlipCoinsExecutor(
         effect: FlipCoinsEffect,
         context: EffectContext
     ): EffectResult {
-        val sourceId = context.sourceId
-        val sourceName = sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name } ?: "Unknown"
-
-        val forced = CoinFlipModifiers.shouldForceWin(state, cardRegistry, context.controllerId)
-
-        var currentState = state
-        val events = mutableListOf<GameEvent>()
-        var heads = 0
-        repeat(effect.count.coerceAtLeast(0)) {
-            val won = if (forced) {
-                true
-            } else {
-                val (result, advanced) = currentState.nextRandom { nextBoolean() }
-                currentState = advanced
-                result
-            }
-            if (won) heads++
-            events.add(CoinFlipEvent(context.controllerId, won, sourceId ?: context.controllerId, sourceName))
-        }
-
-        // Mark the flip only when the event actually flipped one or more coins (count 0 is a no-op).
-        if (effect.count.coerceAtLeast(0) > 0) {
-            currentState = CoinFlipModifiers.markFlipped(currentState, context.controllerId)
-        }
-
-        return EffectResult(
-            state = currentState,
-            events = events,
-            updatedStoredNumbers = mapOf(effect.storeHeadsAs to heads)
+        val resolution = CoinFlipService.flip(
+            state = state,
+            flipperId = context.controllerId,
+            count = effect.count,
+            sourceId = context.sourceId,
+            cardRegistry = cardRegistry,
+            decisionHandler = decisionHandler
         )
+
+        return when (resolution) {
+            is CoinFlipService.Resolution.NeedsChoice -> EffectResult.paused(
+                resolution.state.pushContinuation(
+                    CoinFlipChoiceContinuation(
+                        decisionId = resolution.decision.id,
+                        effect = effect,
+                        effectContext = context,
+                        pending = resolution.pending
+                    )
+                ),
+                resolution.decision,
+                resolution.events
+            )
+
+            is CoinFlipService.Resolution.Resolved -> EffectResult(
+                state = resolution.state,
+                events = resolution.events,
+                updatedStoredNumbers = mapOf(effect.storeHeadsAs to resolution.results.count { it })
+            )
+        }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/FlipCoinsUntilLossExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/FlipCoinsUntilLossExecutor.kt
@@ -1,6 +1,6 @@
 package com.wingedsheep.engine.handlers.effects.composite
 
-import com.wingedsheep.engine.core.CoinFlipEvent
+import com.wingedsheep.engine.core.CoinFlipChoiceContinuation
 import com.wingedsheep.engine.core.DecisionPhase
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.FlipCoinsUntilLossContinuation
@@ -8,7 +8,7 @@ import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.GameLimits
 import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.EffectContext
-import com.wingedsheep.engine.handlers.effects.CoinFlipModifiers
+import com.wingedsheep.engine.handlers.effects.CoinFlipService
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
@@ -33,11 +33,15 @@ import kotlin.reflect.KClass
  * to continue flipping"): the choice only ever follows a *won* flip, because a lost flip has already
  * ended the run and there is nothing left to decide.
  *
- * Unlike [FlipCoinsExecutor], [CoinFlipModifiers.shouldForceWin] is consulted **per flip** and
- * [CoinFlipModifiers.markFlipped] runs after each one. `FlipCoinsEffect` flips its whole batch as a
- * single "flip N coins" event, so one replacement decision covers all of it; here each coin is its own
- * flip, so a "the first time you flip one or more coins each turn" replacement (Edgar, King of Figaro)
- * applies to the first coin only and the rest are honest flips.
+ * This run has **two** pause points, and they must not be confused. The coin itself can pause under a
+ * [com.wingedsheep.sdk.scripting.FlipAdditionalCoins] replacement (Krark's Thumb: "which of these two
+ * do you keep?", a [CoinFlipChoiceContinuation]), and only once that coin has settled does the
+ * "flip again?" question arise. The tally therefore has to survive the *first* pause too, which is
+ * why [CoinFlipChoiceContinuation.winsSoFar] exists.
+ *
+ * Unlike [FlipCoinsExecutor], each coin here is its own flip event: [CoinFlipService] is called once
+ * per coin, so a "the first time you flip one or more coins each turn" replacement (Edgar, King of
+ * Figaro) applies to the first coin only and the rest are honest flips.
  */
 class FlipCoinsUntilLossExecutor(
     private val cardRegistry: CardRegistry,
@@ -52,10 +56,9 @@ class FlipCoinsUntilLossExecutor(
         context: EffectContext
     ): EffectResult = flipOnce(
         state = state,
-        flipperId = context.controllerId,
-        storeWinsAs = effect.storeWinsAs,
+        effect = effect,
+        context = context,
         winsSoFar = 0,
-        sourceId = context.sourceId,
         cardRegistry = cardRegistry,
         decisionHandler = decisionHandler,
         priorEvents = emptyList()
@@ -64,35 +67,76 @@ class FlipCoinsUntilLossExecutor(
     companion object {
 
         /**
-         * Flip one coin for [flipperId] on top of [winsSoFar] already-won flips.
+         * Flip one coin for the run's flipper on top of [winsSoFar] already-won flips.
          *
-         * Returns either a finished result carrying the final tally under [storeWinsAs], or a pause on
-         * the "flip again?" question with a [FlipCoinsUntilLossContinuation] holding the new tally.
+         * Returns a finished result carrying the final tally under
+         * [FlipCoinsUntilLossEffect.storeWinsAs], a pause on "which coin do you keep?" when a
+         * flip-additional-coins replacement applies, or a pause on "flip again?" after a win.
          */
         fun flipOnce(
             state: GameState,
-            flipperId: EntityId,
-            storeWinsAs: String,
+            effect: FlipCoinsUntilLossEffect,
+            context: EffectContext,
             winsSoFar: Int,
-            sourceId: EntityId?,
             cardRegistry: CardRegistry,
             decisionHandler: DecisionHandler,
             priorEvents: List<GameEvent>
         ): EffectResult {
-            val sourceName = sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name } ?: "Unknown"
+            val resolution = CoinFlipService.flip(
+                state = state,
+                flipperId = context.controllerId,
+                count = 1,
+                sourceId = context.sourceId,
+                cardRegistry = cardRegistry,
+                decisionHandler = decisionHandler
+            )
 
-            val forced = CoinFlipModifiers.shouldForceWin(state, cardRegistry, flipperId)
-            val (won, afterFlip) = if (forced) true to state else state.nextRandom { nextBoolean() }
-            val afterMark = CoinFlipModifiers.markFlipped(afterFlip, flipperId)
+            return when (resolution) {
+                is CoinFlipService.Resolution.NeedsChoice -> EffectResult.paused(
+                    resolution.state.pushContinuation(
+                        CoinFlipChoiceContinuation(
+                            decisionId = resolution.decision.id,
+                            effect = effect,
+                            effectContext = context,
+                            pending = resolution.pending,
+                            winsSoFar = winsSoFar
+                        )
+                    ),
+                    resolution.decision,
+                    priorEvents + resolution.events
+                )
 
-            val events = priorEvents +
-                CoinFlipEvent(flipperId, won, sourceId ?: flipperId, sourceName)
+                is CoinFlipService.Resolution.Resolved -> afterFlip(
+                    state = resolution.state,
+                    effect = effect,
+                    context = context,
+                    won = resolution.results.firstOrNull() == true,
+                    winsSoFar = winsSoFar,
+                    decisionHandler = decisionHandler,
+                    priorEvents = priorEvents + resolution.events
+                )
+            }
+        }
 
+        /**
+         * Continue the run now that one coin has settled: a lost flip ends it, a won flip asks
+         * whether to keep going. Shared with the resume path so a coin that paused for a Krark's
+         * Thumb choice rejoins the run exactly where an unreplaced coin would have.
+         */
+        fun afterFlip(
+            state: GameState,
+            effect: FlipCoinsUntilLossEffect,
+            context: EffectContext,
+            won: Boolean,
+            winsSoFar: Int,
+            decisionHandler: DecisionHandler,
+            priorEvents: List<GameEvent>
+        ): EffectResult {
             if (!won) {
                 // The run ends on a lost flip and the flip that lost is not counted. Losing the first
                 // flip therefore stores 0 — which is how "if you lose a flip, this has no effect" is
                 // modelled: every `GTE 1` payoff gate reads the zero and falls away on its own.
-                return finish(afterMark, storeWinsAs, winsSoFar, events)
+                return finish(state, effect.storeWinsAs, winsSoFar, priorEvents)
             }
 
             val wins = winsSoFar + 1
@@ -105,12 +149,15 @@ class FlipCoinsUntilLossExecutor(
                     "GameLimits: flip-until-loss reached $wins won flips — stopping " +
                         "(likely a forced-win replacement with an automated 'continue' answer)."
                 )
-                return finish(afterMark, storeWinsAs, wins, events)
+                return finish(state, effect.storeWinsAs, wins, priorEvents)
             }
 
+            val sourceId = context.sourceId
+            val sourceName = sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name } ?: "Unknown"
+
             val decisionResult = decisionHandler.createYesNoDecision(
-                state = afterMark,
-                playerId = flipperId,
+                state = state,
+                playerId = context.controllerId,
                 sourceId = sourceId,
                 sourceName = sourceName,
                 prompt = "Flip another coin? You have won $wins " +
@@ -120,12 +167,12 @@ class FlipCoinsUntilLossExecutor(
                 phase = DecisionPhase.RESOLUTION
             )
             val decision = decisionResult.pendingDecision
-                ?: return EffectResult.error(afterMark, "Failed to create continue-flipping decision")
+                ?: return EffectResult.error(state, "Failed to create continue-flipping decision")
 
             val continuation = FlipCoinsUntilLossContinuation(
                 decisionId = decision.id,
-                flipperId = flipperId,
-                storeWinsAs = storeWinsAs,
+                flipperId = context.controllerId,
+                storeWinsAs = effect.storeWinsAs,
                 winsSoFar = wins,
                 sourceId = sourceId
             )
@@ -133,9 +180,13 @@ class FlipCoinsUntilLossExecutor(
             return EffectResult.paused(
                 decisionResult.state.pushContinuation(continuation),
                 decision,
-                events + decisionResult.events
+                priorEvents + decisionResult.events
             )
         }
+
+        /** The run's flipper and source, rebuilt for a resume that only kept the frame's fields. */
+        fun contextFor(flipperId: EntityId, sourceId: EntityId?): EffectContext =
+            EffectContext(sourceId = sourceId, controllerId = flipperId)
 
         private fun finish(
             state: GameState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/FlipTwoCoinsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/FlipTwoCoinsExecutor.kt
@@ -1,26 +1,31 @@
 package com.wingedsheep.engine.handlers.effects.composite
 
-import com.wingedsheep.engine.core.CoinFlipEvent
+import com.wingedsheep.engine.core.CoinFlipChoiceContinuation
 import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.EffectContext
-import com.wingedsheep.engine.handlers.effects.CoinFlipModifiers
+import com.wingedsheep.engine.handlers.effects.CoinFlipService
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.FlipTwoCoinsEffect
 import kotlin.reflect.KClass
 
 /**
- * Executor for FlipTwoCoinsEffect.
- * Flips two coins and executes the appropriate sub-effect based on the combined outcome. A
- * [CoinFlipModifiers] result replacement (e.g. Edgar's Two-Headed Coin) forces both coins to heads
- * (CR 705.3) — the two coins are one flip event, so a first-flip-each-turn replacement covers both.
+ * Executor for [FlipTwoCoinsEffect].
+ *
+ * Flips two coins through [CoinFlipService] and executes the sub-effect for the combined outcome.
+ * The two coins are two separate flips, so a
+ * [com.wingedsheep.sdk.scripting.FlipAdditionalCoins] replacement (Krark's Thumb) applies to each
+ * of them independently — "you don't flip four coins and ignore any two; you flip two coins, flip
+ * two coins, and then ignore one flip from each pair" — which is exactly what asking
+ * [CoinFlipService] for a `count` of two does.
  */
 class FlipTwoCoinsExecutor(
     private val cardRegistry: CardRegistry,
-    private val effectExecutor: (GameState, Effect, EffectContext) -> EffectResult
+    private val effectExecutor: (GameState, Effect, EffectContext) -> EffectResult,
+    private val decisionHandler: DecisionHandler = DecisionHandler()
 ) : EffectExecutor<FlipTwoCoinsEffect> {
 
     override val effectType: KClass<FlipTwoCoinsEffect> = FlipTwoCoinsEffect::class
@@ -30,30 +35,48 @@ class FlipTwoCoinsExecutor(
         effect: FlipTwoCoinsEffect,
         context: EffectContext
     ): EffectResult {
-        val forced = CoinFlipModifiers.shouldForceWin(state, cardRegistry, context.controllerId)
-        val (coin1, s1) = if (forced) true to state else state.nextRandom { nextBoolean() }
-        val (coin2, s2) = if (forced) true to s1 else s1.nextRandom { nextBoolean() }
-        val marked = CoinFlipModifiers.markFlipped(s2, context.controllerId)
-
-        val sourceId = context.sourceId
-        val sourceName = sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name } ?: "Unknown"
-
-        val events = listOf(
-            CoinFlipEvent(context.controllerId, coin1, sourceId ?: context.controllerId, sourceName),
-            CoinFlipEvent(context.controllerId, coin2, sourceId ?: context.controllerId, sourceName)
+        val resolution = CoinFlipService.flip(
+            state = state,
+            flipperId = context.controllerId,
+            count = 2,
+            sourceId = context.sourceId,
+            cardRegistry = cardRegistry,
+            decisionHandler = decisionHandler
         )
 
-        val subEffect = when {
-            coin1 && coin2 -> effect.bothHeadsEffect
-            !coin1 && !coin2 -> effect.bothTailsEffect
-            else -> effect.mixedEffect
-        }
+        return when (resolution) {
+            is CoinFlipService.Resolution.NeedsChoice -> EffectResult.paused(
+                resolution.state.pushContinuation(
+                    CoinFlipChoiceContinuation(
+                        decisionId = resolution.decision.id,
+                        effect = effect,
+                        effectContext = context,
+                        pending = resolution.pending
+                    )
+                ),
+                resolution.decision,
+                resolution.events
+            )
 
-        if (subEffect == null) {
-            return EffectResult.success(marked, events)
+            is CoinFlipService.Resolution.Resolved -> {
+                val subEffect = subEffectFor(effect, resolution.results)
+                    ?: return EffectResult.success(resolution.state, resolution.events)
+                val result = effectExecutor(resolution.state, subEffect, context)
+                result.copy(events = resolution.events + result.events)
+            }
         }
+    }
 
-        val result = effectExecutor(marked, subEffect, context)
-        return result.copy(events = events + result.events)
+    companion object {
+
+        /** Which of the three outcome branches the settled coins call for, or null when it is empty. */
+        fun subEffectFor(effect: FlipTwoCoinsEffect, results: List<Boolean>): Effect? {
+            val heads = results.count { it }
+            return when {
+                heads == results.size -> effect.bothHeadsEffect
+                heads == 0 -> effect.bothTailsEffect
+                else -> effect.mixedEffect
+            }
+        }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -1059,9 +1059,11 @@ class StaticAbilityHandler(
             is RevealFirstDrawEachTurn,
             is RevealTopOfLibrary,
 
-            // Coin-flip result replacement (CR 705.3), queried by the coin-flip executors via
-            // CoinFlipModifiers — not a Rule 613 continuous effect:
+            // Coin-flip replacements, queried by CoinFlipService via CoinFlipModifiers — the
+            // result-dictating one (CR 705.3) and the flip-more-coins one (CR 614). Neither is a
+            // Rule 613 continuous effect:
             is WinCoinFlips,
+            is com.wingedsheep.sdk.scripting.FlipAdditionalCoins,
 
             // Stamped as marker components by addContinuousEffectComponent in this
             // handler and read from those components by their subsystems:

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
@@ -560,10 +560,17 @@ sealed interface ClientEvent {
         val sourceId: EntityId,
         val sourceName: String,
         val isYours: Boolean? = null,
-        override val description: String = when (isYours) {
-            true -> "You flipped a coin ($sourceName) — ${if (won) "you won" else "you lost"}"
-            false -> "Opponent flipped a coin ($sourceName) — ${if (won) "they won" else "they lost"}"
-            null -> "Flipped a coin ($sourceName) — ${if (won) "won" else "lost"}"
+        /** True when a "flip N coins and ignore all but one" replacement discarded this flip
+         *  (Krark's Thumb). The coin was really flipped, so it is shown, but its result was not
+         *  used — the log says so rather than reporting a win the player never got. */
+        val ignored: Boolean = false,
+        override val description: String = when {
+            ignored && isYours == true -> "You flipped a coin ($sourceName) — ${if (won) "heads" else "tails"}, ignored"
+            ignored && isYours == false -> "Opponent flipped a coin ($sourceName) — ${if (won) "heads" else "tails"}, ignored"
+            ignored -> "Flipped a coin ($sourceName) — ${if (won) "heads" else "tails"}, ignored"
+            isYours == true -> "You flipped a coin ($sourceName) — ${if (won) "you won" else "you lost"}"
+            isYours == false -> "Opponent flipped a coin ($sourceName) — ${if (won) "they won" else "they lost"}"
+            else -> "Flipped a coin ($sourceName) — ${if (won) "won" else "lost"}"
         }
     ) : ClientEvent
 
@@ -1207,7 +1214,8 @@ object ClientEventTransformer {
                 won = event.won,
                 sourceId = event.sourceId,
                 sourceName = event.sourceName,
-                isYours = event.playerId == viewingPlayerId
+                isYours = event.playerId == viewingPlayerId,
+                ignored = event.ignored
             )
 
             is TurnFaceUpEvent -> ClientEvent.TurnedFaceUp(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlipAdditionalCoinsTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlipAdditionalCoinsTest.kt
@@ -1,0 +1,349 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CoinFlipEvent
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.CoinFlipModifiers
+import com.wingedsheep.engine.handlers.effects.composite.FlipCoinExecutor
+import com.wingedsheep.engine.handlers.effects.composite.FlipCoinsExecutor
+import com.wingedsheep.engine.handlers.effects.composite.FlipTwoCoinsExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.GameRng
+import com.wingedsheep.sdk.scripting.FlipAdditionalCoins
+import com.wingedsheep.sdk.scripting.WinCoinFlips
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.effects.FlipCoinEffect
+import com.wingedsheep.sdk.scripting.effects.FlipCoinsEffect
+import com.wingedsheep.sdk.scripting.effects.FlipTwoCoinsEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * [FlipAdditionalCoins] — "If you would flip a coin, instead flip two coins and ignore one"
+ * (Krark's Thumb).
+ *
+ * The rules matrix here is taken from the card's own rulings, which are what make this a *per-coin*
+ * replacement rather than a per-instruction one:
+ *
+ * - "If an effect tells you to flip more than one coin at once, this replaces each individual coin
+ *   flip … you flip two coins, flip two coins, and then ignore one flip from each pair."
+ * - "You will know the results of all simultaneous flips before choosing which to ignore."
+ * - Two Thumbs flip four coins per flip and ignore three (the replacement applies to each coin the
+ *   previous one produced, so instances multiply).
+ *
+ * Plus the interaction with the other coin-flip replacement the engine has: a
+ * [WinCoinFlips] forced win makes every coin heads, which leaves nothing to ignore.
+ */
+class FlipAdditionalCoinsTest : FunSpec({
+
+    /** A Krark's Thumb stand-in: the static under test and nothing else. */
+    val thumb = card("Test Thumb") {
+        typeLine = "Legendary Artifact"
+        manaCost = "{2}"
+        oracleText = "If you would flip a coin, instead flip two coins and ignore one."
+        staticAbility { ability = FlipAdditionalCoins(coinsPerFlip = 2) }
+    }
+
+    /** "Flip three coins and ignore two" — proves the count is a parameter, not a constant. */
+    val tripleThumb = card("Test Triple Thumb") {
+        typeLine = "Legendary Artifact"
+        manaCost = "{2}"
+        oracleText = "If you would flip a coin, instead flip three coins and ignore two."
+        staticAbility { ability = FlipAdditionalCoins(coinsPerFlip = 3) }
+    }
+
+    /** Edgar's Two-Headed Coin, so the two replacements can be tested together. */
+    val luckyCoin = card("Test Lucky Coin") {
+        typeLine = "Artifact"
+        manaCost = "{2}"
+        oracleText = "You win all coin flips."
+        staticAbility { ability = WinCoinFlips() }
+    }
+
+    /** A spell whose two halves are far enough apart in life to identify which one ran. */
+    val coinToss = card("Test Coin Toss") {
+        typeLine = "Instant"
+        manaCost = "{R}"
+        oracleText = "Flip a coin. If you win the flip, you gain 10 life. If you lose the flip, you lose 3 life."
+        spell {
+            effect = FlipCoinEffect(
+                wonEffect = Effects.GainLife(10),
+                lostEffect = Effects.LoseLife(3, EffectTarget.Controller)
+            )
+        }
+    }
+
+    val extraCards = listOf(thumb, tripleThumb, luckyCoin, coinToss)
+
+    fun driverWith(vararg battlefield: String): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        extraCards.forEach { driver.registerCard(it) }
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        battlefield.forEach { driver.putPermanentOnBattlefield(player, it) }
+        return driver to player
+    }
+
+    /**
+     * Run [effect] on a seeded state and hand back the result.
+     *
+     * Seeds are searched rather than hard-coded because what the test cares about is *which shape*
+     * of batch came up (mixed or unanimous), not any particular coin.
+     */
+    fun flipWithSeed(
+        driver: GameTestDriver,
+        player: EntityId,
+        effect: Effect,
+        seed: Long
+    ): EffectResult {
+        val seeded = driver.state.copy(rng = GameRng.seeded(seed))
+        val context = EffectContext(sourceId = null, controllerId = player)
+        val noSubEffects: (GameState, Effect, EffectContext) -> EffectResult =
+            { s, _, _ -> EffectResult.success(s) }
+        return when (effect) {
+            is FlipCoinEffect ->
+                FlipCoinExecutor(driver.cardRegistry, noSubEffects).execute(seeded, effect, context)
+            is FlipTwoCoinsEffect ->
+                FlipTwoCoinsExecutor(driver.cardRegistry, noSubEffects).execute(seeded, effect, context)
+            is FlipCoinsEffect ->
+                FlipCoinsExecutor(driver.cardRegistry).execute(seeded, effect, context)
+            else -> error("not a flip effect")
+        }
+    }
+
+    /** The first seed in [range] whose flip of [effect] paused (i.e. produced a mixed batch). */
+    fun seedThatPauses(driver: GameTestDriver, player: EntityId, effect: Effect, range: LongRange) =
+        range.firstOrNull { flipWithSeed(driver, player, effect, it).isPaused }
+
+    /** The first seed in [range] whose flip of [effect] did not pause (a unanimous batch). */
+    fun seedThatSettles(driver: GameTestDriver, player: EntityId, effect: Effect, range: LongRange) =
+        range.firstOrNull { !flipWithSeed(driver, player, effect, it).isPaused }
+
+    // ── How many coins are flipped ───────────────────────────────────────
+
+    test("without the replacement a single flip is one coin and never asks anything") {
+        val (driver, player) = driverWith()
+
+        CoinFlipModifiers.coinsPerFlip(driver.state, driver.cardRegistry, player) shouldBe 1
+
+        (1L..40L).forEach { seed ->
+            val result = flipWithSeed(driver, player, FlipCoinEffect(), seed)
+            result.isPaused shouldBe false
+            val flips = result.events.filterIsInstance<CoinFlipEvent>()
+            flips.size shouldBe 1
+            flips.single().ignored shouldBe false
+        }
+    }
+
+    test("one Thumb flips two coins for one flip and ignores exactly one of them") {
+        val (driver, player) = driverWith("Test Thumb")
+
+        CoinFlipModifiers.coinsPerFlip(driver.state, driver.cardRegistry, player) shouldBe 2
+
+        val seed = seedThatSettles(driver, player, FlipCoinEffect(), 1L..200L)
+        seed.shouldNotBeNull()
+        val flips = flipWithSeed(driver, player, FlipCoinEffect(), seed)
+            .events.filterIsInstance<CoinFlipEvent>()
+
+        flips.size shouldBe 2
+        flips.count { !it.ignored } shouldBe 1
+    }
+
+    test("instances multiply: two Thumbs flip four coins per flip and ignore three") {
+        val (driver, player) = driverWith("Test Thumb", "Test Thumb")
+
+        CoinFlipModifiers.coinsPerFlip(driver.state, driver.cardRegistry, player) shouldBe 4
+
+        val seed = seedThatSettles(driver, player, FlipCoinEffect(), 1L..400L)
+        seed.shouldNotBeNull()
+        val flips = flipWithSeed(driver, player, FlipCoinEffect(), seed)
+            .events.filterIsInstance<CoinFlipEvent>()
+
+        flips.size shouldBe 4
+        flips.count { !it.ignored } shouldBe 1
+    }
+
+    test("the coins-per-flip count is a parameter, not a baked-in two") {
+        val (driver, player) = driverWith("Test Triple Thumb")
+        CoinFlipModifiers.coinsPerFlip(driver.state, driver.cardRegistry, player) shouldBe 3
+    }
+
+    test("a Thumb its owner does not control does nothing for them") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        extraCards.forEach { driver.registerCard(it) }
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.putPermanentOnBattlefield(opponent, "Test Thumb")
+
+        CoinFlipModifiers.coinsPerFlip(driver.state, driver.cardRegistry, player) shouldBe 1
+        CoinFlipModifiers.coinsPerFlip(driver.state, driver.cardRegistry, opponent) shouldBe 2
+    }
+
+    // ── Which coin decides the flip ──────────────────────────────────────
+
+    test("a unanimous batch decides itself — no question is raised and the kept coin is that result") {
+        val (driver, player) = driverWith("Test Thumb")
+
+        val seed = seedThatSettles(driver, player, FlipCoinEffect(), 1L..200L)
+        seed.shouldNotBeNull()
+        val flips = flipWithSeed(driver, player, FlipCoinEffect(), seed)
+            .events.filterIsInstance<CoinFlipEvent>()
+
+        // Unanimous is exactly why nothing was asked.
+        flips.map { it.won }.distinct().size shouldBe 1
+        flips.single { !it.ignored }.won shouldBe flips.first().won
+    }
+
+    test("a mixed batch asks the flipper which result to keep") {
+        val (driver, player) = driverWith("Test Thumb")
+
+        val seed = seedThatPauses(driver, player, FlipCoinEffect(), 1L..200L)
+        seed.shouldNotBeNull()
+        val result = flipWithSeed(driver, player, FlipCoinEffect(), seed)
+
+        val decision = result.pendingDecision as? YesNoDecision
+        decision.shouldNotBeNull()
+        decision.playerId shouldBe player
+        decision.yesText shouldBe "Keep heads"
+        decision.noText shouldBe "Keep tails"
+
+        // Both coins were rolled before the question was asked — the ruling's "you will know the
+        // results of all simultaneous flips before choosing which to ignore".
+        decision.prompt shouldBe "You flipped 1 heads and 1 tails. Ignore all but one — which result do you keep?"
+    }
+
+    // ── Interaction with the result-dictating replacement ────────────────
+
+    test("a forced win makes every coin heads, so the flipper is never asked") {
+        val (driver, player) = driverWith("Test Thumb", "Test Lucky Coin")
+
+        (1L..40L).forEach { seed ->
+            val result = flipWithSeed(driver, player, FlipCoinEffect(), seed)
+            result.isPaused shouldBe false
+            val flips = result.events.filterIsInstance<CoinFlipEvent>()
+            flips.size shouldBe 2
+            flips.all { it.won }.shouldBeTrue()
+        }
+    }
+
+    // ── Multi-coin instructions ──────────────────────────────────────────
+
+    test("flip five coins under a Thumb is five pairs, not ten coins with any five ignored") {
+        val (driver, player) = driverWith("Test Thumb")
+
+        // Ten real flips either way; what the ruling pins down is that they are *paired*, so exactly
+        // five survive — one per coin the instruction asked for.
+        val seed = seedThatSettles(driver, player, FlipCoinsEffect(5, "heads"), 1L..4000L)
+        seed.shouldNotBeNull()
+        val result = flipWithSeed(driver, player, FlipCoinsEffect(5, "heads"), seed)
+        val flips = result.events.filterIsInstance<CoinFlipEvent>()
+
+        flips.size shouldBe 10
+        flips.count { !it.ignored } shouldBe 5
+        // The published tally counts the kept coins only.
+        result.updatedStoredNumbers["heads"] shouldBe flips.count { !it.ignored && it.won }
+    }
+
+    test("flipping zero coins under a Thumb still flips nothing") {
+        val (driver, player) = driverWith("Test Thumb")
+        val result = flipWithSeed(driver, player, FlipCoinsEffect(0, "heads"), 1L)
+
+        result.events.filterIsInstance<CoinFlipEvent>().size shouldBe 0
+        result.updatedStoredNumbers["heads"] shouldBe 0
+    }
+
+    test("flip two coins under a Thumb replaces each of the two independently") {
+        val (driver, player) = driverWith("Test Thumb")
+
+        val seed = seedThatSettles(driver, player, FlipTwoCoinsEffect(), 1L..2000L)
+        seed.shouldNotBeNull()
+        val flips = flipWithSeed(driver, player, FlipTwoCoinsEffect(), seed)
+            .events.filterIsInstance<CoinFlipEvent>()
+
+        flips.size shouldBe 4
+        flips.count { !it.ignored } shouldBe 2
+    }
+
+    // ── The full pause / resume path, through the engine ─────────────────
+
+    /**
+     * Cast the coin-toss spell on a seeded game and, if that seed produced a mixed batch, answer
+     * the Krark's Thumb question with [keepHeads]. Returns the life change, or null when the seed
+     * happened to produce a unanimous batch and no question was asked.
+     *
+     * Seeds are searched rather than hard-coded so the resume path is genuinely exercised instead
+     * of silently skipped on a run where both coins agreed.
+     */
+    fun lifeChangeAfterKeeping(keepHeads: Boolean, seed: Long): Int? {
+        val (driver, player) = driverWith("Test Thumb")
+        driver.replaceState(driver.state.copy(rng = GameRng.seeded(seed)))
+        val startingLife = driver.getLifeTotal(player)
+
+        val card = driver.putCardInHand(player, "Test Coin Toss")
+        driver.giveMana(player, com.wingedsheep.sdk.core.Color.RED, 1)
+        driver.castSpell(player, card)
+        driver.bothPass()
+
+        val asked = driver.pendingDecision as? YesNoDecision ?: return null
+        asked.yesText shouldBe "Keep heads"
+        driver.submitYesNo(player, choice = keepHeads)
+        return driver.getLifeTotal(player) - startingLife
+    }
+
+    test("keeping the heads coin runs the won half of the spell") {
+        val change = (1L..80L).firstNotNullOfOrNull { lifeChangeAfterKeeping(keepHeads = true, seed = it) }
+        change.shouldNotBeNull()
+        change shouldBe 10
+    }
+
+    test("keeping the tails coin runs the lost half of the spell") {
+        val change = (1L..80L).firstNotNullOfOrNull { lifeChangeAfterKeeping(keepHeads = false, seed = it) }
+        change.shouldNotBeNull()
+        change shouldBe -3
+    }
+
+    test("a flip nobody had to choose about still runs the half its coins settled on") {
+        // The unanimous case goes straight through without a prompt, and must reach the same halves.
+        val changes = (1L..80L).mapNotNull { seed ->
+            val (driver, player) = driverWith("Test Thumb")
+            driver.replaceState(driver.state.copy(rng = GameRng.seeded(seed)))
+            val startingLife = driver.getLifeTotal(player)
+
+            val card = driver.putCardInHand(player, "Test Coin Toss")
+            driver.giveMana(player, com.wingedsheep.sdk.core.Color.RED, 1)
+            driver.castSpell(player, card)
+            driver.bothPass()
+
+            if (driver.pendingDecision != null) null
+            else driver.getLifeTotal(player) - startingLife
+        }
+        changes.isNotEmpty().shouldBeTrue()
+        changes.all { it == 10 || it == -3 }.shouldBeTrue()
+    }
+
+    test("the batch's ignored coins are reported, so the log shows what was really flipped") {
+        val (driver, player) = driverWith("Test Thumb")
+
+        val seed = seedThatSettles(driver, player, FlipCoinsEffect(3, "heads"), 1L..2000L)
+        seed.shouldNotBeNull()
+        val flips = flipWithSeed(driver, player, FlipCoinsEffect(3, "heads"), seed)
+            .events.filterIsInstance<CoinFlipEvent>()
+
+        flips.count { it.ignored } shouldBe 3
+        flips.size shouldBeGreaterThan flips.count { !it.ignored }
+    }
+})

--- a/web-client/src/components/animations/CoinFlipAnimations.tsx
+++ b/web-client/src/components/animations/CoinFlipAnimations.tsx
@@ -64,11 +64,33 @@ function CoinFlipAnimationCard({
   }
 
   const won = animation.won
-  const glowColor = won ? 'rgba(34, 197, 94, 0.5)' : 'rgba(239, 68, 68, 0.5)'
-  const borderColor = won ? '#22c55e' : '#ef4444'
-  const bgColor = won ? 'rgba(34, 197, 94, 0.15)' : 'rgba(239, 68, 68, 0.15)'
-  const textColor = won ? '#4ade80' : '#f87171'
-  const resultText = won ? 'WON' : 'LOST'
+  const ignored = animation.ignored === true
+
+  // An ignored coin is shown greyed out: it was really flipped, but nothing read its result, so it
+  // must not read as a win or a loss the player actually got.
+  const glowColor = ignored
+    ? 'rgba(148, 163, 184, 0.35)'
+    : won
+      ? 'rgba(34, 197, 94, 0.5)'
+      : 'rgba(239, 68, 68, 0.5)'
+  const borderColor = ignored ? '#64748b' : won ? '#22c55e' : '#ef4444'
+  const bgColor = ignored
+    ? 'rgba(100, 116, 139, 0.12)'
+    : won
+      ? 'rgba(34, 197, 94, 0.15)'
+      : 'rgba(239, 68, 68, 0.15)'
+  const textColor = ignored ? '#94a3b8' : won ? '#4ade80' : '#f87171'
+  const resultText = ignored ? (won ? 'HEADS' : 'TAILS') : won ? 'WON' : 'LOST'
+  const label = ignored
+    ? `${animation.sourceName} — Ignored`
+    : `${animation.sourceName} — Coin flip ${won ? 'won' : 'lost'}`
+
+  // Fan a simultaneous batch out horizontally so two coins from one Krark's Thumb flip do not land
+  // on top of each other. A lone coin keeps the centred position it has always had.
+  const laneCount = animation.laneCount ?? 1
+  const laneIndex = animation.laneIndex ?? 0
+  const laneSpacing = 170
+  const laneOffset = (laneIndex - (laneCount - 1) / 2) * laneSpacing
 
   return (
     <div
@@ -76,8 +98,8 @@ function CoinFlipAnimationCard({
         position: 'fixed',
         left: '50%',
         top: '50%',
-        transform: `translate(-50%, -50%) scale(${scale})`,
-        opacity,
+        transform: `translate(calc(-50% + ${laneOffset}px), -50%) scale(${scale})`,
+        opacity: ignored ? opacity * 0.75 : opacity,
         zIndex: 10002,
         pointerEvents: 'none',
         display: 'flex',
@@ -114,7 +136,7 @@ function CoinFlipAnimationCard({
         <span
           style={{
             color: textColor,
-            fontSize: 28,
+            fontSize: ignored ? 22 : 28,
             fontWeight: 800,
             fontFamily: 'Impact, sans-serif',
             letterSpacing: 2,
@@ -138,7 +160,7 @@ function CoinFlipAnimationCard({
           boxShadow: '0 2px 8px rgba(0, 0, 0, 0.5)',
         }}
       >
-        {animation.sourceName} — Coin flip {won ? 'won' : 'lost'}
+        {label}
       </div>
     </div>
   )

--- a/web-client/src/store/slices/handlers/gameplayHandlers.ts
+++ b/web-client/src/store/slices/handlers/gameplayHandlers.ts
@@ -391,8 +391,12 @@ function processStateUpdate(
     won: boolean
     sourceId: EntityId
     sourceName: string
+    ignored?: boolean
   }[]
 
+  // Coins that were flipped together are shown together, fanned out across the screen rather than
+  // stacked on the centre — a Krark's Thumb flip is always at least two coins, and the point of
+  // showing the ignored ones is that the player can see what was really flipped.
   coinFlipEvents.forEach((event, index) => {
     const isOpponent = event.playerId !== playerId
     newCoinFlipAnimations.push({
@@ -401,6 +405,9 @@ function processStateUpdate(
       won: isOpponent ? !event.won : event.won,
       isOpponent,
       startTime: Date.now() + index * 200,
+      ignored: event.ignored ?? false,
+      laneIndex: index,
+      laneCount: coinFlipEvents.length,
     })
   })
 

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -773,6 +773,15 @@ export interface CoinFlipAnimation {
   won: boolean
   isOpponent: boolean
   startTime: number
+  /** This coin was flipped but ignored by a Krark's Thumb-style replacement. */
+  ignored?: boolean
+  /**
+   * Position of this coin among the ones showing at the same moment, used to fan a batch out
+   * horizontally instead of stacking every coin on the centre of the screen.
+   */
+  laneIndex?: number
+  /** How many coins are showing at the same moment, so each can be placed within the fan. */
+  laneCount?: number
 }
 
 /**

--- a/web-client/src/types/events.ts
+++ b/web-client/src/types/events.ts
@@ -357,6 +357,11 @@ export interface CoinFlippedEvent {
   readonly won: boolean
   readonly sourceId: EntityId
   readonly sourceName: string
+  /**
+   * True when a "flip N coins and ignore all but one" replacement (Krark's Thumb) discarded this
+   * flip. The coin really was flipped, so it is still shown, but its result decided nothing.
+   */
+  readonly ignored?: boolean
   readonly description: string
 }
 


### PR DESCRIPTION
Mirrodin's tail is engine-blocked, not card-blocked: all four remaining cards need a feature before they need a `cardDef`. This is the one whose feature is contained to a single subsystem — the coin-flip path already funnelled through `CoinFlipModifiers`, so the replacement had one seam to land in.

**MRD 287/291 → 288/291.**

## The gap

The engine had a coin-flip replacement that dictates a flip's *result* (`WinCoinFlips`, Edgar's Two-Headed Coin), but nothing that changes *how many coins a flip is made of* — and no flip path could pause for a choice at all. Krark's Thumb needs both.

## The vocabulary

`FlipAdditionalCoins(coinsPerFlip = 2)`, sitting next to `WinCoinFlips` as a non-Rule-613 static consulted through `CoinFlipModifiers`. The count is a parameter, so "flip three coins and ignore two" needs no new type.

Three rulings shape it, and each has a paired test:

- **It replaces each individual coin, not the instruction.** "Flip five coins" under one Thumb is five *pairs* with one kept from each — not ten coins with any five ignored.
- **Every coin is rolled before any is ignored** — "you will know the results of all simultaneous flips before choosing which to ignore" — so the flipper always chooses knowing all of them. A unanimous batch offers nothing to choose and raises no prompt, which is also why a `WinCoinFlips` forced win composes with this for free rather than needing a special case.
- **Instances multiply.** Two Thumbs flip four coins and ignore three, so `coinsPerFlip` takes the product across the flipper's sources.

## Engine shape

All four flip effects (`FlipCoinEffect`, `FlipTwoCoinsEffect`, `FlipCoinsEffect`, `FlipCoinsUntilLossEffect`) now get their coins from one new seam — `CoinFlipService` — instead of calling `nextRandom` themselves. That is what makes the replacement reach every flip in the game, and it leaves a single place where a coin is flipped.

Because the choice pauses mid-resolution, the service is a two-phase API: it returns either a settled batch or the decision plus the part-resolved batch to park in a continuation. **One** continuation serves all four effects (`CoinFlipChoiceContinuation`) — the pause only ever interrupts *producing the results*, and what each effect does with them is read back off the frame. It carries the flip effect and its `EffectContext` whole rather than re-deriving fields, so the branch run afterwards keeps its targets.

Fiery Gambit — same set — is the hard case, and it's tested directly: with a Thumb out its run has **two** questions per coin ("which coin do you keep?" then "flip again?"), and the won-flip tally has to survive both.

## UX

`CoinFlipEvent` gains `ignored`, so the log and the animation show every coin that was really flipped without reporting a win the player never got. Ignored coins render greyed as `HEADS`/`TAILS` rather than `WON`/`LOST`, and simultaneous coins now fan out horizontally instead of stacking on the centre of the screen. The choice itself reuses the existing yes/no decision UI, so there's no new component; the AI needs no change either, since `respondYesNo` simulates both branches and can therefore correctly choose to *lose* a flip when that's better.

## Verification

- `just test` — full suite green.
- `just rebless-cards` — the snapshot diff is Krark's Thumb and nothing else.
- `just check-card-printing "Krark's Thumb"` — canonical sits in MRD, its earliest real printing.
- `npm run typecheck` — clean.
- New: `FlipAdditionalCoinsTest` (15 engine tests, the rules matrix above) and `KrarksThumbScenarioTest` (5 scenarios against Fiery Gambit).
- CR 614.1a and 705.3 checked against the published rules text.

Step 8b does not apply: `Registry.loadEffectSerialNames` scans only the *effects* package, so a bridge entry naming a `StaticAbility` SerialName would self-report as a false `[GAP]`.

## Still blocked in MRD

Soul Foundry (dynamic generic `{X}` in an activation cost — `CostAtom.Mana` is fixed across ~70 read sites), Shared Fate (per-card draw replacement for *each* player plus a per-exiling-player play-from-exile permission), Spellweaver Helix (copy a card in exile and cast the copy during the trigger's own resolution). Each is its own feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)