### PR TITLE
Add card-defined {X} ability costs, finish Mirrodin with Soul Foundry

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/SetArchetypes.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/SetArchetypes.kt
@@ -110,6 +110,29 @@ object SetArchetypes {
                     "Ramp into large green creatures, then leverage their high mana cost for powerful draw spells. Bury opponents in card advantage."),
             )
         ),
+        "MRD" to SetSynergies(
+            setCode = "MRD",
+            setName = "Mirrodin",
+            archetypes = listOf(
+                Archetype("Affinity", listOf(Color.BLUE),
+                    "Flood the board with cheap artifacts, then cast Frogmite, Myr Enforcer and Somber Hoverguard for a fraction of their printed cost. The format's defining deck — count artifacts, not lands."),
+                Archetype("Equipment Aggro", listOf(Color.WHITE),
+                    "Cheap Leonin bodies plus Bonesplitter and Leonin Scimitar. Equipment survives removal and moves on to the next creature, so trades never cost you the beatdown.",
+                    creatureTypes = listOf("Cat")),
+                Archetype("Skyhunter Skies", listOf(Color.WHITE, Color.BLUE),
+                    "Evasive fliers wearing Equipment. Nothing on the ground matters once a Leonin Skyhunter is carrying a Bonesplitter and blue is holding the board back.",
+                    creatureTypes = listOf("Cat", "Drone")),
+                Archetype("Nim Sacrifice", listOf(Color.BLACK, Color.RED),
+                    "Nim creatures grow with every artifact you control, and Disciple of the Vault turns each one you sacrifice into damage. Your own artifacts dying is the payoff, not the cost.",
+                    creatureTypes = listOf("Zombie")),
+                Archetype("Artifact Demolition", listOf(Color.RED, Color.GREEN),
+                    "Shatter effects and Tel-Jilad hate punish a format built out of artifacts, while red removal clears the way for green's oversized bodies.",
+                    creatureTypes = listOf("Elf", "Beast")),
+                Archetype("Myr Ramp", listOf(Color.GREEN),
+                    "Myr and Talismans accelerate you past the aggro decks and fix a splash, then dump the set's biggest artifacts a turn or two early.",
+                    creatureTypes = listOf("Myr")),
+            )
+        ),
         "DOM" to SetSynergies(
             setCode = "DOM",
             setName = "Dominaria",

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7526,6 +7526,34 @@ The X-choice decision clamps its lower bound to this value, the enumerated `Lega
 it to the client's X picker, and the handler rejects an engine-direct activation with a smaller X.
 Defaults to 0.
 
+**`xDefinedAs` — "X is …", an activation cost's X the card defines itself.** Set
+`xDefinedAs = <DynamicAmount>` in the `activatedAbility { }` block for an ability printed with `{X}`
+in its cost whose X is **defined by the ability's own text** (CR 107.3c) rather than announced by its
+controller (CR 107.3a) — **Soul Foundry** ("{X}, {T}: Create a token that's a copy of the exiled
+card. X is the mana value of that card." → `DynamicAmount.EntityProperty(EntityReference
+.LinkedExiledCard(), EntityNumericProperty.ManaValue)`), and the same template on Elite Arcanist,
+Prototype Portal and Caller of the Untamed.
+
+Write the cost as it is printed — `Costs.Mana("{X}")` — and let `xDefinedAs` say what X is. The
+engine evaluates the amount against the source permanent and substitutes it into the cost's `{X}`
+symbols (`ManaCost.withXAs`) at the head of the shared effective-cost pipeline, before the generic
+reductions and before enumeration, validation or payment read the cost. Four consequences:
+
+- the ability is **offered and displayed at its resolved price** ("{3}, {T}: …" for an imprinted
+  three-drop) while the card's oracle text keeps saying `{X}`;
+- there is **no X picker** — `LegalAction.hasXCost` is false and `maxAffordableX` is null;
+  `minimumXValue` does not apply, since a defined X is not a choice to clamp;
+- affordability, validation and payment all charge that number, because all three read the same
+  substituted cost. A cost-increasing static (`IncreaseActivatedAbilityCost`) taxes the *resolved*
+  total (CR 602.2b routes an activation cost through the same 601.2f total-cost step a spell uses);
+- the number is bound as the activation's X value, so the X-linked non-mana costs
+  (`Costs.PayXLife`, `Costs.ExileXFromGraveyard`, `CostAtom.RemoveCounters(count = XValue)`) and any
+  `DynamicAmount.XValue` read in the effect see it too (CR 107.3i, 107.3k).
+
+An amount that resolves to nothing is X = 0 — a Soul Foundry with no imprint offers a legal, and
+entirely pointless, "{0}, {T}", which is exactly what the printed card does. Don't set a
+`description` override on such an ability: the generated label is what carries the resolved cost.
+
 **`cantBeCopied` — "This ability can't be copied".** Set `cantBeCopied = true` in the
 `activatedAbility { }` block so the ability instance on the stack is tagged with the shared
 `CantBeCopiedComponent` marker; a copy-ability effect (`Effects.CopyTargetSpellOrAbility`) makes no

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -1698,6 +1698,12 @@ class ActivatedAbilityBuilder {
     var xManaRestriction: Set<Color> = emptySet()
     /** Minimum legal value for `{X}` in this ability's cost (set to 1 for "X can't be 0"). */
     var minimumXValue: Int = 0
+    /**
+     * Defines the `{X}` in this ability's cost from game state instead of asking the controller
+     * for a number (CR 107.3c) — Soul Foundry's "X is the mana value of that card."
+     * See [ActivatedAbility.xDefinedAs].
+     */
+    var xDefinedAs: DynamicAmount? = null
     /** When true, this ability can't be copied by copy-ability effects (CR 707.10e). */
     var cantBeCopied: Boolean = false
 
@@ -1767,6 +1773,7 @@ class ActivatedAbilityBuilder {
             genericCostReduction = genericCostReduction,
             xManaRestriction = xManaRestriction,
             minimumXValue = minimumXValue,
+            xDefinedAs = xDefinedAs,
             cantBeCopied = cantBeCopied
         )
     }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -140,6 +140,34 @@ data class ActivatedAbility(
      */
     val minimumXValue: Int = 0,
     /**
+     * The value of the `{X}` in this ability's activation cost, **defined by the ability's own
+     * text** (CR 107.3c) instead of chosen by its controller (CR 107.3a).
+     *
+     * Soul Foundry's "{X}, {T}: Create a token that's a copy of the exiled card. X is the mana
+     * value of that card." is the shape: the cost is printed as `{X}`, but the player never picks
+     * a number — the imprinted card decides it. Elite Arcanist, Prototype Portal and Caller of the
+     * Untamed are the same template, and any "X is …" clause attached to an activation cost fits.
+     *
+     * Mechanically this is a *substitution*, not a cost reduction and not a new mana atom: the
+     * amount is evaluated against the source permanent and folded into the cost's `{X}` symbols
+     * with [com.wingedsheep.sdk.core.ManaCost.withXAs] before affordability, the X-choice pause,
+     * or payment ever look at it. Three consequences fall out of that and are the contract here:
+     *  - the ability is offered at its *resolved* price (`{3}, {T}` for an imprinted three-drop),
+     *    while its oracle text keeps saying `{X}`;
+     *  - there is no "choose X" prompt, and [minimumXValue] does not apply — a defined X is not a
+     *    choice to clamp;
+     *  - the same number is bound as the activation's X value, so every other X-linked cost
+     *    ([AbilityCost.PayXLife], [AbilityCost.ExileXFromGraveyard],
+     *    `CostAtom.RemoveCounters(count = XValue)`) and any `DynamicAmount.XValue` read in the
+     *    effect see it too (CR 107.3i, 107.3k).
+     *
+     * X is fixed as the ability is activated, which is when it is paid; an amount that resolves to
+     * nothing (Soul Foundry with no imprint, because the controller declined or the card left
+     * exile) evaluates to 0, leaving a `{0}, {T}` ability that is legal to activate and simply
+     * does nothing — the printed behaviour.
+     */
+    val xDefinedAs: DynamicAmount? = null,
+    /**
      * When true, this activated ability can't be copied by effects that copy abilities (CR 707.10e).
      * The engine tags the ability instance on the stack with a can't-be-copied marker so a
      * copy-ability effect (e.g. another Gogo, Master of Mimicry) produces no copy of it. Models

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityReference.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/EntityReference.kt
@@ -74,7 +74,9 @@ sealed interface EntityReference {
 
     /**
      * A card **exiled with the ability's source** — the source's linked-exile pile (CR 607 linked
-     * abilities), which on Mirrodin's *Imprint* cards (CR 702.15) holds "the exiled card".
+     * abilities), which on Mirrodin's *Imprint* cards holds "the exiled card". (Imprint has no rule
+     * number of its own: it used to be a keyword ability and is now only an ability word, with the
+     * linkage carried by CR 607 and each card's own errata'd text.)
      *
      * This is the read-side companion to the `linkToSource = true` exile that puts a card there:
      * it turns the imprinted card into an ordinary entity reference, so every existing

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/MirrodinSet.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/MirrodinSet.kt
@@ -23,7 +23,8 @@ object MirrodinSet : MtgSet {
     override val displayName = "Mirrodin"
     override val releaseDate = "2003-10-02"
     override val block = "Mirrodin"
-    override val incomplete = true
+    // Complete as of Soul Foundry (291/291) — the flag is what gates `fullyImplemented`, so
+    // leaving it set would keep a finished set out of the lobby's set picker.
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SoulFoundry.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SoulFoundry.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Soul Foundry
+ * {4}
+ * Artifact
+ *
+ * Imprint — When this artifact enters, you may exile a creature card from your hand.
+ * {X}, {T}: Create a token that's a copy of the exiled card. X is the mana value of that card.
+ *
+ * The imprint half is the Isochron Scepter shape: a linked exile (`linkToSource = true`) from your
+ * own hand with no reveal, so the pile the activated ability reads is re-read live — if the
+ * imprinted card leaves exile the gather comes back empty and no token is created.
+ *
+ * The activation cost is the interesting half. It is printed as `{X}` but the player never picks a
+ * number: `xDefinedAs` hands the engine the mana value of the linked exiled card, which is CR
+ * 107.3c's "the value of X is defined by the text of that ability". The `{X}` is substituted before
+ * affordability, so the ability is offered at its resolved price ("{3}, {T}" for an imprinted
+ * three-drop) and there is no X prompt. With no imprint the amount is 0 and the ability is a legal
+ * — and entirely pointless — "{0}, {T}", exactly as printed.
+ *
+ * The token is a copy of the *card in exile*, so per the card's own rulings it keeps that card's
+ * mana cost and mana value rather than a token's usual zero, and it is put onto the battlefield
+ * rather than cast — which is why no optional additional cost (kicker) is ever offered.
+ */
+val SoulFoundry = card("Soul Foundry") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Imprint — When this artifact enters, you may exile a creature card from your hand.\n" +
+        "{X}, {T}: Create a token that's a copy of the exiled card. X is the mana value of that card."
+
+    // Imprint — When this artifact enters, you may exile a creature card from your hand.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            Patterns.Hand.revealHandAndExileChosen(
+                target = EffectTarget.Controller,
+                filter = GameObjectFilter.Creature,
+                prompt = "Choose a creature card to exile",
+                storeChosenAs = "foundryImprint",
+                revealHand = false,
+                linkToSource = true
+            ),
+            descriptionOverride = "You may exile a creature card from your hand."
+        )
+    }
+
+    // {X}, {T}: Create a token that's a copy of the exiled card. X is the mana value of that card.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{X}"), Costs.Tap)
+        xDefinedAs = DynamicAmount.EntityProperty(
+            EntityReference.LinkedExiledCard(),
+            EntityNumericProperty.ManaValue
+        )
+        // No `description` override on the ability itself: the generated label carries the
+        // *resolved* cost ("{3}, {T}: …" for an imprinted three-drop), which is the whole point of
+        // a defined X, and an ability-level override would freeze the printed "{X}" instead.
+        effect = Effects.Composite(
+            effects = listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromLinkedExile(),
+                    storeAs = "foundryImprinted"
+                ),
+                Effects.CreateTokenCopyOfTarget(
+                    target = EffectTarget.PipelineTarget("foundryImprinted")
+                )
+            ),
+            descriptionOverride = "Create a token that's a copy of the exiled card."
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "246"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11b4983a-2a95-4322-a315-27b4bd430d39.jpg?1783944502"
+
+        ruling(
+            "2004-12-01",
+            "Soul Foundry puts a token copy of the imprinted card onto the battlefield. The token " +
+                "is put onto the battlefield, not cast."
+        )
+        ruling(
+            "2004-12-01",
+            "The token is an exact copy in every way, except that it's a token, not a card."
+        )
+        ruling(
+            "2004-12-01",
+            "Most creature tokens have no mana cost and a mana value of 0, but a creature token " +
+                "put onto the battlefield by Soul Foundry has the same mana cost and mana value as " +
+                "the card it copies."
+        )
+        ruling(
+            "2004-10-04",
+            "You do not get a chance to pay any optional costs, such as Kicker, on the imprinted card."
+        )
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulFoundryScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulFoundryScenarioTest.kt
@@ -1,0 +1,178 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.SoulFoundry
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Soul Foundry (MRD #246) — "Imprint — When this artifact enters, you may exile a creature card
+ * from your hand. {X}, {T}: Create a token that's a copy of the exiled card. X is the mana value
+ * of that card."
+ *
+ * Two things are worth pinning. The imprint is the Isochron Scepter shape — the card stays in the
+ * linked-exile pile, so the Foundry keeps minting copies of it. And the activation cost is a
+ * *defined* X (CR 107.3c): the player is never asked for a number, the ability is offered at the
+ * imprinted card's mana value, and with no imprint at all it collapses to a legal but pointless
+ * "{0}, {T}".
+ */
+class SoulFoundryScenarioTest : FunSpec({
+
+    val foundryAbility = SoulFoundry.activatedAbilities.single().id
+    val projector = StateProjector()
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** Cast the Foundry from hand so the imprint trigger actually fires, and return it. */
+    fun GameTestDriver.castFoundry(): EntityId {
+        val inHand = putCardInHand(player1, "Soul Foundry")
+        giveColorlessMana(player1, 4)
+        castSpell(player1, inHand).error shouldBe null
+        // One pass resolves the artifact, the next resolves the imprint trigger it put on the stack.
+        repeat(4) { if (state.pendingDecision == null) bothPass() }
+        return findPermanent(player1, "Soul Foundry")!!
+    }
+
+    fun GameTestDriver.foundryAction(foundry: EntityId) =
+        legalActions(player1).single {
+            val a = it.action
+            a is ActivateAbility && a.sourceId == foundry && a.abilityId == foundryAbility
+        }
+
+    test("imprints a creature card and mints a token copy for its mana value") {
+        val d = driver()
+        val bears = d.putCardInHand(d.player1, "Grizzly Bears") // {1}{G} — mana value 2
+        // A second creature card, so the imprint is a real choice and the price below can only
+        // have come from the card actually chosen.
+        d.putCardInHand(d.player1, "Hill Giant") // {3}{R} — mana value 4
+        val foundry = d.castFoundry()
+
+        withClue("the imprint is a 'may', so it asks first") {
+            d.submitYesNo(d.player1, true).error shouldBe null
+        }
+        d.submitCardSelection(d.player1, listOf(bears)).error shouldBe null
+        d.getExileCardNames(d.player1) shouldBe listOf("Grizzly Bears")
+
+        withClue("the printed {X} is offered as the imprinted card's mana value, with no X picker") {
+            val action = d.foundryAction(foundry)
+            action.manaCostString shouldBe "{2}"
+            action.hasXCost shouldBe false
+        }
+
+        d.giveColorlessMana(d.player1, 2)
+        d.submit(ActivateAbility(d.player1, foundry, foundryAbility)).error shouldBe null
+        withClue("no 'choose X' prompt — the card defined X") {
+            d.state.pendingDecision shouldBe null
+        }
+        d.bothPass()
+
+        val token = d.getCreatures(d.player1).single { d.getCardName(it) == "Grizzly Bears" }
+        withClue("it is a token, not the exiled card moved onto the battlefield") {
+            d.state.getEntity(token)!!.has<TokenComponent>() shouldBe true
+        }
+        withClue("and a copy in every way — same P/T, and the card's own mana cost (2004-12-01 ruling)") {
+            val projected = projector.project(d.state)
+            projected.getPower(token) shouldBe 2
+            projected.getToughness(token) shouldBe 2
+            d.state.getEntity(token)!!.get<CardComponent>()!!.manaValue shouldBe 2
+        }
+        withClue("the imprinted card is still exiled — the Foundry copies, it doesn't spend") {
+            d.getExileCardNames(d.player1) shouldBe listOf("Grizzly Bears")
+        }
+    }
+
+    test("the price follows the imprinted card — a six-drop costs {6}") {
+        val d = driver()
+        val dragon = d.putCardInHand(d.player1, "Shivan Dragon") // {4}{R}{R} — mana value 6
+        d.putCardInHand(d.player1, "Grizzly Bears")
+        val foundry = d.castFoundry()
+
+        d.submitYesNo(d.player1, true).error shouldBe null
+        d.submitCardSelection(d.player1, listOf(dragon)).error shouldBe null
+
+        withClue("five mana isn't enough for a Shivan Dragon imprint") {
+            d.giveColorlessMana(d.player1, 5)
+            d.foundryAction(foundry).let {
+                it.manaCostString shouldBe "{6}"
+                it.affordable shouldBe false
+            }
+        }
+        withClue("the sixth covers it") {
+            d.giveColorlessMana(d.player1, 1)
+            d.foundryAction(foundry).affordable shouldBe true
+        }
+
+        d.submit(ActivateAbility(d.player1, foundry, foundryAbility)).error shouldBe null
+        d.bothPass()
+        d.getCreatures(d.player1).map { d.getCardName(it) } shouldBe listOf("Shivan Dragon")
+    }
+
+    test("a zero-mana-value imprint is free, and still mints the token") {
+        val d = driver()
+        val thopter = d.putCardInHand(d.player1, "Ornithopter") // {0} — mana value 0
+        d.putCardInHand(d.player1, "Grizzly Bears")
+        val foundry = d.castFoundry()
+
+        d.submitYesNo(d.player1, true).error shouldBe null
+        d.submitCardSelection(d.player1, listOf(thopter)).error shouldBe null
+
+        withClue("X is 0 because the card costs nothing, not because nothing is imprinted") {
+            d.foundryAction(foundry).manaCostString shouldBe "{0}"
+        }
+        d.submit(ActivateAbility(d.player1, foundry, foundryAbility)).error shouldBe null
+        d.bothPass()
+
+        d.getCreatures(d.player1).map { d.getCardName(it) } shouldBe listOf("Ornithopter")
+    }
+
+    test("declining the imprint leaves a legal but pointless {0}, {T}") {
+        val d = driver()
+        d.putCardInHand(d.player1, "Grizzly Bears")
+        val foundry = d.castFoundry()
+
+        d.submitYesNo(d.player1, false).error shouldBe null
+        d.getExileCardNames(d.player1) shouldBe emptyList()
+
+        withClue("an empty linked-exile pile defines X as 0") {
+            val action = d.foundryAction(foundry)
+            action.manaCostString shouldBe "{0}"
+            action.affordable shouldBe true
+        }
+
+        d.submit(ActivateAbility(d.player1, foundry, foundryAbility)).error shouldBe null
+        d.state.pendingDecision shouldBe null
+        d.bothPass()
+
+        withClue("nothing to copy, so no token") {
+            d.getCreatures(d.player1) shouldBe emptyList()
+        }
+    }
+
+    test("a hand with no creature card imprints nothing") {
+        val d = driver()
+        val bolt = d.putCardInHand(d.player1, "Lightning Bolt")
+        d.castFoundry()
+
+        d.submitYesNo(d.player1, true).error shouldBe null
+
+        withClue("there were no legal candidates, so nothing was exiled") {
+            d.getExileCardNames(d.player1) shouldBe emptyList()
+            d.findCardInHand(d.player1, "Lightning Bolt") shouldBe bolt
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -12499,6 +12499,132 @@
     ]
 }
 
+// Soul Foundry
+{
+    "name": "Soul Foundry",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "Imprint — When this artifact enters, you may exile a creature card from your hand.\n{X}, {T}: Create a token that's a copy of the exiled card. X is the mana value of that card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "filter": "creature"
+                                },
+                                "storeAs": "foundryImprintCandidates"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "foundryImprintCandidates",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "foundryImprint",
+                                "prompt": "Choose a creature card to exile"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "foundryImprint",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                },
+                                "linkToSource": true
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "You may exile a creature card from your hand."
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "foundryImprinted"
+                        },
+                        {
+                            "type": "CreateTokenCopyOfTarget",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "foundryImprinted"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Create a token that's a copy of the exiled card."
+                },
+                "xDefinedAs": {
+                    "type": "EntityProperty",
+                    "entity": "LinkedExiledCard",
+                    "numericProperty": "ManaValue"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "246",
+        "rarity": "RARE",
+        "artist": "Arnie Swekel",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11b4983a-2a95-4322-a315-27b4bd430d39.jpg?1783944502",
+        "rulings": [
+            {
+                "date": "2004-12-01",
+                "text": "Soul Foundry puts a token copy of the imprinted card onto the battlefield. The token is put onto the battlefield, not cast."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "The token is an exact copy in every way, except that it's a token, not a card."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "Most creature tokens have no mana cost and a mana value of 0, but a creature token put onto the battlefield by Soul Foundry has the same mana cost and mana value as the card it copies."
+            },
+            {
+                "date": "2004-10-04",
+                "text": "You do not get a chance to pay any optional costs, such as Kicker, on the imprinted card."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Soul Nova
 {
     "name": "Soul Nova",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -250,6 +250,21 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // cast-time-value area is exactly what the emitter declines to render exactly (creator's note in
     // mtgish-tooling/CLAUDE.md), so cards using it stay SCAFFOLD even though the capability is present.
     supported("PayManaAnyX", "cost: pay mana with {X} (player-declared, threads to resolution via DynamicAmount.XValue)")
+    // An *activation* cost carrying {X} — the tag covers both halves of CR 107.3, and the engine now
+    // has both. When the ability's text doesn't define X (CR 107.3a) the controller announces it: the
+    // enumerator surfaces `hasXCost` / `maxAffordableX` / `minX`, the handler pauses for a
+    // ChooseNumberDecision, and the chosen value threads to payment and to `DynamicAmount.XValue`
+    // (Necropolis Fiend, Wizard's Rockets, Gogo's `minimumXValue = 1`). When the text *does* define it
+    // (CR 107.3c — "X is the mana value of that card"), `activatedAbility { xDefinedAs = <amount> }`
+    // substitutes the value into the {X} before enumeration, validation and payment read the cost, so
+    // the ability is offered at its resolved price with no picker (Soul Foundry, Elite Arcanist,
+    // Prototype Portal). Capability-only: the {X} / cast-time-value area is exactly what the emitter
+    // declines to render exactly, so these cards stay SCAFFOLD even though the capability is present.
+    supported(
+        "PayManaX",
+        "cost: activation cost with {X} — player-declared (ChooseNumberDecision -> DynamicAmount.XValue) " +
+            "or card-defined (activatedAbility { xDefinedAs = … }, CR 107.3c)"
+    )
     // Planeswalker loyalty cost (CR 606) — the +N / -N ability activation cost. The engine models it
     // via `loyaltyAbility(loyaltyChange) { }` with `startingLoyalty`. Oko, the Ringleader. The emitter
     // declines the whole loyalty-ability envelope (Activated) -> SCAFFOLD, so this is capability-only.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -270,17 +270,21 @@ class ActivateAbilityHandler(
         } else {
             ability.cost
         }
-        // Apply ability-specific generic cost reduction (e.g., The Dominion Bracelet's
+        // Resolve a *defined* {X} (CR 107.3c) before anything else reads the cost, so validation
+        // sees the same fixed cost enumeration offered and payment will charge. Then apply
+        // ability-specific generic cost reduction (e.g., The Dominion Bracelet's
         // "{X} less, where X is this creature's power"). Per Scryfall ruling, the reduced
         // cost is locked in here, before costs are paid. Then apply generic equip-cost reduction
         // (Éowyn) and finally Forge Anew's free-first-equip.
         val equipTargetIdForCost = action.targets.filterIsInstance<ChosenTarget.Permanent>().firstOrNull()?.entityId
+        val costWithDefinedX =
+            castPermissionUtils.applyDefinedXValue(rawCost, ability, state, action.sourceId, action.playerId)
         val effectiveCost = castPermissionUtils.relaxAbilityCostColorsIfAny(
             state, action.sourceId,
             castPermissionUtils.applyFreeFirstEquipDiscount(
                 castPermissionUtils.applyEquipCostReduction(
                     castPermissionUtils.applyActivatedAbilityCostReduction(
-                        applyGenericCostReduction(rawCost, ability, state, action.sourceId, action.playerId, action.targets),
+                        applyGenericCostReduction(costWithDefinedX, ability, state, action.sourceId, action.playerId, action.targets),
                         state, action.sourceId, ability.isExhaust, ability.isPowerUp
                     ),
                     ability, state, action.playerId, equipTargetIdForCost,
@@ -641,17 +645,22 @@ class ActivateAbilityHandler(
         } else {
             ability.cost
         }
-        // Apply ability-specific generic cost reduction (e.g., The Dominion Bracelet's
+        // Resolve a *defined* {X} (CR 107.3c) before the reductions, matching validate() and the
+        // enumerator so all three paths charge the same number. Then apply ability-specific generic
+        // cost reduction (e.g., The Dominion Bracelet's
         // "{X} less, where X is this creature's power"). Locked in before payment. Then apply
         // generic equip-cost reduction (Éowyn) and Forge Anew's free-first-equip discount.
         // Finally relax colored requirements when "mana of any type can be spent" applies (Sharkey).
         val equipTargetIdForCost = action.targets.filterIsInstance<ChosenTarget.Permanent>().firstOrNull()?.entityId
+        val definedXValue = castPermissionUtils.definedXValue(state, ability, action.sourceId, action.playerId)
+        val costWithDefinedX =
+            castPermissionUtils.applyDefinedXValue(rawCost, ability, state, action.sourceId, action.playerId)
         val effectiveCost = castPermissionUtils.relaxAbilityCostColorsIfAny(
             state, action.sourceId,
             castPermissionUtils.applyFreeFirstEquipDiscount(
                 castPermissionUtils.applyEquipCostReduction(
                     castPermissionUtils.applyActivatedAbilityCostReduction(
-                        applyGenericCostReduction(rawCost, ability, state, action.sourceId, action.playerId, action.targets),
+                        applyGenericCostReduction(costWithDefinedX, ability, state, action.sourceId, action.playerId, action.targets),
                         state, action.sourceId, ability.isExhaust, ability.isPowerUp
                     ),
                     ability, state, action.playerId, equipTargetIdForCost,
@@ -669,8 +678,11 @@ class ActivateAbilityHandler(
         // the cost is being paid, the chosen set already rides on the action's costPayment.
         val variablePermanentsCost = extractVariablePermanentsCost(effectiveCost)
         val chosenForCost = action.costPayment?.variableCostPermanents ?: emptyList()
-        val effectiveXValue: Int? =
-            if (variablePermanentsCost != null && chosenForCost.isNotEmpty())
+        // An X the ability's own text defines (CR 107.3c) outranks both: it is not the payer's to
+        // choose, and it is the value every other instance of X on this activation uses (CR 107.3i)
+        // — the X-linked non-mana costs and any `DynamicAmount.XValue` read at resolution.
+        val effectiveXValue: Int? = definedXValue
+            ?: if (variablePermanentsCost != null && chosenForCost.isNotEmpty())
                 variableCostX(state, variablePermanentsCost, chosenForCost)
             else action.xValue
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -158,16 +158,21 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 } else {
                     ability.cost
                 }
-                // Apply ability-specific generic cost reduction so payability is checked against
-                // the locked-in cost (e.g., The Dominion Bracelet — "{X} less, where X is this
-                // creature's power"). Then apply Forge Anew's free-first-equip discount, so the
-                // displayed cost and affordability reflect the {0} the player will actually pay.
+                // Resolve a *defined* {X} (CR 107.3c — Soul Foundry's "X is the mana value of that
+                // card") first, so the ability is offered at the price the player will actually pay
+                // and never flagged as an X-picker cost. Then apply ability-specific generic cost
+                // reduction so payability is checked against the locked-in cost (e.g., The Dominion
+                // Bracelet — "{X} less, where X is this creature's power"). Then apply Forge Anew's
+                // free-first-equip discount, so the displayed cost and affordability reflect the {0}
+                // the player will actually pay.
+                val costWithDefinedX =
+                    context.castPermissionUtils.applyDefinedXValue(rawCost, ability, state, entityId, playerId)
                 val effectiveCost = context.castPermissionUtils.relaxAbilityCostColorsIfAny(
                     state, entityId,
                     context.castPermissionUtils.applyFreeFirstEquipDiscount(
                         context.castPermissionUtils.applyEquipCostReduction(
                             context.castPermissionUtils.applyActivatedAbilityCostReduction(
-                                applyAbilityGenericCostReduction(rawCost, ability, state, entityId, playerId, context),
+                                applyAbilityGenericCostReduction(costWithDefinedX, ability, state, entityId, playerId, context),
                                 state, entityId, ability.isExhaust, ability.isPowerUp
                             ),
                             ability, state, playerId, abilitySourceId = entityId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ZoneActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ZoneActivatedAbilityEnumerator.kt
@@ -83,8 +83,12 @@ class ZoneActivatedAbilityEnumerator(private val zone: Zone) : ActionEnumerator 
                 }
                 if (!restrictionsMet) continue
 
-                // Check cost requirements and build cost info
-                val effectiveCost = ability.cost
+                // Check cost requirements and build cost info. A *defined* {X} (CR 107.3c) is
+                // resolved here for the same reason the battlefield enumerator resolves it: the
+                // affordability check below and the cost shown in the menu both have to be the
+                // number the handler will charge, not an unresolved `{X}`.
+                val effectiveCost = context.castPermissionUtils
+                    .applyDefinedXValue(ability.cost, ability, state, entityId, playerId)
                 var costCanBePaid = true
                 val handCards = state.getZone(playerId, Zone.HAND)
                 var hasDiscardCost = false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -729,6 +729,52 @@ class CastPermissionUtils(
     }
 
     /**
+     * The value of an ability's `{X}` when its own text defines it (CR 107.3c) — Soul Foundry's
+     * "X is the mana value of that card." — or null when X is the controller's choice (CR 107.3a),
+     * which is every other ability.
+     *
+     * Evaluated against the source permanent, so a [DynamicAmount] that reads the source's
+     * linked-exile pile, its counters, or the board resolves the way it would inside the ability's
+     * effect. A negative amount is clamped to 0: `{X}` can never be a refund.
+     */
+    fun definedXValue(
+        state: GameState,
+        ability: ActivatedAbility,
+        sourceId: EntityId?,
+        controllerId: EntityId
+    ): Int? {
+        val amount = ability.xDefinedAs ?: return null
+        val context = EffectContext(sourceId = sourceId, controllerId = controllerId)
+        return DynamicAmountEvaluator().evaluate(state, amount, context).coerceAtLeast(0)
+    }
+
+    /**
+     * Substitute an ability's *defined* X (CR 107.3c) into the `{X}` symbols of its [cost], turning
+     * `{X}, {T}` into `{3}, {T}` for an imprinted three-drop.
+     *
+     * This is the first step of the shared effective-cost pipeline — before the generic reductions,
+     * the equip discounts and the colour relaxation — for two reasons. It has to run before them so
+     * a reduction or a tax applies to the *resolved* total the way CR 601.2f expects (CR 602.2b
+     * routes an activation cost through that same total-cost step), and it has to
+     * run before anything reads the cost so that the X-choice pause, the affordability check and
+     * the payment all see an ordinary fixed cost. That is what keeps a defined X out of the ~70
+     * `CostAtom.Mana` read sites: none of them ever meets one.
+     *
+     * A cost with no mana component is returned unchanged — there are no `{X}` symbols to define,
+     * and unlike a tax ([applyActivatedAbilityCostReduction]) a definition has nothing to add.
+     */
+    fun applyDefinedXValue(
+        cost: AbilityCost,
+        ability: ActivatedAbility,
+        state: GameState,
+        sourceId: EntityId?,
+        controllerId: EntityId
+    ): AbilityCost {
+        val x = definedXValue(state, ability, sourceId, controllerId) ?: return cost
+        return mapFirstManaComponent(cost) { it.withXAs(x) } ?: cost
+    }
+
+    /**
      * Reduce the generic portion of an activated ability's [cost] by any [ReduceActivatedAbilityCost]
      * static on the battlefield whose [filter] matches the ability's source ([sourceId]) — e.g.
      * Power Artifact reducing the enchanted artifact's activated abilities by {2} (floored so the

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/DefinedXAbilityCostTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/DefinedXAbilityCostTest.kt
@@ -1,0 +1,220 @@
+package com.wingedsheep.engine.legalactions
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.legalactions.support.EnumerationTestDriver
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.IncreaseActivatedAbilityCost
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * `ActivatedAbility.xDefinedAs` — an activation cost's `{X}` whose value the ability's own text
+ * defines (CR 107.3c) instead of the controller announcing it (CR 107.3a).
+ *
+ * The engine models it as a *substitution*: the amount is evaluated against the source and folded
+ * into the cost's `{X}` symbols before any of the three mana paths (enumeration, validation,
+ * payment) reads the cost, so all three necessarily agree on the number. These tests pin the four
+ * observable consequences — the offered cost, affordability, the absent X prompt, and the value
+ * reaching the effect — plus the interaction with a cost-increasing static.
+ *
+ * Soul Foundry is the shipped card; the inline artifact below uses "the number of creatures you
+ * control" instead of an imprinted card's mana value so the amount is trivial to vary.
+ */
+class DefinedXAbilityCostTest : FunSpec({
+
+    val creaturesYouControl = DynamicAmount.Count(
+        player = Player.You,
+        zone = Zone.BATTLEFIELD,
+        filter = GameObjectFilter.Creature
+    )
+
+    // "{X}: Draw X cards. X is the number of creatures you control."
+    val definedXEngine = card("Test Defined X Engine") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        oracleText = "{X}: Draw X cards. X is the number of creatures you control."
+        activatedAbility {
+            cost = Costs.Mana("{X}")
+            xDefinedAs = creaturesYouControl
+            effect = Effects.DrawCards(DynamicAmount.XValue)
+        }
+    }
+
+    // "{X}: Draw X cards." — the ordinary, player-announced X, as the control case.
+    val chosenXEngine = card("Test Chosen X Engine") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        oracleText = "{X}: Draw X cards."
+        activatedAbility {
+            cost = Costs.Mana("{X}")
+            effect = Effects.DrawCards(DynamicAmount.XValue)
+        }
+    }
+
+    // "Artifacts' activated abilities cost {2} more to activate."
+    val taxer = card("Test Ability Taxer") {
+        manaCost = "{3}"
+        typeLine = "Enchantment"
+        oracleText = "Artifacts' activated abilities cost {2} more to activate."
+        staticAbility {
+            ability = IncreaseActivatedAbilityCost(
+                filter = GroupFilter(GameObjectFilter.Artifact),
+                amount = DynamicAmount.Fixed(2)
+            )
+        }
+    }
+
+    fun driverInMainPhase(): EnumerationTestDriver {
+        val driver = EnumerationTestDriver()
+        driver.registerCards(TestCards.all + listOf(definedXEngine, chosenXEngine, taxer))
+        driver.game.initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.game.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun EnumerationTestDriver.abilityAction(sourceId: EntityId) =
+        enumerateFor(player1).activatedAbilityActionsFor(sourceId).single()
+
+    /** Colorless mana left unspent — `giveColorlessMana` is the only source these tests use. */
+    fun EnumerationTestDriver.manaLeft(playerId: EntityId): Int =
+        game.state.getEntity(playerId)?.get<ManaPoolComponent>()?.colorless ?: 0
+
+    test("the ability is offered at its resolved price, with no X picker") {
+        val driver = driverInMainPhase()
+        val engine = driver.game.putPermanentOnBattlefield(driver.player1, "Test Defined X Engine")
+        repeat(2) { driver.game.putCreatureOnBattlefield(driver.player1, "Grizzly Bears") }
+        driver.game.giveColorlessMana(driver.player1, 5)
+
+        val action = driver.abilityAction(engine)
+
+        withClue("two creatures make the printed {X} an ordinary {2}") {
+            action.manaCostString shouldBe "{2}"
+        }
+        withClue("a defined X is not the player's to choose, so it is not an X-picker cost") {
+            action.hasXCost shouldBe false
+            action.maxAffordableX shouldBe null
+        }
+    }
+
+    test("the control case still asks for X — this test's card is the only thing that changed") {
+        val driver = driverInMainPhase()
+        val engine = driver.game.putPermanentOnBattlefield(driver.player1, "Test Chosen X Engine")
+        repeat(2) { driver.game.putCreatureOnBattlefield(driver.player1, "Grizzly Bears") }
+        driver.game.giveColorlessMana(driver.player1, 5)
+
+        val action = driver.abilityAction(engine)
+
+        action.hasXCost shouldBe true
+        action.maxAffordableX shouldBe 5
+    }
+
+    test("affordability tracks the resolved X, not the printed {X}") {
+        val driver = driverInMainPhase()
+        val engine = driver.game.putPermanentOnBattlefield(driver.player1, "Test Defined X Engine")
+        repeat(3) { driver.game.putCreatureOnBattlefield(driver.player1, "Grizzly Bears") }
+
+        driver.game.giveColorlessMana(driver.player1, 2)
+        withClue("{3} can't be paid out of two mana") {
+            driver.abilityAction(engine).affordable shouldBe false
+        }
+
+        driver.game.giveColorlessMana(driver.player1, 1)
+        withClue("a third mana covers it") {
+            driver.abilityAction(engine).affordable shouldBe true
+        }
+    }
+
+    test("activating pays the resolved X without a prompt, and the effect sees the same X") {
+        val driver = driverInMainPhase()
+        val engine = driver.game.putPermanentOnBattlefield(driver.player1, "Test Defined X Engine")
+        repeat(2) { driver.game.putCreatureOnBattlefield(driver.player1, "Grizzly Bears") }
+        driver.game.giveColorlessMana(driver.player1, 5)
+        val handBefore = driver.game.getHandSize(driver.player1)
+
+        val abilityId = definedXEngine.activatedAbilities.single().id
+        driver.game.submit(ActivateAbility(driver.player1, engine, abilityId)).error shouldBe null
+
+        withClue("no ChooseNumber decision: the ability defined X itself") {
+            driver.game.state.pendingDecision shouldBe null
+        }
+        driver.game.bothPass()
+
+        withClue("X reached the effect through EffectContext.xValue (CR 107.3i)") {
+            driver.game.getHandSize(driver.player1) shouldBe handBefore + 2
+        }
+        withClue("exactly {2} was spent of the five available") {
+            driver.manaLeft(driver.player1) shouldBe 3
+        }
+    }
+
+    test("an amount that resolves to nothing is X = 0 — a legal, pointless activation") {
+        val driver = driverInMainPhase()
+        val engine = driver.game.putPermanentOnBattlefield(driver.player1, "Test Defined X Engine")
+        val handBefore = driver.game.getHandSize(driver.player1)
+
+        val action = driver.abilityAction(engine)
+        withClue("no creatures, so the cost is {0} and the ability is still offered") {
+            action.manaCostString shouldBe "{0}"
+            action.affordable shouldBe true
+        }
+
+        val abilityId = definedXEngine.activatedAbilities.single().id
+        driver.game.submit(ActivateAbility(driver.player1, engine, abilityId)).error shouldBe null
+        driver.game.state.pendingDecision shouldBe null
+        driver.game.bothPass()
+
+        driver.game.getHandSize(driver.player1) shouldBe handBefore
+    }
+
+    test("a cost-increasing static taxes the resolved X, not the {X} symbol") {
+        val driver = driverInMainPhase()
+        val engine = driver.game.putPermanentOnBattlefield(driver.player1, "Test Defined X Engine")
+        driver.game.putPermanentOnBattlefield(driver.player1, "Test Ability Taxer")
+        repeat(2) { driver.game.putCreatureOnBattlefield(driver.player1, "Grizzly Bears") }
+        driver.game.giveColorlessMana(driver.player1, 6)
+
+        val action = driver.abilityAction(engine)
+        withClue("X resolves to 2, then the static adds {2}") {
+            action.manaCostString shouldBe "{4}"
+            action.hasXCost shouldBe false
+        }
+
+        val abilityId = definedXEngine.activatedAbilities.single().id
+        driver.game.submit(ActivateAbility(driver.player1, engine, abilityId)).error shouldBe null
+        driver.game.state.pendingDecision shouldBe null
+        driver.game.bothPass()
+
+        withClue("the tax is paid too, but the *effect* still uses the defined X of 2") {
+            driver.manaLeft(driver.player1) shouldBe 2
+        }
+    }
+
+    test("the value is re-read on every activation, so the board decides the price") {
+        val driver = driverInMainPhase()
+        val engine = driver.game.putPermanentOnBattlefield(driver.player1, "Test Defined X Engine")
+        driver.game.giveColorlessMana(driver.player1, 9)
+
+        driver.abilityAction(engine).manaCostString shouldBe "{0}"
+        driver.game.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.abilityAction(engine).manaCostString shouldBe "{1}"
+        driver.game.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.abilityAction(engine).manaCostString shouldBe "{2}"
+
+        withClue("the printed cost never changed — only what the player is charged for it") {
+            definedXEngine.activatedAbilities.single().cost.description shouldBe "{X}"
+        }
+    }
+})

--- a/web-client/src/components/draft/SetSynergiesOverlay.tsx
+++ b/web-client/src/components/draft/SetSynergiesOverlay.tsx
@@ -198,6 +198,53 @@ const SET_SYNERGIES: Record<string, SetSynergies> = {
       },
     ],
   },
+  MRD: {
+    setCode: 'MRD',
+    setName: 'Mirrodin',
+    archetypes: [
+      {
+        name: 'Affinity',
+        colors: ['U'],
+        keyCard: 'Somber Hoverguard',
+        description: 'Flood the board with cheap artifacts, then cast Frogmite, Myr Enforcer and Somber Hoverguard for a fraction of their printed cost. The format\'s defining deck — count artifacts, not lands.',
+      },
+      {
+        name: 'Equipment Aggro',
+        colors: ['W'],
+        creatureTypes: ['Cat'],
+        keyCard: 'Bonesplitter',
+        description: 'Cheap Leonin bodies plus Bonesplitter and Leonin Scimitar. Equipment survives removal and moves on to the next creature, so trades never cost you the beatdown.',
+      },
+      {
+        name: 'Skyhunter Skies',
+        colors: ['W', 'U'],
+        creatureTypes: ['Cat', 'Drone'],
+        keyCard: 'Leonin Skyhunter',
+        description: 'Evasive fliers wearing Equipment. Nothing on the ground matters once a Leonin Skyhunter is carrying a Bonesplitter and blue is holding the board back.',
+      },
+      {
+        name: 'Nim Sacrifice',
+        colors: ['B', 'R'],
+        creatureTypes: ['Zombie'],
+        keyCard: 'Disciple of the Vault',
+        description: 'Nim creatures grow with every artifact you control, and Disciple of the Vault turns each one you sacrifice into damage. Your own artifacts dying is the payoff, not the cost.',
+      },
+      {
+        name: 'Artifact Demolition',
+        colors: ['R', 'G'],
+        creatureTypes: ['Elf', 'Beast'],
+        keyCard: 'Electrostatic Bolt',
+        description: 'Shatter effects and Tel-Jilad hate punish a format built out of artifacts, while red removal clears the way for green\'s oversized bodies.',
+      },
+      {
+        name: 'Myr Ramp',
+        colors: ['G'],
+        creatureTypes: ['Myr'],
+        keyCard: 'Copper Myr',
+        description: 'Myr and Talismans accelerate you past the aggro decks and fix a splash, then dump the set\'s biggest artifacts a turn or two early.',
+      },
+    ],
+  },
   DOM: {
     setCode: 'DOM',
     setName: 'Dominaria',


### PR DESCRIPTION
Mirrodin's last unimplemented card, plus the engine vocabulary it needed.

## The gap

**Soul Foundry** — "Imprint — When this artifact enters, you may exile a creature card from your hand. `{X}, {T}`: Create a token that's a copy of the exiled card. X is the mana value of that card."

The `{X}` is printed, but the player never picks a number: the imprinted card decides it. That is **CR 107.3c** — "if the value of X is defined by the text of that spell or ability, then that's the value of X … the controller doesn't get to choose the value" — and the engine could only express CR 107.3a, the announced X.

## `ActivatedAbility.xDefinedAs`

Write the cost as printed (`Costs.Mana("{X}")`) and let `xDefinedAs: DynamicAmount?` say what X is.

It is a **substitution**, not a new mana atom and not a cost delta: the amount is evaluated against the source and folded into the cost's `{X}` symbols with `ManaCost.withXAs` at the head of the shared effective-cost pipeline, *before* the generic reductions and before enumeration, validation or payment read the cost. That placement is the whole design — it keeps a defined X out of the ~70 `CostAtom.Mana` read sites (none of them ever meets one), and it makes the three mana paths agree by construction instead of by three parallel edits.

Four consequences, each with a test:

- the ability is **offered and displayed at its resolved price** — "{3}, {T}: …" for an imprinted three-drop — while the oracle text keeps saying `{X}`;
- **no X picker**: `LegalAction.hasXCost` is false and `maxAffordableX` null. `minimumXValue` doesn't apply — a defined X is not a choice to clamp;
- a cost-increasing static taxes the **resolved** total (CR 602.2b routes an activation cost through the same 601.2f total-cost step a spell uses);
- the number is bound as the activation's X value, so the X-linked non-mana costs (`Costs.PayXLife`, `Costs.ExileXFromGraveyard`, `RemoveCounters(count = XValue)`) and any `DynamicAmount.XValue` in the effect see it too (CR 107.3i / 107.3k).

An amount that resolves to nothing is X = 0, so a Foundry with no imprint offers a legal and entirely pointless `{0}, {T}` — the printed behaviour.

Wired at all four cost sites: `ActivatedAbilityEnumerator`, `ZoneActivatedAbilityEnumerator`, and `ActivateAbilityHandler`'s `validate` and `execute`.

## The card

Soul Foundry needed **no other new vocabulary**. The imprint is Isochron Scepter's linked exile verbatim, and `DynamicAmount.EntityProperty(EntityReference.LinkedExiledCard(), ManaValue)` already read the imprinted card's mana value — it just had no route into a cost. Elite Arcanist, Prototype Portal and Caller of the Untamed are the same template and now compose.

## Mirrodin is done

- **291/291** (`just card-status --set MRD`), so the `incomplete = true` override is dropped. That flag gates `fullyImplemented`, which is what keeps a finished set out of the lobby's set picker; `SetCoverageServiceTest` fails if a 100% set keeps it.
- **Six limited archetypes** added to `SetArchetypes.kt` (AI deckbuilder + deckbuild chat advisor) and `SetSynergiesOverlay.tsx` (the draft/sealed overlay) — the two tables are kept in lockstep by hand. Affinity (U), Equipment Aggro (W), Skyhunter Skies (WU), Nim Sacrifice (BR), Artifact Demolition (RG), Myr Ramp (G). Without them an MRD build fell back to a random deck and the synergies button rendered nothing.

## Also

- Registered the mtgish `PayManaX` cost tag. It covers **both** halves of CR 107.3 and was unmapped, so it was blocking every `{X}` activated ability in the corpus — Necropolis Fiend goes BLOCKED → COVERABLE-NOW. Capability-only; the emitter still declines the `{X}` area, so those cards stay SCAFFOLD.
- Corrected the Imprint rule citation on `EntityReference.LinkedExiledCard` — 702.15 is lifelink, and imprint is now only an ability word with no rule number of its own.

## Tests

- `DefinedXAbilityCostTest` (rules-engine, 7 cases) — resolved price, the chosen-X control case, affordability, no prompt + X reaching the effect, X = 0, the cost-increasing static, and re-reading the amount per activation.
- `SoulFoundryScenarioTest` (5 cases) — imprint and mint a copy that keeps the card's own mana value (2004-12-01 ruling) with the card still exiled, the price following a six-drop, a zero-mana-value imprint, a declined imprint, and a hand with no creature card.

## Verification

`just build` and `just test` green; card snapshot re-blessed (`MRD.json`, +126 lines, Soul Foundry's tree only — nothing else moved). `just check-card-printing "Soul Foundry"` ok. Web client `npm run typecheck` clean and `SetSynergiesOverlay.test.ts` passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
