### PR TITLE
Add target-derived collect-evidence costs, and Urgent Necropsy to MKM

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -31,6 +31,7 @@ import com.wingedsheep.engine.legalactions.LegalAction
 import com.wingedsheep.engine.legalactions.MeaningfulActionFilter
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.sdk.core.Format
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.ManaSymbol
@@ -687,7 +688,9 @@ class Strategist(
         forceTargetRefinement: Boolean = false,
     ): com.wingedsheep.engine.core.GameAction {
         val baseAction = withAutomaticPayments(action)
-        if (TargetSelection.targetsAlreadyFilled(baseAction) != false) return baseAction
+        if (TargetSelection.targetsAlreadyFilled(baseAction) != false) {
+            return withSumGatedExilePayment(state, action, baseAction)
+        }
         if (!budget.allowances.refineTargetsBySimulation && !forceTargetRefinement) {
             return heuristicTargets(state, action, playerId)
         }
@@ -746,7 +749,9 @@ class Strategist(
             chosenTargets[i] = TargetSelection.toChosenTarget(state, info, best, playerId)
             chosenTargetIds[i] = best
         }
-        return TargetSelection.applyTargets(baseAction, chosenTargets)
+        return withSumGatedExilePayment(
+            state, action, TargetSelection.applyTargets(baseAction, chosenTargets)
+        )
     }
 
     /** The cheap target pick — one heuristic choice per requirement, no simulation. */
@@ -754,9 +759,12 @@ class Strategist(
         state: GameState,
         action: LegalAction,
         playerId: EntityId,
-    ): com.wingedsheep.engine.core.GameAction = TargetSelection.fillHeuristically(
-        state, action.copy(action = withAutomaticPayments(action)), playerId,
-        fillPartialRequirements = useMeaningfulFilter, intents = intents
+    ): com.wingedsheep.engine.core.GameAction = withSumGatedExilePayment(
+        state, action,
+        TargetSelection.fillHeuristically(
+            state, action.copy(action = withAutomaticPayments(action)), playerId,
+            fillPartialRequirements = useMeaningfulFilter, intents = intents
+        ),
     )
 
     /**
@@ -825,6 +833,75 @@ class Strategist(
             is ActivateAbility -> gameAction.copy(costPayment = payment)
             else -> gameAction
         }
+    }
+
+    /** The entity a chosen target points at, whichever arm of the union it is. */
+    private fun targetEntityId(target: ChosenTarget): EntityId = when (target) {
+        is ChosenTarget.Player -> target.playerId
+        is ChosenTarget.Permanent -> target.entityId
+        is ChosenTarget.Card -> target.cardId
+        is ChosenTarget.Spell -> target.spellEntityId
+    }
+
+    /**
+     * Pay a **sum-gated graveyard exile** cast cost — collect evidence N and its filtered sibling —
+     * once the targets are known.
+     *
+     * Every other additional cost is filled by [withAutomaticPayments] before targeting, which is
+     * where the AI picks its targets from. This one can't be: Urgent Necropsy's threshold *is* the
+     * summed mana value of the targets ("collect evidence X, where X is the total mana value of the
+     * permanents this spell targets"), so it isn't determined until CR 601.2f, after the targets are
+     * announced at 601.2c. `exileWeightPerTarget` is what the enumerator ships for exactly that, and
+     * this runs on the finished action rather than the bare one.
+     *
+     * Cards are spent highest-mana-value-first, the same choice `CollectEvidenceResolver.autoSelect`
+     * makes, so the AI's selection and the engine's fallback can't disagree about what a payment
+     * looks like. When the graveyard can't cover what was targeted the *targets* give way, trimmed
+     * from the end until the price is affordable (down to none, which prices at 0 and is always
+     * payable): per the printed ruling an unreachable threshold means the caster "can't choose to
+     * collect evidence at all", so such a cast would simply be rejected — trimming turns a rejected
+     * action into a smaller legal one, and never into a worse one, since a target the AI drops was
+     * one it could not have kept.
+     */
+    private fun withSumGatedExilePayment(
+        state: GameState,
+        action: LegalAction,
+        gameAction: GameAction,
+    ): GameAction {
+        val cast = gameAction as? CastSpell ?: return gameAction
+        val info = action.additionalCostInfo ?: return gameAction
+        if (info.costType != "CollectEvidence" && info.costType != "ExileForTotal") return gameAction
+
+        // Most expensive first: the fewest cards that clear the floor.
+        val pool = info.validExileTargets
+            .filter { state.getEntity(it) != null }
+            .sortedByDescending { info.exileCardWeights[it] ?: 0 }
+        val available = pool.sumOf { info.exileCardWeights[it] ?: 0 }
+
+        var targets = cast.targets
+        var required = info.exileMinTotalWeight + targets.sumOf {
+            info.exileWeightPerTarget[targetEntityId(it)] ?: 0
+        }
+        while (required > available && targets.isNotEmpty()) {
+            targets = targets.dropLast(1)
+            required = info.exileMinTotalWeight + targets.sumOf {
+                info.exileWeightPerTarget[targetEntityId(it)] ?: 0
+            }
+        }
+        if (required > available) return gameAction // nothing left to trim; the engine will refuse
+
+        val chosen = mutableListOf<EntityId>()
+        var total = 0
+        for (cardId in pool) {
+            if (total >= required) break
+            chosen += cardId
+            total += info.exileCardWeights[cardId] ?: 0
+        }
+        return cast.copy(
+            targets = targets,
+            additionalCostPayment = (cast.additionalCostPayment ?: AdditionalCostPayment())
+                .copy(exiledCards = chosen),
+        )
     }
 
     /**

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -533,6 +533,27 @@ exist in the cost and charges the life through the shared life-payment service.
   under-total submission is rejected rather than trimmed. For collect evidence as an *effect* rather
   than a cost, use `Effects.CollectEvidence(n)` (§ effects).
 
+  `Costs.additional.CollectEvidenceForTargetsTotalManaValue` is the one shape whose threshold isn't
+  printed — **Urgent Necropsy**'s "collect evidence X, where X is the total mana value of the
+  permanents this spell targets". `CostAtom.CollectEvidence.amount` is a `DynamicAmount` for it, and
+  accepts exactly the three shapes a cost can be priced from before it is paid: a literal, the
+  cast's `XValue`, and `ContextPropertyKey.TARGETS_TOTAL_MANA_VALUE` (an `init` guard rejects the
+  rest, so a cost can never carry an amount the cost-time evaluator has no context to read). This is
+  the opposite call from `Effects.CollectEvidenceChosenAmount` (§ effects), which stayed a separate
+  effect precisely because a player-*chosen* X isn't a `DynamicAmount` at all — a derived one is.
+
+  Two consequences worth knowing, both from the card's own rulings. **X is locked in after targets,
+  before payment** (CR 601.2c → 601.2f → 601.2h): the engine prices it from `CastSpell.targets`, so
+  it counts what the caster actually chose, not what they could have. And a graveyard that can't
+  reach it makes the cast **illegal, not cheaper** (CR 601.2e) — the reachability gate has nowhere to
+  fail closed at enumeration time, since the price doesn't exist yet, so the check moves to cast-time
+  validation. Client-side that is why the evidence picker runs **after** the targeting step for this
+  cost: the enumerator ships `AdditionalCostData.exileWeightPerTarget` (what each legal target would
+  add), whose presence is both the per-target price list and the instruction to defer — the same
+  deferral `manaCostPerExtraTarget` already does for mana-source selection. With no targets chosen X
+  is 0, which collects evidence 0: legal, exiles nothing, and still counts as having collected
+  evidence per the 2024-02-02 ruling.
+
   `Costs.CollectEvidence(n, linkToSource = true)` tethers the cards this payment exiles to the
   *source permanent's* `LinkedExileComponent`, so a later ability on that same permanent can name
   them — "cards exiled **with it**". That is the only thing the flag does: it grants no permission
@@ -9935,6 +9956,14 @@ Army just amassed by a sibling/action effect, or any cost-chosen entity. The plu
   - `ADDITIONAL_COST_EXILED_COUNT` — cost-step accumulator. (The blight-X amount moved to
     `DynamicAmount.CastChoice(ChoiceSlot.BLIGHT_AMOUNT)`.)
   - `TARGET_COUNT` — still-legal targets in the current effect context.
+  - `TARGETS_TOTAL_MANA_VALUE` — the summed mana value of the objects targeted (CR 202.3); the
+    summing sibling of `TARGET_COUNT`, read from the same target list. Player targets have no mana
+    value and contribute nothing. Unusually for a context key it is also readable **while a spell is
+    being cast**, which is what it exists for: an additional cost priced off the targets is
+    determined at CR 601.2f, after the targets are announced at 601.2c and before it is paid at
+    601.2h, so a cost carrying this key reads `CastSpell.targets`. See
+    `Costs.additional.CollectEvidenceForTargetsTotalManaValue` (§ additional costs) — Urgent
+    Necropsy. In a context with no targets it reads `0`.
   - `LINKED_EXILE_CARD_COUNT` / `LINKED_EXILE_DISTINCT_CARD_TYPE_COUNT` — cards / distinct
     types in the source's linked exile pile (Veteran Survivor / Keen-Eyed Curator).
   - `MODES_CHOSEN_ON_TRIGGERING_SPELL` — number of mode picks recorded on the cast that fired

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -625,6 +625,21 @@ object Costs {
             AdditionalCost.Atom(CostAtom.CollectEvidence(amount))
 
         /**
+         * "Collect evidence X, where X is the total mana value of the permanents this spell
+         * targets" — Urgent Necropsy, the one printed collect-evidence cost whose threshold is
+         * derived rather than literal.
+         *
+         * X is determined once the targets are announced and before the cost is paid (CR 601.2c →
+         * 601.2f → 601.2h), and the ruling that follows from CR 701.59b is that a caster who
+         * cannot exile that much **can't choose to collect evidence at all** — so a target set the
+         * graveyard can't pay for is an illegal cast (CR 601.2e), not a discounted one. The client
+         * therefore runs its evidence picker *after* targeting for this cost, priced on what was
+         * actually chosen.
+         */
+        val CollectEvidenceForTargetsTotalManaValue: AdditionalCost =
+            AdditionalCost.Atom(CostAtom.CollectEvidence(CostAtom.CollectEvidence.TARGET_SUM))
+
+        /**
          * Cost-vs-cost — the caster pays exactly one of [options] ("discard a card **or** sacrifice a
          * permanent"; Souls of the Lost). For options that are each independently payable non-mana
          * costs; use the `*OrPay` family instead when one branch pays extra *mana*. See

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtom.kt
@@ -411,6 +411,20 @@ sealed interface CostAtom : TextReplaceable<CostAtom> {
      * option must be *hidden*, not offered and refused. Every affordability check therefore fails
      * closed on "sum of available mana values < [amount]".
      *
+     * **[amount] is a [DynamicAmount], not an [Int]**, because one printed card prices the
+     * threshold off the spell it is paying for: Urgent Necropsy's "collect evidence X, where X is
+     * the total mana value of the permanents this spell targets". That X is a *derived* quantity —
+     * unlike [com.wingedsheep.sdk.scripting.effects.CollectEvidenceChosenAmountEffect]'s X, which
+     * is a player *decision* and so is deliberately its own effect rather than a `DynamicAmount`.
+     * The atom accepts only the three shapes the corpus prints, enforced below, so a cost can
+     * never carry an amount the cost-time evaluator has no context to read:
+     *
+     *  - [DynamicAmount.Fixed] — every literal "collect evidence 3";
+     *  - [DynamicAmount.XValue] — the cast's chosen X;
+     *  - [DynamicAmount.ContextProperty] of
+     *    [com.wingedsheep.sdk.scripting.values.ContextPropertyKey.TARGETS_TOTAL_MANA_VALUE] — the
+     *    summed mana value of the targets, read from the announced targets at CR 601.2f.
+     *
      * @property amount The mana-value floor N — the total the exiled cards must meet or exceed.
      * @property linkToSource When true, the cards exiled to pay this cost join the *source
      *   permanent's* linked-exile pile
@@ -424,13 +438,41 @@ sealed interface CostAtom : TextReplaceable<CostAtom> {
     @SerialName("AtomCollectEvidence")
     @Serializable
     data class CollectEvidence(
-        val amount: Int,
+        val amount: DynamicAmount,
         val linkToSource: Boolean = false,
     ) : CostAtom {
+        init {
+            require(amount is DynamicAmount.Fixed || amount is DynamicAmount.XValue || amount == TARGET_SUM) {
+                "CollectEvidence's amount must be a literal, XValue, or the summed mana value of " +
+                    "the spell's targets — the three shapes a cost can be priced from before it " +
+                    "is paid. Got ${amount::class.simpleName}: ${amount.description}"
+            }
+        }
+
+        /** Convenience for the overwhelmingly common literal "collect evidence N". */
+        constructor(amount: Int, linkToSource: Boolean = false) :
+            this(DynamicAmount.Fixed(amount), linkToSource)
+
         // Variable count: at least one card must be exiled, but the binding constraint is the
         // total mana value, carried separately to the picker.
         override val selectionCount: Int get() = 1
