### PR TITLE
Add Aurelia's Vindicator to Murders at Karlov Manor

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -113,6 +113,14 @@ section; do not let SDK additions land without a corresponding doc update.
 - `disguise: String?` — disguise mana cost (CR 702.168): cast face down for `{3}` as a 2/2 **with
   ward {2}**, flip for this cost.
 - `disguiseCost: PayCost?` — non-mana disguise cost.
+- **`{X}` in a turn-up cost** — `Disguise {X}{3}{W}` (Aurelia's Vindicator) is legal, and the chosen X
+  is readable by the card's `Triggers.TurnedFaceUp` ability as **`DynamicAmount.XValue`** — carried
+  `TurnFaceUp.xValue` → `TurnFaceUpEvent.xValue` → `TriggerContext.xValue` → the trigger's stack
+  object → `EffectContext.xValue`. It is **not `DynamicAmount.CastX`**, which is the X paid to cast a
+  *spell*: a disguised card was cast face down for `{3}`, with no X anywhere in that cost, so `CastX`
+  reads 0 here. The same `XValue` feeds a `dynamicMaxCount` target cap ("exile up to X other target
+  creatures"), snapshotted when the trigger goes on the stack. Turn-up X applies to morph costs
+  identically; disguise is simply where it is printed.
 - `disguiseFaceUpEffect: Effect?` — the disguise-side sibling of `morphFaceUpEffect`, for the
   "As this creature is turned face up, …" replacement clause (Bubble Smuggler = "put four +1/+1
   counters on it" → `Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 4, EffectTarget.Self)`). It is

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AureliasVindicator.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AureliasVindicator.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Aurelia's Vindicator — Murders at Karlov Manor #4
+ * {2}{W}{W} · Creature — Angel · Mythic
+ * 4/2
+ *
+ * Flying, lifelink, ward {2}
+ * Disguise {X}{3}{W}
+ * When this creature is turned face up, exile up to X other target creatures from the battlefield
+ * and/or creature cards from graveyards.
+ * When this creature leaves the battlefield, return the exiled cards to their owners' hands.
+ *
+ * The printed `ward {2}` is a face-*up* keyword and is unrelated to the ward {2} every disguised
+ * permanent has while face down (CR 702.168a) — that one rides `FaceDownMode.DISGUISE`. Both exist;
+ * only one applies at a time.
+ *
+ * **X survives the flip already.** The disguise cost is the only place X is chosen, and the turn-up
+ * is a special action, not a cast — so this is `DynamicAmount.XValue` (the ability's own X, carried
+ * `TurnFaceUp.xValue` → `TurnFaceUpEvent.xValue` → `TriggerContext.xValue` → the trigger's stack
+ * object), **not** `DynamicAmount.CastX`, which is the X paid to cast a *spell* and would read 0
+ * here: this card was cast face down for {3}, with no X anywhere in that cost.
+ *
+ * The target is one requirement with a cross-zone union (CR 115.1) — `TargetFilter.OtherCreature`
+ * or `TargetFilter.CreatureInGraveyard` — clamped by `dynamicMaxCount = XValue`, the same shape
+ * Savior of Ollenbock uses one target at a time. `optional = true` is what makes X = 0, and "fewer
+ * legal targets than X", resolve instead of fizzling.
+ *
+ * The exile is **not** [Effects.ExileUntilLeaves], and that is deliberate: that executor carries a
+ * modern-template gate that skips the exile when the source has already left the battlefield, and
+ * the printed ruling says the opposite — if the Vindicator dies with the trigger on the stack, the
+ * leaves trigger does nothing and the turn-up trigger still exiles the targets, permanently. So the
+ * effect gathers the chosen targets and moves them itself, linking them to the source; the link is
+ * simply never read when the source is already gone. Gathering also handles all X targets at once,
+ * where `ExileUntilLeaves` resolves a single [com.wingedsheep.sdk.scripting.targets.EffectTarget].
+ *
+ * The leaves trigger returns the whole linked pile to *hand*. The pile prunes itself — anything
+ * that already left exile is dropped from `LinkedExileComponent` — so cards moved on by some other
+ * effect aren't clawed back.
+ */
+val AureliasVindicator = card("Aurelia's Vindicator") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    power = 4
+    toughness = 2
+    oracleText = "Flying, lifelink, ward {2}\n" +
+        "Disguise {X}{3}{W} (You may cast this card face down for {3} as a 2/2 creature with " +
+        "ward {2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this creature is turned face up, exile up to X other target creatures from the " +
+        "battlefield and/or creature cards from graveyards.\n" +
+        "When this creature leaves the battlefield, return the exiled cards to their owners' hands."
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+    keywordAbility(KeywordAbility.ward("{2}"))
+    disguise = "{X}{3}{W}"
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        target(
+            "up to X other target creatures from the battlefield and/or creature cards from graveyards",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter.OtherCreature.or(TargetFilter.CreatureInGraveyard),
+                dynamicMaxCount = DynamicAmount.XValue,
+            ),
+        )
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "vindicated"),
+                MoveCollectionEffect(
+                    from = "vindicated",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                    linkToSource = true,
+                ),
+            )
+        )
+        description = "When this creature is turned face up, exile up to X other target creatures " +
+            "from the battlefield and/or creature cards from graveyards."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileToHand()
+        description = "When this creature leaves the battlefield, return the exiled cards to " +
+            "their owners' hands."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "4"
+        artist = "Victor Adame Minguez"
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/5901dff4-e09b-4747-9297-797a1a057cd5.jpg?1783912930"
+
+        ruling(
+            "2024-02-02",
+            "If Aurelia's Vindicator leaves the battlefield before its \"turned face up\" ability " +
+                "has resolved, its leaves the battlefield ability will trigger and do nothing. Then " +
+                "the \"turned face up\" ability will resolve and exile the targeted creatures and/or " +
+                "creature cards indefinitely."
+        )
+        ruling(
+            "2024-02-02",
+            "If a creature targeted by the \"turned face up\" ability dies before that ability " +
+                "resolves, it will become an illegal target even though it may be a creature card " +
+                "in a graveyard when the ability resolves. It won't be exiled."
+        )
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AureliasVindicatorScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AureliasVindicatorScenarioTest.kt
@@ -1,0 +1,215 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.AureliasVindicator
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Aurelia's Vindicator (MKM) — {2}{W}{W} 4/2 Angel with flying, lifelink, ward {2} and
+ * Disguise {X}{3}{W}.
+ *
+ * "When this creature is turned face up, exile up to X other target creatures from the battlefield
+ *  and/or creature cards from graveyards."
+ * "When this creature leaves the battlefield, return the exiled cards to their owners' hands."
+ *
+ * This is the only card in Magic whose X is chosen inside a *turn-up* cost, so these tests pin the
+ * whole path the X takes — `TurnFaceUp.xValue` → `TurnFaceUpEvent` → the trigger's stack object →
+ * `DynamicAmount.XValue` as the target-count cap — plus the fact that the pool is actually charged
+ * for it, which it previously was not.
+ */
+class AureliasVindicatorScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AureliasVindicator))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Cast the Vindicator face down for {3} and return the resulting face-down permanent. */
+    fun castFaceDown(driver: GameTestDriver, player: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Aurelia's Vindicator")
+        driver.giveColorlessMana(player, 3)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        driver.bothPass()
+        return driver.getPermanents(player).single {
+            driver.state.getEntity(it)?.has<FaceDownComponent>() == true
+        }
+    }
+
+    /** Mana for `Disguise {X}{3}{W}` at the given X: {3} + {W} + X generic. */
+    fun fundFlip(driver: GameTestDriver, player: EntityId, x: Int) {
+        driver.giveColorlessMana(player, 3 + x)
+        driver.giveMana(player, Color.WHITE, 1)
+    }
+
+    test("turned face up for X=2 it exiles two targets — one on the battlefield, one in a graveyard") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val courser = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        val lions = driver.putCardInGraveyard(opponent, "Savannah Lions")
+
+        val vindicator = castFaceDown(driver, player)
+        fundFlip(driver, player, x = 2)
+
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = vindicator,
+                paymentStrategy = PaymentStrategy.FromPool,
+                xValue = 2
+            )
+        ).error shouldBe null
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+
+        withClue("the union offers both the battlefield creature and the graveyard creature card") {
+            val offered = decision.legalTargets[0].orEmpty()
+            offered shouldContain courser
+            offered shouldContain lions
+        }
+
+        driver.submitTargetSelection(player, listOf(courser, lions)).error shouldBe null
+        repeat(2) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+
+        withClue("both chosen objects are exiled, from either zone") {
+            driver.getExile(opponent) shouldContainExactlyInAnyOrder listOf(courser, lions)
+        }
+        withClue("face up it is the printed 4/2 flier") {
+            driver.state.projectedState.getPower(vindicator) shouldBe 4
+            driver.state.projectedState.getToughness(vindicator) shouldBe 2
+            driver.state.projectedState.hasKeyword(vindicator, Keyword.FLYING) shouldBe true
+            driver.state.projectedState.hasKeyword(vindicator, Keyword.LIFELINK) shouldBe true
+        }
+    }
+
+    test("X caps the target count — flipping for X=1 allows only one target") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val courser = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        driver.putCreatureOnBattlefield(opponent, "Savannah Lions")
+
+        val vindicator = castFaceDown(driver, player)
+        fundFlip(driver, player, x = 1)
+
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = vindicator,
+                paymentStrategy = PaymentStrategy.FromPool,
+                xValue = 1
+            )
+        ).error shouldBe null
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+
+        withClue("DynamicAmount.XValue clamps the requirement to the X actually paid") {
+            decision.targetRequirements[0].maxTargets shouldBe 1
+        }
+
+        driver.submitTargetSelection(player, listOf(courser)).error shouldBe null
+        repeat(2) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+
+        driver.getExile(opponent) shouldBe listOf(courser)
+    }
+
+    test("the pool is charged for X — X=2 on only enough mana for {3}{W} is rejected") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(driver.getOpponent(player), "Centaur Courser")
+
+        val vindicator = castFaceDown(driver, player)
+        // Exactly {3}{W}: enough for the printed pips, nothing for X.
+        fundFlip(driver, player, x = 0)
+
+        withClue("{X} carries no mana of its own, so the pool must be charged X separately") {
+            driver.submit(
+                TurnFaceUp(
+                    playerId = player,
+                    sourceId = vindicator,
+                    paymentStrategy = PaymentStrategy.FromPool,
+                    xValue = 2
+                )
+            ).error shouldNotBe null
+        }
+        withClue("the rejected flip leaves it face down") {
+            driver.state.getEntity(vindicator)?.has<FaceDownComponent>() shouldBe true
+        }
+    }
+
+    test("when it leaves the battlefield the exiled cards go to their owners' hands") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val courser = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        val lions = driver.putCardInGraveyard(opponent, "Savannah Lions")
+
+        val vindicator = castFaceDown(driver, player)
+        fundFlip(driver, player, x = 2)
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = vindicator,
+                paymentStrategy = PaymentStrategy.FromPool,
+                xValue = 2
+            )
+        ).error shouldBe null
+        driver.submitTargetSelection(player, listOf(courser, lions)).error shouldBe null
+        repeat(2) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+        driver.getExile(opponent) shouldContainExactlyInAnyOrder listOf(courser, lions)
+
+        // Bolt it: 3 damage kills the 4/2 and fires the leaves-the-battlefield trigger.
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpellWithTargets(
+            player,
+            bolt,
+            listOf(com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent(vindicator))
+        ).error shouldBe null
+        repeat(3) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+
+        withClue("both exiled cards return to their owner's hand, not to the battlefield") {
+            driver.getHand(opponent) shouldContain courser
+            driver.getHand(opponent) shouldContain lions
+        }
+        withClue("nothing is left in exile") {
+            driver.getExile(opponent).none { it == courser || it == lions } shouldBe true
+        }
+        withClue("the Vindicator itself is in its owner's graveyard") {
+            driver.findCardInHand(opponent, "Aurelia's Vindicator") shouldBe null
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -1557,6 +1557,139 @@
     ]
 }
 
