### PR TITLE
Stop the AI looping on a free redundant Equip activation

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/StateProgress.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/StateProgress.kt
@@ -1,11 +1,13 @@
 package com.wingedsheep.ai.engine
 
+import com.wingedsheep.engine.state.Component
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.AbilityActivatedEverComponent
 import com.wingedsheep.engine.state.components.battlefield.AbilityActivatedThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.HasBecomeTappedComponent
 import com.wingedsheep.engine.state.components.battlefield.TargetedByControllerThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.TimestampComponent
+import com.wingedsheep.engine.state.components.player.EquipActivationsThisTurnComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.model.GameRng
@@ -133,7 +135,7 @@ object StateProgress {
         for (component in container.all()) {
             val type = component::class.java
             if (type in IGNORED_COMPONENTS) continue
-            components += type.name.hashCode().toLong().mix(component.hashCode())
+            components += type.name.hashCode().toLong().mix(saturated(component).hashCode())
         }
         return entityId.hashCode().toLong().mix(components)
     }
@@ -171,6 +173,40 @@ object StateProgress {
         HasBecomeTappedComponent::class.java,
         TimestampComponent::class.java,
     )
+
+    /**
+     * The half-measure between counting a component and ignoring it: a tally whose readers only
+     * ever ask "any yet?", clamped to `0` or `1` so its second and later increments are not a new
+     * position.
+     *
+     * [IGNORED_COMPONENTS] is too blunt for [EquipActivationsThisTurnComponent]. Its `0 -> 1` step
+     * is a game fact — Forge Anew's "you may pay {0} rather than pay the equip cost the first time
+     * you activate an equip ability each turn" is exactly that boundary, and dropping the component
+     * would tell the AI that using up the free equip changed nothing. Its `1 -> 2 -> 3 -> ...`
+     * steps are not: `CastPermissionUtils.applyFreeFirstEquipDiscount` is the component's only
+     * reader and it tests `count == 0`, so nothing in the game can distinguish a second equip
+     * activation from a third. Clamping keeps the boundary and discards the rest.
+     *
+     * Which is what closes the loop this was written for. Equip's target is "target creature you
+     * control" (CR 702.6a) with no exclusion for the creature the Equipment is already on, and
+     * re-attaching it there "does nothing" (CR 701.3b) — so the activation is inert by rule. Put it
+     * on a board that reduces the cost to {0} (The Hobbit's Dwarven Mauler discounting equip
+     * abilities aimed at itself) and it is free as well, leaving nothing behind but this tally.
+     * Under the unclamped count every repetition hashed as a fresh position, so [Strategist] had
+     * nothing to refuse and an evaluator that preferred holding priority activated equip until the
+     * game had to be abandoned. Equip stays legal — this is the AI declining a line, not the rules
+     * forbidding one.
+     *
+     * `ExhaustAbilitiesActivatedThisTurnComponent` is the same activation-counter shape and is
+     * deliberately *not* here: `PlayerActivatedExhaustAbilitiesThisTurn` carries an `atLeast`
+     * threshold, so a card may yet ask whether the count reached two, and an exhaust ability can
+     * only be activated once per permanent anyway (CR 702.177a) — there is no loop for it to feed.
+     */
+    private fun saturated(component: Component): Component = when (component) {
+        is EquipActivationsThisTurnComponent ->
+            if (component.count > 1) component.copy(count = 1) else component
+        else -> component
+    }
 
     private const val SEED = -0x340d631b7bdddcdbL
 }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/LoopingActionAiTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/LoopingActionAiTest.kt