-        override val description: String get() = "collect evidence $amount"
+
+        // "Collect evidence 3" for a literal; "collect evidence X" for either derived shape —
+        // which is how both printed cards word it.
+        override val description: String get() =
+            if (amount is DynamicAmount.Fixed) "collect evidence ${amount.amount}"
+            else "collect evidence X"
+
+        companion object {
+            /**
+             * "X, where X is the total mana value of the permanents this spell targets" — the one
+             * derived threshold in print (Urgent Necropsy). Named here so a card never has to
+             * spell the `ContextProperty` out and the `init` guard has one thing to compare to.
+             */
+            val TARGET_SUM: DynamicAmount = DynamicAmount.ContextProperty(
+                com.wingedsheep.sdk.scripting.values.ContextPropertyKey.TARGETS_TOTAL_MANA_VALUE
+            )
+        }
     }
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtoms.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtoms.kt
@@ -55,8 +55,16 @@ fun CostAtom.repeated(times: Int): CostAtom {
         // Collecting evidence N twice is collecting evidence 2N: CR 601.2f folds the repeated cost
         // into one payment, and one exile of total mana value 2N satisfies that just as two
         // separate exiles of N would. (No printed card repeats it — escalate is the only caller —
-        // but the threshold multiplies cleanly, so there's nothing to reject.)
-        is CostAtom.CollectEvidence -> copy(amount = amount * times)
+        // but a literal threshold multiplies cleanly, so there's nothing to reject.) A *derived*
+        // threshold is rejected for the same reason RemoveCounters rejects one above: doubling a
+        // number that isn't known yet has no meaning to fold into.
+        is CostAtom.CollectEvidence -> {
+            val fixed = amount as? DynamicAmount.Fixed
+                ?: throw IllegalArgumentException(
+                    "Cannot repeat a collect-evidence cost with a variable amount: $amount"
+                )
+            copy(amount = DynamicAmount.Fixed(fixed.amount * times))
+        }
         // Same reasoning as CollectEvidence: the constraint is a summed floor, and CR 601.2f folds
         // the repeated cost into one payment, so paying it N times is one selection reaching N
         // times the threshold.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -302,6 +302,22 @@ enum class ContextPropertyKey(val description: String) {
     ADDITIONAL_COST_EXILED_COUNT("the number of cards exiled"),
     /** Number of (still-legal) targets in the current effect context. */
     TARGET_COUNT("the number of targets"),
+    /**
+     * Combined mana value of the objects the current spell or ability targets — Urgent Necropsy's
+     * "collect evidence X, where X is the total mana value of the permanents this spell targets".
+     *
+     * The summing sibling of [TARGET_COUNT], and read from the same target list. Player targets
+     * have no mana value and contribute nothing, so a mixed "target creature and target player"
+     * requirement measures only the objects.
+     *
+     * **Also readable while a spell is being cast**, which is the shape it exists for: an
+     * additional cost priced off the targets is determined at CR 601.2f, *after* the targets are
+     * announced at 601.2c and before the cost is paid at 601.2h, so a cost carrying this key reads
+     * the targets the caster just chose (`CastSpell.targets`) rather than a resolution context. In
+     * any context that has no targets at all it reads 0 — which for collect evidence is a real
+     * threshold, not a failure: collecting evidence 0 exiles nothing and is legal.
+     */
+    TARGETS_TOTAL_MANA_VALUE("the total mana value of the permanents this spell targets"),
     /** Number of +1/+1 counters on the source as it last existed on the battlefield (Hooded Hydra). */
     LAST_KNOWN_PLUS_ONE_COUNTER_COUNT("the number of +1/+1 counters on it"),
     /**

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtomRepeatedTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtomRepeatedTest.kt
@@ -2,6 +2,10 @@ package com.wingedsheep.sdk.scripting.costs
 
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -35,7 +39,25 @@ class CostAtomRepeatedTest : FunSpec({
 
     test("collecting evidence N twice is collecting evidence 2N") {
         (CostAtom.CollectEvidence(amount = 3).repeated(2) as CostAtom.CollectEvidence)
-            .amount shouldBe 6
+            .amount shouldBe DynamicAmount.Fixed(6)
+    }
+
+    test("a derived collect-evidence threshold can't be repeated — there is no number to double") {
+        shouldThrow<IllegalArgumentException> {
+            CostAtom.CollectEvidence(CostAtom.CollectEvidence.TARGET_SUM).repeated(2)
+        }
+    }
+
+    test("the atom rejects an amount no cost-time evaluator could price") {
+        shouldThrow<IllegalArgumentException> {
+            CostAtom.CollectEvidence(DynamicAmount.Count(Player.You, Zone.HAND))
+        }
+    }
+
+    test("a literal threshold prints its number; a derived one prints X, as both cards are worded") {
+        CostAtom.CollectEvidence(6).description shouldBe "collect evidence 6"
+        CostAtom.CollectEvidence(CostAtom.CollectEvidence.TARGET_SUM)
+            .description shouldBe "collect evidence X"
     }
 
     test("repeating once returns the atom unchanged") {

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CostAtomSerializationTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CostAtomSerializationTest.kt
@@ -45,6 +45,9 @@ class CostAtomSerializationTest : FunSpec({
         CostAtom.RemoveCounters(counterType = null, filter = GameObjectFilter.Creature),
         CostAtom.PutCountersOnSelf(Counters.PAGE, count = 1),
         CostAtom.CollectEvidence(amount = 6),
+        // Urgent Necropsy's derived threshold — the shape that made `amount` a DynamicAmount, and
+        // so the one whose round-trip is worth pinning separately from the literal.
+        CostAtom.CollectEvidence(CostAtom.CollectEvidence.TARGET_SUM),
         CostAtom.RevealNotedCreatureType,
         CostAtom.ExileFromGraveyardForTotal(
             filter = GameObjectFilter.Any.withColor(Color.BLACK),

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/UrgentNecropsy.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/UrgentNecropsy.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Urgent Necropsy
+ * {2}{B}{G}
+ * Instant
+ *
+ * As an additional cost to cast this spell, collect evidence X, where X is the total mana value of
+ * the permanents this spell targets.
+ * Destroy up to one target artifact, up to one target creature, up to one target enchantment, and
+ * up to one target planeswalker.
+ *
+ * Two shapes, both already spoken by the SDK:
+ *
+ * **The cost.** `Costs.additional.CollectEvidenceForTargetsTotalManaValue` is the ordinary
+ * collect-evidence atom carrying a derived threshold instead of a literal one. The engine prices it
+ * at CR 601.2f — after the targets are announced at 601.2c, before it is paid at 601.2h — so the
+ * card names no number of its own. Per the printed ruling a caster who can't reach that total
+ * *can't choose to collect evidence at all*, which makes such a set of targets an illegal cast
+ * (CR 601.2e) rather than a cheaper one; the client therefore raises its evidence picker only once
+ * targets are chosen, priced on what was actually chosen.
+ *
+ * **The targets.** Four independent "up to one target" requirements, each its own optional prompt
+ * over its own type — so the caster may pick any subset, including none. The effect gathers
+ * whatever was chosen ([CardSource.ChosenTargets]) and destroys it in one step, the same routing
+ * Boom Box uses; binding each target positionally would break the moment a middle requirement is
+ * skipped.
+ */
+val UrgentNecropsy = card("Urgent Necropsy") {
+    manaCost = "{2}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, collect evidence X, where X is the " +
+        "total mana value of the permanents this spell targets.\n" +
+        "Destroy up to one target artifact, up to one target creature, up to one target " +
+        "enchantment, and up to one target planeswalker."
+
+    additionalCost(Costs.additional.CollectEvidenceForTargetsTotalManaValue)
+
+    spell {
+        target(
+            "up to one target artifact",
+            TargetObject(optional = true, filter = TargetFilter.Artifact),
+        )
+        target(
+            "up to one target creature",
+            TargetObject(optional = true, filter = TargetFilter.Creature),
+        )
+        target(
+            "up to one target enchantment",
+            TargetObject(optional = true, filter = TargetFilter.Enchantment),
+        )
+        target(
+            "up to one target planeswalker",
+            TargetObject(optional = true, filter = TargetFilter.Planeswalker),
+        )
+        effect = Effects.Pipeline {
+            val chosen = gather(CardSource.ChosenTargets)
+            destroy(chosen)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "240"
+        artist = "Uriah Voth"
+        flavorText = "\"The Golgari can read the dead like a newspaper.\"\n" +
+            "—Taboro of the Foundway Associates"
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d2ac346a-fc46-4023-aa60-4d55170697dc.jpg?1783912833"
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/UrgentNecropsyScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/UrgentNecropsyScenarioTest.kt
@@ -1,0 +1,212 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Urgent Necropsy (MKM) — {2}{B}{G} instant.
+ *
+ * "As an additional cost to cast this spell, collect evidence X, where X is the total mana value of
+ * the permanents this spell targets. Destroy up to one target artifact, up to one target creature,
+ * up to one target enchantment, and up to one target planeswalker."
+ *
+ * The only collect-evidence cost in print whose threshold is *derived*. What these tests pin down
+ * is the pricing rule and its consequences, from the card's rulings and CR 601.2:
+ *
+ *  - X is the summed mana value of the targets the caster **actually chose** (601.2c), determined
+ *    before the cost is paid (601.2f → 601.2h);
+ *  - a payment that doesn't reach X is refused outright — per the printed ruling a caster who
+ *    can't exile that much "can't choose to collect evidence at all", making such a cast illegal
+ *    (601.2e) rather than cheaper;
+ *  - overpaying is legal, because the threshold is a floor on total mana value (CR 701.59a);
+ *  - and with no targets chosen X is 0, which collects evidence 0 and exiles nothing.
+ *
+ * The board is priced so every number in the assertions is checkable by hand:
+ * Bonesplitter {1} = 1, Grizzly Bears {1}{G} = 2, Mass Hysteria {R} = 1, Liliana of the Veil
+ * {1}{B}{B} = 3 — 7 in total. The graveyard holds Air Elemental (5), Hill Giant (4) and a second
+ * Grizzly Bears (2), so 5 + 2 pays exactly 7 and 4 + 2 falls one short.
+ */
+class UrgentNecropsyScenarioTest : ScenarioTestBase() {
+
+    private fun board() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Urgent Necropsy")
+        .withLandsOnBattlefield(1, "Swamp", 2)
+        .withLandsOnBattlefield(1, "Forest", 2)
+        // The four target types, all under the opponent.
+        .withCardOnBattlefield(2, "Bonesplitter")
+        .withCardOnBattlefield(2, "Grizzly Bears")
+        .withCardOnBattlefield(2, "Mass Hysteria")
+        .withCardOnBattlefield(2, "Liliana of the Veil")
+        // Evidence to spend: 5 + 4 + 2.
+        .withCardInGraveyard(1, "Air Elemental")
+        .withCardInGraveyard(1, "Hill Giant")
+        .withCardInGraveyard(1, "Grizzly Bears")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+    init {
+        test("X is the summed mana value of every chosen target, and all four are destroyed") {
+            val game = board().build()
+
+            val cast = game.castNecropsy(
+                targets = game.allFourTargets(),
+                evidence = listOf("Air Elemental", "Grizzly Bears"), // 5 + 2 = exactly 7
+            )
+            withClue("exiling exactly the total mana value of the targets pays the cost: ${cast.error}") {
+                cast.error shouldBe null
+            }
+            game.resolveStack()
+
+            withClue("every targeted permanent is destroyed") {
+                game.findPermanent("Bonesplitter") shouldBe null
+                game.findPermanent("Mass Hysteria") shouldBe null
+                game.findPermanent("Liliana of the Veil") shouldBe null
+                game.state.getBattlefield(game.player2Id).none {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+                } shouldBe true
+            }
+            withClue("the two chosen evidence cards left the graveyard for exile") {
+                game.graveyardNames(1).sorted() shouldBe listOf("Hill Giant", "Urgent Necropsy")
+                game.exileNames(1).contains("Air Elemental") shouldBe true
+                game.exileNames(1).contains("Grizzly Bears") shouldBe true
+            }
+        }
+
+        test("a payment short of the targets' total mana value is refused") {
+            val game = board().build()
+
+            val cast = game.castNecropsy(
+                targets = game.allFourTargets(),
+                evidence = listOf("Hill Giant", "Grizzly Bears"), // 4 + 2 = 6, one short of 7
+            )
+            withClue("CR 601.2e — the cast is illegal, not discounted") {
+                cast.error shouldNotBe null
+            }
+            withClue("nothing was exiled and nothing was destroyed") {
+                game.graveyardNames(1).sorted() shouldBe
+                    listOf("Air Elemental", "Grizzly Bears", "Hill Giant")
+                game.findPermanent("Liliana of the Veil") shouldNotBe null
+            }
+        }
+
+        test("only the chosen targets are counted, not every legal one") {
+            val game = board().build()
+
+            // Just the artifact — mana value 1 — even though 7 worth of targets is on the board.
+            val cast = game.castNecropsy(
+                targets = listOf(ChosenTarget.Permanent(game.oppPermanent("Bonesplitter"))),
+                evidence = listOf("Grizzly Bears"), // mana value 2, which clears a threshold of 1
+            )
+            withClue("a cheap target makes a cheap cost: ${cast.error}") { cast.error shouldBe null }
+            game.resolveStack()
+
+            withClue("the targeted artifact dies") { game.findPermanent("Bonesplitter") shouldBe null }
+            withClue("the untargeted permanents are untouched") {
+                game.findPermanent("Mass Hysteria") shouldNotBe null
+                game.findPermanent("Liliana of the Veil") shouldNotBe null
+            }
+            withClue("overpaying is legal — the whole 2-mana-value card is exiled for a cost of 1") {
+                game.exileNames(1) shouldBe listOf("Grizzly Bears")
+            }
+        }
+
+        test("with no targets chosen the cost is collect evidence 0 and nothing is exiled") {
+            val game = board().build()
+
+            val cast = game.castNecropsy(targets = emptyList(), evidence = emptyList())
+            withClue("every target is 'up to one', so casting with none is legal: ${cast.error}") {
+                cast.error shouldBe null
+            }
+            game.resolveStack()
+
+            withClue("collecting evidence 0 exiles nothing") {
+                game.exileNames(1) shouldBe emptyList()
+                game.graveyardNames(1).sorted() shouldBe
+                    listOf("Air Elemental", "Grizzly Bears", "Hill Giant", "Urgent Necropsy")
+            }
+            withClue("nothing was destroyed") {
+                game.findPermanent("Bonesplitter") shouldNotBe null
+                game.findPermanent("Liliana of the Veil") shouldNotBe null
+            }
+        }
+
+        test("the legal action defers its evidence picker and ships a price per target") {
+            val game = board().build()
+
+            val cast = game.getLegalActions(1)
+                .first { it.description.contains("Urgent Necropsy") }
+            val cost = cast.additionalCostInfo
+            withClue("the mandatory collect-evidence cost reaches the client at all") {
+                cost shouldNotBe null
+                cost!!.costType shouldBe "CollectEvidence"
+            }
+            withClue("the threshold is not knowable yet — it starts at 0") {
+                cost!!.exileMinTotalWeight shouldBe 0
+            }
+            withClue("every legal target is priced so the client can total up its own selection") {
+                val weights = cost!!.exileWeightPerTarget
+                weights[game.oppPermanent("Bonesplitter")] shouldBe 1
+                weights[game.oppPermanent("Grizzly Bears")] shouldBe 2
+                weights[game.oppPermanent("Mass Hysteria")] shouldBe 1
+                weights[game.oppPermanent("Liliana of the Veil")] shouldBe 3
+            }
+            withClue("the whole graveyard is spendable, priced by mana value") {
+                cost!!.exileCardWeights.values.sorted() shouldBe listOf(2, 4, 5)
+                cost.exileWeightUnit shouldBe "mana value"
+            }
+        }
+    }
+
+    // -- helpers ------------------------------------------------------------------------------
+
+    private fun TestGame.oppPermanent(name: String): EntityId =
+        state.getBattlefield(player2Id).first {
+            state.getEntity(it)?.get<CardComponent>()?.name == name
+        }
+
+    /** The four requirements in printed order: artifact, creature, enchantment, planeswalker. */
+    private fun TestGame.allFourTargets(): List<ChosenTarget> = listOf(
+        ChosenTarget.Permanent(oppPermanent("Bonesplitter")),
+        ChosenTarget.Permanent(oppPermanent("Grizzly Bears")),
+        ChosenTarget.Permanent(oppPermanent("Mass Hysteria")),
+        ChosenTarget.Permanent(oppPermanent("Liliana of the Veil")),
+    )
+
+    private fun TestGame.castNecropsy(
+        targets: List<ChosenTarget>,
+        evidence: List<String>,
+    ) = execute(
+        CastSpell(
+            playerId = player1Id,
+            cardId = state.getHand(player1Id).first {
+                state.getEntity(it)?.get<CardComponent>()?.name == "Urgent Necropsy"
+            },
+            targets = targets,
+            additionalCostPayment = AdditionalCostPayment(exiledCards = evidence.map { name ->
+                state.getZone(ZoneKey(player1Id, Zone.GRAVEYARD)).first {
+                    state.getEntity(it)?.get<CardComponent>()?.name == name
+                }
+            }),
+        )
+    )
+
+    private fun TestGame.zoneNames(playerNumber: Int, zone: Zone): List<String> =
+        state.getZone(ZoneKey(if (playerNumber == 1) player1Id else player2Id, zone))
+            .mapNotNull { state.getEntity(it)?.get<CardComponent>()?.name }
+
+    private fun TestGame.graveyardNames(playerNumber: Int) = zoneNames(playerNumber, Zone.GRAVEYARD)
+
+    private fun TestGame.exileNames(playerNumber: Int) = zoneNames(playerNumber, Zone.EXILE)
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -997,7 +997,10 @@
                 "type": "AdditionalAtom",
                 "atom": {
                     "type": "AtomCollectEvidence",
-                    "amount": 8
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 8
+                    }
                 }
             },
             "declaredSlot": "EVIDENCE_COLLECTED"
@@ -2073,7 +2076,10 @@
                 "type": "AdditionalAtom",
                 "atom": {
                     "type": "AtomCollectEvidence",
-                    "amount": 6
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 6
+                    }
                 }
             },
             "declaredSlot": "EVIDENCE_COLLECTED"
@@ -2241,7 +2247,10 @@
                 "type": "AdditionalAtom",
                 "atom": {
                     "type": "AtomCollectEvidence",
-                    "amount": 6
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 6
+                    }
                 }
             },
             "declaredSlot": "EVIDENCE_COLLECTED"
