### PR TITLE
Add Kaya, Spirits' Justice — Murders at Karlov Manor is complete (276/276)

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/SetArchetypes.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/SetArchetypes.kt
@@ -182,6 +182,33 @@ object SetArchetypes {
                     "Take the board early with cheap creatures and pile on +1/+1 counters. Station synergies and counter payoffs build a sticky, go-tall-and-wide deck that's hard to climb back against."),
             )
         ),
+        "MKM" to SetSynergies(
+            setCode = "MKM",
+            setName = "Murders at Karlov Manor",
+            archetypes = listOf(
+                Archetype("Detectives", listOf(Color.WHITE, Color.BLUE),
+                    "Field a squad of Detectives, turn Clues into cards, and ride the format's best evasive bodies. A tempo-value deck that never runs out of gas.",
+                    creatureTypes = listOf("Detective")),
+                Archetype("Surveil", listOf(Color.BLUE, Color.BLACK),
+                    "Surveil to fix your draws and stock your graveyard, then take over with cheap interaction and recursive threats. A grindy control deck that wins the long game."),
+                Archetype("Sacrifice", listOf(Color.BLACK, Color.RED),
+                    "Suspect your own creatures to push damage, then sacrifice them for value before the drawback bites. An aggressive deck that turns every body into reach."),
+                Archetype("Disguise", listOf(Color.RED, Color.GREEN),
+                    "Deploy face-down 2/2s early and flip them at the perfect moment for a blowout. A midrange deck that turns every attack into a guessing game."),
+                Archetype("Face-Down Counters", listOf(Color.GREEN, Color.WHITE),
+                    "Cloak and disguise creatures, then cash in the turn-up triggers for +1/+1 counters. A go-tall midrange deck that snowballs off every flip."),
+                Archetype("Small Creatures", listOf(Color.WHITE, Color.BLACK),
+                    "Flood the board with cheap creatures with power 2 or less and drain the opponent with the payoffs that count them. A wide, incremental aggro deck."),
+                Archetype("Artifacts", listOf(Color.BLUE, Color.RED),
+                    "Investigate for Clues, then sacrifice artifacts to trigger payoffs and refuel. An artifact-fueled tempo deck that converts leftovers into damage."),
+                Archetype("Graveyard", listOf(Color.BLACK, Color.GREEN),
+                    "Fill your graveyard and spend it — collect evidence, recur creature cards, and out-attrition the table. A resilient midrange deck with a deep back end."),
+                Archetype("Go Wide Aggro", listOf(Color.RED, Color.WHITE),
+                    "Attack with three or more creatures every turn to switch on the format's go-wide payoffs. The fastest deck in the format, backed by burn."),
+                Archetype("Collect Evidence", listOf(Color.GREEN, Color.BLUE),
+                    "Bank cards in your graveyard, collect evidence to unlock discounted spells, and grow a threat with +1/+1 counters. A ramp-value deck that plays the biggest spells."),
+            )
+        ),
         "OTJ" to SetSynergies(
             setCode = "OTJ",
             setName = "Outlaws of Thunder Junction",

--- a/backlog/mkm-engine-gaps.md
+++ b/backlog/mkm-engine-gaps.md
@@ -4,7 +4,13 @@ Cross-reference of the **260 remaining (unimplemented, non-basic) MKM cards** ag
 actual capabilities (SDK reference + source verification, June 2026). Generated to scope what must be
 built before the set can be completed.
 
-**Status:** 14 / 276 implemented (5%). The 14 done are almost entirely the ten surveil dual lands
+> **DONE — MKM is 276/276 as of 2026-08-21.** Every gap below was built; the set is
+> `sealedSupported = true` with draft/sealed archetypes. The last card in was Kaya, Spirits'
+> Justice, which needed the ownership-scoped/token-inclusive exile batch trigger and the
+> one-target-per-other-player requirement shape. Kept for the build-order reasoning, which is the
+> template the next set's gap analysis follows.
+
+**Status (at time of writing):** 14 / 276 implemented (5%). The 14 done are almost entirely the ten surveil dual lands
 (Raucous Theater, Hedge Maze, Undercity Sewers, Elegant Parlor, Underground Mortuary, Lush Portico,
 Meticulous Archive, …) — essentially no MKM *mechanic* is built yet. Card list comes from
 `scripts/card-status --list --set MKM`; oracle text pulled from Scryfall (`set:mkm`, 279 printings).

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3108,6 +3108,7 @@ with cards):
 
 | Builder verb | Serializes to |
 |---|---|
+| `triggerCaptured` (a slot, not a step — the collection the engine already seeded for a batch trigger; see below) | — |
 | `gather(source)` / `gather(filter, player?, …)` (battlefield shorthand) | `GatherCardsEffect` |
 | `gatherUntilMatch(filter, …)` → `(match, revealed)` | `GatherUntilMatchEffect` |
 | `chooseExactly(n, from)` / `chooseUpTo` / `chooseAnyNumber` / `chooseRandom` / `selectAll` (+ `…Split` variants returning `(selected, remainder)`) | `SelectFromCollectionEffect` |
@@ -3127,6 +3128,30 @@ with cards):
 | `ifNotEmpty(slot, filter?, minSize?) { … } orElse { … }` | `ConditionalOnCollectionEffect` |
 | `whenMatches(slot, filter)` (returns a `Condition`, adds no step) | `CollectionContainsMatch` |
 | `run(effect)` | any other `Effect`, verbatim |
+
+**`triggerCaptured`** — the collection a **batch trigger** already seeded for this resolution: the
+objects that caused it to fire, i.e. a printed "them" / "those creatures" / "that many". It is
+produced by the engine, not by a step in this pipeline, so it takes no slot index and is read
+directly — `filter(triggerCaptured, GameObjectFilter.Creature)`. (The same collection an untargeted
+batch payoff reaches as `IterationSpace.TRIGGER_CAPTURED_COLLECTION`; this is the typed handle for
+it.) Empty when the trigger captured nothing, which every downstream step treats as "no cards".
+
+```kotlin
+// Kaya, Spirits' Justice: "…are put into exile, you may choose a creature card from among them.
+// Until end of turn, target token you control becomes a copy of it, except it has flying."
+effect = Effects.Pipeline {
+    val creatureCards = filter(triggerCaptured, GameObjectFilter.Creature.nontoken())
+    val stillExiled = filter(creatureCards, CollectionFilter.InZone(Zone.EXILE))
+    val chosen = chooseUpTo(1, from = stillExiled, prompt = "You may choose a creature card …")
+    run(Effects.EachPermanentBecomesCopyOfTarget(
+        target = EffectTarget.PipelineTarget(chosen.key),
+        affected = EffectTarget.ContextTarget(0),
+        duration = Duration.EndOfTurn,
+        sourceFromAnyZone = true,
+        exceptions = CopyExceptions(addedKeywords = setOf(Keyword.FLYING)),
+    ))
+}
+```
 
 **`chooseOnePerCategory(from, categories)`** — "…chooses a permanent they control of each permanent
 type…". Each *controller* represented in `from` picks one of their own members for every filter in
@@ -3433,6 +3458,7 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
 - `Targets.Planeswalker` — any planeswalker.
 - `Targets.Permanent` — any permanent.
 - `Targets.PermanentYouControl` / `PermanentOpponentControls` — controller-restricted permanent ("target permanent you control gains protection …" — Razor Barrier).
+- `Targets.TokenYouControl` — any **token** permanent you control, not just a creature token: "target token you control becomes a copy of it" (Kaya, Spirits' Justice) is deliberately wide enough to turn a Clue or a Treasure into a creature.
 - `Targets.PermanentOrPlayer` — "target permanent or player" (Powerful Broker). The general member of
   the "object or player" family: `TargetPermanentOrPlayer(permanentFilter = …)` narrows the permanent
   half ("target artifact or player") while each half keeps the legality checks of its single-kind
@@ -3609,6 +3635,19 @@ Every `TargetRequirement` carries count semantics (defaults shown):
   interactive target decision, `DecisionValidators` (via `TargetRequirementInfo.differentNames`),
   grouping by projected name (battlefield) / base card name (other zones). E.g.
   `TargetObject(count = 6, optional = true, filter = TargetFilter.CreatureInYourGraveyard, differentNames = true)`.
+- `differentControllers = false` — on `TargetObject` / `TargetCreature(...)`; the exact inverse of
+  `sameController`. When `true` and more than one target is chosen, no two may share a **controller**,
+  read from *projected* state so a control-change effect is respected. Enforced cross-target by
+  `TargetValidator` (authoritative) and, on the interactive target decision, `DecisionValidators` (via
+  `TargetRequirementInfo.differentControllers`). This is the **"one per player" distribution** wording,
+  and it is spelled by composing three orthogonal knobs rather than a bespoke requirement type: the
+  scope (`dynamicMaxCount = DynamicAmount.PlayerCount(Player.EachOpponent)` — how many players may be
+  hit), the cap (`differentControllers = true` — at most one each), and the "up to" (`optional = true`).
+  "**For each other player, exile up to one target creature that player controls**" (Kaya, Spirits'
+  Justice) is `TargetCreature(filter = TargetFilter.CreatureOpponentControls, optional = true,
+  dynamicMaxCount = DynamicAmount.PlayerCount(Player.EachOpponent), differentControllers = true,
+  id = "one target creature each other player controls")`. Give it an `id` — the generated description
+  reads "controlled by different players", which is the constraint, not the printed sentence.
 - `chooser = TargetChooser.Controller` — **who selects this requirement's target(s)**. Set to
   `TargetChooser.Opponent` for "**… of an opponent's choice**" wording (Cuombajj Witches). The chosen
   target is still a real target of *your* spell/ability — announced together with your own targets,
@@ -5013,13 +5052,29 @@ in the repo today):
   **during your turn**" wording, add `triggerRestriction = Conditions.IsYourTurn`; for "this
   ability triggers only once each turn", add `oncePerTurn = true`. (Attuned Hunter, Kishla
   Skimmer, Kheru Goldkeeper.)
-- `CardsPutIntoExile(fromZones?, filter?)` — batching trigger; fires once per event batch when one
-  or more matching **cards** are put into exile from any of `fromZones` (default: graveyard and
-  battlefield). Unlike the graveyard batches above it is **not** scoped to one player's zones —
+- `CardsPutIntoExile(fromZones?, filter?, includeTokens?)` — batching trigger; fires once per event
+  batch when one or more matching **cards** are put into exile from any of `fromZones` (default:
+  graveyard and battlefield). Left unfiltered it is **not** scoped to one player's zones —
   "graveyards and/or the battlefield" means any graveyard and anyone's permanents, so every
