### PR TITLE
Bound a runaway game, and the replay it would write

### DIFF
--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -646,6 +646,27 @@ running without one. In-progress recordings are flushed to the store every few s
 `ReplayCheckpointFlusher` and picked back up on restart, which is what lets the Redis session blob
 carry no replay data at all.
 
+#### Bounded recordings
+
+A recording stops after `ReplayRecordingPolicy.MAX_RECORDED_ACTIONS` (25,000) actions and the record
+is flagged `truncated`. Storage isn't the reason — the input log is ~7 stored bytes per action — the
+cost of *recording* is: the live log is a copy-on-write list, so a game's recording is O(n²) element
+copies in its own length, and the flusher re-encodes the whole log every few seconds until the game
+ends. Both are free at the few hundred actions a real game takes and ruinous at six figures.
+
+Past the cap the log is frozen: an undo may still shorten it (leaving a valid shorter prefix) but
+nothing may extend it again, or the record would have a hole in the middle and reconstruct a game
+nobody played. The result is the same "keep the honest shorter prefix" outcome a lost flush already
+produces, and `viewerPayload` reports it — the frames are an exact re-simulation and
+`stateReproducible` stays true, so the scenario buttons keep working; only the ending is missing, and
+the viewer shows a **Partial recording** badge (as against **From archive**, which means `DIVERGED`).
+
+The cap sits deliberately *below* the game-level runaway backstop
+(`GameStallGuard.MAX_ACTIONS`, 50,000 — see
+[engine-server-interface.md](engine-server-interface.md) → *The server's own game over*): if a game
+gets that long we would rather truncate the record than end a game somebody is playing, so the
+recording gives up first and the game carries on.
+
 The flush is on a timer, not per action, so a crash can lose the tail of a recording. Splicing the
 rest of the game onto that short prefix would produce a record of a game nobody played, so each
 flush also writes a `resume_fingerprint` of the live position; on restore, `GameSession` compares it

--- a/docs/engine-server-interface.md
+++ b/docs/engine-server-interface.md
@@ -249,6 +249,39 @@ data class GameOver(
 
 ```
 
+#### The server's own game over: a game that stopped progressing
+
+Every terminal state above is the engine's. The server adds exactly one of its own, in
+`GameSession` (`GameStallGuard`): a game that is applying actions but going nowhere is ended as a
+draw, with a player-facing explanation (`GameSession.stallMessage()`, preferred over the stock
+reason text by `GamePlayHandler.handleGameOver`).
+
+This is a backstop, not a rules feature. The AI chooses by scoring the position each candidate move
+leads to, so a free ability that resolves back onto the board it started from can outscore passing —
+forever. `StateProgress` (in the `ai` module) refuses those candidates, but it recognises *shapes* of
+loop and new shapes keep appearing, and every one of them wedges a live game the same way: the
+WebSocket ping-pong never stops, the session is never swept, the replay grows without limit, and a
+tournament round blocks on a match that cannot finish. CR 104.4b agrees with the verdict — a loop of
+mandatory actions with no way to stop **is** a draw.
+
+Three clocks, all reset by progress, all far above any real game (a whole game measures a few
+hundred to ~1,650 actions across ~32 player turns):
+
+| Clock | Default | Catches |
+|---|---|---|
+| actions since the turn last changed hands | 2,000 | a loop inside one turn — the AI shape above |
+| player turns | 400 | a soft lock where turns keep passing and nobody can close the game |
+| actions in the game | 50,000 | anything that satisfies both of the above and is still pathological |
+
+A fourth counter covers the case where *nothing* is applied: when an AI's chosen action is rejected
+and no safe fallback applies either, the server re-broadcasts the state so the AI can try again —
+which, given the same state, produces the same rejected action. That loop applies no actions, so the
+clocks above cannot see it; after 10 consecutive rejections with no fallback the seat is conceded
+instead (`GameStallGuard.onActionRejected`).
+
+Every threshold is a constructor parameter on the guard, so tests reach them in a handful of actions
+(`GameStallGuardTest`, `GameSessionBackstopTest`) rather than by playing tens of thousands.
+
 ---
 
 ## 5. Side Effects: Game Events

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -635,8 +635,11 @@ class GamePlayHandler(
     fun handleGameOver(gameSession: GameSession, reason: GameOverReason? = null, events: List<GameEvent> = emptyList()) {
         val winnerId = gameSession.getWinnerId()
         val gameOverReason = reason ?: gameSession.getGameOverReason() ?: GameOverReason.LIFE_ZERO
-        // Extract custom message from PlayerLostEvent if present
-        val customMessage = events.filterIsInstance<PlayerLostEvent>().firstOrNull()?.message
+        // Extract custom message from PlayerLostEvent if present. A game the server abandoned for
+        // lack of progress explains itself first — its stock reason is a bare "Draw", which reads
+        // like a rules outcome the players brought about rather than a loop nobody could break.
+        val customMessage = gameSession.stallMessage()
+            ?: events.filterIsInstance<PlayerLostEvent>().firstOrNull()?.message
         val message = ServerMessage.GameOver(winnerId, gameOverReason, customMessage, gameSession.sessionId)
 
         gameSession.getPlayers().forEach { sender.send(it.webSocketSession, message) }
@@ -719,6 +722,7 @@ class GamePlayHandler(
                 engineVersion = engineVersion.value,
                 pinnedCards = gameSession.getPinnedCards(),
                 checkpoints = gameSession.getReplayCheckpoints(),
+                truncated = gameSession.isReplayTruncated(),
             )
             // AI-only games (e.g. the LLM tournament) are stored — that page links straight at their
             // replays — but skip the archived frame stream, which is orders of magnitude larger than
@@ -1296,8 +1300,28 @@ class GamePlayHandler(
                         if (recovered) break
                     }
                     if (!recovered) {
-                        // Last resort: broadcast current state so the AI gets another chance.
-                        broadcastStateUpdate(gameSession, emptyList())
+                        // Last resort: broadcast current state so the AI gets another chance. That
+                        // is a loop with nothing bounding it — the AI is handed the same state, so
+                        // it re-chooses the same rejected action, and nothing was applied for the
+                        // stall guard to notice — so the seat gets a bounded number of chances and
+                        // is then conceded. See [GameStallGuard.onActionRejected].
+                        if (gameSession.noteActionRejected(aiPlayerId)) {
+                            logger.error(
+                                "AI seat {} has had {} actions in a row rejected with no legal " +
+                                    "fallback in game {} — conceding the seat rather than " +
+                                    "re-broadcasting forever",
+                                aiPlayerId.value,
+                                com.wingedsheep.gameserver.session.GameStallGuard.MAX_CONSECUTIVE_REJECTIONS,
+                                gameSession.sessionId,
+                            )
+                            gameSession.playerConcedes(aiPlayerId)
+                            broadcastStateUpdate(gameSession, emptyList())
+                            if (gameSession.isGameOver()) {
+                                handleGameOver(gameSession, GameOverReason.CONCESSION)
+                            }
+                        } else {
+                            broadcastStateUpdate(gameSession, emptyList())
+                        }
                     }
                 }
             }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/CompactReplay.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/CompactReplay.kt
@@ -70,6 +70,17 @@ data class CompactReplay(
      * reconstruct unverified exactly as before.
      */
     val checkpoints: List<ReplayCheckpoint> = emptyList(),
+    /**
+     * True when recording was frozen before the game ended, so [actions] is an honest *prefix* of
+     * the game rather than all of it — the game went on past the last frame here.
+     *
+     * Set when a game passes [ReplayRecordingPolicy.MAX_RECORDED_ACTIONS] (a wedge that outlived
+     * the stall guard, a mill-loop stalemate, an AI grinding hundreds of turns). The prefix
+     * reconstructs exactly as any other record does; what it must not do is *look* complete, so the
+     * viewer is told to say the recording stops early. Defaults false, so every record written
+     * before this existed reads as the complete game it was.
+     */
+    val truncated: Boolean = false,
 ) {
     /** Number of reconstructable frames: the initial state plus one per applied action. */
     val frameCount: Int get() = 1 + actions.size
@@ -119,6 +130,8 @@ data class ReplayRecordingSnapshot(
     val startedAt: java.time.Instant?,
     /** Sampled with the rest, so a game that ended mid-sweep isn't flushed as in-progress. */
     val gameOver: Boolean,
+    /** Whether the recording has been frozen by the size cap — see [CompactReplay.truncated]. */
+    val truncated: Boolean,
 )
 
 /** Cadence knobs for the live recorder. */
@@ -128,6 +141,23 @@ object ReplayRecordingPolicy {
      * cadence, dense enough to pin a divergence to a handful of actions.
      */
     const val CHECKPOINT_EVERY_ACTIONS = 20
+
+    /**
+     * Actions after which a recording is frozen and marked [CompactReplay.truncated].
+     *
+     * Not a storage limit — the input log is ~7 stored bytes per action, so even this many is a
+     * couple of hundred KB, less than the archived frame stream of an ordinary game. It is a limit
+     * on the *cost of recording*: the live log is a copy-on-write list, so appending is O(n) and a
+     * game's recording is O(n²) in its own length, and the flusher re-encodes the whole log every
+     * few seconds until the game ends.
+     *
+     * A whole game of purely random play measures ~1,650 actions (`CompactReplaySizeBenchmark`) and
+     * a real one a few hundred, so this is an order of magnitude clear of any honest game and only
+     * a game that has already gone wrong can reach it. Deliberately below
+     * [com.wingedsheep.gameserver.session.GameStallGuard.MAX_ACTIONS], so the record gives up before
+     * the game does.
+     */
+    const val MAX_RECORDED_ACTIONS = 25_000
 }
 
 /** Which yield mutation a [ReplayYieldEntry] records. */

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/ReplayCheckpointFlusher.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/ReplayCheckpointFlusher.kt
@@ -33,8 +33,16 @@ class ReplayCheckpointFlusher(
 ) {
     private val logger = LoggerFactory.getLogger(ReplayCheckpointFlusher::class.java)
 
-    /** sessionId -> action count at last flush, so an idle game isn't rewritten every sweep. */
-    private val flushed = ConcurrentHashMap<String, Int>()
+    /** sessionId -> what the last flush wrote, so an idle game isn't rewritten every sweep. */
+    private val flushed = ConcurrentHashMap<String, Flushed>()
+
+    /**
+     * The action count is what normally moves; [truncated] is here because it can flip *without*
+     * the count moving — a recording frozen by the size cap stops appending, so a game that was
+     * flushed at exactly the cap would otherwise keep a stored record that claims to be the whole
+     * game right up until game over.
+     */
+    private data class Flushed(val actions: Int, val truncated: Boolean)
 
     /** Guards the one-time startup reconciliation in [adoptRecordsLeftByAPreviousRun]. */
     private val reconciled = AtomicBoolean(false)
@@ -81,7 +89,7 @@ class ReplayCheckpointFlusher(
         for (record in stranded) {
             val gameId = record.replay.gameId
             if (gameId in liveIds) {
-                flushed[gameId] = record.replay.actions.size
+                flushed[gameId] = Flushed(record.replay.actions.size, record.replay.truncated)
             } else {
                 runCatching { replayService.finalizePartial(gameId) }
                     .onFailure { logger.warn("Failed to finalize stranded replay $gameId: ${it.message}") }
@@ -109,7 +117,7 @@ class ReplayCheckpointFlusher(
         // live and still recorded; there is nothing left to checkpoint, and [ReplayService] would
         // refuse the write anyway. Skip before paying for the encode.
         if (snapshot.gameOver) return
-        if (flushed[session.sessionId] == snapshot.actions.size) return
+        if (flushed[session.sessionId] == Flushed(snapshot.actions.size, snapshot.truncated)) return
 
         replayService.saveInProgress(
             replay = CompactReplay(
@@ -125,10 +133,11 @@ class ReplayCheckpointFlusher(
                 // Independent of the action count — derived from the decklists, which never change.
                 pinnedCards = session.getPinnedCards(),
                 checkpoints = snapshot.checkpoints,
+                truncated = snapshot.truncated,
             ),
             resumeFingerprint = snapshot.fingerprint,
         )
-        flushed[session.sessionId] = snapshot.actions.size
+        flushed[session.sessionId] = Flushed(snapshot.actions.size, snapshot.truncated)
     }
 
     private companion object {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/ReplayService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/ReplayService.kt
@@ -189,7 +189,14 @@ class ReplayService(
                 body = presentation.compose(reconstructed),
                 frameCount = reconstructed.frameCount,
                 fidelity = reconstructed.fidelity,
-                degradedReason = null,
+                // A truncated record re-simulates perfectly — it is simply not the whole game, and
+                // the one thing it must not do is look like it is. Note this says nothing about
+                // fidelity: these frames are exact, there are just fewer of them than were played.
+                degradedReason = if (stored.replay.truncated) {
+                    "Only the first ${stored.replay.frameCount} frames of this game were recorded — " +
+                        "it ran long enough that recording had to stop, and it continued past the end " +
+                        "of what you can watch here."
+                } else null,
                 stateReproducible = true,
             )
         }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -229,6 +229,17 @@ class GameSession(
         val aiModelOverride: String? = null
     )
 
+    /**
+     * Runaway/wedge backstop for this game — see [GameStallGuard]. Lives on the session because
+     * every applied action funnels through [recordAction], which is the only place that can see
+     * "the game moved" for every path at once.
+     */
+    private var stallGuard = GameStallGuard()
+
+    /** Where [appendToReplayLog] stops recording. Mutable only for the test seam below. */
+    private var replayActionCap =
+        com.wingedsheep.gameserver.replay.ReplayRecordingPolicy.MAX_RECORDED_ACTIONS
+
     private val actionProcessor = ActionProcessor(services)
     private val gameInitializer = GameInitializer(cardRegistry, services.printingRegistry)
     private val autoPassManager = AutoPassManager(cardRegistry)
@@ -258,6 +269,10 @@ class GameSession(
     @Volatile
     private var replaySetup: com.wingedsheep.gameserver.replay.ReplaySetup? = null
     private val recordedActions = CopyOnWriteArrayList<GameAction>()
+    // Set once the recording has hit [ReplayRecordingPolicy.MAX_RECORDED_ACTIONS] and been frozen.
+    // Sticky, and stored with the record — see [recordAction].
+    @Volatile
+    private var replayTruncated = false
     // Persistent-yield mutations applied out-of-band of [recordedActions]. Captured in turn order so
     // the reconstructor can re-apply each at the action position it was set (see [CompactReplay.yields]).
     private val recordedYields = CopyOnWriteArrayList<com.wingedsheep.gameserver.replay.ReplayYieldEntry>()
@@ -1342,10 +1357,85 @@ class GameSession(
     // Replay Recording
     // =========================================================================
 
-    /** Append an applied, state-advancing action to the compact replay log. */
+    /**
+     * The one thing every applied action passes through: append it to the compact replay log, and
+     * ask the [stallGuard] whether this game is still going anywhere.
+     *
+     * Both halves are bounded on purpose, and for different reasons — see [appendToReplayLog] and
+     * [enforceProgress].
+     */
     private fun recordAction(action: GameAction) {
+        appendToReplayLog(action)
+        enforceProgress()
+    }
+
+    /**
+     * Append to the replay log, up to [ReplayRecordingPolicy.MAX_RECORDED_ACTIONS] actions.
+     *
+     * A replay costs ~7 stored bytes per action, so length is not what makes a runaway game
+     * expensive — this list is. It is a [CopyOnWriteArrayList] (read by the flusher off the game
+     * thread, appended under the state lock), so every append copies the whole array: the recording
+     * costs O(n²) element copies over a game, which is nothing at the few hundred actions a real
+     * game takes and ruinous at six figures. On top of that the flusher re-encodes the entire log
+     * every few seconds for as long as the game lasts.
+     *
+     * So the recording gives up rather than the game: past the cap the log is frozen and marked
+     * [replayTruncated], which is the same "keep the honest shorter prefix" outcome a lost flush
+     * already produces (see [restoreReplayRecording]) and which the viewer reports as a partial
+     * recording. Freezing is permanent for the session — an undo may shorten the log afterwards
+     * (leaving a valid, shorter prefix) but nothing may extend it again, or the record would have a
+     * hole in the middle and reconstruct a game nobody played.
+     */
+    private fun appendToReplayLog(action: GameAction) {
+        if (replayTruncated) return
+        if (recordedActions.size >= replayActionCap) {
+            replayTruncated = true
+            logger.warn(
+                "Replay recording for $sessionId hit $replayActionCap actions — freezing the log; " +
+                    "the game continues but its replay stops here"
+            )
+            return
+        }
         recordedActions.add(action)
         stampCheckpointIfDue()
+    }
+
+    /**
+     * End the game as a draw when it has stopped making progress — see [GameStallGuard] for the two
+     * shapes this catches and CR 104.4b for why a draw is the right verdict.
+     *
+     * The draw is expressed the way the engine expresses one (`gameOver` with no winner), so every
+     * caller's existing `isGameOver()` check finalizes the match through the normal game-over path:
+     * players and spectators are notified, the replay is saved, the lobby callback fires, the
+     * session is cleaned up. Nothing needs to know this particular game over was our idea except
+     * [stallMessage], which explains it to the players.
+     */
+    private fun enforceProgress() {
+        val state = gameState ?: return
+        if (state.gameOver) return
+        val stall = stallGuard.onActionApplied(state) ?: return
+        logger.error(
+            "Game $sessionId is not making progress (${stall.code}) — ending it as a draw. " +
+                "This is a backstop for a loop the AI's own guard missed; the replay is worth reading."
+        )
+        gameState = state.copy(gameOver = true, winnerId = null)
+    }
+
+    /**
+     * Why this game was abandoned, for the game-over overlay, or null for a game that ended on its
+     * own terms. Preferred over the engine's stock reason text because "Draw" alone reads like a
+     * rules outcome the players caused.
+     */
+    fun stallMessage(): String? = stallGuard.stall?.playerMessage
+
+    /**
+     * Record that [playerId]'s action was rejected and no fallback could be applied either, and
+     * report whether that seat has run out of moves it will make — see
+     * [GameStallGuard.onActionRejected]. Nothing reached the engine, so this is invisible to
+     * [recordAction] and has to be reported by the caller that saw the rejection.
+     */
+    fun noteActionRejected(playerId: EntityId): Boolean = synchronized(stateLock) {
+        stallGuard.onActionRejected(playerId)
     }
 
     /**
@@ -1404,6 +1494,12 @@ class GameSession(
     /** The persistent-yield mutations applied to this game, in order, for replay reconstruction. */
     fun getReplayYields(): List<com.wingedsheep.gameserver.replay.ReplayYieldEntry> = recordedYields.toList()
 
+    /**
+     * Whether this game's recording was frozen before the game ended (see [appendToReplayLog]), so
+     * the stored record is an honest prefix rather than the whole game.
+     */
+    fun isReplayTruncated(): Boolean = replayTruncated
+
     /** Sparse position fingerprints taken while this game was played. */
     fun getReplayCheckpoints(): List<com.wingedsheep.gameserver.replay.ReplayCheckpoint> =
         recordedCheckpoints.toList()
@@ -1447,6 +1543,7 @@ class GameSession(
                 fingerprint = com.wingedsheep.gameserver.replay.ReplayFingerprint.of(state),
                 startedAt = replayStartedAt,
                 gameOver = state.gameOver,
+                truncated = replayTruncated,
             )
         }
 
@@ -1459,6 +1556,20 @@ class GameSession(
     // =========================================================================
     // Test Support (for scenario-based testing)
     // =========================================================================
+
+    /**
+     * Replace the runaway backstops with tighter ones.
+     *
+     * **Testing only.** The shipped thresholds are set so that only a game that has already gone
+     * wrong can reach them, which also puts them out of reach of a test that would have to play
+     * tens of thousands of actions to get there. Must be called before the game starts — the guard
+     * carries the counters, so swapping it mid-game resets them.
+     */
+    internal fun tightenBackstopsForTesting(guard: GameStallGuard, replayCap: Int) {
+        stallGuard = guard
+        replayActionCap = replayCap
+    }
+
 
     /**
      * Inject a pre-built game state for testing purposes.
@@ -1687,6 +1798,10 @@ class GameSession(
         recordedYields.addAll(record.yields)
         recordedCheckpoints.clear()
         recordedCheckpoints.addAll(record.checkpoints)
+        // A record frozen by the size cap before the restart stays frozen: the actions played
+        // between the cap and now were never recorded, so appending from here would splice a hole
+        // into the log exactly as extending a stale prefix would.
+        replayTruncated = record.truncated
         replayStartedAt = runCatching { Instant.parse(record.startedAt) }.getOrNull()
         return true
     }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameStallGuard.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameStallGuard.kt
@@ -1,0 +1,193 @@
+package com.wingedsheep.gameserver.session
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * The live game's answer to "has this stopped being a game?".
+ *
+ * A wedged game is not a hypothetical here. The AI picks its move by scoring the position each
+ * candidate leads to, and a free ability that resolves back onto the board it started from can
+ * outscore passing — from which it outscores passing again, identically, forever
+ * ([com.wingedsheep.ai.engine.StateProgress] is the AI-side defence against exactly that, and the
+ * reason it exists is that the AI once activated Aphetto Alchemist until the game had to be
+ * abandoned). That defence is a heuristic over a *shape* of loop, and new shapes keep arriving —
+ * two permanents untapping each other, a decision the engine re-raises, a mandatory trigger that
+ * puts the board back. Every one of them ends the same way if nothing else is watching: the
+ * WebSocket ping-pong never stops, the session is never swept, the replay log grows without limit,
+ * and a tournament round blocks on a match that will never finish.
+ *
+ * So this is the backstop underneath every one of those: not "is this move good" but "is this game
+ * still going anywhere". The rules make the same call — CR 104.4b: a game that enters a loop of
+ * mandatory actions with no way to stop **is a draw** — and when the loop contains an *optional*
+ * action instead, CR 732.3 requires the looping player to make a different choice, which is the
+ * requirement the AI-side guard implements. A draw is therefore the honest outcome when the AI-side
+ * guard misses: the position genuinely cannot be resolved by anyone playing it.
+ *
+ * ## The two shapes, and why one counter can't see both
+ *
+ * - **Actions apply, the game doesn't move.** Each activation is legal and changes *something*
+ *   (a tap, a stack entity, an untap) but the position comes back. [onActionApplied] watches this
+ *   with the same clock the arena harness uses: actions since the turn last changed hands.
+ * - **Nothing applies at all.** The AI's chosen action is rejected, every safe fallback is
+ *   rejected too, and the server re-broadcasts the state so the AI can try again — with the same
+ *   state, so it chooses the same rejected action. No action is ever applied, so the counter above
+ *   never moves and cannot see this. [onActionRejected] counts those instead, per seat, and gives
+ *   up on a seat that has run out of legal moves it is willing to make.
+ *
+ * Both counters are reset by progress, so a long, healthy game never approaches either.
+ *
+ * ## Thresholds
+ *
+ * Deliberately far looser than the arena's ([com.wingedsheep.ai.arena] stops a game after 300
+ * actions without a turn handover). A false stall there discards one data point; here it ends a
+ * game somebody is playing, so every threshold below sits an order of magnitude above the largest
+ * real game we have measured — ~1,650 actions across ~32 player turns for a whole game of random
+ * play (`CompactReplaySizeBenchmark`), a few hundred for a normal one.
+ *
+ * Thread confinement: one instance per [GameSession], only ever touched under that session's state
+ * lock. No synchronization of its own.
+ *
+ * Every threshold is a constructor parameter defaulting to the shipped policy, so a test can reach
+ * a backstop in a handful of actions instead of tens of thousands — the numbers below are chosen to
+ * be unreachable by anything but a broken game, which also makes them unreachable by a test.
+ */
+class GameStallGuard(
+    private val maxActionsPerTurn: Int = MAX_ACTIONS_PER_TURN,
+    private val maxPlayerTurns: Int = MAX_PLAYER_TURNS,
+    private val maxActions: Int = MAX_ACTIONS,
+    private val maxConsecutiveRejections: Int = MAX_CONSECUTIVE_REJECTIONS,
+) {
+
+    /** Total actions applied to this game. */
+    private var actions = 0
+
+    /** Who was the active player when the turn last changed hands, and at what action count. */
+    private var lastActivePlayer: EntityId? = null
+    private var actionsAtHandover = 0
+
+    /** Consecutive rejected actions per seat since that seat last had one applied. */
+    private val rejections = mutableMapOf<EntityId, Int>()
+
+    /**
+     * Sticky: once a game is called stalled it stays stalled, and it is only reported once.
+     *
+     * Written under the session's state lock but read off it by the game-over path, which builds the
+     * player-facing message — hence volatile.
+     */
+    @Volatile
+    var stall: Stall? = null
+        private set
+
+    /**
+     * Why a game was abandoned. [code] is for the log (dense, greppable, mirrors the arena's draw
+     * taxonomy); [playerMessage] is shown in the game-over overlay, so it says what happened
+     * without blaming the player who happened to be holding priority.
+     */
+    data class Stall(val code: String, val playerMessage: String)
+
+    /**
+     * Called after every action the engine has actually applied, with the state it produced.
+     * Returns the verdict when this game has to be abandoned, or null to carry on.
+     */
+    fun onActionApplied(state: GameState): Stall? {
+        actions++
+        // A turn changing hands is the one signal that is cheap, monotone, and impossible to fake
+        // from inside a loop. `GameState.turnNumber` counts player turns, so it advances on every
+        // turn regardless of seat count or who has already been eliminated — but the *handover* is
+        // what resets the per-turn budget, and reading the active player catches a turn that ends
+        // without the counter being what moved.
+        if (state.activePlayerId != lastActivePlayer) {
+            lastActivePlayer = state.activePlayerId
+            actionsAtHandover = actions
+        }
+        // A seat that just had an action applied is plainly able to act.
+        rejections.clear()
+
+        stall?.let { return null } // already reported
+
+        val verdict = when {
+            actions - actionsAtHandover > maxActionsPerTurn -> Stall(
+                code = "wedged(turn=${state.turnNumber},step=${state.step.name},actions=$actions)",
+                playerMessage = "This game was ended as a draw: it repeated more than " +
+                    "$maxActionsPerTurn actions in a single turn without the turn ever ending, " +
+                    "which means it had entered a loop that could not be broken (CR 104.4b).",
+            )
+
+            state.turnNumber > maxPlayerTurns -> Stall(
+                code = "turnLimit(turn=${state.turnNumber},actions=$actions)",
+                playerMessage = "This game was ended as a draw: it passed $maxPlayerTurns turns " +
+                    "with neither side able to finish it.",
+            )
+
+            actions > maxActions -> Stall(
+                code = "actionLimit(turn=${state.turnNumber},actions=$actions)",
+                playerMessage = "This game was ended as a draw: it passed $maxActions actions " +
+                    "without reaching a result.",
+            )
+
+            else -> null
+        }
+        return verdict?.also { stall = it }
+    }
+
+    /**
+     * Called when [playerId]'s chosen action was rejected and no safe fallback could be applied
+     * either — nothing reached the game, so [onActionApplied] cannot see this at all.
+     *
+     * Returns true when this seat has failed often enough in a row that it should be treated as
+     * unable to continue. The caller concedes it rather than ending the whole game: one seat with
+     * no move it will make is that seat's problem, and conceding is a resolution every format,
+     * lobby and stats path already understands.
+     */
+    fun onActionRejected(playerId: EntityId): Boolean {
+        val count = (rejections[playerId] ?: 0) + 1
+        rejections[playerId] = count
+        return count >= maxConsecutiveRejections
+    }
+
+    /** Total actions applied, for logging. */
+    fun actionCount(): Int = actions
+
+    companion object {
+        /**
+         * Actions inside one player turn before the game is called a loop.
+         *
+         * A whole game of random play is ~1,650 actions over ~32 player turns — ~50 per turn, and
+         * that is the noisy end of the range. A real combo turn is in the low hundreds. 2,000 is
+         * far enough above both that reaching it means the turn is not going to end.
+         */
+        const val MAX_ACTIONS_PER_TURN = 2_000
+
+        /**
+         * Player turns (not rounds) before a game nobody can close out is called a draw. A duel
+         * gets 200 turns each, a four-player pod 100.
+         *
+         * This is the *other* loop: a soft lock where turns keep passing — two players who can each
+         * neutralise the other's every threat — so the per-turn budget above never fires. Tournament
+         * Magic reaches the same verdict by a clock rather than a turn count; we have no clock,
+         * because a human's thinking time is not the engine's problem and must never end their game.
+         */
+        const val MAX_PLAYER_TURNS = 400
+
+        /**
+         * Total actions in one game, as the backstop under both of the above: 400 turns of 1,999
+         * actions each would satisfy them and still be pathological.
+         *
+         * Deliberately larger than [com.wingedsheep.gameserver.replay.ReplayRecordingPolicy.MAX_RECORDED_ACTIONS]:
+         * if a game somehow gets that long we would rather truncate the *record* than end the game
+         * somebody is playing, so the recording gives up first and the game keeps going.
+         */
+        const val MAX_ACTIONS = 50_000
+
+        /**
+         * Consecutive rejected-with-no-fallback actions from one seat before it is conceded.
+         *
+         * Only the AI can reach this: a human's rejected action is an error message and they pick
+         * something else, while the AI is handed the same state and deterministically re-chooses
+         * the same illegal move. Small on purpose — every iteration is a round trip that produces
+         * nothing, and there is no reason to expect the eleventh to differ from the tenth.
+         */
+        const val MAX_CONSECUTIVE_REJECTIONS = 10
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/replay/ReplayTruncationTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/replay/ReplayTruncationTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.gameserver.replay
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.gameserver.session.GameSession
+import com.wingedsheep.gameserver.session.GameStallGuard
+import com.wingedsheep.gameserver.session.PlayerSession
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.web.socket.WebSocketSession
+
+/**
+ * A recording that had to stop early is still a real replay — it just isn't the whole game.
+ *
+ * The failure this guards against is not losing the tail; it's a record that *looks* complete.
+ * Nothing downstream can tell a game that ended at frame 25,000 from a game whose recording did, so
+ * the flag has to survive storage and reach the viewer as words a player can read.
+ */
+class ReplayTruncationTest : ScenarioTestBase() {
+
+    private fun mockWs(id: String): WebSocketSession =
+        mockk(relaxed = true) { every { this@mockk.id } returns id }
+
+    /** A real recorded game whose log was frozen after [cap] actions. */
+    private fun truncatedGame(cap: Int): GameSession {
+        val session = GameSession(cardRegistry = cardRegistry, maxPlayers = 2)
+        session.tightenBackstopsForTesting(GameStallGuard(), cap)
+        val p1 = EntityId.of("trunc-p1")
+        val p2 = EntityId.of("trunc-p2")
+        session.addPlayer(PlayerSession(mockWs("trunc-ws1"), p1, "Alice"), mapOf("Forest" to 40))
+        session.addPlayer(PlayerSession(mockWs("trunc-ws2"), p2, "Bob"), mapOf("Forest" to 40))
+        session.startGame()
+        session.keepHand(p1)
+        session.keepHand(p2)
+        repeat(30) {
+            val state = session.getStateForTesting() ?: return@repeat
+            if (state.gameOver) return@repeat
+            state.priorityPlayerId?.let { session.executeAutoPass(it) }
+        }
+        return session
+    }
+
+    private fun GameSession.record(truncated: Boolean = isReplayTruncated()): CompactReplay {
+        val snapshot = replayRecordingSnapshot().shouldNotBeNull()
+        return CompactReplay(
+            gameId = sessionId,
+            players = getPlayers().map { ReplayPlayerInfo(it.playerId.value, it.playerName) },
+            startedAt = "2026-01-01T00:00:00Z",
+            endedAt = "2026-01-01T00:30:00Z",
+            winnerName = null,
+            setup = snapshot.setup,
+            actions = snapshot.actions,
+            yields = snapshot.yields,
+            checkpoints = snapshot.checkpoints,
+            truncated = truncated,
+        )
+    }
+
+    init {
+        test("the flag survives the store's gzip+base64 round trip") {
+            val record = truncatedGame(cap = 8).record()
+            record.truncated shouldBe true
+
+            ReplayCodec.decode(ReplayCodec.encode(record)).truncated shouldBe true
+        }
+
+        test("a record written before the flag existed reads as the complete game it was") {
+            // Decoding is deliberately tolerant so a rolling deploy can read both ways; the failure
+            // direction that matters is a pre-existing complete game being labelled partial. Older
+            // records have no such key at all, so drop it to get one.
+            val whole = truncatedGame(cap = 10_000).record(truncated = false)
+            val legacy = com.wingedsheep.gameserver.persistence.persistenceJson
+                .encodeToString(CompactReplay.serializer(), whole)
+                .replace("\"truncated\":false,", "")
+                .replace(",\"truncated\":false", "")
+            legacy shouldNotContain "truncated"
+
+            ReplayCodec.decode(ReplayCodec.encodeText(legacy)).truncated shouldBe false
+        }
+
+        test("the viewer is told the recording stops before the game did") {
+            val record = truncatedGame(cap = 8).record()
+            val store = InMemoryReplayStore().apply {
+                save(StoredReplay(record, ReplayStatus.FINISHED))
+            }
+            val service = ReplayService(
+                store,
+                ReplayReconstructor(cardRegistry, null),
+                mockk(relaxed = true),
+            )
+
+            val payload = service.viewerPayload(record.gameId).shouldNotBeNull()
+
+            // The prefix re-simulates perfectly — this is not a fidelity problem (the frames came
+            // back complete, or `viewerPayload` would have taken the diverged branch), and the
+            // position is still reproducible, so "share as scenario" keeps working. There are simply
+            // fewer frames than were played, and the viewer has to say so.
+            payload.stateReproducible shouldBe true
+            payload.degradedReason.shouldNotBeNull() shouldContain "recorded"
+        }
+
+        test("an untruncated replay is served without a caveat") {
+            val record = truncatedGame(cap = 10_000).record()
+            record.truncated shouldBe false
+            val store = InMemoryReplayStore().apply {
+                save(StoredReplay(record, ReplayStatus.FINISHED))
+            }
+            val service = ReplayService(
+                store,
+                ReplayReconstructor(cardRegistry, null),
+                mockk(relaxed = true),
+            )
+
+            service.viewerPayload(record.gameId).shouldNotBeNull().degradedReason shouldBe null
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/GameSessionBackstopTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/GameSessionBackstopTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.gameserver.session
+
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.gameserver.protocol.GameOverReason
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.web.socket.WebSocketSession
+
+/**
+ * The two runaway backstops, wired end to end through a real recorded session.
+ *
+ * Both are reached here with tightened thresholds ([GameSession.tightenBackstopsForTesting]) rather
+ * than by playing 25,000 actions, so what these prove is the *wiring*: that the replay log really
+ * stops growing and says so, that the game really ends and explains itself, and — the part that is
+ * easy to get backwards — that the recording gives up without taking the game down with it.
+ */
+class GameSessionBackstopTest : ScenarioTestBase() {
+
+    private fun mockWs(id: String): WebSocketSession =
+        mockk(relaxed = true) { every { this@mockk.id } returns id }
+
+    /** A real two-seat recorded game, with the backstops shrunk to test size before it starts. */
+    private fun startedGame(guard: GameStallGuard, replayCap: Int): GameSession {
+        val session = GameSession(cardRegistry = cardRegistry, maxPlayers = 2)
+        session.tightenBackstopsForTesting(guard, replayCap)
+        val p1 = com.wingedsheep.sdk.model.EntityId.of("backstop-p1")
+        val p2 = com.wingedsheep.sdk.model.EntityId.of("backstop-p2")
+        session.addPlayer(PlayerSession(mockWs("backstop-ws1"), p1, "Alice"), mapOf("Forest" to 40))
+        session.addPlayer(PlayerSession(mockWs("backstop-ws2"), p2, "Bob"), mapOf("Forest" to 40))
+        session.startGame()
+        session.keepHand(p1)
+        session.keepHand(p2)
+        return session
+    }
+
+    /** Auto-pass until the game ends or [rounds] passes run out. */
+    private fun GameSession.autoPass(rounds: Int) {
+        repeat(rounds) {
+            val state = getStateForTesting() ?: return
+            if (state.gameOver) return
+            state.priorityPlayerId?.let { executeAutoPass(it) }
+        }
+    }
+
+    init {
+        test("the replay recording freezes at its cap, and the game plays on") {
+            val session = startedGame(GameStallGuard(), replayCap = 6)
+
+            session.autoPass(40)
+
+            // The record is a prefix and admits it. Frame count is 1 + actions, so it describes the
+            // recording rather than the game — which is exactly what the viewer needs to know.
+            session.getRecordedActions().size shouldBe 6
+            session.isReplayTruncated() shouldBe true
+            session.getReplayFrameCount() shouldBe 7
+            // The game itself is untouched: dropping the *record* of a pathological game is cheap,
+            // ending the game somebody is playing is not, so this ordering is load-bearing.
+            session.isGameOver() shouldBe false
+
+            // And the flush snapshot carries the flag, so the stored row stops claiming to be whole.
+            session.replayRecordingSnapshot().shouldNotBeNull().truncated shouldBe true
+        }
+
+        test("a game that stops making progress is ended as a draw that explains itself") {
+            // keepHand ×2 are already recorded, so this trips a few auto-passes in.
+            val session = startedGame(GameStallGuard(maxActions = 8), replayCap = 10_000)
+
+            session.autoPass(40)
+
+            session.isGameOver() shouldBe true
+            // A draw, not a win for whoever happened to hold priority when the clock ran out.
+            session.getWinnerId() shouldBe null
+            session.getGameOverReason() shouldBe GameOverReason.DRAW
+            session.stallMessage().shouldNotBeNull() shouldContain "draw"
+            // Nobody is eliminated by a draw — the Free-for-All standings read this order, and a
+            // seat listed as eliminated would be reported as having lost a game that nobody lost.
+            session.getEliminationOrder() shouldBe emptyList()
+        }
+
+        test("an ordinary game is neither truncated nor called stalled") {
+            val session = startedGame(GameStallGuard(), replayCap = 10_000)
+
+            session.autoPass(40)
+
+            session.stallMessage() shouldBe null
+            session.isReplayTruncated() shouldBe false
+        }
+    }
+}

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/GameStallGuardTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/session/GameStallGuardTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.gameserver.session
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * What [GameStallGuard] must and must not call a stall.
+ *
+ * The direction of the failures matters more here than the numbers do. Missing a wedge costs a
+ * session that never ends, a replay that grows forever and a tournament round that blocks; calling a
+ * *healthy* game stalled ends a game somebody is playing. So these tests pin both sides: a long
+ * game with turns passing is never touched however many actions it takes, and a game that stops
+ * handing the turn over is stopped.
+ */
+class GameStallGuardTest : FunSpec({
+
+    val alice = EntityId.of("alice")
+    val bob = EntityId.of("bob")
+
+    fun state(turn: Int, active: EntityId) = GameState(turnNumber = turn, activePlayerId = active)
+
+    test("a game whose turns keep changing hands is never called stalled") {
+        val guard = GameStallGuard(maxActionsPerTurn = 10, maxPlayerTurns = 1_000, maxActions = 1_000)
+
+        // 20 turns of 9 actions each — comfortably more actions than the per-turn budget, but the
+        // budget is per turn and every turn ends.
+        var turn = 0
+        repeat(20) {
+            turn++
+            val seat = if (turn % 2 == 0) bob else alice
+            repeat(9) { guard.onActionApplied(state(turn, seat)) shouldBe null }
+        }
+        guard.stall shouldBe null
+        guard.actionCount() shouldBe 180
+    }
+
+    test("actions that never hand the turn over are a loop, and the game becomes a draw") {
+        val guard = GameStallGuard(maxActionsPerTurn = 10)
+
+        repeat(11) { guard.onActionApplied(state(turn = 3, active = alice)) shouldBe null }
+        val stall = guard.onActionApplied(state(turn = 3, active = alice)).shouldNotBeNull()
+
+        stall.code shouldContain "wedged(turn=3"
+        // The overlay text has to explain a draw nobody asked for — and cite the rule that says a
+        // loop with no way out *is* one, so it doesn't read as the server giving up arbitrarily.
+        stall.playerMessage shouldContain "CR 104.4b"
+        stall.playerMessage shouldContain "10 actions in a single turn"
+    }
+
+    test("the verdict is sticky and reported exactly once") {
+        val guard = GameStallGuard(maxActionsPerTurn = 1)
+
+        repeat(3) { guard.onActionApplied(state(turn = 1, active = alice)) }
+        val stall = guard.stall.shouldNotBeNull()
+
+        // The session ends the game on the first verdict; anything still in flight afterwards must
+        // not produce a second game-over, and must not overwrite the reason the first one gave.
+        guard.onActionApplied(state(turn = 1, active = alice)) shouldBe null
+        guard.stall shouldBe stall
+    }
+
+    test("a game nobody can close out is a draw on the turn limit") {
+        val guard = GameStallGuard(maxActionsPerTurn = 100, maxPlayerTurns = 4)
+
+        // Turns pass — so the per-turn budget resets every time and can never fire — but the game
+        // is going nowhere all the same. This is the soft-lock shape the per-turn clock cannot see.
+        for (turn in 1..4) guard.onActionApplied(state(turn, if (turn % 2 == 0) bob else alice)) shouldBe null
+        val stall = guard.onActionApplied(state(turn = 5, active = alice)).shouldNotBeNull()
+
+        stall.code shouldContain "turnLimit(turn=5"
+    }
+
+    test("the total-action backstop catches a game that satisfies both other clocks") {
+        val guard = GameStallGuard(maxActionsPerTurn = 5, maxPlayerTurns = 1_000, maxActions = 12)
+
+        // Four actions per turn, turns always advancing: under the per-turn budget, under the turn
+        // limit, and still a loop that would run until the process died.
+        var stall: GameStallGuard.Stall? = null
+        var turn = 0
+        while (stall == null && turn < 100) {
+            turn++
+            repeat(4) { stall = stall ?: guard.onActionApplied(state(turn, if (turn % 2 == 0) bob else alice)) }
+        }
+        stall.shouldNotBeNull().code shouldContain "actionLimit"
+        guard.actionCount() shouldBe 13 // the 13th action is the one past the budget of 12
+    }
+
+    test("a seat whose actions are all rejected is given up on, and progress forgives it") {
+        val guard = GameStallGuard(maxConsecutiveRejections = 3)
+
+        guard.onActionRejected(alice) shouldBe false
+        guard.onActionRejected(alice) shouldBe false
+        // A seat that manages to act is plainly not out of moves — one rejected block followed by a
+        // legal one is ordinary play, and must not accumulate toward a concession.
+        guard.onActionApplied(state(turn = 1, active = alice))
+        guard.onActionRejected(alice) shouldBe false
+        guard.onActionRejected(alice) shouldBe false
+        guard.onActionRejected(alice) shouldBe true
+    }
+
+    test("rejections are counted per seat, so one stuck AI doesn't concede the other") {
+        val guard = GameStallGuard(maxConsecutiveRejections = 2)
+
+        guard.onActionRejected(alice) shouldBe false
+        guard.onActionRejected(bob) shouldBe false
+        guard.onActionRejected(alice) shouldBe true
+    }
+
+    test("the shipped policy lets the record give up before the game does") {
+        // Both KDocs claim this ordering, and it is the whole reason a pathological game degrades
+        // to a partial replay instead of being ended early: the recording stops first.
+        val cap = com.wingedsheep.gameserver.replay.ReplayRecordingPolicy.MAX_RECORDED_ACTIONS
+        (cap < GameStallGuard.MAX_ACTIONS) shouldBe true
+    }
+})

--- a/web-client/src/components/replay/ReplayPlayer.tsx
+++ b/web-client/src/components/replay/ReplayPlayer.tsx
@@ -253,14 +253,17 @@ export function ReplayPlayer({
             )}
           </div>
           {/*
-            Archived replay: the recorded inputs no longer re-simulate on this build, so the server
-            served the frames it stored when the game was played. Everything on screen is the real
-            game — but there is no live game state behind it, so the scenario buttons are gone
-            rather than merely failing when clicked.
+            Something about these frames isn't the plain case, and the badge says which. DIVERGED:
+            the recorded inputs no longer re-simulate on this build, so the server served the frames
+            it stored when the game was played — everything on screen is the real game, but there is
+            no live game state behind it, so the scenario buttons are gone rather than merely
+            failing when clicked. Otherwise the frames are an exact re-simulation of a recording
+            that stops before the game did (a game long enough that recording had to give up), so
+            the scenario buttons keep working and only the ending is missing.
           */}
           {metadata?.degradedReason && (
             <span style={styles.archivedBadge} title={metadata.degradedReason}>
-              From archive
+              {metadata.fidelity === 'DIVERGED' ? 'From archive' : 'Partial recording'}
             </span>
           )}
           {!isMobile && (


### PR DESCRIPTION
Two backstops for the same failure: a game that stops going anywhere. Neither had one before.

## The AI loop

The AI picks its move by scoring the position each candidate leads to, so a free ability that resolves back onto the board it started from can outscore passing — and then outscore it again from the identical position, forever. `StateProgress` refuses those candidates, but it recognises *shapes* of loop and new shapes keep arriving (the last one was a redundant Equip activation, #1982). Nothing was watching underneath it, and a wedge in a live game means the WebSocket ping-pong never stops, the session is never swept, the replay log grows without limit, and a tournament round blocks on a match that cannot finish. Production had no stall detection at all — only the arena harness did.

**`GameStallGuard`**, consulted from the one place every applied action funnels through (`GameSession.recordAction`), ends such a game as a draw — which is what CR 104.4b calls it ("a loop of mandatory actions with no way to stop"). Three clocks, all reset by progress, all an order of magnitude above the largest game we have measured (~1,650 actions over ~32 player turns, `CompactReplaySizeBenchmark`):

| Clock | Default | Catches |
|---|---|---|
| actions since the turn changed hands | 2,000 | a loop inside one turn — the AI shape above |
| player turns | 400 | a soft lock where turns pass and nobody can close the game |
| actions in the game | 50,000 | anything satisfying both of the above and still pathological |

The draw is expressed the way the engine expresses one (`gameOver`, no winner), so every existing `isGameOver()` check finalizes the match through the normal path — players and spectators notified, replay saved, lobby callback, session cleanup. The only new thing is the player-facing explanation, which `handleGameOver` prefers over the stock bare "Draw".

**The loop that applies nothing at all** is invisible to those clocks, and it was already in the code: when an AI's action is rejected and no safe fallback applies either, `handleAiAction` re-broadcasts the state so the AI can try again — same state, same rejected action, unbounded (a slow spin, since it costs a thinking delay per round, but it never ends). A fourth counter gives that seat 10 rounds and then concedes it.

## Replay size

Recordings are now bounded, and give up *before* the game does (25,000 actions, against the guard's 50,000): we would rather truncate a record than end a game somebody is playing.

Length isn't what makes a long game expensive — the input log is ~7 stored bytes per action. The live `CopyOnWriteArrayList` is: every append copies the whole array, so a game's recording costs O(n²) element copies in its own length, and the flusher re-encodes the entire log every five seconds for as long as the game lasts. Free at a few hundred actions, ruinous at six figures. (The archived frame stream was already capped, at 4 MB stored.)

Past the cap the log freezes and the record is marked `truncated`. It still reconstructs exactly and `stateReproducible` stays true, so "share as scenario" keeps working; it simply isn't the whole game, and the one thing it must not do is look complete — so the viewer shows **Partial recording** (as against **From archive**, which is `DIVERGED`). Freezing is permanent for the session: an undo may shorten the log, nothing may extend it, or the record would have a hole in the middle and reconstruct a game nobody played. The flag survives a flush, a restart mid-recording, and the codec round trip, and defaults false so every existing record reads as the complete game it was.

## Verification

- `just test-server` — full module green (`GameStallGuardTest`, `GameSessionBackstopTest`, `ReplayTruncationTest` new; the existing replay/tournament/session suites unchanged).
- `just client-typecheck` — clean.
- Every threshold is a constructor parameter on the guard and the replay cap has a test seam, so the new tests reach both backstops in a handful of actions instead of tens of thousands — the shipped numbers are deliberately out of a test's reach.
- Docs: `docs/engine-server-interface.md` (the server's own game over) and `docs/data-contracts.md` (bounded recordings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)