@@ -5854,7 +5863,10 @@
                         "type": "AdditionalAtom",
                         "atom": {
                             "type": "AtomCollectEvidence",
-                            "amount": 10
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 10
+                            }
                         }
                     }
                 ]
@@ -6281,7 +6293,10 @@
                 "type": "AdditionalAtom",
                 "atom": {
                     "type": "AtomCollectEvidence",
-                    "amount": 6
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 6
+                    }
                 }
             },
             "declaredSlot": "EVIDENCE_COLLECTED"
@@ -6435,7 +6450,10 @@
                             "type": "CostAtomWrapper",
                             "atom": {
                                 "type": "AtomCollectEvidence",
-                                "amount": 3
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
                             }
                         }
                     ]
@@ -6914,7 +6932,10 @@
                 "type": "AdditionalAtom",
                 "atom": {
                     "type": "AtomCollectEvidence",
-                    "amount": 6
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 6
+                    }
                 }
             },
             "declaredSlot": "EVIDENCE_COLLECTED"
@@ -8583,7 +8604,10 @@
                 "type": "AdditionalAtom",
                 "atom": {
                     "type": "AtomCollectEvidence",
-                    "amount": 6
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 6
+                    }
                 }
             },
             "declaredSlot": "EVIDENCE_COLLECTED"