@@ -11,10 +11,15 @@ import com.wingedsheep.engine.core.PassPriority
 import com.wingedsheep.engine.legalactions.LegalAction
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.player.EquipActivationsThisTurnComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.DwarvenMauler
+import com.wingedsheep.mtg.sets.definitions.hob.cards.WellWornSpatula
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import io.kotest.assertions.withClue
@@ -170,6 +175,64 @@ class LoopingActionAiTest : FunSpec({
         // the whole cycle. The only other option, untapping itself, changes nothing at all.
         val reply = chooseFor(strategist, registry, afterOpening, ai)
         reply.actionType shouldBe "PassPriority"
+    }
+
+    test("the AI stops re-equipping the creature the Equipment is already attached to") {
+        // Reported from an AI-vs-AI draft tournament: Well-Worn Spatula activated its Equip over
+        // and over while already attached to Dwarven Mauler. Equip may legally target the creature
+        // the Equipment is on (CR 702.6a names no exception) and re-attaching it there does nothing
+        // (CR 701.3b) — and the Mauler's own "equip abilities you activate that target this
+        // creature cost {2} less" takes the Spatula's Equip {1} down to {0}, so the no-op is free
+        // as well as inert. The only trace it left was the per-turn equip tally, which the digest
+        // used to read raw; every repetition therefore hashed as a fresh position.
+        val cards = TestCards.all + WellWornSpatula + DwarvenMauler
+        val registry = CardRegistry().apply { register(cards) }
+        val driver = GameTestDriver()
+        driver.registerCards(cards)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val ai = driver.activePlayer!!
+
+        // Equip is sorcery-speed, so unlike the Alchemist cases this has to be the AI's own main
+        // phase. Both hands are emptied so pass and the equip are the only things on offer —
+        // otherwise `stepPreferring` is just as happy playing a land, and the assertion below
+        // would pass for the wrong reason.
+        driver.replaceState(
+            driver.state.copy(
+                zones = driver.state.zones.mapValues { (key, contents) ->
+                    if (key.zoneType == Zone.HAND) emptyList() else contents
+                }
+            )
+        )
+        val mauler = driver.putCreatureOnBattlefield(ai, "Dwarven Mauler")
+        val spatula = driver.putPermanentOnBattlefield(ai, "Well-Worn Spatula")
+        val equipId = WellWornSpatula.activatedAbilities.first().id
+        fun equip() = ActivateAbility(ai, spatula, equipId, targets = listOf(ChosenTarget.Permanent(mauler)))
+
+        // Attaching it the first time is real progress, and free — which is the whole setup.
+        driver.submitSuccess(equip())
+        driver.bothPass()
+        driver.state.getEntity(spatula)?.get<AttachedToComponent>()?.targetId shouldBe mauler
+        driver.state.step shouldBe Step.PRECOMBAT_MAIN
+
+        val simulator = GameSimulator(registry)
+        val here = StateProgress.digest(driver.state)
+
+        withClue("the redundant equip is still offered — this fixes the AI, not the rules") {
+            simulator.getLegalActions(driver.state, ai)
+                .any { (it.action as? ActivateAbility)?.sourceId == spatula } shouldBe true
+        }
+        val again = simulator.simulate(driver.state, equip()).state
+        withClue("and activating it lands back on the position it started from") {
+            StateProgress.digest(again) shouldBe here
+        }
+        withClue("the engine still counts it — Forge Anew's free-first-equip depends on that") {
+            again.getEntity(ai)?.get<EquipActivationsThisTurnComponent>()?.count shouldBe 2
+        }
+
+        // So the AI passes, even though the evaluator would rather stay in this step forever.
+        val strategist = strategistFor(registry, Step.PRECOMBAT_MAIN)
+        chooseFor(strategist, registry, driver.state, ai).actionType shouldBe "PassPriority"
     }
 })
 

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/StateProgressTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/StateProgressTest.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.ai.engine
 
 import com.wingedsheep.engine.state.components.battlefield.HasBecomeTappedComponent
 import com.wingedsheep.engine.state.components.battlefield.TargetedByControllerThisTurnComponent
+import com.wingedsheep.engine.state.components.player.EquipActivationsThisTurnComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.DayNight
@@ -103,6 +104,25 @@ class StateProgressTest : FunSpec({
             }
             StateProgress.digest(targeted) shouldBe here
         }