-  controller of the trigger sees the same batch. Tokens never satisfy it (CR 111.6). Add
+  controller of the trigger sees the same batch (Ketramose, the New Dawn). Add
   `triggerRestriction = Conditions.IsYourTurn` for the "during your turn" wording.
-  (Ketramose, the New Dawn.)
+  - **Ownership scoping.** `filter`'s controller predicate is honored, and it reads *per zone*: a
+    battlefield exit is tested against the permanent's **last known controller** (CR 603.10 — it is
+    already in exile by detection time), every other zone against the card's **owner**, because a
+    card in a graveyard/hand/library has no controller. One filter therefore spells both arms of
+    "creatures **you control** and/or creature cards in **your** graveyard" —
+    `GameObjectFilter.Creature.youControl()` (Kaya, Spirits' Justice).
+  - **`includeTokens = true`** makes a token satisfy it. The axis is the printed noun, not a
+    convenience: "one or more **cards** are put into exile" excludes tokens outright (CR 111.6),
+    while "one or more **creatures you control** … are put into exile" counts a token creature like
+    any other. CR 111.7 ("applicable triggered abilities will trigger before the token ceases to
+    exist") is what makes the token-inclusive reading detectable at all — and also why the token is
+    gone from the captured collection by the time the ability resolves.
+  - **The batch is captured.** The matching objects reach the payoff as
+    `IterationSpace.TRIGGER_CAPTURED_COLLECTION` (the `triggerCaptured` slot in an
+    `Effects.Pipeline { }`), which is what a printed "from among **them**" refers to. Narrow it with
+    `CollectionFilter.InZone(Zone.EXILE)` when the payoff must still find the card *in exile* — a
+    card pulled back out of exile before the ability resolves is no longer choosable (Kaya's ruling).
 
 ### Discard
 
@@ -9548,6 +9603,18 @@ Numbers computed at resolution time.
 - `Min(a, b)` — minimum.
 - `Max(a, b)` — maximum.
 - `Absolute(a)` — `|a|`.
+
+### Player counting
+
+- `PlayerCount(scope = Player.EachOpponent)` — how many players the `scope` names, counting only
+  players still in the game (a player who has lost drops out, so a shrinking pod reports the live
+  number). `Player.EachOpponent` is "for each opponent" and, outside team play, also "for each other
+  player"; `Player.Each` counts the whole table including you. The unconditional sibling of
+  `CountPlayersWith` — reach for that one when the count is qualified ("each opponent **who has one
+  or fewer cards in hand**"). Its other home is `TargetObject.dynamicMaxCount`, where paired with
+  `optional = true` and `differentControllers = true` it spells "for each other player, exile up to
+  one target creature that player controls" (Kaya, Spirits' Justice) — see `differentControllers`
+  in the targeting section.
 
 ### Battlefield aggregation
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/PipelineBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/PipelineBuilder.kt
@@ -23,6 +23,7 @@ import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.GatherSubtypesEffect
 import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.IterationSpace
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.MoveType
 import com.wingedsheep.sdk.scripting.effects.NoteCreatureTypeEffect
@@ -157,6 +158,20 @@ class PipelineBuilder private constructor(private val shared: Shared) {
     // =========================================================================
     // Gather
     // =========================================================================
+
+    /**
+     * The collection a batch trigger already seeded for this resolution — the objects that caused
+     * it to fire, i.e. printed "them" / "those creatures" / "that many". Produced by the engine
+     * rather than by a step in this pipeline, so it takes no slot index and can be read straight
+     * away:
+     *
+     * ```kotlin
+     * val creatureCards = filter(triggerCaptured, GameObjectFilter.Creature)
+     * ```
+     *
+     * Empty when the trigger captured nothing, which every downstream step treats as "no cards".
+     */
+    val triggerCaptured: CollectionSlot get() = CollectionSlot(IterationSpace.TRIGGER_CAPTURED_COLLECTION)
 
     /** Gather cards from [source] into a new collection ([GatherCardsEffect]). */
     fun gather(source: CardSource, revealed: Boolean = false, name: String? = null): CollectionSlot {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
@@ -203,6 +203,13 @@ object Targets {
     val PermanentOpponentControls: TargetRequirement = TargetPermanent(filter = TargetFilter.PermanentOpponentControls)
 
     /**
+     * Target **token** you control — any token permanent, not just a creature token. "Target token
+     * you control becomes a copy of it" (Kaya, Spirits' Justice) is deliberately wide enough to
+     * turn a Clue or a Treasure into a creature.
+     */
+    val TokenYouControl: TargetRequirement = TargetPermanent(filter = TargetFilter.TokenYouControl)
+
+    /**
      * Target planeswalker (any player's) — "destroy target planeswalker" (Graf Reaver).
      */
     val Planeswalker: TargetRequirement = TargetPermanent(filter = TargetFilter.Planeswalker)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -866,17 +866,31 @@ object Triggers {
     /**
      * Whenever one or more cards matching [filter] are put into exile from [fromZones].
      * Batching trigger — fires at most once per event batch regardless of how many cards were
-     * exiled or which of the watched zones each came from, and it is *not* scoped to one player's
-     * zones ("graveyards", plural, and anyone's battlefield permanents).
+     * exiled or which of the watched zones each came from. Unfiltered it is *not* scoped to one
+     * player's zones ("graveyards", plural, and anyone's battlefield permanents); give [filter] a
+     * controller predicate to narrow it ("creatures **you control** and/or creature cards in
+     * **your** graveyard" — Kaya, Spirits' Justice).
+     *
+     * The matching objects reach the payoff as the ability's captured collection
+     * ([com.wingedsheep.sdk.scripting.effects.IterationSpace.TRIGGER_CAPTURED_COLLECTION]), which is
+     * what "from among them" refers to.
+     *
+     * Pass [includeTokens] for a wording whose battlefield noun is *permanents* rather than *cards*
+     * — see [CardsPutIntoExileEvent.includeTokens].
      *
      * Pair with `triggerRestriction = Conditions.IsYourTurn` for the common "during your turn"
      * wording (Ketramose, the New Dawn).
      */
     fun CardsPutIntoExile(
         fromZones: Set<Zone> = setOf(Zone.GRAVEYARD, Zone.BATTLEFIELD),
-        filter: GameObjectFilter = GameObjectFilter.Any
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        includeTokens: Boolean = false
     ): TriggerSpec = TriggerSpec(
-        event = CardsPutIntoExileEvent(fromZones = fromZones, filter = filter),
+        event = CardsPutIntoExileEvent(
+            fromZones = fromZones,
+            filter = filter,
+            includeTokens = includeTokens
+        ),
         binding = TriggerBinding.ANY
     )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -2409,8 +2409,24 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
      * to a single player's zone: "from graveyards and/or the battlefield" means *any* graveyard and
      * *any* player's permanents, so every controller with this trigger sees the same batch.
      *
-     * Only cards fire it — tokens are not cards (CR 111.6), so a token exiled from the battlefield
-     * never satisfies it even though it briefly occupies the exile zone before CR 111.7 sweeps it.
+     * By default only cards fire it — tokens are not cards (CR 111.6), so a token exiled from the
+     * battlefield never satisfies it even though it briefly occupies the exile zone before CR 111.7
+     * sweeps it. [includeTokens] flips that for the wordings whose battlefield noun is *permanents*
+     * rather than *cards*; see its own doc.
+     *
+     * [filter]'s **controller predicate is honored**, so the batch can be narrowed to one player's
+     * objects: `GameObjectFilter.Creature.youControl()` reads as "creatures you control and/or
+     * creature cards in your graveyard", because ownership is what "your graveyard" means and
+     * control is what "you control" means. The detector tests the *last known* controller for a
+     * battlefield exit (the permanent is already in exile by then, CR 603.10) and the owner for a
+     * card leaving any other zone — a graveyard/hand/library card has no controller.
+     *
+     * The matching exiled objects are handed to the resolving ability as its captured collection
+     * ([com.wingedsheep.sdk.scripting.effects.IterationSpace.TRIGGER_CAPTURED_COLLECTION]), so a
+     * payoff can say "from among **them**". Note CR 111.7 has already swept any token out of that
+     * collection by the time the ability resolves, and a card that has since left exile is likewise
+     * no longer choosable (Kaya, Spirits' Justice's ruling) — filter the collection with
+     * `CollectionFilter.InZone(Zone.EXILE)` when the payoff must still find the card in exile.
      *
      * The common "during your turn" timing restriction is expressed on the card via
      * `triggerRestriction = Conditions.IsYourTurn` rather than baked into the event.
@@ -2419,12 +2435,23 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
      * - "Whenever one or more cards are put into exile from graveyards and/or the battlefield
      *   during your turn, …" → `CardsPutIntoExileEvent()` + `triggerRestriction = Conditions.IsYourTurn`
      *   (Ketramose, the New Dawn)
+     * - "Whenever one or more creatures you control and/or creature cards in your graveyard are put
+     *   into exile, …" → `CardsPutIntoExileEvent(filter = GameObjectFilter.Creature.youControl(),
+     *   includeTokens = true)` (Kaya, Spirits' Justice)
+     *
+     * @param includeTokens When true, a **token** put into exile satisfies the trigger too. The axis
+     *   is the printed noun, not a convenience: "one or more **cards** are put into exile" excludes
+     *   tokens outright (CR 111.6), while "one or more **creatures you control** … are put into
+     *   exile" counts a token creature like any other creature. CR 111.7's "applicable triggered
+     *   abilities will trigger before the token ceases to exist" is what makes the token-inclusive
+     *   reading detectable at all.
      */
     @SerialName("CardsPutIntoExileEvent")
     @Serializable
     data class CardsPutIntoExileEvent(
         val fromZones: Set<Zone> = setOf(Zone.GRAVEYARD, Zone.BATTLEFIELD),
-        val filter: GameObjectFilter = GameObjectFilter.Any
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        val includeTokens: Boolean = false
     ) : EventPattern {
         override val description: String = buildString {
             append("one or more ")
@@ -2432,7 +2459,13 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
                 append(filter.cardPredicates.joinToString(" ") { it.description })
                 append(" ")
             }
-            append("cards are put into exile from ")
+            append(if (includeTokens) "permanents" else "cards")
+            val controllerClause = filter.controllerPredicate?.description.orEmpty()
+            if (controllerClause.isNotEmpty()) {
+                append(" ")
+                append(controllerClause)
+            }
+            append(" are put into exile from ")
             append(
                 fromZones.sortedBy { it.ordinal }.joinToString(" and/or ") { zone ->
                     when (zone) {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -157,6 +157,13 @@ data class TargetFilter(
         /** Target permanent you control */
         val PermanentYouControl = TargetFilter(GameObjectFilter.Companion.Permanent.youControl())
 
+        /**
+         * Target token you control — any token permanent, not just a creature one. "Target token
+         * you control becomes a copy of it" (Kaya, Spirits' Justice) is deliberately wide enough to
+         * turn a Clue or a Treasure into a creature.
+         */
+        val TokenYouControl = TargetFilter(GameObjectFilter.Companion.Permanent.token().youControl())
+
         /** Target nonland permanent an opponent controls */
         val NonlandPermanentOpponentControls = TargetFilter(GameObjectFilter.Companion.NonlandPermanent.opponentControls())
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
@@ -185,6 +185,7 @@ fun TargetCreature(
     id: String? = null,
     dynamicMaxCount: DynamicAmount? = null,
     sameController: Boolean = false,
+    differentControllers: Boolean = false,
     sameCreatureType: Boolean = false
 ): TargetObject = TargetObject(
     count = count,
@@ -195,6 +196,7 @@ fun TargetCreature(
     id = id,
     dynamicMaxCount = dynamicMaxCount,
     sameController = sameController,
+    differentControllers = differentControllers,
     sameCreatureType = sameCreatureType
 )
 
@@ -499,6 +501,19 @@ data class TargetObject(
      */
     val differentNames: Boolean = false,
     /**
+     * When true and more than one target is chosen for this requirement, every chosen target must
+     * be controlled by a **different player** — the "one per player" distribution wording, whose
+     * canonical shape is "for each other player, exile **up to one** target creature that player
+     * controls" (Kaya, Spirits' Justice). The exact inverse of [sameController], and it composes
+     * with `optional = true` + `dynamicMaxCount = DynamicAmount.PlayerCount(Player.EachOpponent)`
+     * to spell that clause completely: the count says *how many* players are in scope, this says
+     * *at most one each*, and `optional` is the "up to". Enforced cross-target by `TargetValidator`
+     * (authoritative) and the interactive `DecisionValidators`, grouping by each permanent's
+     * *projected* controller so a control-change effect is respected; a no-op for single-target
+     * requirements and for non-permanent targets. Defaults to false.
+     */
+    val differentControllers: Boolean = false,
+    /**
      * Who picks which legal object this requirement lands on. See [TargetChooser] — the target
      * stays the *controller's* target either way (legality, respondability and CR 115 all still
      * run relative to the controller); only the selection decision is routed elsewhere.
@@ -538,6 +553,7 @@ data class TargetObject(
         }
         val qualified = when {
             sameController -> "$base controlled by the same player"
+            differentControllers -> "$base controlled by different players"
             sameOwner -> "$base from a single graveyard"
             sameCreatureType -> "$base that share a creature type"
             sameCardType -> "$base that share a card type"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -989,6 +989,27 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     }
 
     /**
+     * How many players are in [scope] — "for each opponent", "for each other player", "the number
+     * of players in the game". Counts only players still in the game (CR 800.4a: a player who
+     * leaves is no longer a player), so a pod that shrinks mid-game reports the live number.
+     *
+     * The unconditional sibling of [CountPlayersWith]; reach for that one when the count is
+     * qualified ("each opponent **who has one or fewer cards in hand**"). Its main use is as a
+     * [com.wingedsheep.sdk.scripting.targets.TargetObject.dynamicMaxCount]: paired with
+     * `optional = true` and `differentControllers = true` it spells "for each other player, ... up
+     * to one target creature that player controls" (Kaya, Spirits' Justice), where the scope names
+     * how many players may be hit and the other two flags cap it at one each.
+     *
+     * [Player.EachOpponent] (the default) is the "each other player" reading in every free-for-all
+     * game; [Player.Each] counts the whole table including you.
+     */
+    @SerialName("PlayerCount")
+    @Serializable
+    data class PlayerCount(val scope: Player = Player.EachOpponent) : DynamicAmount {
+        override val description: String = "the number of ${scope.description}"
+    }
+
+    /**
      * Count of players in [scope] for whom [condition] evaluates to true.
      *
      * The condition is evaluated with the context's controllerId rebound to each candidate

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/MurdersAtKarlovManorSet.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/MurdersAtKarlovManorSet.kt
@@ -16,7 +16,7 @@ object MurdersAtKarlovManorSet : MtgSet {
     override val code = "MKM"
     override val displayName = "Murders at Karlov Manor"
     override val releaseDate = "2024-02-09"
-    override val incomplete = true
+    override val sealedSupported = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/KayaSpiritsJustice.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/KayaSpiritsJustice.kt
@@ -1,0 +1,205 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.CopyExceptions
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Kaya, Spirits' Justice
+ * {2}{W}{B}
+ * Legendary Planeswalker — Kaya
+ * Starting Loyalty: 3
+ *
+ * Whenever one or more creatures you control and/or creature cards in your graveyard are put into
+ * exile, you may choose a creature card from among them. Until end of turn, target token you
+ * control becomes a copy of it, except it has flying.
+ * +2: Surveil 2, then exile a card from a graveyard.
+ * +1: Create a 1/1 white and black Spirit creature token with flying.
+ * −2: Exile target creature you control. For each other player, exile up to one target creature
+ * that player controls.
+ *
+ * Implementation:
+ * - **The trigger** is the exile batch ([Triggers.CardsPutIntoExile]) narrowed two ways. The filter
+ *   carries the ownership — `GameObjectFilter.Creature.youControl()` reads as "creatures **you
+ *   control**" for the battlefield arm and "creature cards in **your** graveyard" for the graveyard
+ *   arm, because the detector tests last-known control for a battlefield exit and ownership
+ *   everywhere else. `includeTokens = true` is the other half: the battlefield noun here is
+ *   *creatures*, not *cards*, so a token creature counts (CR 111.6 excludes tokens only from the
+ *   "cards" wording, and CR 111.7 guarantees the trigger fires before the token ceases to exist).
+ * - **"From among them"** is the batch the trigger captured (`triggerCaptured`). It is narrowed
+ *   twice before the choice: to creature *cards* — a token that was in the batch has already been
+ *   swept out of exile by CR 111.7 — and to cards still `InZone(EXILE)`, which is Kaya's own ruling
+ *   that a card pulled back out of exile before this resolves can no longer be chosen.
+ * - **The copy** is [Effects.EachPermanentBecomesCopyOfTarget] with the chosen card as the source
+ *   (`sourceFromAnyZone = true` — it is sitting in exile) and the targeted token as `affected`,
+ *   for [Duration.EndOfTurn], plus `exceptions = CopyExceptions(addedKeywords = FLYING)` for the
+ *   "except it has flying" clause. Copiable values only (Rule 707.2), which is why the ruling says
+ *   the token copies the card's *printed* values even if the permanent it came from was itself a
+ *   copy. Declining the optional choice leaves the copy source unresolved and the effect is a
+ *   no-op, which is the "you may".
+ * - **+2** is Lazav, Familiar Stranger's shape verbatim: surveil 2, then gather every graveyard and
+ *   exile one pick. Kaya's wording is not a "may", so the pick is [PipelineBuilder.chooseExactly] —
+ *   with every graveyard empty there is nothing to choose and the step simply does nothing.
+ * - **−2** is two target requirements, and CR 601.2c chooses all of them (the ruling: "You choose
+ *   all targets for Kaya's last ability"). The second is the "one per player" distribution:
+ *   `dynamicMaxCount = PlayerCount(EachOpponent)` says how many players are in scope,
+ *   `differentControllers = true` caps it at one creature each, and `optional = true` is the "up
+ *   to". ("Each other player" and "each opponent" name the same set outside team play, which is
+ *   every format this set is drafted and built for; the scope is a parameter, so a future
+ *   team-aware player reference is a one-word change here.)
+ * - The −2 exiling your own creature is what turns the trigger on: exiling a creature you control
+ *   feeds the batch, and the +2's graveyard exile does too when it takes a creature card out of
+ *   *your* graveyard.
+ */
+private const val SPIRIT_TOKEN_IMAGE =
+    "https://cards.scryfall.io/normal/front/f/4/f4588570-bde4-4c2f-8469-81a3e15fb57b.jpg?1783912607"
+
+val KayaSpiritsJustice = card("Kaya, Spirits' Justice") {
+    manaCost = "{2}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Planeswalker — Kaya"
+    startingLoyalty = 3
+    oracleText = "Whenever one or more creatures you control and/or creature cards in your " +
+        "graveyard are put into exile, you may choose a creature card from among them. Until end " +
+        "of turn, target token you control becomes a copy of it, except it has flying.\n" +
+        "+2: Surveil 2, then exile a card from a graveyard.\n" +
+        "+1: Create a 1/1 white and black Spirit creature token with flying.\n" +
+        "−2: Exile target creature you control. For each other player, exile up to one target " +
+        "creature that player controls."
+
+    triggeredAbility {
+        trigger = Triggers.CardsPutIntoExile(
+            fromZones = setOf(Zone.BATTLEFIELD, Zone.GRAVEYARD),
+            filter = GameObjectFilter.Creature.youControl(),
+            includeTokens = true,
+        )
+        target("token you control", Targets.TokenYouControl)
+        effect = Effects.Pipeline {
+            // "from among them" — the exiled batch, narrowed to creature cards that are still in
+            // exile when this resolves.
+            val creatureCards = filter(
+                triggerCaptured,
+                GameObjectFilter.Creature.nontoken(),
+                name = "kayaExiledCreatures",
+            )
+            val stillExiled = filter(
+                creatureCards,
+                CollectionFilter.InZone(Zone.EXILE),
+                name = "kayaChoosable",
+            )
+            val chosen = chooseUpTo(
+                1,
+                from = stillExiled,
+                prompt = "You may choose a creature card from among the exiled cards",
+                selectedLabel = "Copy",
+                name = "kayaCopySource",
+            )
+            run(
+                Effects.EachPermanentBecomesCopyOfTarget(
+                    target = EffectTarget.PipelineTarget(chosen.key),
+                    duration = Duration.EndOfTurn,
+                    affected = EffectTarget.ContextTarget(0),
+                    sourceFromAnyZone = true,
+                    exceptions = CopyExceptions(addedKeywords = setOf(Keyword.FLYING)),
+                )
+            )
+        }
+        description = "Whenever one or more creatures you control and/or creature cards in your " +
+            "graveyard are put into exile, you may choose a creature card from among them. Until " +
+            "end of turn, target token you control becomes a copy of it, except it has flying."
+    }
+
+    // +2: Surveil 2, then exile a card from a graveyard.
+    loyaltyAbility(+2) {
+        effect = Effects.Pipeline {
+            run(Effects.Surveil(2))
+            val graveyardCards = gather(
+                CardSource.FromZone(Zone.GRAVEYARD, Player.Each, GameObjectFilter.Any)
+            )
+            val picked = chooseExactly(
+                1,
+                from = graveyardCards,
+                useTargetingUI = true,
+                prompt = "Exile a card from a graveyard",
+                selectedLabel = "Exile",
+                name = "kayaGraveyardExile",
+            )
+            exile(picked)
+        }
+        description = "Surveil 2, then exile a card from a graveyard."
+    }
+
+    // +1: Create a 1/1 white and black Spirit creature token with flying.
+    loyaltyAbility(+1) {
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE, Color.BLACK),
+            creatureTypes = setOf("Spirit"),
+            keywords = setOf(Keyword.FLYING),
+            name = "Spirit",
+            imageUri = SPIRIT_TOKEN_IMAGE,
+        )
+    }
+
+    // -2: Exile target creature you control. For each other player, exile up to one target creature
+    // that player controls.
+    loyaltyAbility(-2) {
+        target("creature you control", TargetCreature(filter = TargetFilter.CreatureYouControl))
+        target(
+            "creature that player controls",
+            TargetCreature(
+                filter = TargetFilter.CreatureOpponentControls,
+                optional = true,
+                dynamicMaxCount = DynamicAmount.PlayerCount(Player.EachOpponent),
+                differentControllers = true,
+                id = "one target creature each other player controls",
+            ),
+        )
+        effect = Effects.Composite(
+            listOf(
+                Effects.Exile(EffectTarget.ContextTarget(0)),
+                Effects.Exile(EffectTarget.ContextTarget(1)),
+            )
+        )
+        description = "Exile target creature you control. For each other player, exile up to one " +
+            "target creature that player controls."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "211"
+        artist = "Magali Villeneuve"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/" +
+            "a2827593-4951-4ba7-b73e-c27de56f2606.jpg?1783912848"
+
+        ruling(
+            "2024-02-02",
+            "The target token copies the printed values of the card in exile, with the noted " +
+                "exception. It doesn't matter if that card was a copy of something else when it " +
+                "was on the battlefield.",
+        )
+        ruling(
+            "2024-02-02",
+            "If a creature card that was exiled is no longer in exile when Kaya, Spirits' " +
+                "Justice's first ability resolves (perhaps because of Pull from Eternity or a " +
+                "similar effect), you can't choose that creature card with that ability.",
+        )
+        ruling("2024-02-02", "You choose all targets for Kaya, Spirits' Justice's last ability.")
+    }
+}

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/KayaSpiritsJusticeScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/KayaSpiritsJusticeScenarioTest.kt
@@ -1,0 +1,262 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Kaya, Spirits' Justice (MKM #211, {2}{W}{B} planeswalker, loyalty 3).
+ *
+ *   Whenever one or more creatures you control and/or creature cards in your graveyard are put
+ *   into exile, you may choose a creature card from among them. Until end of turn, target token
+ *   you control becomes a copy of it, except it has flying.
+ *   +2: Surveil 2, then exile a card from a graveyard.
+ *   +1: Create a 1/1 white and black Spirit creature token with flying.
+ *   −2: Exile target creature you control. For each other player, exile up to one target creature
+ *   that player controls.
+ *
+ * The two engine capabilities this card needed both show up here: the exile batch trigger scoped
+ * to one player's creatures and graveyard (and capturing that batch as "them"), and the
+ * one-target-per-other-player shape on the −2.
+ *
+ * Kaya is also the first card that is a batch trigger *and* targets, so the copy tests below are
+ * the regression for `TriggeredAbilityContinuation.capturedEntityIds`: the captured batch used to
+ * be dropped while the ability paused to choose its token target, and "them" resolved empty.
+ */
+class KayaSpiritsJusticeScenarioTest : ScenarioTestBase() {
+
+    private fun loyalty(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+
+    /** Seed a planeswalker's starting loyalty — withCardOnBattlefield doesn't stamp it. */
+    private fun seedLoyalty(game: TestGame, id: EntityId, amount: Int) {
+        game.state = game.state.updateEntity(id) { c ->
+            c.with(CountersComponent().withAdded(CounterType.LOYALTY, amount))
+        }
+    }
+
+    private fun abilityId(index: Int) =
+        cardRegistry.getCard("Kaya, Spirits' Justice")!!.script.activatedAbilities[index].id
+
+    init {
+        test("+1: create a 1/1 white and black Spirit token with flying") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Kaya, Spirits' Justice")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val kaya = game.findPermanent("Kaya, Spirits' Justice")!!
+            seedLoyalty(game, kaya, 3)
+
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = kaya, abilityId = abilityId(1))
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("+1 leaves Kaya at 4 loyalty") { loyalty(game, kaya) shouldBe 4 }
+
+            val spirit = game.findPermanents("Spirit").single {
+                game.state.getEntity(it)?.has<TokenComponent>() == true
+            }
+            game.state.projectedState.getPower(spirit) shouldBe 1
+            game.state.projectedState.getToughness(spirit) shouldBe 1
+            withClue("the Spirit flies") {
+                game.state.projectedState.getKeywords(spirit) shouldContain Keyword.FLYING.name
+            }
+        }
+
+        test("-2 exiles your creature and one the opponent controls, and the trigger copies it onto your token") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Kaya, Spirits' Justice")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(1, "Clue", isToken = true)
+                .withCardOnBattlefield(2, "Runeclaw Bear")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val kaya = game.findPermanent("Kaya, Spirits' Justice")!!
+            seedLoyalty(game, kaya, 3)
+            val myBears = game.findPermanent("Grizzly Bears")!!
+            val theirBear = game.findPermanent("Runeclaw Bear")!!
+            val token = game.findPermanents("Clue").single {
+                game.state.getEntity(it)?.has<TokenComponent>() == true
+            }
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = kaya,
+                    abilityId = abilityId(2),
+                    targets = listOf(ChosenTarget.Permanent(myBears), ChosenTarget.Permanent(theirBear)),
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("-2 leaves Kaya at 1 loyalty") { loyalty(game, kaya) shouldBe 1 }
+            withClue("both creatures were exiled") {
+                game.state.getZone(game.player1Id, Zone.EXILE) shouldContain myBears
+                game.state.getZone(game.player2Id, Zone.EXILE) shouldContain theirBear
+            }
+
+            // The exile of a creature you control fires Kaya's trigger. Its token target is chosen
+            // as it goes on the stack (CR 603.3d); the "you may choose a creature card from among
+            // them" pick follows on resolution.
+            game.selectTargets(listOf(token))
+            game.resolveStack()
+            game.selectCards(listOf(myBears))
+            game.resolveStack()
+
+            withClue("the token became a copy of the exiled creature you controlled") {
+                game.state.getEntity(token)?.get<CardComponent>()?.name shouldBe "Grizzly Bears"
+                game.state.projectedState.getPower(token) shouldBe 2
+                game.state.projectedState.getToughness(token) shouldBe 2
+            }
+            withClue("\"except it has flying\" — Grizzly Bears has no flying of its own") {
+                game.state.projectedState.getKeywords(token) shouldContain Keyword.FLYING.name
+            }
+        }
+
+        test("the opponent's exiled creature is not choosable — \"creatures you control\" scopes the batch") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Kaya, Spirits' Justice")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(1, "Clue", isToken = true)
+                .withCardOnBattlefield(2, "Serra Angel")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val kaya = game.findPermanent("Kaya, Spirits' Justice")!!
+            seedLoyalty(game, kaya, 3)
+            val myBears = game.findPermanent("Grizzly Bears")!!
+            val theirAngel = game.findPermanent("Serra Angel")!!
+            val token = game.findPermanents("Clue").single {
+                game.state.getEntity(it)?.has<TokenComponent>() == true
+            }
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = kaya,
+                    abilityId = abilityId(2),
+                    targets = listOf(ChosenTarget.Permanent(myBears), ChosenTarget.Permanent(theirAngel)),
+                )
+            ).error shouldBe null
+            game.resolveStack()
+            game.selectTargets(listOf(token))
+            game.resolveStack()
+
+            // Only Grizzly Bears is on offer; picking it is the only legal non-empty choice.
+            game.selectCards(listOf(myBears))
+            game.resolveStack()
+
+            withClue("the 4/4 flier the opponent controlled was never part of \"them\"") {
+                game.state.getEntity(token)?.get<CardComponent>()?.name shouldNotBe "Serra Angel"
+                game.state.projectedState.getPower(token) shouldBe 2
+            }
+        }
+
+        test("declining the optional choice leaves the token alone") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Kaya, Spirits' Justice")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(1, "Clue", isToken = true)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val kaya = game.findPermanent("Kaya, Spirits' Justice")!!
+            seedLoyalty(game, kaya, 3)
+            val myBears = game.findPermanent("Grizzly Bears")!!
+            val token = game.findPermanents("Clue").single {
+                game.state.getEntity(it)?.has<TokenComponent>() == true
+            }
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = kaya,
+                    abilityId = abilityId(2),
+                    targets = listOf(ChosenTarget.Permanent(myBears)),
+                )
+            ).error shouldBe null
+            game.resolveStack()
+            game.selectTargets(listOf(token))
+            game.resolveStack()
+            game.selectCards(emptyList())
+            game.resolveStack()
+
+            withClue("\"you may choose\" — declining is a no-op, the Clue stays a Clue") {
+                game.state.getEntity(token)?.get<CardComponent>()?.name shouldBe "Clue"
+            }
+        }
+
+        test("+2: surveil 2, then exile a card from a graveyard — a creature card from YOUR yard fires the trigger") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Kaya, Spirits' Justice")
+                .withCardOnBattlefield(1, "Clue", isToken = true)
+                .withCardInGraveyard(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Plains")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val kaya = game.findPermanent("Kaya, Spirits' Justice")!!
+            seedLoyalty(game, kaya, 3)
+            val token = game.findPermanents("Clue").single {
+                game.state.getEntity(it)?.has<TokenComponent>() == true
+            }
+            val bearsInYard = game.findCardsInGraveyard(1, "Grizzly Bears").first()
+
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = kaya, abilityId = abilityId(0))
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("+2 leaves Kaya at 5 loyalty") { loyalty(game, kaya) shouldBe 5 }
+
+            // Surveil 2: bin nothing, keep the two cards in order. Then exile the creature card
+            // from your graveyard.
+            game.selectCards(emptyList())
+            game.keepLibraryOrder()
+            game.selectCards(listOf(bearsInYard))
+            game.resolveStack()
+
+            withClue("the graveyard card is now in exile") {
+                game.state.getZone(game.player1Id, Zone.EXILE) shouldContain bearsInYard
+            }
+
+            // Exiling a creature card from your graveyard is the other arm of the and/or.
+            game.selectTargets(listOf(token))
+            game.resolveStack()
+            game.selectCards(listOf(bearsInYard))
+            game.resolveStack()
+
+            withClue("the token copied the creature card exiled out of your own graveyard") {
+                game.state.getEntity(token)?.get<CardComponent>()?.name shouldBe "Grizzly Bears"
+                game.state.projectedState.getKeywords(token) shouldContain Keyword.FLYING.name
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -12672,6 +12672,244 @@
     ]
 }
 
+// Kaya, Spirits' Justice
+{
+    "name": "Kaya, Spirits' Justice",
+    "manaCost": "{2}{W}{B}",
+    "typeLine": "Legendary Planeswalker — Kaya",
+    "oracleText": "Whenever one or more creatures you control and/or creature cards in your graveyard are put into exile, you may choose a creature card from among them. Until end of turn, target token you control becomes a copy of it, except it has flying.\n+2: Surveil 2, then exile a card from a graveyard.\n+1: Create a 1/1 white and black Spirit creature token with flying.\n−2: Exile target creature you control. For each other player, exile up to one target creature that player controls.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "CardsPutIntoExileEvent",
+                    "filter": "creature ctrl:you",
+                    "includeTokens": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "FilterCollection",
+                            "from": "trigger.captured",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "creature nontoken"
+                            },
+                            "storeMatching": "kayaExiledCreatures"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "kayaExiledCreatures",
+                            "filter": {
+                                "type": "InZone",
+                                "zone": "Exile"
+                            },
+                            "storeMatching": "kayaChoosable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "kayaChoosable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "kayaCopySource",
+                            "prompt": "You may choose a creature card from among the exiled cards",
+                            "selectedLabel": "Copy"
+                        },
+                        {
+                            "type": "EachPermanentBecomesCopyOfTarget",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "kayaCopySource"
+                            },
+                            "duration": "EndOfTurn",
+                            "affected": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "sourceFromAnyZone": true,
+                            "exceptions": {
+                                "addedKeywords": [
+                                    "FLYING"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent token ctrl:you"
+                    },
+                    "id": "token you control"
+                },
+                "descriptionOverride": "Whenever one or more creatures you control and/or creature cards in your graveyard are put into exile, you may choose a creature card from among them. Until end of turn, target token you control becomes a copy of it, except it has flying."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 2
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Surveil",
+                            "count": 2
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "player": "Each"
+                            },
+                            "storeAs": "gathered1"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered1",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "kayaGraveyardExile",
+                            "prompt": "Exile a card from a graveyard",
+                            "selectedLabel": "Exile",
+                            "useTargetingUI": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kayaGraveyardExile",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true,
+                "descriptionOverride": "Surveil 2, then exile a card from a graveyard."
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE",
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "name": "Spirit",
+                    "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4588570-bde4-4c2f-8469-81a3e15fb57b.jpg?1783912607"
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -2
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 1
+                            },
+                            "destination": "Exile"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    },
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        },
+                        "id": "creature that player controls",
+                        "dynamicMaxCount": "PlayerCount",
+                        "differentControllers": true
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true,
+                "descriptionOverride": "Exile target creature you control. For each other player, exile up to one target creature that player controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "MYTHIC",
+        "artist": "Magali Villeneuve",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2827593-4951-4ba7-b73e-c27de56f2606.jpg?1783912848",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "The target token copies the printed values of the card in exile, with the noted exception. It doesn't matter if that card was a copy of something else when it was on the battlefield."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a creature card that was exiled is no longer in exile when Kaya, Spirits' Justice's first ability resolves (perhaps because of Pull from Eternity or a similar effect), you can't choose that creature card with that ability."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "You choose all targets for Kaya, Spirits' Justice's last ability."
+            }
+        ]
+    },
+    "startingLoyalty": 3,
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Kellan, Inquisitive Prodigy
 {
     "name": "Kellan, Inquisitive Prodigy",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CoreContinuations.kt
@@ -108,6 +108,13 @@ data class TriggeredAbilityContinuation(
     /** Pipeline state carried from a `ReflexiveTriggerEffect`'s action half, preserved across target
      *  selection so the stack object built on resume carries it (CR 603.12). Null otherwise. */
     val carriedPipeline: com.wingedsheep.engine.handlers.PipelineState? = null,
+    /** The objects a batch trigger captured as "the ones that caused it" (CR 603.2c), preserved
+     *  across target selection so the stack object built on resume still exposes them to the
+     *  payoff under `PipelineState.TRIGGER_CAPTURED_COLLECTION`. Without this a batch trigger that
+     *  *also* targets — "…are put into exile, you may choose a creature card from among them.
+     *  Until end of turn, **target** token you control becomes a copy of it" (Kaya, Spirits'
+     *  Justice) — resolves with an empty "them". Empty for non-batch triggers. */
+    val capturedEntityIds: List<EntityId> = emptyList(),
     /** The ability's intervening-"if" (CR 603.4), preserved across target selection so the stack
      *  object built on resume can re-check it as it resolves. See
      *  [com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent.interveningIf]. */
@@ -161,6 +168,9 @@ data class TriggerDamageDistributionContinuation(
     val totalDamage: Int,
     val lastKnownPower: Int? = null,
     val lastKnownToughness: Int? = null,
+    /** The objects a batch trigger captured (CR 603.2c), carried on through this second pause so
+     *  they reach the stack object alongside the distribution. Empty for non-batch triggers. */
+    val capturedEntityIds: List<EntityId> = emptyList(),
     /** The ability's intervening-"if" (CR 603.4), preserved across the distribution decision so the
      *  stack object built on resume can re-check it as it resolves. */
     val interveningIf: com.wingedsheep.sdk.scripting.conditions.Condition? = null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
@@ -151,7 +151,14 @@ data class TargetRequirementInfo(
      * cards with different names" (Behold the Sinister Six!). Enforced against each selected
      * target's name in [DecisionValidators.validateTargets].
      */
-    val differentNames: Boolean = false
+    val differentNames: Boolean = false,
+    /**
+     * When true, no two chosen targets for this requirement may share a controller — "for each
+     * other player, exile up to one target creature that player controls" (Kaya, Spirits'
+     * Justice). Enforced against each selected permanent's projected controller in
+     * [DecisionValidators.validateTargets].
+     */
+    val differentControllers: Boolean = false
 )
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -51,6 +51,7 @@ import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
 import com.wingedsheep.sdk.scripting.*
 import com.wingedsheep.sdk.scripting.predicates.evaluateWith
 import com.wingedsheep.sdk.scripting.events.DamageType
@@ -2120,11 +2121,21 @@ class TriggerDetector(
                 val trigger = ability.trigger
                 if (trigger !is EventPattern.CardsPutIntoExileEvent) continue
 
-                val hasMatch = exiled.any { event ->
+                // The objects that caused this firing. They are handed to the payoff as the
+                // ability's captured collection so "choose a creature card from among them" has a
+                // referent (Kaya, Spirits' Justice); an unfiltered Ketramose-style trigger simply
+                // ignores it.
+                val matchingIds = exiled.filter { event ->
                     event.fromZone in trigger.fromZones &&
-                        cardMatchesGraveyardBatchFilter(state, event.entityId, trigger.filter)
-                }
-                if (!hasMatch) continue
+                        exileBatchOwnershipMatches(event, trigger.filter, entry.controllerId) &&
+                        cardMatchesGraveyardBatchFilter(
+                            state = state,
+                            entityId = event.entityId,
+                            filter = trigger.filter,
+                            includeTokens = trigger.includeTokens
+                        )
+                }.map { it.entityId }
+                if (matchingIds.isEmpty()) continue
 
                 triggers.add(
                     PendingTrigger(
@@ -2132,10 +2143,38 @@ class TriggerDetector(
                         sourceId = entry.entityId,
                         sourceName = entry.cardComponent.name,
                         controllerId = entry.controllerId,
-                        triggerContext = TriggerContext()
+                        triggerContext = TriggerContext(capturedEntityIds = matchingIds)
                     )
                 )
             }
+        }
+    }
+
+    /**
+     * Whether the object this [event] moved into exile satisfies [filter]'s controller predicate for
+     * a trigger controlled by [observerId].
+     *
+     * The object is already in exile when this runs, so control is read from last-known information
+     * (CR 603.10) for a battlefield exit and from ownership for every other zone — a card in a
+     * graveyard, hand or library has no controller, and "creature cards in **your** graveyard" is a
+     * statement about whose graveyard it is. Predicates the exile batch can't meaningfully answer
+     * (the target-relative ones, which have no target at detection time) fall through as matching,
+     * the same way [cardMatchesGraveyardBatchFilter] treats card predicates it doesn't model.
+     */
+    private fun exileBatchOwnershipMatches(
+        event: ZoneChangeEvent,
+        filter: GameObjectFilter,
+        observerId: EntityId
+    ): Boolean {
+        val holderId = if (event.fromZone == Zone.BATTLEFIELD) {
+            event.lastKnown?.controllerId ?: event.ownerId
+        } else {
+            event.ownerId
+        }
+        return when (filter.controllerPredicate) {
+            ControllerPredicate.ControlledByYou -> holderId == observerId
+            ControllerPredicate.ControlledByOpponent -> holderId != observerId
+            else -> true
         }
     }
 
@@ -2147,14 +2186,17 @@ class TriggerDetector(
     private fun cardMatchesGraveyardBatchFilter(
         state: GameState,
         entityId: EntityId,
-        filter: GameObjectFilter
+        filter: GameObjectFilter,
+        includeTokens: Boolean = false
     ): Boolean {
         // Tokens aren't cards (CR 111.6), so a token put into a graveyard never satisfies a
         // "one or more [permanent] cards are put into your graveyard" trigger — even though it
         // momentarily occupies the graveyard zone before CR 704.5s/111.7 sweeps it away (which
-        // is also why it can still be present here at trigger-detection time).
+        // is also why it can still be present here at trigger-detection time). [includeTokens]
+        // is the opposite reading, for a trigger whose printed noun is permanents rather than
+        // cards ("one or more creatures you control … are put into exile").
         val entity = state.getEntity(entityId) ?: return false
-        if (entity.has<TokenComponent>()) return false
+        if (!includeTokens && entity.has<TokenComponent>()) return false
         if (filter == GameObjectFilter.Any) return true
         val cardComponent = entity.get<CardComponent>() ?: return false
         return filter.cardPredicates.all { predicate ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -716,7 +716,9 @@ class TriggerProcessor(
                 maxTargets = maxTargets,
                 sameOwner = (req as? com.wingedsheep.sdk.scripting.targets.TargetObject)?.sameOwner == true,
                 totalManaValueAtMost = resolveTotalManaValueAtMost(state, trigger, req),
-                differentNames = (req as? com.wingedsheep.sdk.scripting.targets.TargetObject)?.differentNames == true
+                differentNames = (req as? com.wingedsheep.sdk.scripting.targets.TargetObject)?.differentNames == true,
+                differentControllers =
+                    (req as? com.wingedsheep.sdk.scripting.targets.TargetObject)?.differentControllers == true
             )
         }
 
@@ -816,6 +818,7 @@ class TriggerProcessor(
             triggerXValueOfTriggeringSpell = trigger.triggerContext.xValueOfTriggeringSpell,
             xValue = trigger.triggerContext.xValue,
             carriedPipeline = trigger.carriedPipeline,
+            capturedEntityIds = trigger.triggerContext.capturedEntityIds ?: emptyList(),
             interveningIf = ability.interveningIf
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -431,6 +431,11 @@ class DynamicAmountEvaluator(
                 else evaluate(state, amount.ifFalse, context, projectedState)
             }
 
+            // "For each opponent" / "for each other player" — how many players the scope names.
+            // resolveUnifiedPlayerIds already yields only players still in the game, so a pod that
+            // has lost a player reports the live number (CR 800.4a).
+            is DynamicAmount.PlayerCount -> resolveUnifiedPlayerIds(state, amount.scope, context).size
+
             is DynamicAmount.CountPlayersWith -> {
                 val eval = conditionEvaluator ?: ConditionEvaluator()
                 val playerIds = resolveUnifiedPlayerIds(state, amount.scope, context)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/DecisionValidators.kt
@@ -41,6 +41,7 @@ import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.core.YesNoResponse
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.sdk.model.EntityId
 
@@ -232,6 +233,18 @@ object DecisionValidators {
                     }
                     if (names.size != names.toSet().size) {
                         return "Targets for requirement $reqIndex must have different names"
+                    }
+                }
+                // "For each other player, ... up to one target creature that player controls" — no
+                // two chosen targets may share a controller (Kaya, Spirits' Justice). TargetValidator
+                // is authoritative; this rejects it interactively too.
+                if (req.differentControllers && selectedIds.size > 1 && state != null) {
+                    val controllers = selectedIds.map { id ->
+                        state.projectedState.getController(id)
+                            ?: state.getEntity(id)?.get<ControllerComponent>()?.playerId
+                    }
+                    if (controllers.size != controllers.toSet().size) {
+                        return "Targets for requirement $reqIndex must be controlled by different players"
                     }
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -196,6 +196,10 @@ class EffectAndTriggerContinuationResumer(
             triggerXValueOfTriggeringSpell = continuation.triggerXValueOfTriggeringSpell,
             xValue = continuation.xValue,
             carriedPipeline = continuation.carriedPipeline,
+            // A batch trigger's captured objects survive the target-selection pause, so a payoff
+            // that says "from among them" still finds them (CR 603.2c) — Kaya, Spirits' Justice
+            // is a batch trigger that also targets.
+            capturedEntityIds = continuation.capturedEntityIds,
             interveningIf = continuation.interveningIf
         )
 
@@ -269,6 +273,7 @@ class EffectAndTriggerContinuationResumer(
             selectedTargets = selectedTargets,
             targetRequirements = continuation.targetRequirements,
             totalDamage = totalDamage,
+            capturedEntityIds = continuation.capturedEntityIds,
             interveningIf = continuation.interveningIf
         )
 
@@ -322,6 +327,7 @@ class EffectAndTriggerContinuationResumer(
             lastKnownPower = continuation.lastKnownPower,
             lastKnownToughness = continuation.lastKnownToughness,
             damageDistribution = response.distribution,
+            capturedEntityIds = continuation.capturedEntityIds,
             interveningIf = continuation.interveningIf
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -260,6 +260,21 @@ class TargetValidator {
                     return "Targets must have different names"
                 }
             }
+
+            // "For each other player, ... up to one target creature that player controls" — no two
+            // chosen targets for this requirement may share a controller (Kaya, Spirits' Justice).
+            // CR 601.2c. Read from projected state so a control-change effect is respected.
+            if (requirement is TargetObject && requirement.differentControllers && targetsForReq.size > 1) {
+                val controllers = targetsForReq.map { target ->
+                    (target as? ChosenTarget.Permanent)?.entityId?.let { id ->
+                        state.projectedState.getController(id)
+                            ?: state.getEntity(id)?.get<ControllerComponent>()?.playerId
+                    }
+                }
+                if (controllers.size != controllers.toSet().size) {
+                    return "Targets must be controlled by different players"
+                }
+            }
         }
 
         return null

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/targeting/OneTargetPerOtherPlayerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/targeting/OneTargetPerOtherPlayerTest.kt
@@ -1,0 +1,154 @@
+package com.wingedsheep.engine.targeting
+
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.legalactions.utils.TargetEnumerationUtils
+import com.wingedsheep.engine.mechanics.targeting.TargetValidator
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine coverage for the "one per other player" distribution shape —
+ * "For each other player, exile **up to one** target creature that player controls"
+ * (Kaya, Spirits' Justice's −2).
+ *
+ * It is spelled as three orthogonal knobs on one [TargetCreature] requirement rather than a bespoke
+ * type, and this test pins each one:
+ *
+ *  - `dynamicMaxCount = DynamicAmount.PlayerCount(Player.EachOpponent)` — how many players are in
+ *    scope, resolved from the live table;
+ *  - `differentControllers = true` — at most one creature each;
+ *  - `optional = true` — the "up to", so hitting fewer than the maximum is legal.
+ *
+ * CR 601.2c chooses all of a spell or ability's targets together, and the card's own ruling says
+ * "You choose all targets for Kaya, Spirits' Justice's last ability."
+ */
+class OneTargetPerOtherPlayerTest : FunSpec({
+
+    val bear = card("Per Player Target Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    /** The −2's second requirement, exactly as the card declares it. */
+    val perOtherPlayer = TargetCreature(
+        filter = TargetFilter.CreatureOpponentControls,
+        optional = true,
+        dynamicMaxCount = DynamicAmount.PlayerCount(Player.EachOpponent),
+        differentControllers = true,
+        id = "one target creature each other player controls",
+    )
+
+    fun driverWith(seats: Int): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(bear))
+        driver.initMultiplayer(decks = List(seats) { Deck.of("Forest" to 40) })
+        return driver
+    }
+
+    context("DynamicAmount.PlayerCount") {
+
+        test("counts the opponents at the table, not the whole table") {
+            val fourSeats = driverWith(4)
+            val evaluator = DynamicAmountEvaluator()
+            val context = EffectContext(sourceId = null, controllerId = fourSeats.player1)
+
+            withClue("three other players in a four-player game") {
+                evaluator.evaluate(
+                    fourSeats.state,
+                    DynamicAmount.PlayerCount(Player.EachOpponent),
+                    context,
+                ) shouldBe 3
+            }
+            withClue("Player.Each counts you as well") {
+                evaluator.evaluate(
+                    fourSeats.state,
+                    DynamicAmount.PlayerCount(Player.Each),
+                    context,
+                ) shouldBe 4
+            }
+        }
+
+        test("a two-player game leaves exactly one target available") {
+            val heads = driverWith(2)
+            DynamicAmountEvaluator().evaluate(
+                heads.state,
+                DynamicAmount.PlayerCount(Player.EachOpponent),
+                EffectContext(sourceId = null, controllerId = heads.player1),
+            ) shouldBe 1
+        }
+    }
+
+    context("the requirement's resolved cap") {
+
+        test("the enumerator caps the requirement at the number of other players") {
+            val driver = driverWith(3)
+            val seats = driver.state.activePlayers
+            seats.drop(1).forEach { driver.putCreatureOnBattlefield(it, "Per Player Target Bear") }
+
+            val info = TargetEnumerationUtils(PredicateEvaluator())
+                .buildTargetInfos(driver.state, driver.player1, listOf(perOtherPlayer))
+                .single()
+
+            withClue("two opponents => up to two targets") { info.maxTargets shouldBe 2 }
+            withClue("\"up to\" means picking none is legal") { info.minTargets shouldBe 0 }
+        }
+    }
+
+    context("differentControllers (CR 601.2c)") {
+
+        fun validate(driver: GameTestDriver, targets: List<ChosenTarget>) =
+            TargetValidator().validateTargets(
+                state = driver.state,
+                targets = targets,
+                requirements = listOf(perOtherPlayer),
+                casterId = driver.player1,
+            )
+
+        test("one creature from each of two opponents is legal") {
+            val driver = driverWith(3)
+            val seats = driver.state.activePlayers
+            val first = driver.putCreatureOnBattlefield(seats[1], "Per Player Target Bear")
+            val second = driver.putCreatureOnBattlefield(seats[2], "Per Player Target Bear")
+
+            validate(driver, listOf(ChosenTarget.Permanent(first), ChosenTarget.Permanent(second)))
+                .shouldBeNull()
+        }
+
+        test("two creatures the SAME player controls is rejected") {
+            val driver = driverWith(3)
+            val seats = driver.state.activePlayers
+            val one = driver.putCreatureOnBattlefield(seats[1], "Per Player Target Bear")
+            val two = driver.putCreatureOnBattlefield(seats[1], "Per Player Target Bear")
+
+            withClue("\"up to one ... that player controls\" is one per player, not two from one") {
+                validate(driver, listOf(ChosenTarget.Permanent(one), ChosenTarget.Permanent(two)))
+                    .shouldNotBeNull()
+            }
+        }
+
+        test("a single target is always fine, and so is none") {
+            val driver = driverWith(3)
+            val seats = driver.state.activePlayers
+            val only = driver.putCreatureOnBattlefield(seats[1], "Per Player Target Bear")
+
+            validate(driver, listOf(ChosenTarget.Permanent(only))).shouldBeNull()
+            validate(driver, emptyList()).shouldBeNull()
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/triggers/CardsPutIntoExileBatchTriggerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/triggers/CardsPutIntoExileBatchTriggerTest.kt
@@ -1,0 +1,254 @@
+package com.wingedsheep.engine.triggers
+
+import com.wingedsheep.engine.core.ZoneChangeEvent
+import com.wingedsheep.engine.event.TriggerDetector
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.components.stack.EntitySnapshot
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine coverage for the exile batch trigger — `EventPattern.CardsPutIntoExileEvent`, detected by
+ * `TriggerDetector.detectCardsPutIntoExileBatchTriggers`.
+ *
+ * Two observers are built from the same pattern so every case asserts both readings side by side:
+ *
+ *  - the **unscoped** one, Ketramose, the New Dawn's "whenever one or more **cards** are put into
+ *    exile from graveyards and/or the battlefield" — anyone's cards, tokens excluded (CR 111.6:
+ *    a token isn't a card);
+ *  - the **scoped, token-inclusive** one, Kaya, Spirits' Justice's "whenever one or more
+ *    **creatures you control** and/or **creature cards in your graveyard** are put into exile" —
+ *    where the battlefield noun is *creatures*, so a token counts, and both arms are narrowed to
+ *    one player.
+ *
+ * CR 603.2c: both fire at most once per batch, however many objects moved.
+ *
+ * The detector is driven directly with synthesized [ZoneChangeEvent]s, which is the shape
+ * `ZoneTransitionService` emits — a battlefield exit carries the `lastKnown` snapshot with the
+ * controller frozen at the moment it left (CR 603.10), and every exit carries `ownerId`.
+ */
+class CardsPutIntoExileBatchTriggerTest : FunSpec({
+
+    // Ketramose's reading: any card, from any graveyard or anyone's battlefield.
+    val anyCardObserver = card("Any Card Exile Observer") {
+        manaCost = "{0}"
+        typeLine = "Creature — Human Cleric"
+        power = 0
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.CardsPutIntoExile()
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    // Kaya's reading: creatures *you control* and/or creature cards in *your* graveyard, tokens included.
+    val yourCreaturesObserver = card("Your Creatures Exile Observer") {
+        manaCost = "{0}"
+        typeLine = "Creature — Human Cleric"
+        power = 0
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.CardsPutIntoExile(
+                fromZones = setOf(Zone.BATTLEFIELD, Zone.GRAVEYARD),
+                filter = GameObjectFilter.Creature.youControl(),
+                includeTokens = true,
+            )
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    val bear = card("Exile Batch Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    val relic = card("Exile Batch Relic") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(anyCardObserver, yourCreaturesObserver, bear, relic)
+        )
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        return driver
+    }
+
+    /** A battlefield → exile move, carrying the last-known controller the way a real exit does. */
+    fun exiledFromBattlefield(entityId: EntityId, controllerId: EntityId, ownerId: EntityId) =
+        ZoneChangeEvent(
+            entityId = entityId,
+            entityName = "",
+            fromZone = Zone.BATTLEFIELD,
+            toZone = Zone.EXILE,
+            ownerId = ownerId,
+            lastKnown = EntitySnapshot(entityId = entityId, controllerId = controllerId),
+        )
+
+    /** A graveyard → exile move. Graveyard cards have no controller — ownership is the whole scope. */
+    fun exiledFromGraveyard(entityId: EntityId, ownerId: EntityId) =
+        ZoneChangeEvent(
+            entityId = entityId,
+            entityName = "",
+            fromZone = Zone.GRAVEYARD,
+            toZone = Zone.EXILE,
+            ownerId = ownerId,
+        )
+
+    fun exileTriggersOf(driver: GameTestDriver, events: List<ZoneChangeEvent>, sourceId: EntityId) =
+        TriggerDetector(driver.cardRegistry)
+            .detectTriggers(driver.state, events)
+            .filter { it.ability.trigger is EventPattern.CardsPutIntoExileEvent && it.sourceId == sourceId }
+
+    context("controller and owner scoping") {
+
+        test("a creature you control leaving the battlefield fires the scoped trigger") {
+            val driver = createDriver()
+            val observer = driver.putCreatureOnBattlefield(driver.player1, "Your Creatures Exile Observer")
+            val mine = driver.putCreatureOnBattlefield(driver.player1, "Exile Batch Bear")
+
+            val triggers = exileTriggersOf(
+                driver,
+                listOf(exiledFromBattlefield(mine, driver.player1, driver.player1)),
+                observer,
+            )
+            triggers shouldHaveSize 1
+        }
+
+        test("a creature an OPPONENT controls does not fire the scoped trigger, but does fire the unscoped one") {
+            val driver = createDriver()
+            val scoped = driver.putCreatureOnBattlefield(driver.player1, "Your Creatures Exile Observer")
+            val unscoped = driver.putCreatureOnBattlefield(driver.player1, "Any Card Exile Observer")
+            val theirs = driver.putCreatureOnBattlefield(driver.player2, "Exile Batch Bear")
+
+            val events = listOf(exiledFromBattlefield(theirs, driver.player2, driver.player2))
+
+            withClue("\"creatures you control\" is not satisfied by the opponent's creature") {
+                exileTriggersOf(driver, events, scoped) shouldHaveSize 0
+            }
+            withClue("Ketramose's wording watches every battlefield") {
+                exileTriggersOf(driver, events, unscoped) shouldHaveSize 1
+            }
+        }
+
+        test("a creature card in YOUR graveyard fires; one in an opponent's graveyard does not") {
+            val driver = createDriver()
+            val observer = driver.putCreatureOnBattlefield(driver.player1, "Your Creatures Exile Observer")
+            val mine = driver.putCardInGraveyard(driver.player1, "Exile Batch Bear")
+            val theirs = driver.putCardInGraveyard(driver.player2, "Exile Batch Bear")
+
+            withClue("ownership is what \"in your graveyard\" means") {
+                exileTriggersOf(driver, listOf(exiledFromGraveyard(mine, driver.player1)), observer) shouldHaveSize 1
+                exileTriggersOf(driver, listOf(exiledFromGraveyard(theirs, driver.player2)), observer) shouldHaveSize 0
+            }
+        }
+
+        test("a noncreature card you own does not fire a creature-scoped trigger") {
+            val driver = createDriver()
+            val observer = driver.putCreatureOnBattlefield(driver.player1, "Your Creatures Exile Observer")
+            val artifact = driver.putCardInGraveyard(driver.player1, "Exile Batch Relic")
+
+            exileTriggersOf(driver, listOf(exiledFromGraveyard(artifact, driver.player1)), observer) shouldHaveSize 0
+        }
+    }
+
+    context("tokens (CR 111.6 / 111.7)") {
+
+        test("a token creature you control fires the token-inclusive trigger but never the card one") {
+            val driver = createDriver()
+            val scoped = driver.putCreatureOnBattlefield(driver.player1, "Your Creatures Exile Observer")
+            val unscoped = driver.putCreatureOnBattlefield(driver.player1, "Any Card Exile Observer")
+            val token = driver.putCreatureOnBattlefield(driver.player1, "Exile Batch Bear")
+            driver.replaceState(driver.state.updateEntity(token) { it.with(TokenComponent) })
+
+            val events = listOf(exiledFromBattlefield(token, driver.player1, driver.player1))
+
+            withClue("\"creatures you control\" counts a token creature like any other creature") {
+                exileTriggersOf(driver, events, scoped) shouldHaveSize 1
+            }
+            withClue("a token is not a card (CR 111.6), so the \"cards\" wording ignores it") {
+                exileTriggersOf(driver, events, unscoped) shouldHaveSize 0
+            }
+        }
+    }
+
+    context("batching and capture (CR 603.2c)") {
+
+        test("several matching objects in one batch fire the trigger once and are all captured") {
+            val driver = createDriver()
+            val observer = driver.putCreatureOnBattlefield(driver.player1, "Your Creatures Exile Observer")
+            val onBoard = driver.putCreatureOnBattlefield(driver.player1, "Exile Batch Bear")
+            val inYard = driver.putCardInGraveyard(driver.player1, "Exile Batch Bear")
+
+            val triggers = exileTriggersOf(
+                driver,
+                listOf(
+                    exiledFromBattlefield(onBoard, driver.player1, driver.player1),
+                    exiledFromGraveyard(inYard, driver.player1),
+                ),
+                observer,
+            )
+
+            triggers shouldHaveSize 1
+            withClue("\"from among them\" is the captured batch — both arms of the and/or") {
+                triggers.single().triggerContext.capturedEntityIds
+                    .shouldContainExactlyInAnyOrder(listOf(onBoard, inYard))
+            }
+        }
+
+        test("the capture holds only the matching objects, not the whole batch") {
+            val driver = createDriver()
+            val observer = driver.putCreatureOnBattlefield(driver.player1, "Your Creatures Exile Observer")
+            val mine = driver.putCreatureOnBattlefield(driver.player1, "Exile Batch Bear")
+            val theirs = driver.putCreatureOnBattlefield(driver.player2, "Exile Batch Bear")
+            val myRelic = driver.putCardInGraveyard(driver.player1, "Exile Batch Relic")
+
+            val triggers = exileTriggersOf(
+                driver,
+                listOf(
+                    exiledFromBattlefield(mine, driver.player1, driver.player1),
+                    exiledFromBattlefield(theirs, driver.player2, driver.player2),
+                    exiledFromGraveyard(myRelic, driver.player1),
+                ),
+                observer,
+            )
+
+            triggers shouldHaveSize 1
+            withClue("only your creature is choosable from among them") {
+                triggers.single().triggerContext.capturedEntityIds shouldBe listOf(mine)
+            }
+        }
+
+        test("a move out of an unwatched zone does not fire it") {
+            val driver = createDriver()
+            val observer = driver.putCreatureOnBattlefield(driver.player1, "Your Creatures Exile Observer")
+            val inHand = driver.putCardInHand(driver.player1, "Exile Batch Bear")
+
+            val fromHand = ZoneChangeEvent(
+                entityId = inHand,
+                entityName = "",
+                fromZone = Zone.HAND,
+                toZone = Zone.EXILE,
+                ownerId = driver.player1,
+            )
+            exileTriggersOf(driver, listOf(fromHand), observer) shouldHaveSize 0
+        }
+    }
+})

--- a/web-client/src/components/draft/SetSynergiesOverlay.tsx
+++ b/web-client/src/components/draft/SetSynergiesOverlay.tsx
@@ -482,6 +482,83 @@ const SET_SYNERGIES: Record<string, SetSynergies> = {
       },
     ],
   },
+  MKM: {
+    setCode: 'MKM',
+    setName: 'Murders at Karlov Manor',
+    archetypes: [
+      {
+        name: 'Detectives',
+        colors: ['W', 'U'],
+        creatureTypes: ['Detective'],
+        keyCard: 'Private Eye',
+        description:
+          "Field a squad of Detectives, turn Clues into cards, and ride the format's best evasive bodies. A tempo-value deck that never runs out of gas.",
+      },
+      {
+        name: 'Surveil',
+        colors: ['U', 'B'],
+        keyCard: 'Curious Cadaver',
+        description:
+          'Surveil to fix your draws and stock your graveyard, then take over with cheap interaction and recursive threats. A grindy control deck that wins the long game.',
+      },
+      {
+        name: 'Sacrifice',
+        colors: ['B', 'R'],
+        keyCard: 'Rune-Brand Juggler',
+        description:
+          'Suspect your own creatures to push damage, then sacrifice them for value before the drawback bites. An aggressive deck that turns every body into reach.',
+      },
+      {
+        name: 'Disguise',
+        colors: ['R', 'G'],
+        keyCard: 'Tin Street Gossip',
+        description:
+          'Deploy face-down 2/2s early and flip them at the perfect moment for a blowout. A midrange deck that turns every attack into a guessing game.',
+      },
+      {
+        name: 'Face-Down Counters',
+        colors: ['G', 'W'],
+        keyCard: 'Sumala Sentry',
+        description:
+          'Cloak and disguise creatures, then cash in the turn-up triggers for +1/+1 counters. A go-tall midrange deck that snowballs off every flip.',
+      },
+      {
+        name: 'Small Creatures',
+        colors: ['W', 'B'],
+        keyCard: 'Wispdrinker Vampire',
+        description:
+          'Flood the board with cheap creatures with power 2 or less and drain the opponent with the payoffs that count them. A wide, incremental aggro deck.',
+      },
+      {
+        name: 'Artifacts',
+        colors: ['U', 'R'],
+        keyCard: 'Gleaming Geardrake',
+        description:
+          'Investigate for Clues, then sacrifice artifacts to trigger payoffs and refuel. An artifact-fueled tempo deck that converts leftovers into damage.',
+      },
+      {
+        name: 'Graveyard',
+        colors: ['B', 'G'],
+        keyCard: 'Insidious Roots',
+        description:
+          'Fill your graveyard and spend it — collect evidence, recur creature cards, and out-attrition the table. A resilient midrange deck with a deep back end.',
+      },
+      {
+        name: 'Go Wide Aggro',
+        colors: ['R', 'W'],
+        keyCard: 'Meddling Youths',
+        description:
+          "Attack with three or more creatures every turn to switch on the format's go-wide payoffs. The fastest deck in the format, backed by burn.",
+      },
+      {
+        name: 'Collect Evidence',
+        colors: ['G', 'U'],
+        keyCard: 'Evidence Examiner',
+        description:
+          'Bank cards in your graveyard, collect evidence to unlock discounted spells, and grow a threat with +1/+1 counters. A ramp-value deck that plays the biggest spells.',
+      },
+    ],
+  },
   OTJ: {
     setCode: 'OTJ',
     setName: 'Outlaws of Thunder Junction',


### PR DESCRIPTION
The last card in Murders at Karlov Manor, the two engine capabilities it needed, and the set-completion bookkeeping.

## Kaya, Spirits' Justice

```
{2}{W}{B}  Legendary Planeswalker — Kaya  (3)

Whenever one or more creatures you control and/or creature cards in your graveyard are put into
exile, you may choose a creature card from among them. Until end of turn, target token you control
becomes a copy of it, except it has flying.
+2: Surveil 2, then exile a card from a graveyard.
+1: Create a 1/1 white and black Spirit creature token with flying.
−2: Exile target creature you control. For each other player, exile up to one target creature that
    player controls.
```

Most of her is existing vocabulary. The +2 is **Lazav, Familiar Stranger**'s surveil-then-exile-from-a-graveyard pipeline verbatim; the copy is **Likeness Looter**'s `EachPermanentBecomesCopyOfTarget(sourceFromAnyZone = true, exceptions = CopyExceptions(addedKeywords = FLYING))`; the Spirit token already existed on Teysa, Opulent Oligarch. Two things did not exist.

## Engine

### The exile batch trigger is now scopable, and captures its batch

`CardsPutIntoExileEvent` previously shipped for Ketramose, the New Dawn — "one or more **cards** are put into exile from graveyards and/or the battlefield", anyone's. Kaya reads the same event three ways Ketramose doesn't:

- **Its filter's controller predicate was silently dropped.** It is now honored, and read *per zone*: a battlefield exit tests the permanent's **last known controller** (CR 603.10 — it's already in exile by detection time), every other zone tests the card's **owner**, because a graveyard/hand/library card has no controller. One filter therefore spells both arms of "creatures **you control** and/or creature cards in **your** graveyard".
- **The matching objects are captured** into `TRIGGER_CAPTURED_COLLECTION`, which is what a printed "from among **them**" refers to. `PipelineBuilder.triggerCaptured` is the typed handle for that engine-seeded slot.
- **`includeTokens`** flips the CR 111.6 token exclusion. The axis is the printed noun, not a convenience: "one or more **cards**" never counts a token; "one or more **creatures you control**" counts a token creature like any other. CR 111.7 ("applicable triggered abilities will trigger before the token ceases to exist") is what makes that reading detectable at all — and also why the token is gone from the collection by resolution, so it can never be chosen as a *card*.

**Bug found on the way:** a batch trigger that *also targets* lost its captured collection while it paused to choose targets, so "them" resolved empty. `TriggeredAbilityContinuation` now carries `capturedEntityIds` through the target-selection and damage-distribution hops. No shipped card hit this — Kambal, Hedge Shredder, Paranormal Analyst and The Millennium Calendar are all untargeted batch payoffs, and Kaya is the first that is both.

### "For each other player, … up to one target creature that player controls"

Three orthogonal knobs on one requirement rather than a new requirement type:

| knob | says |
|---|---|
| `dynamicMaxCount = DynamicAmount.PlayerCount(Player.EachOpponent)` | how many players are in scope |
| `differentControllers = true` | at most one creature each |
| `optional = true` | the "up to" |

`differentControllers` is the exact inverse of the existing `sameController`, grouped by *projected* controller so a control-change effect is respected, and enforced at every site `differentNames` already is — `TargetValidator` (authoritative) plus `DecisionValidators` on the interactive path. `PlayerCount` is the unconditional sibling of `CountPlayersWith`, counting only players still in the game.

Also adds `Targets.TokenYouControl` — any token permanent, not just a creature token, so a Clue or a Treasure can become a creature.

### Scope note

"Each other player" and "each opponent" name the same set outside team play, so `Player.EachOpponent` is used. In Two-Headed Giant a teammate is an "other player" but not an opponent; `PlayerCount`'s scope is a parameter, so a future team-aware player reference is a one-word change on the card. Adding one now would mean a branch in each of the 21 engine files that dispatch on `Player`, which is the fallthrough shape most likely to be got wrong for a format whose client and AI support is itself still open.

## Set completion

MKM is **276/276**. `incomplete = true` → `sealedSupported = true`, which is the flag that puts a set in the draft/sealed deckbuilder — `SetCoverageServiceTest`'s "complete sets still flagged incomplete" assertion is what demanded it once Kaya landed.

Ten guild archetypes added, keyed off the set's gold signpost uncommons, to **both** halves that must stay in lockstep — `SetArchetypes.kt` (backend source of truth, consumed by the AI deckbuilder and `GET /api/sets/{code}/archetypes`) and `SetSynergiesOverlay.tsx` (the deckbuilder's filter/highlight):

WU Detectives · UB Surveil · BR Sacrifice · RG Disguise · GW Face-Down Counters · WB Small Creatures · UR Artifacts · BG Graveyard · RW Go Wide Aggro · GU Collect Evidence

## Verification

`just build` green (full compile + every module's tests, including `FacadeBoundaryTest` and the card snapshots) and `just check` green. New tests:

- `CardsPutIntoExileBatchTriggerTest` (8) — controller/owner scoping per zone, the token axis asserted against a Ketramose-style observer side by side, batching and what the capture holds.
- `OneTargetPerOtherPlayerTest` (6) — `PlayerCount` at 2/3/4 seats, the enumerator's resolved cap, and `differentControllers` accepting one-each while rejecting two-from-one.
- `KayaSpiritsJusticeScenarioTest` (5) — the +1 token, the −2 into the copy trigger (also the regression for the dropped capture), opponent-creature scoping, declining the "you may", and the +2 arm.

The web-client change is a data-only addition to a typed `Record` mirroring the existing OTJ/DSK entries; `node_modules` isn't installed in this worktree, so its typecheck is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