@@ -9552,7 +9576,10 @@
                             "type": "CostAtomWrapper",
                             "atom": {
                                 "type": "AtomCollectEvidence",
-                                "amount": 3
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
                             }
                         }
                     ]
@@ -11064,7 +11091,10 @@
                             "type": "CostAtomWrapper",
                             "atom": {
                                 "type": "AtomCollectEvidence",
-                                "amount": 4
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
                             }
                         }
                     ]
@@ -13363,7 +13393,10 @@
                     "type": "CostAtomWrapper",
                     "atom": {
                         "type": "AtomCollectEvidence",
-                        "amount": 6,
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 6
+                        },
                         "linkToSource": true
                     }
                 },
@@ -16302,7 +16335,10 @@
                             "type": "CostAtomWrapper",
                             "atom": {
                                 "type": "AtomCollectEvidence",
-                                "amount": 3
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
                             }
                         }
                     ]
@@ -19873,7 +19909,10 @@
                             "type": "CostAtomWrapper",
                             "atom": {
                                 "type": "AtomCollectEvidence",
-                                "amount": 2
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
                             }
                         }
                     ]
@@ -19915,7 +19954,10 @@
                             "type": "CostAtomWrapper",
                             "atom": {
                                 "type": "AtomCollectEvidence",
-                                "amount": 4
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
                             }
                         }
                     ]
@@ -21594,6 +21636,92 @@
     ]
 }
 