+// Aurelia's Vindicator
+{
+    "name": "Aurelia's Vindicator",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "Flying, lifelink, ward {2}\nDisguise {X}{3}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, exile up to X other target creatures from the battlefield and/or creature cards from graveyards.\nWhen this creature leaves the battlefield, return the exiled cards to their owners' hands.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        },
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{X}{3}{W}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "vindicated"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "vindicated",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature",
+                        "excludeSelf": true,
+                        "alternatives": [
+                            {
+                                "baseFilter": "creature",
+                                "zone": "Graveyard"
+                            }
+                        ]
+                    },
+                    "id": "up to X other target creatures from the battlefield and/or creature cards from graveyards",
+                    "dynamicMaxCount": "XValue"
+                },
+                "descriptionOverride": "When this creature is turned face up, exile up to X other target creatures from the battlefield and/or creature cards from graveyards."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return_hand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return_hand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature leaves the battlefield, return the exiled cards to their owners' hands."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "rarity": "MYTHIC",
+        "artist": "Victor Adame Minguez",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/5901dff4-e09b-4747-9297-797a1a057cd5.jpg?1783912930",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If Aurelia's Vindicator leaves the battlefield before its \"turned face up\" ability has resolved, its leaves the battlefield ability will trigger and do nothing. Then the \"turned face up\" ability will resolve and exile the targeted creatures and/or creature cards indefinitely."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a creature targeted by the \"turned face up\" ability dies before that ability resolves, it will become an illegal target even though it may be a creature card in a graveyard when the ability resolves. It won't be exiled."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Aurelia, the Law Above
 {
     "name": "Aurelia, the Law Above",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
@@ -31,6 +31,8 @@ import com.wingedsheep.engine.state.components.identity.MorphDataComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.state.components.player.TurnedPermanentFaceUpThisTurnComponent
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.ManaSymbol
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
@@ -63,6 +65,23 @@ class TurnFaceUpHandler(
     // Lets restricted mana tagged "spend only to turn permanents face up" (Overgrown Zealot,
     // Creeping Peeper) be recognized when paying a turn-face-up cost from the pool.
     private val faceUpContext = SpellPaymentContext(isTurnFaceUpAction = true)
+
+    /**
+     * The turn-up cost as a *concrete* amount of mana, with the chosen X folded in.
+     *
+     * A `{X}` symbol has no mana of its own (CR 107.3 — X is 0 until a value is announced), so a
+     * cost like Aurelia's Vindicator's `Disguise {X}{3}{W}` reads as `{3}{W}` to anything that just
+     * pays a [ManaCost]. The [ManaSolver] paths take `xValue` as a separate argument and charge it
+     * themselves; [ManaPool.pay] has no such argument, so the pool paths must resolve X into
+     * generic mana up front or the player flips for free. `xCount` is the number of `{X}` symbols
+     * (`{X}{X}{R}` charges X twice).
+     */
+    private fun withXResolved(cost: ManaCost, xValue: Int): ManaCost {
+        if (!cost.hasX) return cost
+        val xMana = xValue * cost.xCount.coerceAtLeast(1)
+        val withoutX = ManaCost(cost.symbols.filterNot { it is ManaSymbol.X })
+        return if (xMana > 0) withoutX + ManaCost(listOf(ManaSymbol.generic(xMana))) else withoutX
+    }
 
     override fun validate(state: GameState, action: TurnFaceUp): String? {
         if (state.priorityPlayerId != action.playerId) {
@@ -131,7 +150,7 @@ class TurnFaceUpHandler(
                             colorless = poolComponent.colorless,
                             restrictedMana = poolComponent.restrictedMana
                         )
-                        if (!costHandler.canPayManaCost(pool, manaCost, faceUpContext)) {
+                        if (!costHandler.canPayManaCost(pool, withXResolved(manaCost, xValue), faceUpContext)) {
                             return "Insufficient mana in pool to turn this creature face up"
                         }
                     }
@@ -215,7 +234,7 @@ class TurnFaceUpHandler(
                             restrictedMana = poolComponent.restrictedMana
                         )
 
-                        val newPool = costHandler.payManaCost(pool, manaCost, faceUpContext)
+                        val newPool = costHandler.payManaCost(pool, withXResolved(manaCost, xValue), faceUpContext)
                             ?: return ExecutionResult.error(currentState, "Insufficient mana in pool")
 
                         currentState = currentState.updateEntity(action.playerId) { c ->


### PR DESCRIPTION
Implements **Aurelia's Vindicator** (MKM #4) — `{2}{W}{W}` 4/2 Angel with flying, lifelink, ward {2} and `Disguise {X}{3}{W}`. Turned face up it exiles up to X other target creatures from the battlefield and/or creature cards from graveyards; when it leaves the battlefield those cards return to their owners' hands.

MKM goes from 273/276 to **274/276**.

### The triage said this needed engine work. It didn't.

`backlog`/working notes had this card down as needing an X slot on `TurnUpProcedure` plus a cross-zone union target. Re-verifying each claim, the whole X path already exists end to end — `TurnFaceUp.xValue` → `TurnFaceUpEvent.xValue` → `TriggerContext.xValue` → the trigger's stack object → `EffectContext.xValue` → `DynamicAmount.XValue` — and `TurnFaceUpEnumerator` already prices and offers X (`hasXCost` / `maxAffordableX`), which `useInteraction.ts` already routes to the X selector. Cross-zone union targets are `TargetFilter.or`, and `Patterns.Exile.returnLinkedExileToHand()` was already the return half.

So the card needs **no new SDK vocabulary**.

### One real engine bug, found by writing the test

`TurnFaceUpHandler`'s `FromPool` payment branch never charged the X, in `validate` or in `execute`. A `{X}` symbol carries no mana of its own, so `ManaPool.pay` read `{X}{3}{W}` as `{3}{W}`; AutoPay and Explicit hand `xValue` to the `ManaSolver` and charge it separately, but the pool path did neither. No card had an X in a turn-up cost until now, which is why it never fired.

`withXResolved` folds the chosen X into generic mana up front (honoring `xCount`, so `{X}{X}{R}` charges twice) and returns every non-X cost unchanged, so no existing morph or disguise card changes behaviour. Confirmed the new test fails without it.

### Modelling notes

- X is `DynamicAmount.XValue`, **not** `CastX` — the card was cast face down for `{3}`, so `CastX` reads 0. It caps the target count through `dynamicMaxCount`, snapshotted when the trigger goes on the stack; `optional = true` is what lets X = 0 and "fewer legal targets than X" resolve instead of fizzling.
- The target is a single requirement with a cross-zone union (`TargetFilter.OtherCreature.or(TargetFilter.CreatureInGraveyard)`) — the same shape Savior of Ollenbock uses one target at a time.
- The exile is a `ChosenTargets` gather plus a linked move rather than `Effects.ExileUntilLeaves`. That executor carries a modern-template gate that skips the exile when the source has already left the battlefield, and the printed ruling says the opposite: if the Vindicator dies with the trigger on the stack, the leaves trigger does nothing and the exile still happens, permanently. Gathering also handles all X targets at once, where `ExileUntilLeaves` resolves a single `EffectTarget`.

### Tests

`AureliasVindicatorScenarioTest` — the X=2 cross-zone exile (one battlefield creature, one graveyard card), the X=1 target cap, the leaves-the-battlefield return to hand, and the pool being charged for X.

### Verification

`just test` green (after the expected `CardDefinitionSnapshotTest` re-bless — only `MKM.json` moved, 133 insertions, no deletions). `just check-card-printing "Aurelia's Vindicator"` ok — canonical sits in MKM, its earliest real printing.

### Still open in MKM

Both remaining cards are genuinely multi-feature engine work, not `add-card` batches:

- **Urgent Necropsy** — needs `DynamicAmount` evaluation inside cost atoms (currently a hand-rolled `Fixed`/`XValue` `when` duplicated across 6 sites) for a target-derived collect-evidence X, plus a client change deferring the `costPayment` phase past `targeting` (#1963 is the precedent for that half).
- **Kaya, Spirits' Justice** — batch "put into exile" trigger, choose-from-among-them, a token copy "except it has flying", and per-player "for each other player, exile up to one target creature that player controls".

🤖 Generated with [Claude Code](https://claude.com/claude-code)