### PR TITLE
A permanent's own "enters tapped" now applies to every off-stack entry

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -11005,6 +11005,15 @@ The priority groups are (CR 616.1a–f):
   which is a fact about these twenty cards rather than about the shape. `payLifeCost` renders
   the "you may pay N life; if you don't, it enters tapped" variant. Assay reads every shape of this
   line — the condition is a slot over the whole condition vocabulary, not a rule per land cycle.
+  The clause applies **however the permanent enters** (CR 614.1d / 614.12), so three disjoint paths
+  read it: `PlayLandHandler` (playing a land), `StackResolver` (a resolving permanent spell), and
+  `ZoneTransitionService.moveToZone` (everything else — reanimation, a return from exile, a
+  search-library or collection move). A card put onto the battlefield by an effect that says nothing
+  about tapped therefore needs no `ZonePlacement.Tapped` of its own; spelling one anyway is a
+  divergence Assay's differential reports, because the printed line says nothing about it. Only
+  `PlayLandHandler` and `StackResolver` can pause for the `payLifeCost` prompt; `moveToZone` is a pure
+  state transition, so a reanimated or fetched shock land resolves fail-closed to **tapped** without
+  being asked.
 - `EntersUntapped(appliesTo = ZoneChangeEvent(filter, to = Zone.BATTLEFIELD))` — the inverse of
   `EntersTapped`: "[filter] enter the battlefield untapped" (The Wandering Minstrel — "Lands you
   control enter untapped", `filter = GameObjectFilter.Land.youControl()`). Unlike `EntersTapped`,

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/UrbanRetreat.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/UrbanRetreat.kt
@@ -9,7 +9,6 @@ import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.EntersTapped
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TimingRule
-import com.wingedsheep.sdk.scripting.effects.ZonePlacement
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.ManaColorSet
 
@@ -30,14 +29,9 @@ import com.wingedsheep.sdk.scripting.values.ManaColorSet
  * [activateFromZone] once the ability is on the stack, so without it a card that left the hand in
  * response would still be put onto the battlefield — from wherever it now is.
  *
- * "This land enters tapped" is the [EntersTapped] self-replacement, which the normal land-play
- * path honors. The engine's effect-based entry path does **not** re-apply a card's own
- * self-replacement — removing the explicit placement here fails
- * `UrbanRetreatScenarioTest:148` — so the from-hand put also spells [ZonePlacement.Tapped]; both
- * routes make it enter tapped, and an "enters untapped" replacement still overrides either. That
- * duplication is why Argentum Assay's differential reports this card: the printed line says nothing
- * about tapped, and the grammar reads what the line says. Sorcery-speed via
- * [TimingRule.SorcerySpeed].
+ * "This land enters tapped" is the [EntersTapped] self-replacement, and it is the *only* place
+ * this card says tapped: the from-hand put spells no placement, because the effect-based entry
+ * path applies the entering card's own clause too. Sorcery-speed via [TimingRule.SorcerySpeed].
  */
 val UrbanRetreat = card("Urban Retreat") {
     manaCost = ""
@@ -71,7 +65,6 @@ val UrbanRetreat = card("Urban Retreat") {
         effect = Effects.Move(
             EffectTarget.Self,
             Zone.BATTLEFIELD,
-            placement = ZonePlacement.Tapped,
             fromZone = Zone.HAND
         )
         timing = TimingRule.SorcerySpeed

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -13153,7 +13153,6 @@
                     "type": "MoveToZone",
                     "target": "Self",
                     "destination": "Battlefield",
-                    "placement": "Tapped",
                     "fromZone": "Hand"
                 },
                 "timing": "SorcerySpeed",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -5,6 +5,8 @@ import com.wingedsheep.engine.core.CardsDiscardedEvent
 import com.wingedsheep.engine.core.CountersAddedEvent
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.mechanics.daynight.DayNightService
@@ -52,6 +54,7 @@ import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.TypeLine
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.EntersTapped
 
 
 /**
@@ -138,6 +141,9 @@ object ZoneTransitionService {
      */
     lateinit var staticAbilityHandler: StaticAbilityHandler
     lateinit var cardRegistry: CardRegistry
+
+    /** Evaluates the `unless` clause of an entering card's own [EntersTapped]. */
+    private val conditionEvaluator = ConditionEvaluator()
 
     /**
      * Move one entity between zones with full cleanup + setup.
@@ -1234,15 +1240,29 @@ object ZoneTransitionService {
             entityId,
             controllerId
         )
+        // The entering card's OWN printed "this permanent enters tapped" clause. The cast path
+        // (StackResolver) and the land-play path (PlayLandHandler) read it themselves because
+        // neither routes through this method; every *other* card-based entry — reanimation, a
+        // return from exile, a search-library move — arrives here, and until this call each of
+        // them entered untapped no matter what the card said.
+        val selfEntersTapped = !options.faceDown &&
+            selfEntersTapped(withDayboundEntry, entityId, controllerId)
         val withTapResolved = when {
-            // A tapped entry (ramp/fetch) overridden by "enters untapped" (The Wandering Minstrel).
-            options.tapped && !options.tappedAndAttacking && entersUntapped ->
+            // A tapped entry — asked for by the effect (ramp/fetch) or printed on the card itself
+            // — overridden by "enters untapped" (The Wandering Minstrel). Two applicable entry
+            // replacements leave the order to the permanent's controller (CR 616.1e); the engine
+            // always resolves this pair to untapped, matching the cast path and the token path
+            // (EnterTappedReplacements.applyCreatedTokenEntryTap).
+            (options.tapped || selfEntersTapped) && !options.tappedAndAttacking && entersUntapped ->
                 withDayboundEntry.updateEntity(entityId) { it.without<TappedComponent>() }
-            // An untapped entry forced tapped by a global "[filter] enter tapped" (Zhao, the Moon
-            // Slayer's "Nonbasic lands enter tapped"). Gated on !entersUntapped so an "enters
-            // untapped" replacement still wins (CR 614).
+            // An untapped entry forced tapped by the card's own clause, or by a global
+            // "[filter] enter tapped" (Zhao, the Moon Slayer's "Nonbasic lands enter tapped").
+            // Gated on !entersUntapped so an "enters untapped" replacement still wins (CR 614).
             !options.tapped && !entersUntapped &&
-                EnterTappedReplacements.entersTapped(withDayboundEntry, entityId, controllerId) ->
+                (
+                    selfEntersTapped ||
+                        EnterTappedReplacements.entersTapped(withDayboundEntry, entityId, controllerId)
+                    ) ->
                 withDayboundEntry.updateEntity(entityId) { it.with(TappedComponent) }
             else -> withDayboundEntry
         }
@@ -1256,6 +1276,50 @@ object ZoneTransitionService {
                 ?: PermanentEnteredFaceDownThisTurnComponent()
             playerContainer.with(PermanentEnteredFaceDownThisTurnComponent(existing.count + 1))
         }
+    }
+
+    /**
+     * Whether the entering permanent's **own** printed "[this permanent] enters tapped" clause
+     * applies to this entry — a continuous replacement effect the object carries about itself
+     * (CR 614.1d), applied as it enters (CR 614.12: "Such effects may come from the permanent
+     * itself if they affect only that permanent").
+     *
+     * Three printed shapes, and only two of them can be decided from a pure state transition:
+     *  - **plain** ("This land enters tapped.") — always applies;
+     *  - **`unlessCondition`** ("… unless you control two or more other lands.") — applies when the
+     *    condition evaluates **false**, the same polarity the cast path uses in `StackResolver`;
+     *  - **`payLifeCost`** (shock lands: "… unless you pay 2 life.") — a *player decision*, and
+     *    [moveToZone] has nowhere to pause. It resolves fail-closed to **tapped**: the outcome a
+     *    player who declines to pay gets. Offering the choice needs a continuation in the two
+     *    off-stack executors (`MoveToZoneEffectExecutor`, `MoveCollectionExecutor`) the way
+     *    `StackResolver` offers it for a resolving permanent spell; until then a reanimated or
+     *    fetched shock land enters tapped without being asked, rather than silently untapped as it
+     *    did before this method consulted the clause at all.
+     *
+     * The card definition is re-read from [state] rather than taken from the caller's snapshot so
+     * a double-faced card that reverted to its front face on the way in is asked about the face
+     * that is actually entering. Face-down entries never reach here — a face-down permanent has
+     * no abilities (CR 708.2).
+     */
+    private fun selfEntersTapped(
+        state: GameState,
+        entityId: EntityId,
+        controllerId: EntityId,
+    ): Boolean {
+        if (!::cardRegistry.isInitialized) return false
+        val cardDefinitionId = state.getEntity(entityId)?.get<CardComponent>()?.cardDefinitionId
+            ?: return false
+        val cardDef = cardRegistry.getCard(cardDefinitionId) ?: return false
+        val entersTapped = cardDef.script.replacementEffects
+            .filterIsInstance<EntersTapped>()
+            .firstOrNull()
+            ?: return false
+        val unlessCondition = entersTapped.unlessCondition ?: return true
+        return !conditionEvaluator.evaluate(
+            state,
+            unlessCondition,
+            EffectContext(sourceId = entityId, controllerId = controllerId)
+        )
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelfEntersTappedOffStackEntryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelfEntersTappedOffStackEntryScenarioTest.kt
@@ -1,0 +1,303 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.handlers.effects.ZoneEntryOptions
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * A permanent's own printed "[this permanent] enters tapped" clause is a replacement effect the
+ * object carries about itself (CR 614.1d), applied as it enters (CR 614.12 — "Such effects may come
+ * from the permanent itself if they affect only that permanent"). Nothing in that rule cares *how*
+ * the permanent got to the battlefield, so a reanimated, blinked or fetched tapland must arrive
+ * tapped exactly like one that was played from hand.
+ *
+ * The engine reads the clause on three disjoint paths, and until this change only two of them
+ * existed:
+ *  - **playing a land** — `PlayLandHandler`, which never calls `ZoneTransitionService.moveToZone`;
+ *  - **resolving a permanent spell** — `StackResolver`, which places permanents with `addToZone`;
+ *  - **every other card-based entry** — reanimation and returns from exile
+ *    (`MoveToZoneEffectExecutor`) and search-library / collection moves (`MoveCollectionExecutor`),
+ *    both of which funnel through `moveToZone`. That third path ignored the clause entirely and the
+ *    permanent entered untapped.
+ *
+ * These tests pin the third path down in all three printed shapes, pin the CR 616.1e ordering
+ * against an "enters untapped" replacement, and guard the two paths that already worked against a
+ * double application.
+ */
+class SelfEntersTappedOffStackEntryScenarioTest : ScenarioTestBase() {
+
+    private fun GameState.isTapped(entityId: EntityId): Boolean =
+        getEntity(entityId)?.has<TappedComponent>() == true
+
+    /** The entity id of [cardName] sitting in player 1's graveyard. */
+    private fun graveyardCard(state: GameState, ownerId: EntityId, cardName: String): EntityId =
+        state.getGraveyard(ownerId).first { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name == cardName
+        }
+
+    init {
+
+        context("a card's own 'enters tapped' applies to an off-stack entry") {
+
+            test("a reanimation spell brings back a creature that says 'enters tapped' TAPPED") {
+                // The MoveToZoneEffectExecutor path, through a real card: Zombify is
+                // Effects.PutOntoBattlefieldFromGraveyard, and it says nothing about tapped.
+                // Diregraf Ghoul's own line does.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Zombify")
+                    .withCardInGraveyard(1, "Diregraf Ghoul")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ghoul = graveyardCard(game.state, game.player1Id, "Diregraf Ghoul")
+                val cast = game.castSpellTargetingGraveyardCard(1, "Zombify", listOf(ghoul))
+                withClue("casting Zombify should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("the reanimated creature is on the battlefield") {
+                    game.findPermanent("Diregraf Ghoul") shouldBe ghoul
+                }
+                withClue("CR 614.1d — its own printed clause applies however it entered") {
+                    game.state.isTapped(ghoul) shouldBe true
+                }
+            }
+
+            test("a tapland moved from the graveyard onto the battlefield enters TAPPED") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Jungle Hollow")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val land = graveyardCard(game.state, game.player1Id, "Jungle Hollow")
+                val moved = ZoneTransitionService.moveToZone(
+                    game.state, land, Zone.BATTLEFIELD,
+                    ZoneEntryOptions(controllerId = game.player1Id)
+                )
+
+                moved.state.isTapped(land) shouldBe true
+            }
+
+            test("a land with no such clause still enters untapped") {
+                // The control: the new reconciliation must not tap everything that arrives by
+                // effect.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forest = graveyardCard(game.state, game.player1Id, "Forest")
+                val moved = ZoneTransitionService.moveToZone(
+                    game.state, forest, Zone.BATTLEFIELD,
+                    ZoneEntryOptions(controllerId = game.player1Id)
+                )
+
+                moved.state.isTapped(forest) shouldBe false
+            }
+
+            test("a search-library move honors the fetched land's own clause") {
+                // The MoveCollectionExecutor path. Wood Elves' trigger is
+                // Patterns.Library.searchLibrary(destination = BATTLEFIELD) — it asks for no
+                // placement at all, so Highland Forest's own "enters tapped" is the only thing
+                // that can tap it.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Wood Elves")
+                    .withCardInLibrary(1, "Highland Forest")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Wood Elves")
+                withClue("casting Wood Elves should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val search = game.state.pendingDecision as? SelectCardsDecision
+                    ?: error("expected a library search; got ${game.state.pendingDecision}")
+                val fetched = search.options.first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Highland Forest"
+                }
+                game.submitDecision(CardsSelectedResponse(search.id, listOf(fetched)))
+                game.resolveStack()
+
+                withClue("the fetched land is on the battlefield") {
+                    game.findPermanent("Highland Forest") shouldBe fetched
+                }
+                withClue("and it entered tapped, as its own line says") {
+                    game.state.isTapped(fetched) shouldBe true
+                }
+            }
+        }
+
+        context("the 'unless' shape is evaluated, not assumed") {
+
+            // Overgrown Farmland: "This land enters tapped unless you control two or more other
+            // lands." The permanent enters tapped when the condition is FALSE — the same polarity
+            // the cast path uses.
+
+            test("condition false — reanimated with no other lands, it enters TAPPED") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Overgrown Farmland")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val land = graveyardCard(game.state, game.player1Id, "Overgrown Farmland")
+                val moved = ZoneTransitionService.moveToZone(
+                    game.state, land, Zone.BATTLEFIELD,
+                    ZoneEntryOptions(controllerId = game.player1Id)
+                )
+
+                moved.state.isTapped(land) shouldBe true
+            }
+
+            test("condition true — reanimated with two other lands, it enters UNTAPPED") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Overgrown Farmland")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val land = graveyardCard(game.state, game.player1Id, "Overgrown Farmland")
+                val moved = ZoneTransitionService.moveToZone(
+                    game.state, land, Zone.BATTLEFIELD,
+                    ZoneEntryOptions(controllerId = game.player1Id)
+                )
+
+                moved.state.isTapped(land) shouldBe false
+            }
+        }
+
+        context("CR 616.1e — an applicable 'enters untapped' still wins") {
+
+            test("The Wandering Minstrel untaps a reanimated tapland") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Wandering Minstrel")
+                    .withCardInGraveyard(1, "Jungle Hollow")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val land = graveyardCard(game.state, game.player1Id, "Jungle Hollow")
+                val moved = ZoneTransitionService.moveToZone(
+                    game.state, land, Zone.BATTLEFIELD,
+                    ZoneEntryOptions(controllerId = game.player1Id)
+                )
+
+                withClue("\"Lands you control enter untapped\" beats the land's own clause") {
+                    moved.state.isTapped(land) shouldBe false
+                }
+            }
+
+            test("without the Minstrel the same land enters tapped") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Jungle Hollow")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val land = graveyardCard(game.state, game.player1Id, "Jungle Hollow")
+                val moved = ZoneTransitionService.moveToZone(
+                    game.state, land, Zone.BATTLEFIELD,
+                    ZoneEntryOptions(controllerId = game.player1Id)
+                )
+
+                moved.state.isTapped(land) shouldBe true
+            }
+        }
+
+        context("the shock-land shape resolves fail-closed") {
+
+            test("a shock land put onto the battlefield by an effect enters TAPPED, unasked") {
+                // Godless Shrine is EntersTapped(payLifeCost = 2). Offering the choice needs a
+                // continuation the two off-stack executors don't have yet, so moveToZone resolves
+                // the pair to the outcome a player who declines gets: tapped. Deliberately
+                // asserted, because the alternative (silently untapped) is the bug this change
+                // fixes.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Godless Shrine")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val land = graveyardCard(game.state, game.player1Id, "Godless Shrine")
+                val moved = ZoneTransitionService.moveToZone(
+                    game.state, land, Zone.BATTLEFIELD,
+                    ZoneEntryOptions(controllerId = game.player1Id)
+                )
+
+                moved.state.isTapped(land) shouldBe true
+                withClue("a pure state transition cannot pause, so nothing was asked") {
+                    moved.state.pendingDecision shouldBe null
+                }
+            }
+        }
+
+        context("the two paths that already read the clause are unchanged") {
+
+            test("playing a tapland from hand still enters it tapped, exactly once") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Jungle Hollow")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val inHand = game.state.getHand(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Jungle Hollow"
+                }
+                val played = game.execute(PlayLand(game.player1Id, inHand))
+                withClue("playing the land should succeed: ${played.error}") {
+                    played.error shouldBe null
+                }
+
+                val land = game.findPermanent("Jungle Hollow")
+                    ?: error("the played land is not on the battlefield")
+                game.state.isTapped(land) shouldBe true
+            }
+
+            test("casting a creature that says 'enters tapped' still enters it tapped") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Diregraf Ghoul")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Diregraf Ghoul")
+                withClue("casting should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val ghoul = game.findPermanent("Diregraf Ghoul")
+                    ?: error("the cast creature is not on the battlefield")
+                game.state.isTapped(ghoul) shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
## The bug

A card's printed **"[this permanent] enters tapped"** is a replacement effect the object carries about itself (**CR 614.1d**), applied as it enters because it affects only that permanent (**CR 614.12**). Neither rule cares *how* the permanent reached the battlefield.

The engine read it on exactly two paths:

- `PlayLandHandler` — playing it as a land;
- `StackResolver` — resolving it as a permanent spell (including the shock-land `payLifeCost` prompt).

Every other card-based entry ignored it. A reanimated, blinked or fetched tapland entered **untapped** no matter what its own line said.

Found by Argentum Assay's differential in #1986 and deliberately left out of that PR — it is a replacement-path change, not a grammar one.

## The fix

One chokepoint, not two executors. Both broken paths — `MoveToZoneEffectExecutor` (reanimation, returns from exile, a self-return like Urban Retreat's) and `MoveCollectionExecutor` (search-library and other collection moves) — funnel through `ZoneTransitionService.moveToZone`, which already owns the tapped/untapped reconciliation against the *global* `EntersUntapped` and `PermanentsEnterTapped` replacements. The entering card's **own** clause joins that same `when`, so the fix covers those two executors and anything added later.

The three paths stay disjoint, which is what makes this safe: spell resolution places permanents with `addToZone`, and playing a land bypasses `moveToZone` entirely. Neither can double-apply.

**Ordering is unchanged, and still CR 616.1e.** An applicable "enters untapped" (The Wandering Minstrel — "Lands you control enter untapped") beats the card's own clause exactly as it already beat an explicit tapped placement; `tappedAndAttacking` keeps its carve-out.

### The three printed shapes

| shape | handled |
|---|---|
| plain (`This land enters tapped.`) | applied |
| `unlessCondition` (`… unless you control two or more other lands.`) | evaluated, same polarity `StackResolver` uses — tapped when the condition is **false** |
| `payLifeCost` (shock lands) | **fail-closed to tapped**, documented — see below |

`moveToZone` is a pure state transition with nowhere to pause, so a shock land put onto the battlefield by an effect enters tapped without being offered the choice: the outcome a player who declines to pay gets. That is written up in the helper's KDoc with the reason. It is strictly better than the current behaviour, which was silently *untapped*.

**Named follow-up:** offering the shock-land choice on these paths needs its own continuation in `MoveToZoneEffectExecutor` and `MoveCollectionExecutor`, the way `StackResolver` offers it for a resolving permanent spell. `MoveCollectionExecutor`'s group path is the harder half — a pause there abandons the group. Out of scope here.

## What it lets us delete

`UrbanRetreat.kt` was the one card in the corpus compensating for the gap (285 cards carry `EntersTapped()`; one of those also moves itself to the battlefield). Its from-hand put spelled `placement = ZonePlacement.Tapped` so the land would arrive tapped anyway. That line and the paragraph of KDoc explaining the workaround are gone; `fromZone = Zone.HAND` (the resolution guard from #1986) stays. All six of its scenario tests pass on the engine's behaviour now, including *"from-hand ability bounces a tapped creature and puts Urban Retreat onto the battlefield tapped"* — the assertion that only passed because of the workaround, and the regression test for this change.

`SPM.json` loses exactly that `"placement": "Tapped"`.

## Tests

New `SelfEntersTappedOffStackEntryScenarioTest` (11 tests, `:rules-engine`):

- reanimation through a real card — Zombify on Diregraf Ghoul → tapped;
- a tapland moved graveyard → battlefield → tapped; a land with no clause → still untapped (the control);
- the **search-library** path — Wood Elves fetching Highland Forest → tapped (`MoveCollectionExecutor`);
- `unlessCondition` both ways — Overgrown Farmland reanimated with 0 other lands (tapped) and with 2 (untapped);
- CR 616.1e ordering — The Wandering Minstrel untaps a reanimated tapland, and the same land without it does not;
- the shock-land shape — Godless Shrine enters tapped and nothing was asked;
- the two paths that already worked — playing a tapland from hand, casting Diregraf Ghoul — unchanged.

## Gates

- `just test-rules` — green (`:rules-engine:test` plus every card scenario; this is the one that matters, the change touches the entry path every reanimation, fetch and blink goes through).
- `:mtg-sets:test`, `:mtg-sdk:test`, `:oracle-assay:test` — green.
- `just assay-gate --limit 2000` — green.
- `just check` — green.
- `just rebless-cards` — one line, the `placement` above.

## One correction to the brief

Two things did not land as the brief predicted, both worth reading:

1. **The CR number is 614.1**d**, not 614.1c.** 614.1c is `"[This permanent] enters with …"` / `"As [this permanent] enters …"` / `"[This permanent] enters as …"`. The bare `"[This permanent] enters …"` continuous form — which is what "This land enters tapped" is — is 614.1d. Verified against the 2025-11-14 Comprehensive Rules text. Code, KDoc and commit message all cite 614.1d.

2. **`just assay-differential` still reads 44, not 43.** The placement axis *is* closed — Assay and the card now agree byte-for-byte on that ability's `MoveToZone`. But Urban Retreat carries a **second, independent divergence** the brief did not account for: Assay reads `"{T}: Add {G}, {W}, or {U}."` as three separate `AddMana` abilities, while the card spells one `AddManaOfChoice(ManaColorSet.Specific(...))`. That is the corpus-wide tri-land mana spelling — Sultai Banner and friends use three abilities and are confirmed; 17 cards use `ManaColorSet.Specific`, and the rest of them aren't compared, so Urban Retreat is the only one visible in the differential. Deciding which spelling is canonical is an Assay band or a corpus sweep over those 17 cards, not a replacement-path change, so it stays out of this PR. The band's residue is one card short of closed, and this is the reason.

`just assay-bake` moved two unrelated `LINE_DECLINED` rows (Landlore Navigator, Painful Bond) — upstream Scryfall Oracle-text drift, not this change. Reverted rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)