+// Urgent Necropsy
+{
+    "name": "Urgent Necropsy",
+    "manaCost": "{2}{B}{G}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, collect evidence X, where X is the total mana value of the permanents this spell targets.\nDestroy up to one target artifact, up to one target creature, up to one target enchantment, and up to one target planeswalker.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": "ChosenTargets",
+                    "storeAs": "gathered0"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "gathered0",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "artifact"
+                },
+                "id": "up to one target artifact"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "up to one target creature"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "enchantment"
+                },
+                "id": "up to one target enchantment"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "planeswalker"
+                },
+                "id": "up to one target planeswalker"
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomCollectEvidence",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TARGETS_TOTAL_MANA_VALUE"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "240",
+        "rarity": "MYTHIC",
+        "artist": "Uriah Voth",
+        "flavorText": "\"The Golgari can read the dead like a newspaper.\"\n—Taboro of the Foundway Associates",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d2ac346a-fc46-4023-aa60-4d55170697dc.jpg?1783912833"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Vannifar, Evolved Enigma
 {
     "name": "Vannifar, Evolved Enigma",
@@ -21890,7 +22018,10 @@
                 "type": "AdditionalAtom",
                 "atom": {
                     "type": "AtomCollectEvidence",
-                    "amount": 6
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 6
+                    }
                 }
             },
             "declaredSlot": "EVIDENCE_COLLECTED"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -600,7 +600,11 @@ class CostHandler {
         // never its card count.
         is CostAtom.CollectEvidence ->
             com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver
-                .canCollect(state, controllerId, atom.amount)
+                .canCollect(
+                    state, controllerId,
+                    com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                        .evaluate(state, atom.amount),
+                )
         // Same fail-closed gate collect evidence gets, over the filtered pool and the atom's own
         // measure: the ability isn't activatable unless the matching graveyard cards can reach the
         // floor. Card count is never the question — the summed measure is.
@@ -720,7 +724,10 @@ class CostHandler {
         is CostAtom.CollectEvidence ->
             when (
                 val result = com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver.collect(
-                    state, controllerId, atom.amount, choices.exileChoices,
+                    state, controllerId,
+                    com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                        .evaluate(state, atom.amount, choices.xValue),
+                    choices.exileChoices,
                     state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Collect evidence",
                     // "Cards exiled with it": an atom that asked to link hands the payment the
                     // permanent whose ability is being activated, so the exiles land in its pile.
@@ -1234,9 +1241,20 @@ class CostHandler {
                     findMatchingCardsUnified(state, state.getZone(ZoneKey(controllerId, atom.zone)), atom.filter, controllerId).size >= atom.count
                 // CR 701.59b — see canPayAtom. An optional collect-evidence cast cost that can't be
                 // reached simply isn't offered as a second cast action.
+                //
+                // A *target-derived* threshold has no price yet: this check runs before the caster
+                // announces targets (CR 601.2c), and the cost isn't determined until 601.2f. It
+                // therefore withholds judgement rather than guessing — the cast is offered, and an
+                // unreachable one is caught when the submitted targets are validated, which is
+                // exactly the 601.2e/733 rewind the printed ruling describes.
                 is CostAtom.CollectEvidence ->
-                    com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver
-                        .canCollect(state, controllerId, atom.amount)
+                    com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                        .dependsOnTargets(atom.amount) ||
+                        com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver.canCollect(
+                            state, controllerId,
+                            com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                                .evaluate(state, atom.amount),
+                        )
                 // Not payable as a *spell's* additional cost today: nothing offers this atom in a
                 // cast context, and the cast-time picker has no sum-gated exile mode to raise, so
                 // an unreachable one would be offered and then fail at payment. Fails closed until

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -857,6 +857,13 @@ class DynamicAmountEvaluator(
 
         ContextPropertyKey.TARGET_COUNT -> context.targets.size
 
+        // The summing sibling of TARGET_COUNT, over the same list. A cost carrying this key is
+        // priced before resolution by CostAtomAmounts instead — both read the announced targets,
+        // so the two paths agree by construction.
+        ContextPropertyKey.TARGETS_TOTAL_MANA_VALUE ->
+            com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                .totalManaValueOf(state, context.targets)
+
         ContextPropertyKey.MODES_CHOSEN_ON_TRIGGERING_SPELL -> context.triggerModesChosenCount ?: 0
 
         ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL -> context.triggerManaSpentOnTriggeringSpell ?: 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1806,11 +1806,18 @@ class CastSpellHandler(
                     // A GameAction is client-supplied: never trust the submitted selection.
                     is CostAtom.CollectEvidence -> {
                         val exiled = action.additionalCostPayment?.exiledCards ?: emptyList()
+                        // CR 601.2f — the threshold is determined here, from the targets announced
+                        // at 601.2c, and then locked in. Urgent Necropsy's ruling spells the
+                        // consequence out: if the graveyard can't reach it, the caster can't
+                        // choose to collect evidence at all, so this rejection *is* the 601.2e
+                        // illegal-cast rewind rather than a discount.
+                        val required = com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                            .evaluate(state, atom.amount, action.xValue, action.targets)
                         if (!com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver
-                                .isLegalSelection(state, action.playerId, atom.amount, exiled)
+                                .isLegalSelection(state, action.playerId, required, exiled)
                         ) {
-                            return "You must exile cards with total mana value ${atom.amount} or " +
-                                "greater from your graveyard to collect evidence ${atom.amount}"
+                            return "You must exile cards with total mana value $required or " +
+                                "greater from your graveyard to collect evidence $required"
                         }
                     }
                     is CostAtom.ExileFrom -> {
@@ -2687,7 +2694,10 @@ class CastSpellHandler(
                                 .CollectEvidenceResolver.collect(
                                     state = currentState,
                                     playerId = action.playerId,
-                                    amount = atom.amount,
+                                    // Priced from the same targets validateAdditionalCosts read,
+                                    // so the payment can't drift from the check that allowed it.
+                                    amount = com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                                        .evaluate(currentState, atom.amount, action.xValue, action.targets),
                                     chosenCards = action.additionalCostPayment.exiledCards,
                                     sourceName = cardDef?.name ?: "Collect evidence",
                                 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/costs/CostAtomAmounts.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/costs/CostAtomAmounts.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.handlers.costs
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * The one place a [DynamicAmount] carried by a **cost atom** is turned into a number.
+ *
+ * A cost is priced *before* anything resolves, so it can't go through
+ * [com.wingedsheep.engine.handlers.DynamicAmountEvaluator] — there is no `EffectContext` yet, only
+ * the half-announced spell or ability the cost belongs to. What that half-announcement does carry
+ * is exactly the two things a printed cost is ever priced from: the X the caster chose, and the
+ * targets they announced (CR 601.2b–c, both settled before the total cost is determined at
+ * 601.2f). Everything else evaluates to 0.
+ *
+ * Before this existed the same `Fixed` / `XValue` `when` was hand-written in six places, which is
+ * why the seventh shape — Urgent Necropsy's "collect evidence X, where X is the total mana value of
+ * the permanents this spell targets" — would otherwise have had to be added six times.
+ *
+ * **Zero means zero, not "unknown".** For a counted cost a zero requirement is trivially met; for a
+ * summed one (collect evidence) exiling nothing legitimately satisfies a threshold of 0. Callers
+ * that need to distinguish "cannot be priced yet" from "prices to 0" ask [dependsOnTargets] rather
+ * than reading a sentinel out of the number.
+ */
+object CostAtomAmounts {
+
+    /**
+     * Evaluate [amount] for a cost being paid by the controller of the spell/ability it belongs to.
+     *
+     * @param xValue the X declared for this cast/activation (`CastSpell.xValue`,
+     *   `CostPaymentChoices.xValue`), or null where the context has none.
+     * @param targets the targets already announced for the object this cost is being paid for.
+     *   Empty in every context that has no target list of its own — a resolution-time `PayCost`, a
+     *   ward payment, an affordability probe run before targets are chosen. A target-derived amount
+     *   then reads 0, which is why [dependsOnTargets] exists for the callers that must not treat
+     *   that as the final price.
+     */
+    fun evaluate(
+        state: GameState,
+        amount: DynamicAmount,
+        xValue: Int? = null,
+        targets: List<ChosenTarget> = emptyList(),
+    ): Int = when (amount) {
+        is DynamicAmount.Fixed -> amount.amount
+        is DynamicAmount.XValue -> xValue ?: 0
+        is DynamicAmount.ContextProperty -> when (amount.key) {
+            ContextPropertyKey.TARGETS_TOTAL_MANA_VALUE -> totalManaValueOf(state, targets)
+            // Every other context key reads a trigger payload or a resolution pipeline, neither of
+            // which exists while a cost is being priced.
+            else -> 0
+        }
+        else -> 0
+    }
+
+    /**
+     * Whether [amount] can only be priced once the object's targets are announced — the signal an
+     * enumerator uses to publish a *deferred* cost rather than a wrong one, and an affordability
+     * check uses to withhold judgement instead of failing closed on a price it hasn't got yet.
+     */
+    fun dependsOnTargets(amount: DynamicAmount): Boolean =
+        amount is DynamicAmount.ContextProperty &&
+            amount.key == ContextPropertyKey.TARGETS_TOTAL_MANA_VALUE
+
+    /**
+     * Summed mana value of the objects among [targets] (CR 202.3).
+     *
+     * Players have no mana value and contribute nothing, so a mixed "target creature and target
+     * player" requirement measures only the objects. Read off the base [CardComponent] like every
+     * other mana-value read in the engine: mana value is intrinsic, so a permanent's projection has
+     * nothing different to say, and a token (no mana cost) is worth 0. An entity the engine can't
+     * read is worth 0, which keeps the price from silently inflating.
+     */
+    fun totalManaValueOf(state: GameState, targets: List<ChosenTarget>): Int =
+        targets.sumOf { manaValueOf(state, it) }
+
+    private fun manaValueOf(state: GameState, target: ChosenTarget): Int {
+        val entityId: EntityId = when (target) {
+            is ChosenTarget.Permanent -> target.entityId
+            is ChosenTarget.Card -> target.cardId
+            is ChosenTarget.Spell -> target.spellEntityId
+            is ChosenTarget.Player -> return 0
+        }
+        return state.getEntity(entityId)?.get<CardComponent>()?.manaValue ?: 0
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/costs/GraveyardTotalExileResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/costs/GraveyardTotalExileResolver.kt
@@ -102,10 +102,18 @@ object GraveyardTotalExileResolver {
     ): Boolean = candidates(state, playerId, measure, filter, excludeCardId).canReach(minTotal)
 
     /**
-     * Whether [chosenCards] is a legal payment: a non-empty selection drawn entirely from
-     * [candidates] whose weights sum to at least [minTotal]. A deliberately *overpaying* selection
-     * is legal — exiling more than needed is the payer's right. Every `GameAction` field is
-     * client-supplied, so this runs on the server before anything is exiled.
+     * Whether [chosenCards] is a legal payment: a selection drawn entirely from [candidates] whose
+     * weights sum to at least [minTotal]. A deliberately *overpaying* selection is legal — exiling
+     * more than needed is the payer's right. Every `GameAction` field is client-supplied, so this
+     * runs on the server before anything is exiled.
+     *
+     * **The empty selection is legal exactly when [minTotal] is 0**, which the sum test decides on
+     * its own: "any number of cards" includes none, and their total of 0 meets a threshold of 0.
+     * Only collect evidence can reach here with a threshold of 0 — the filtered form requires a
+     * floor of at least 1 — and it does so for two printed shapes, Incinerator of the Guilty's
+     * chosen X and Urgent Necropsy cast with no targets. Both still *count* as having collected
+     * evidence per the 2024-02-02 ruling, which is why the payment must succeed rather than be
+     * refused as an empty one.
      */
     fun isLegalSelection(
         candidates: Candidates,
@@ -113,8 +121,7 @@ object GraveyardTotalExileResolver {
         chosenCards: List<EntityId>,
     ): Boolean {
         val distinct = chosenCards.distinct()
-        return distinct.isNotEmpty() &&
-            distinct.all { it in candidates.weightById } &&
+        return distinct.all { it in candidates.weightById } &&
             distinct.sumOf { candidates.weightById.getValue(it) } >= minTotal
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
@@ -433,6 +433,25 @@ data class AdditionalCostData(
      * unit and the client never has to know which cost it is looking at.
      */
     val exileWeightUnit: String = "",
+    /**
+     * What each of the spell's *legal targets* would add to [exileMinTotalWeight] if chosen —
+     * non-empty only for a cost whose threshold is priced off the targets rather than printed:
+     * Urgent Necropsy's "collect evidence X, where X is the total mana value of the permanents this
+     * spell targets".
+     *
+     * Its presence is the whole contract, and it says two things at once. **The threshold is not
+     * final**: [exileMinTotalWeight] is the part that is already known (0 for Urgent Necropsy,
+     * whose four targets are each "up to one"), and the client adds these per-target weights for
+     * whatever the caster actually chooses. And **the picker runs after targeting** — a cost
+     * determined at CR 601.2f cannot be paid before the targets are announced at 601.2c, so the
+     * client moves its cost-payment step behind the targeting step for exactly these costs, the
+     * way `manaCostPerExtraTarget` already defers mana-source selection.
+     *
+     * A map rather than a boolean because the client must be able to *price* a selection, not just
+     * know that it is deferred, and shipping the weights keeps the one sum-gated picker: the same
+     * running total, drawn from the same server-side reading of the cards.
+     */
+    val exileWeightPerTarget: Map<EntityId, Int> = emptyMap(),
     val validBeholdTargets: List<EntityId> = emptyList(),
     val beholdCount: Int = 0,
     val counterRemovalCreatures: List<CounterRemovalCreatureData> = emptyList(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -334,7 +334,11 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                         // entirely rather than surfacing an unpayable one.
                         is CostAtom.CollectEvidence -> {
                             prebuiltCostInfo = com.wingedsheep.engine.handlers.costs
-                                .CollectEvidenceResolver.costInfo(state, playerId, atom.amount)
+                                .CollectEvidenceResolver.costInfo(
+                                    state, playerId,
+                                    com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                                        .evaluate(state, atom.amount),
+                                )
                                 ?: continue
                         }
                         // Same fail-closed shape as collect evidence over a filtered pool: when the
@@ -515,7 +519,11 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                                     is CostAtom.CollectEvidence -> {
                                         prebuiltCostInfo = com.wingedsheep.engine.handlers.costs
                                             .CollectEvidenceResolver
-                                            .costInfo(state, playerId, atom.amount)
+                                            .costInfo(
+                                                state, playerId,
+                                                com.wingedsheep.engine.handlers.costs
+                                                    .CostAtomAmounts.evaluate(state, atom.amount),
+                                            )
                                         if (prebuiltCostInfo == null) {
                                             costCanBePaid = false
                                             break

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -2514,10 +2514,9 @@ class CastFromZoneEnumerator : ActionEnumerator {
                 val manaKicker = kickers.firstOrNull { it.manaCost != null && it.keyword != Keyword.OFFSPRING }
                 val additionalCostKicker = kickers.firstOrNull { it.additionalCost != null }
                 val offspringAbility = kickers.firstOrNull { it.keyword == Keyword.OFFSPRING }
-                val collectEvidenceAmount = (
+                val collectEvidenceAtom = (
                     (additionalCostKicker?.additionalCost as? AdditionalCost.Atom)?.atom
-                        as? CostAtom.CollectEvidence
-                    )?.amount
+                    ) as? CostAtom.CollectEvidence
 
                 // Calculate the cost for this branch — a declaration-gated reduction ("costs {2} less
                 // to cast if it's bargained") applies only to the variant that declares it.
@@ -2613,7 +2612,9 @@ class CastFromZoneEnumerator : ActionEnumerator {
                     declaredSlot == ChoiceSlot.BARGAINED -> "Bargained"
                     // See CastSpellEnumerator — the amount is the choice.
                     declaredSlot == ChoiceSlot.EVIDENCE_COLLECTED ->
-                        collectEvidenceAmount?.let { "Collect evidence $it" } ?: "Collect evidence"
+                        collectEvidenceAtom
+                            ?.description?.replaceFirstChar { it.uppercase() }
+                            ?: "Collect evidence"
                     // Teamwork prints its N, so the variant reads "Cast X (Teamwork 2)".
                     declaredSlot == ChoiceSlot.TEAMWORK ->
                         additionalCostKicker?.displayPrefix ?: "Teamwork"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -215,6 +215,7 @@ class CastSpellEnumerator : ActionEnumerator {
             var variableSacrificeReduction = 0
             var exileTargets = emptyList<EntityId>()
             var exileMinCount = 0
+            var collectEvidenceCost: CostAtom.CollectEvidence? = null
             var discardTargets = emptyList<EntityId>()
             var discardCount = 0
             var bounceTargets = emptyList<EntityId>()
@@ -253,6 +254,30 @@ class CastSpellEnumerator : ActionEnumerator {
                             }
                             exileTargets = validExileTargets
                             exileMinCount = atom.count
+                        }
+                        // Collect evidence N as a *mandatory* cast cost (CR 701.59a) — Urgent
+                        // Necropsy. The optional linked form rides the kicker rail further down;
+                        // this is the plain `Costs.additional.CollectEvidence(...)` shape.
+                        is CostAtom.CollectEvidence -> {
+                            collectEvidenceCost = atom
+                            // CR 701.59b fails closed on a threshold that is already known: a
+                            // graveyard that can't reach it means the spell can't be cast at all.
+                            // A *target-derived* threshold isn't known yet — targets are announced
+                            // at CR 601.2c and the cost isn't determined until 601.2f — so the cast
+                            // is offered and an unreachable choice of targets is rejected at
+                            // validation, which is the 601.2e rewind the printed ruling describes.
+                            if (!com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                                    .dependsOnTargets(atom.amount) &&
+                                !com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver
+                                    .canCollect(
+                                        state, playerId,
+                                        com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                                            .evaluate(state, atom.amount),
+                                        excludeCardId = cardId,
+                                    )
+                            ) {
+                                canPayAdditionalCosts = false
+                            }
                         }
                         is CostAtom.Discard -> {
                             val handZone = ZoneKey(playerId, Zone.HAND)
@@ -654,6 +679,23 @@ class CastSpellEnumerator : ActionEnumerator {
                 cardDef.script.auraTarget?.let { add(it) }
             }
 
+            // What each legal target would add to a target-derived collect-evidence threshold
+            // ("collect evidence X, where X is the total mana value of the permanents this spell
+            // targets"). Built only for the one cost shape that needs it — enumerating targets is
+            // the expensive part of this loop, and every other spell would pay for a map nothing
+            // reads. `mustDifferFromEarlier` and per-requirement caps don't matter here: the client
+            // prices whatever set the targeting step let it choose.
+            val evidenceTargetWeights: Map<EntityId, Int> =
+                if (collectEvidenceCost != null &&
+                    com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                        .dependsOnTargets(collectEvidenceCost.amount)
+                ) {
+                    context.targetUtils.buildTargetInfos(state, playerId, targetReqs, cardId)
+                        .flatMap { it.validTargets }
+                        .distinct()
+                        .associateWith { state.getEntity(it)?.get<CardComponent>()?.manaValue ?: 0 }
+                } else emptyMap()
+
             // Build additional cost info for the client
             val costInfo = buildAdditionalCostData(
                 additionalCosts, sacrificeTargets, variableSacrificeTargets,
@@ -662,7 +704,9 @@ class CastSpellEnumerator : ActionEnumerator {
                 tapTargets, tapCount,
                 beholdTargets, beholdCount,
                 blightVariableCost, blightVariableCreatures, blightVariableMaxX,
-                payXLifeCost, payXLifeMaxX
+                payXLifeCost, payXLifeMaxX,
+                collectEvidenceCost, evidenceTargetWeights,
+                state, playerId, cardId
             )
 
             // Compute the "… or pay {N}" cast paths — one extra legal action each, carrying the
@@ -2141,10 +2185,9 @@ class CastSpellEnumerator : ActionEnumerator {
                 val manaKicker = kickers.firstOrNull { it.manaCost != null && it.keyword != Keyword.OFFSPRING }
                 val additionalCostKicker = kickers.firstOrNull { it.additionalCost != null }
                 val offspringAbility = kickers.firstOrNull { it.keyword == Keyword.OFFSPRING }
-                val collectEvidenceAmount = (
+                val collectEvidenceAtom = (
                     (additionalCostKicker?.additionalCost as? AdditionalCost.Atom)?.atom
-                        as? CostAtom.CollectEvidence
-                    )?.amount
+                    ) as? CostAtom.CollectEvidence
 
                 // Re-check timing per slot: the flash unlock belongs to the mechanic that prints it
                 // (Ghitu Fire's pay-{2}-more clause), so a bargain variant on the same card must not
@@ -2205,8 +2248,17 @@ class CastSpellEnumerator : ActionEnumerator {
                             // the picker payload, whose candidate pool is the whole graveyard and
                             // whose real constraint is the mana-value floor, not a card count.
                             is CostAtom.CollectEvidence -> {
+                                // The optional rail is enumerated before targets exist, so only a
+                                // statically-priced threshold can be gated here; nothing prints a
+                                // target-derived one as an optional cost (Urgent Necropsy's is
+                                // mandatory — see the mandatory branch above).
                                 val info = com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver
-                                    .costInfo(state, playerId, atom.amount, excludeCardId = cardId)
+                                    .costInfo(
+                                        state, playerId,
+                                        com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                                            .evaluate(state, atom.amount),
+                                        excludeCardId = cardId,
+                                    )
                                 if (info == null) canPayKickerAdditionalCost = false
                                 else kickerCostInfo = info
                             }
@@ -2285,7 +2337,9 @@ class CastSpellEnumerator : ActionEnumerator {
                     // "Collect evidence 6" reads the way the card is printed, where a bare
                     // "Evidence" would not (CR 701.59).
                     declaredSlot == ChoiceSlot.EVIDENCE_COLLECTED ->
-                        collectEvidenceAmount?.let { "Collect evidence $it" } ?: "Collect evidence"
+                        collectEvidenceAtom
+                            ?.description?.replaceFirstChar { it.uppercase() }
+                            ?: "Collect evidence"
                     // Teamwork prints its N, so the variant reads "Cast X (Teamwork 2)".
                     declaredSlot == ChoiceSlot.TEAMWORK ->
                         additionalCostKicker?.displayPrefix ?: "Teamwork"
@@ -2649,8 +2703,35 @@ class CastSpellEnumerator : ActionEnumerator {
         blightVariableCreatures: List<EntityId> = emptyList(),
         blightVariableMaxX: Int = 0,
         payXLifeCost: AdditionalCost.PayXLife? = null,
-        payXLifeMaxX: Int = 0
+        payXLifeMaxX: Int = 0,
+        collectEvidenceCost: CostAtom.CollectEvidence? = null,
+        evidenceTargetWeights: Map<EntityId, Int> = emptyMap(),
+        state: GameState? = null,
+        payerId: EntityId? = null,
+        castCardId: EntityId? = null
     ): AdditionalCostData? {
+        // Collect evidence N as a *mandatory* cast cost. Priced through the same resolver every
+        // other collect-evidence context uses, so the picker, the reachability gate and the exile
+        // can't drift. What is specific here is that the threshold may not be known yet: a
+        // target-derived one is published as 0 plus `exileWeightPerTarget`, and the client adds up
+        // whichever targets the caster actually chooses (CR 601.2c → 601.2f).
+        if (collectEvidenceCost != null && state != null && payerId != null) {
+            val dependsOnTargets = com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                .dependsOnTargets(collectEvidenceCost.amount)
+            val known = com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                .evaluate(state, collectEvidenceCost.amount)
+            val candidates = com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver
+                .candidates(state, payerId, excludeCardId = castCardId)
+            return com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver
+                .costInfo(candidates, known)
+                ?.let { info ->
+                    if (!dependsOnTargets) info else info.copy(
+                        description = "Collect evidence X — exile cards from your graveyard with " +
+                            "total mana value equal to the total mana value of this spell's targets",
+                        exileWeightPerTarget = evidenceTargetWeights,
+                    )
+                }
+        }
         if (blightVariableCost != null) {
             return AdditionalCostData(
                 description = blightVariableCost.description,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/SelectionCostPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/SelectionCostPresentation.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.legalactions.utils
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver
+import com.wingedsheep.engine.handlers.costs.CostAtomAmounts
 import com.wingedsheep.engine.handlers.costs.GraveyardTotalExileResolver
 import com.wingedsheep.engine.legalactions.AdditionalCostData
 import com.wingedsheep.engine.state.GameState
@@ -115,7 +116,11 @@ object SelectionCostPresentation {
         val atom = (cost as? AdditionalCost.Atom)?.atom
         return when (atom) {
             is CostAtom.CollectEvidence ->
-                CollectEvidenceResolver.canCollect(state, playerId, atom.amount, excludeCardId = castCardId)
+                CollectEvidenceResolver.canCollect(
+                    state, playerId,
+                    CostAtomAmounts.evaluate(state, atom.amount),
+                    excludeCardId = castCardId,
+                )
             is CostAtom.ExileFromGraveyardForTotal -> GraveyardTotalExileResolver
                 .canPay(state, playerId, atom.measure, atom.minTotal, atom.filter, excludeCardId = castCardId)
             else -> {
@@ -197,9 +202,18 @@ object SelectionCostPresentation {
                 // "Collect evidence" would not (CR 701.59).
                 is CostAtom.CollectEvidence -> {
                     val info = CollectEvidenceResolver
-                        .costInfo(state, playerId, atom.amount, excludeCardId = castCardId)
+                        .costInfo(
+                            state, playerId,
+                            CostAtomAmounts.evaluate(state, atom.amount),
+                            excludeCardId = castCardId,
+                        )
                         ?: return null
-                    "Collect evidence ${atom.amount}" to info
+                    // This rail is an *alternative* cast cost (Conspiracy Unraveler), enumerated
+                    // before any target is announced, so a target-derived threshold would price at
+                    // 0 here. Nothing prints one on this rail; the atom's own description is used
+                    // so that if something ever does, the label reads "Collect evidence X" rather
+                    // than a fabricated number.
+                    atom.description.replaceFirstChar { it.uppercase() } to info
                 }
                 is CostAtom.ExileFromGraveyardForTotal -> {
                     val info = GraveyardTotalExileResolver

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -138,10 +138,17 @@ class CostPaymentService(private val services: EngineServices) {
                     selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, candidates, atom.count, useTargetingUI = atom.zone == Zone.BATTLEFIELD)
                 // Collect evidence N (CR 701.59a) — the whole graveyard is selectable and the gate
                 // is the summed mana value, so the count cap is simply "all of them".
+                //
+                // This is the resolution-time `PayCost` rail (ward, "unless you …"): it has no
+                // target list of its own, so a target-derived threshold would read 0 here. Nothing
+                // prints one on this rail — the derived shape is a cast-time additional cost, where
+                // `CastSpellHandler` prices it from the announced targets.
                 is CostAtom.CollectEvidence ->
                     selectionPrompt(
                         state, payerId, resolved, sourceId, sourceName, ctx, candidates, candidates.size,
-                        useTargetingUI = false, minTotalManaValue = atom.amount
+                        useTargetingUI = false,
+                        minTotalManaValue = com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                            .evaluate(state, atom.amount),
                     )
                 // Milling takes no selection — the cards are the top of the library — so this is a
                 // plain yes/no like paying life.
@@ -343,7 +350,10 @@ class CostPaymentService(private val services: EngineServices) {
             is CostAtom.CollectEvidence ->
                 when (
                     val result = com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver.collect(
-                        state, payerId, atom.amount, selected.keys.toList(),
+                        state, payerId,
+                        com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                            .evaluate(state, atom.amount),
+                        selected.keys.toList(),
                         state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Collect evidence",
                         linkToSourceId = sourceId.takeIf { atom.linkToSource },
                     )
@@ -691,7 +701,11 @@ class CostPaymentService(private val services: EngineServices) {
                     // Card count says nothing here: five lands total 0 and pay nothing.
                     is CostAtom.CollectEvidence ->
                         com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver
-                            .canCollect(state, payerId, atom.amount)
+                            .canCollect(
+                                state, payerId,
+                                com.wingedsheep.engine.handlers.costs.CostAtomAmounts
+                                    .evaluate(state, atom.amount),
+                            )
                     // Activated-ability-only; nothing prompts or pays it as a PayCost, so it is
                     // reported unaffordable rather than offered into a dead payment path.
                     is CostAtom.ExileFromGraveyardForTotal -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
@@ -280,6 +280,7 @@ class LegalActionEnricher(
         exileMinTotalWeight = exileMinTotalWeight,
         exileCardWeights = exileCardWeights,
         exileWeightUnit = exileWeightUnit,
+        exileWeightPerTarget = exileWeightPerTarget,
         validBeholdTargets = validBeholdTargets,
         beholdCount = beholdCount,
         counterRemovalCreatures = counterRemovalCreatures.map { it.toDto() },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
@@ -285,6 +285,13 @@ data class AdditionalCostInfo(
     val exileMinTotalWeight: Int = 0,
     val exileCardWeights: Map<EntityId, Int> = emptyMap(),
     val exileWeightUnit: String = "",
+    /**
+     * What each legal target would add to [exileMinTotalWeight] — see
+     * [com.wingedsheep.engine.legalactions.AdditionalCostData.exileWeightPerTarget]. Non-empty only
+     * for a cost priced off the spell's targets, and its presence is what tells the client to run
+     * this cost's picker *after* targeting and to price it on what was chosen.
+     */
+    val exileWeightPerTarget: Map<EntityId, Int> = emptyMap(),
     val validBeholdTargets: List<EntityId> = emptyList(),
     val beholdCount: Int = 0,
     val counterRemovalCreatures: List<CounterRemovalCreatureInfo> = emptyList(),

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/costs/TargetsTotalManaValueTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/costs/TargetsTotalManaValueTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.handlers.costs
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [ContextPropertyKey.TARGETS_TOTAL_MANA_VALUE] — "the total mana value of the permanents this spell
+ * targets" (CR 202.3), the summing sibling of `TARGET_COUNT`.
+ *
+ * It is read from two places that must agree, because Urgent Necropsy depends on them agreeing: a
+ * *cost* is priced from the announced targets before it is paid (CR 601.2f), while an *effect* is
+ * evaluated from the resolving object's target list. `CostAtomAmounts` and `DynamicAmountEvaluator`
+ * are the two readers, and both sum the same list the same way. The card's own behaviour is pinned
+ * by `UrgentNecropsyScenarioTest`; what is pinned here is the vocabulary underneath it, on the
+ * resolution side and at its edges.
+ */
+class TargetsTotalManaValueTest : FunSpec({
+
+    // "Draw cards equal to the total mana value of the permanents this spell targets."
+    val probe = card("Evidence Probe") {
+        manaCost = "{1}"
+        typeLine = "Instant"
+        spell {
+            target = Targets.Creature
+            effect = Effects.DrawCards(
+                DynamicAmount.ContextProperty(ContextPropertyKey.TARGETS_TOTAL_MANA_VALUE)
+            )
+        }
+    }
+
+    // Same, but targeting a player — who has no mana value at all.
+    val playerProbe = card("Bystander Probe") {
+        manaCost = "{1}"
+        typeLine = "Instant"
+        spell {
+            target = Targets.Player
+            effect = Effects.DrawCards(
+                DynamicAmount.ContextProperty(ContextPropertyKey.TARGETS_TOTAL_MANA_VALUE)
+            )
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(probe, playerProbe))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("an effect reads the summed mana value of the spell's targets") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Air Elemental is {3}{U}{U} — mana value 5.
+        val elemental = driver.putCreatureOnBattlefield(opp, "Air Elemental")
+        val spell = driver.putCardInHand(me, "Evidence Probe")
+        driver.giveColorlessMana(me, 1)
+        val handBefore = driver.getHandSize(me)
+
+        val cast = driver.submit(
+            CastSpell(me, spell, targets = listOf(ChosenTarget.Permanent(elemental)))
+        )
+        withClue("cast should succeed: ${cast.error}") { cast.isSuccess shouldBe true }
+        driver.bothPass()
+
+        // -1 for the spell leaving hand, +5 drawn.
+        driver.getHandSize(me) shouldBe handBefore - 1 + 5
+    }
+
+    test("a targeted player contributes nothing — players have no mana value") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val spell = driver.putCardInHand(me, "Bystander Probe")
+        driver.giveColorlessMana(me, 1)
+        val handBefore = driver.getHandSize(me)
+
+        val cast = driver.submit(
+            CastSpell(me, spell, targets = listOf(ChosenTarget.Player(opp)))
+        )
+        withClue("cast should succeed: ${cast.error}") { cast.isSuccess shouldBe true }
+        driver.bothPass()
+
+        driver.getHandSize(me) shouldBe handBefore - 1
+    }
+})

--- a/web-client/src/store/slices/ui/pipelinePhases.test.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.test.ts
@@ -314,3 +314,84 @@ describe('computePhases — per-target mana tax (Officious Interrogation)', () =
     expect(phases).toEqual([{ type: 'targeting' }])
   })
 })
+
+describe('computePhases — target-priced collect evidence (Urgent Necropsy)', () => {
+  /**
+   * "Collect evidence X, where X is the total mana value of the permanents this spell targets."
+   * The threshold is determined at CR 601.2f, after the targets are announced at 601.2c — so the
+   * evidence picker cannot run before the targeting step, and once it does run it has to be priced
+   * on what was actually chosen. `exileWeightPerTarget` carries both facts: the per-target prices,
+   * and (by being present at all) the instruction to defer.
+   */
+  function necropsy(costInfo: Record<string, unknown> = {}): LegalActionInfo {
+    return castAction({
+      actionType: 'CastSpell',
+      description: 'Cast Urgent Necropsy',
+      manaCostString: '{2}{B}{G}',
+      requiresTargets: true,
+      validTargets: ['artifact1', 'creature1'],
+      additionalCostInfo: {
+        costType: 'CollectEvidence',
+        description: 'Collect evidence X',
+        validExileTargets: ['gy1', 'gy2'],
+        exileMinTotalWeight: 0,
+        exileCardWeights: { gy1: 5, gy2: 2 },
+        exileWeightUnit: 'mana value',
+        exileWeightPerTarget: { artifact1: 1, creature1: 2 },
+        ...costInfo,
+      },
+    })
+  }
+
+  function captureEvidencePicker(
+    info: LegalActionInfo,
+    targets: unknown[],
+  ): Record<string, unknown> | null {
+    let captured: Record<string, unknown> | null = null
+    const store = {
+      startTargeting: (arg: Record<string, unknown>) => {
+        captured = arg
+      },
+    } as unknown as Parameters<typeof enterPhase>[3]
+    enterPhase({ type: 'costPayment' }, info, { ...info.action, targets } as never, store)
+    return captured
+  }
+
+  it('runs the evidence picker after targeting, never before', () => {
+    expect(computePhases(necropsy(), { autoTapEnabled: true })).toEqual([
+      { type: 'targeting' },
+      { type: 'costPayment' },
+    ])
+  })
+
+  it('keeps costPayment before targeting when the threshold is printed, not derived', () => {
+    const phases = computePhases(necropsy({ exileWeightPerTarget: {}, exileMinTotalWeight: 6 }), {
+      autoTapEnabled: true,
+    })
+    expect(phases).toEqual([{ type: 'costPayment' }, { type: 'targeting' }])
+  })
+
+  it('prices the picker on the targets the caster chose', () => {
+    const captured = captureEvidencePicker(necropsy(), [
+      { type: 'Permanent', entityId: 'artifact1' },
+      { type: 'Permanent', entityId: 'creature1' },
+    ])
+    expect(captured).toMatchObject({
+      minTotalWeight: 3, // 1 + 2
+      minTargets: 1,
+      cardWeights: { gy1: 5, gy2: 2 },
+    })
+  })
+
+  it('counts only the chosen targets, not every legal one', () => {
+    const captured = captureEvidencePicker(necropsy(), [
+      { type: 'Permanent', entityId: 'creature1' },
+    ])
+    expect(captured).toMatchObject({ minTotalWeight: 2, minTargets: 1 })
+  })
+
+  it('a cast with no targets asks for evidence 0 and lets the player confirm with none', () => {
+    const captured = captureEvidencePicker(necropsy(), [])
+    expect(captured).toMatchObject({ minTotalWeight: 0, minTargets: 0 })
+  })
+})

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -5,7 +5,7 @@
  * - mergeResult: applies a phase result to the accumulated action
  * - enterPhase: calls the appropriate start* method for a phase
  */
-import type { EntityId, LegalActionInfo, GameAction, ClientGameState } from '@/types'
+import type { ChosenTarget, EntityId, LegalActionInfo, GameAction, ClientGameState } from '@/types'
 import { TAP_FOR_GENERIC_LABEL_IMPROVISE, TAP_FOR_GENERIC_LABEL_WATERBEND } from '@/types'
 import type {
   PipelinePhase,
@@ -30,6 +30,20 @@ import type {
  * requirement (Sorceress's Schemes: graveyard ∪ exile) matches it to the correct clause.
  */
 const CARD_TARGET_ZONES = new Set(['Graveyard', 'Exile', 'Hand', 'Library', 'Command'])
+
+/** The entity a chosen target points at, whichever arm of the union it is. */
+function targetEntityId(target: ChosenTarget): EntityId {
+  switch (target.type) {
+    case 'Player':
+      return target.playerId
+    case 'Permanent':
+      return target.entityId
+    case 'Spell':
+      return target.spellEntityId
+    case 'Card':
+      return target.cardId
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Store method interface (decouples pure logic from Zustand)
@@ -208,8 +222,16 @@ export function computePhases(actionInfo: LegalActionInfo, options?: ComputePhas
     phases.push({ type: 'manaSource' })
   }
 
+  // A cost priced off the spell's targets can't be paid before they're chosen — the engine
+  // determines it at CR 601.2f, after targets are announced at 601.2c. `exileWeightPerTarget`
+  // carries the per-target prices *and* is the signal to defer, exactly as `manaCostPerExtraTarget`
+  // defers the manaSource step above. Urgent Necropsy: "collect evidence X, where X is the total
+  // mana value of the permanents this spell targets."
+  const costAfterTargeting =
+    Object.keys(actionInfo.additionalCostInfo?.exileWeightPerTarget ?? {}).length > 0
+
   // 5. Cost payment (sacrifice/discard/tap/bounce/exile) — emerge already pushed its own above.
-  if (actionInfo.additionalCostInfo?.costType && !isEmergeCast) {
+  if (actionInfo.additionalCostInfo?.costType && !isEmergeCast && !costAfterTargeting) {
     const costType = actionInfo.additionalCostInfo.costType
     const costTypesNeedingSelection = [
       'SacrificePermanent',
@@ -253,6 +275,12 @@ export function computePhases(actionInfo: LegalActionInfo, options?: ComputePhas
   // 6. Targeting
   if (actionInfo.requiresTargets && actionInfo.validTargets && actionInfo.validTargets.length > 0) {
     phases.push({ type: 'targeting' })
+  }
+
+  // 6a. The deferred cost-payment step for a target-priced cost (see phase 5): the targets are
+  //     chosen now, so the threshold the picker gates on is the real one.
+  if (costAfterTargeting) {
+    phases.push({ type: 'costPayment' })
   }
 
   // 6b. The deferred manaSource step for a per-target-taxed spell (see phase 4): now that the
@@ -947,19 +975,36 @@ export function enterPhase(
         // server's per-card weights: the client computes no measure of its own, which is what lets
         // one branch serve both costs.
         case 'CollectEvidence':
-        case 'ExileForTotal':
+        case 'ExileForTotal': {
           validTargets = [...(costInfo.validExileTargets ?? [])]
-          minTargets = 1
           maxTargets = costInfo.validExileTargets?.length ?? 1
           flags.isSacrificeSelection = true
           flags.targetZone = 'Graveyard'
           flags.targetDescription = costInfo.description
           if (costInfo.exileMinTotalWeight != null) {
-            flags.minTotalWeight = costInfo.exileMinTotalWeight
+            // A target-priced threshold (Urgent Necropsy) reaches its real value only here, once
+            // `computePhases` has run this step behind targeting: the server's floor plus the
+            // per-target price of everything the caster actually chose (CR 601.2c → 601.2f). The
+            // weights are still the server's — the client only adds up the ones it picked.
+            const perTarget = costInfo.exileWeightPerTarget
+            const chosenTargets =
+              perTarget && (action.type === 'CastSpell' || action.type === 'ActivateAbility')
+                ? (action.targets ?? [])
+                : []
+            const targetTotal = chosenTargets.reduce(
+              (sum, t) => sum + (perTarget![targetEntityId(t)] ?? 0),
+              0,
+            )
+            flags.minTotalWeight = costInfo.exileMinTotalWeight + targetTotal
             flags.cardWeights = { ...(costInfo.exileCardWeights ?? {}) }
             if (costInfo.exileWeightUnit != null) flags.weightUnit = costInfo.exileWeightUnit
           }
+          // The count floor follows the sum gate rather than leading it: any threshold above 0
+          // needs at least one card, but collecting evidence 0 — Urgent Necropsy cast with no
+          // targets — is paid by exiling nothing, and a floor of 1 would make Confirm unreachable.
+          minTargets = (flags.minTotalWeight ?? 0) > 0 ? 1 : 0
           break
+        }
         case 'ExileFromZone':
           validTargets = [...(costInfo.validExileTargets ?? [])]
           minTargets = costInfo.exileMaxCount ?? 1

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1124,6 +1124,18 @@ export interface AdditionalCostInfo {
   readonly exileMinTotalWeight?: number
   readonly exileCardWeights?: Readonly<Record<EntityId, number>>
   readonly exileWeightUnit?: string
+  /**
+   * What each legal target would add to `exileMinTotalWeight` — present only for a cost whose
+   * threshold is priced off the spell's targets rather than printed (Urgent Necropsy's "collect
+   * evidence X, where X is the total mana value of the permanents this spell targets").
+   *
+   * Its presence says the threshold isn't final and the picker has to wait: `exileMinTotalWeight`
+   * carries only the part already known, and the real floor is that plus these weights summed over
+   * whatever the caster targets. So the cost-payment step runs *after* the targeting step for this
+   * cost — the same deferral `manaCostPerExtraTarget` already does for mana sources. Like every
+   * other weight here, the numbers are the server's, not the client's.
+   */
+  readonly exileWeightPerTarget?: Readonly<Record<EntityId, number>>
   readonly validBeholdTargets?: readonly EntityId[]
   readonly beholdCount?: number
   readonly counterRemovalCreatures?: readonly CounterRemovalCreatureInfo[]


### PR DESCRIPTION
Murders at Karlov Manor goes from 274/276 to **275/276**. The one card left after this is
Kaya, Spirits' Justice, which is genuinely four features.

## The card

**Urgent Necropsy** — {2}{B}{G} instant, MKM #240.

> As an additional cost to cast this spell, collect evidence X, where X is the total mana value of
> the permanents this spell targets.
> Destroy up to one target artifact, up to one target creature, up to one target enchantment, and up
> to one target planeswalker.

The destroy half needed nothing new — four optional target requirements and Boom Box's
`gather(CardSource.ChosenTargets)` → `destroy` routing, which stays correct when the caster skips a
requirement. The cost half is the feature.

## The feature: a cost amount priced off the spell's targets

`CostAtom.CollectEvidence.amount` becomes a `DynamicAmount` (it was an `Int`), accepting exactly the
three shapes a cost can be priced from *before* it is paid:

| shape | what it reads |
|---|---|
| `DynamicAmount.Fixed` | every literal "collect evidence 3" |
| `DynamicAmount.XValue` | the cast's chosen X |
| `ContextPropertyKey.TARGETS_TOTAL_MANA_VALUE` | **new** — the summed mana value of the announced targets |

An `init` guard rejects anything else, so a cost can never carry an amount the cost-time evaluator
has no context to read. The new context key is the *summing* sibling of the existing `TARGET_COUNT`
and reads the same target list, so it also works at resolution time through
`DynamicAmountEvaluator` — both readers are pinned against each other by a test.

This is the opposite call from `CollectEvidenceChosenAmountEffect`, which stayed a separate effect
because a player-*chosen* X isn't a `DynamicAmount` at all. A *derived* one is, and the KDoc now
says which is which.

**`CostAtomAmounts`** is the one place a cost atom's `DynamicAmount` becomes a number. Before it, the
same `Fixed`/`XValue` `when` was hand-written in six call sites (`CostHandler.getAtomCount`,
`CostPaymentService` ×3, `CastSpellHandler`, `ActivatedAbilityEnumerator` ×2) — which is why a
seventh shape would otherwise have had to be added six times. It also answers
`dependsOnTargets(amount)`, so a caller that can't price a cost yet withholds judgement instead of
guessing 0.

### CR 601.2 decides the plumbing

Targets are announced at **601.2c**, the total cost is determined at **601.2f**, and it is paid at
**601.2h**. Two consequences, both of which are the card's printed rulings:

- **X counts what the caster actually chose**, not what they could have. The engine prices it from
  `CastSpell.targets` in `validateAdditionalCosts` and again in payment, from the same list.
- **An unreachable threshold is an illegal cast, not a discount** (601.2e). The reachability gate has
  nowhere to fail closed at enumeration time, because the price doesn't exist yet — so
  `canPayAdditionalCost` withholds judgement for a target-derived amount and cast-time validation
  rejects the submission. That *is* the rewind the ruling describes.
- With no targets chosen X is **0**, which collects evidence 0: legal, exiles nothing, and still
  counts as having collected evidence per the 2024-02-02 ruling.

### The client half

The evidence picker cannot run before targeting, and once it does it has to be priced on what was
chosen. The enumerator ships `AdditionalCostData.exileWeightPerTarget` — what each legal target would
add — and its *presence* is both the price list and the instruction to defer. `computePhases` moves
the `costPayment` step behind `targeting` for exactly these costs, mirroring what
`manaCostPerExtraTarget` already does for mana-source selection (#1963's precedent). The picker's
count floor now follows the sum gate rather than leading it, so a threshold of 0 can be confirmed
with nothing selected. The weights stay the server's; the client only adds up the ones it picked.

## Three gaps closed on the way

- **A mandatory collect-evidence cast cost was never enumerated.** `Costs.additional.CollectEvidence`
  only ever reached the alternative-cost rail (Conspiracy Unraveler); the plain
  `script.additionalCosts` loop in `CastSpellEnumerator` had no branch for it, so its picker never
  reached the client and the cast would submit unpaid.
- **`isLegalSelection` refused an empty selection.** Correct for any threshold ≥ 1, wrong at 0 —
  "exile any number of cards" includes none, and their total of 0 meets a floor of 0. The sum test
  decides it on its own now; the `isNotEmpty()` guard was redundant everywhere else.
- **The AI had no collect-evidence payment at all.** `Strategist.withAutomaticPayments` runs *before*
  targeting, so a target-priced cost gets a second pass on the finished action. It spends
  highest-mana-value-first (the same choice `CollectEvidenceResolver.autoSelect` makes) and, when the
  graveyard can't cover what was targeted, trims targets from the end until the price is affordable
  rather than submitting a cast the engine will refuse.

## Tests

- `UrgentNecropsyScenarioTest` (5) — the card, on a board priced so every number is checkable by
  hand: exact payment destroys all four; a payment one short is refused and changes nothing; a single
  cheap target makes a cheap cost (and overpaying is legal); no targets collects evidence 0; and the
  legal action ships a deferred picker with a per-target price table.
- `TargetsTotalManaValueTest` (2) — the new vocabulary on the resolution side, including a targeted
  player contributing nothing.
- SDK: the `init` guard, the two descriptions ("collect evidence 6" vs "collect evidence X"), the
  refusal to repeat a derived threshold, and a serialization round-trip for the derived shape.
- Client: `pipelinePhases.test.ts` (5) — phase order both ways, pricing from the chosen targets only,
  and the 0-threshold confirm.

`just test`, `just check`, `just client-typecheck` and the full client suite are green.

## Notes

- **Snapshot churn is expected.** Widening `amount` re-serializes every collect-evidence card as
  `{"type":"Fixed","amount":N}`; `MKM.json` is the only golden affected, and the only new tree in it
  is Urgent Necropsy's.
- **mtgish (skill step 8b) does not apply.** The generator has no collect-evidence knowledge at all —
  the mechanic has no IR tag registered to extend — so there is nothing for a one-card derived
  variant to hang off.
- **`just assay-differential` reports 43 divergences**, none of them in a collect-evidence card or in
  anything this branch touches (they are mostly LRW harbingers and look like another agent's
  in-flight work). They are present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