+    }
+
+    test("the equip tally counts its first activation and then stops counting") {
+        // The one component that is neither read in full nor ignored wholesale, because its
+        // readers only ask "any yet?": `CastPermissionUtils.applyFreeFirstEquipDiscount` tests
+        // `count == 0`, so 0 -> 1 spends Forge Anew's free equip for the turn and is a game fact,
+        // while 1 -> 2 -> 3 is bookkeeping no card can see. Reading the raw count is what let a
+        // free equip aimed at the creature the Equipment was already on hash as a fresh position
+        // every time round, which is the loop `saturated` exists to close.
+        val base = state()
+        val you = base.turnOrder[0]
+        fun withEquips(count: Int) =
+            base.updateEntity(you) { it.with(EquipActivationsThisTurnComponent(count)) }
+
+        val none = StateProgress.digest(withEquips(0))
+        val once = StateProgress.digest(withEquips(1))
+        withClue("spending the turn's first equip is a change") { once shouldNotBe none }
+        withClue("a second equip activation is not") { StateProgress.digest(withEquips(2)) shouldBe once }
+        withClue("nor a third") { StateProgress.digest(withEquips(3)) shouldBe once }
     }
 
     test("turn and step are part of the position, so a digest can only recur inside one window") {


### PR DESCRIPTION
Fixes #1981.

## The loop

Equip's target is "target creature you control" (CR 702.6a) with no exclusion for the creature the Equipment is already attached to, and re-attaching it there "does nothing" (CR 701.3b). Put that on a board where the activation is also free — The Hobbit's **Dwarven Mauler** discounts equip abilities that target it by `{2}`, taking **Well-Worn Spatula**'s `Equip {1}` down to `{0}` — and the whole activation leaves nothing behind but the per-turn equip tally.

`StateProgress.digest` read that tally raw. `EquipActivationsThisTurnComponent.count` going `1 -> 2 -> 3 -> ...` made an otherwise identical position hash differently every time, so `Strategist` had no repetition to refuse. An evaluator that prefers holding priority over letting the next step happen then re-equipped forever — which is what the reported AI-vs-AI draft game hit.

## The fix

Clamp the component to `0`-or-`1` for the digest, rather than adding it to `IGNORED_COMPONENTS`:

- `0 -> 1` **is** a game fact. Forge Anew's "the first time you activate an equip ability each turn, you may pay `{0}`" keys off `count == 0` (`CastPermissionUtils.applyFreeFirstEquipDiscount`), so dropping the component outright would tell the AI that spending the free equip changed nothing.
- `1 -> 2 -> 3` is not. That discount is the component's only reader, so nothing in the game can distinguish a second equip activation from a third.

`ExhaustAbilitiesActivatedThisTurnComponent` is the same activation-counter shape and is deliberately left alone: `PlayerActivatedExhaustAbilitiesThisTurn` carries an `atLeast` threshold, so a card may yet ask whether the count reached two — and an exhaust ability can only be activated once per permanent anyway (CR 702.177a), so there is no loop for it to feed.

Nothing about the rules changes: Equip stays legal against its current creature and the engine still increments the tracker on every activation. This is the AI declining a line.

## Tests

- `StateProgressTest` — "the equip tally counts its first activation and then stops counting": `0` and `1` are different positions, `1`/`2`/`3` are the same one.
- `LoopingActionAiTest` — "the AI stops re-equipping the creature the Equipment is already attached to": builds the real Spatula-on-Mauler board with both hands emptied so pass and the equip are the only options, asserts the redundant equip is *still offered* and still counted, that its leaf digests back to the position it started from, and that `Strategist` passes even under `stepPreferring(PRECOMBAT_MAIN)`. Confirmed failing on `main`'s digest and passing with the clamp.

## Verification

`just test-class LoopingActionAiTest`, `just test-class StateProgressTest`, and the full `just test-ai` — all green. The change is confined to `:ai`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)