### PR TITLE
Draw a creature cast with disguise as "A Mysterious Creature"

### DIFF
--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/FaceDownMode.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/FaceDownMode.kt
@@ -19,9 +19,18 @@ import kotlinx.serialization.Serializable
  * down, and disguise (CR 702.168a) and cloak (CR 701.58a) list ward {2} among theirs. It is
  * therefore part of the characteristic-defining effect, not an ability of the card underneath —
  * which is why it lives on the mode rather than on the card's keyword abilities.
+ *
+ * [helperCardImageUri] is the *display* counterpart: the art of the helper card paper Magic
+ * supplies for that mechanic, which every surface that draws a face-down object uses in place of
+ * the hidden card's own art. The client mirrors these three URLs in `web-client/src/utils/
+ * cardImages.ts` for the surfaces where it renders a face-down object without a server-sent image;
+ * keep the two in sync.
  */
 @Serializable
-enum class FaceDownMode(val faceDownWard: WardCost? = null) {
+enum class FaceDownMode(
+    val faceDownWard: WardCost? = null,
+    val helperCardImageUri: String = MORPH_HELPER_CARD_IMAGE_URI,
+) {
     /**
      * Morph (CR 702.37) / Megamorph: the permanent is turned face up by paying the card's morph
      * cost, taken from its [com.wingedsheep.sdk.scripting.KeywordAbility.Morph] ability.
@@ -34,21 +43,21 @@ enum class FaceDownMode(val faceDownWard: WardCost? = null) {
      * card has no way to be turned face up that way — though per CR 701.40c/d a manifested card
      * that has morph or disguise may instead be turned face up by *that* mechanic's procedure.
      */
-    MANIFEST,
+    MANIFEST(helperCardImageUri = MANIFEST_HELPER_CARD_IMAGE_URI),
 
     /**
      * Disguise (CR 702.168): morph with ward {2}. Cast face down for {3} at sorcery speed, turned
      * face up any time you have priority by paying the card's
      * [com.wingedsheep.sdk.scripting.KeywordAbility.Disguise] cost.
      */
-    DISGUISE(WardCost.Mana("{2}")),
+    DISGUISE(WardCost.Mana("{2}"), MYSTERIOUS_CREATURE_HELPER_CARD_IMAGE_URI),
 
     /**
      * Cloak (CR 701.58): manifest with ward {2}. Turned face up by paying the card's mana cost,
      * only if it is a creature card (CR 701.58b); per CR 701.58c/d a cloaked card that has morph
      * or disguise may instead be turned face up by that mechanic's procedure.
      */
-    CLOAK(WardCost.Mana("{2}")),
+    CLOAK(WardCost.Mana("{2}"), MYSTERIOUS_CREATURE_HELPER_CARD_IMAGE_URI),
 
     /**
      * Face down with no turn-up procedure — e.g. a card exiled face down for Hideaway. It is
@@ -56,3 +65,22 @@ enum class FaceDownMode(val faceDownWard: WardCost? = null) {
      */
     HIDDEN
 }
+
+/**
+ * The Morph token (TC19 #27) — the helmeted figure paper Magic supplies for a face-down morph, and
+ * the fallback for any face-down object whose mechanic is unknown.
+ */
+const val MORPH_HELPER_CARD_IMAGE_URI =
+    "https://cards.scryfall.io/normal/front/e/9/e9375cbe-93c0-41a5-a6e3-fb4416f54a69.jpg"
+
+/** The Manifest token (TDSK #18), used for manifested permanents (CR 701.40). */
+const val MANIFEST_HELPER_CARD_IMAGE_URI =
+    "https://cards.scryfall.io/normal/front/0/1/01104ab1-84e1-4c78-853d-637c6554bdf9.jpg"
+
+/**
+ * "A Mysterious Creature" (TMKM #21) — the single helper card printed for *both* disguise
+ * (CR 702.168) and cloak (CR 701.58); its own reminder text covers either mechanic, so paper Magic
+ * uses this one card for both and so do we.
+ */
+const val MYSTERIOUS_CREATURE_HELPER_CARD_IMAGE_URI =
+    "https://cards.scryfall.io/normal/front/2/4/241b3b6d-a25f-4a43-b5d6-1d1079e7e498.jpg"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/FaceDownTurnUp.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/FaceDownTurnUp.kt
@@ -21,6 +21,21 @@ import com.wingedsheep.sdk.scripting.effects.FaceDownMode
  */
 object FaceDownTurnUp {
 
+    /**
+     * Which face-down mechanic lets [cardDef] be *cast* face down for {3} — morph (CR 702.37a) or
+     * disguise (CR 702.168a) — or null when it can't be cast face down at all. A card never prints
+     * both; morph wins if one somehow did.
+     *
+     * The single place that maps the printed keyword to its mode, so the cast path, the resolution
+     * path and the client view all agree on which helper card a face-down spell is drawn as.
+     */
+    fun castMode(cardDef: CardDefinition?): FaceDownMode? = when {
+        cardDef == null -> null
+        cardDef.keywordAbilities.any { it is KeywordAbility.Morph } -> FaceDownMode.MORPH
+        cardDef.keywordAbilities.any { it is KeywordAbility.Disguise } -> FaceDownMode.DISGUISE
+        else -> null
+    }
+
     fun dataFor(
         cardDef: CardDefinition?,
         cardDefinitionId: String,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -3631,15 +3631,11 @@ class StackResolver(
 
     /**
      * Which face-down mechanic lets [cardDef] be cast face down for {3} — morph (CR 702.37a) or
-     * disguise (CR 702.168a) — or null when it can't be cast face down at all. A card never prints
-     * both; morph wins if one somehow did.
+     * disguise (CR 702.168a) — or null when it can't be cast face down at all. Delegates to
+     * [FaceDownTurnUp.castMode], which owns the keyword-to-mode mapping.
      */
-    fun faceDownCastMode(cardDef: com.wingedsheep.sdk.model.CardDefinition?): FaceDownMode? = when {
-        cardDef == null -> null
-        cardDef.keywordAbilities.any { it is KeywordAbility.Morph } -> FaceDownMode.MORPH
-        cardDef.keywordAbilities.any { it is KeywordAbility.Disguise } -> FaceDownMode.DISGUISE
-        else -> null
-    }
+    fun faceDownCastMode(cardDef: com.wingedsheep.sdk.model.CardDefinition?): FaceDownMode? =
+        FaceDownTurnUp.castMode(cardDef)
 
     /**
      * Once a player casts a card face down, opponents can no longer know whether any previously

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -37,11 +37,13 @@ import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.composite.asConditional
 import com.wingedsheep.sdk.scripting.events.DamageType
 import com.wingedsheep.engine.state.permissions.hasMayPlayFor
+import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.GiftGivenEffect
 import com.wingedsheep.sdk.scripting.effects.GatedEffect
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.MORPH_HELPER_CARD_IMAGE_URI
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.imageOverrideFor
@@ -777,6 +779,16 @@ class ClientStateTransformer(
             ?.mapNotNull { try { Color.valueOf(it.removePrefix(protectionPrefix)) } catch (_: Exception) { null } }
             ?: emptyList()
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
+        // Which face-down mechanic this object is *drawn* as: it decides the helper card every
+        // surface shows in place of the hidden art (morph's helmet, the Manifest token, "A
+        // Mysterious Creature" for disguise/cloak). A permanent carries the mode as a component
+        // from the moment it enters, but a spell still on the stack does not — it is stamped when
+        // it resolves — so derive that one from the keyword it was cast under. Without the
+        // fallback a creature *being cast* with disguise would be drawn as a morph.
+        val faceDownDisplayMode = container.get<FaceDownModeComponent>()?.mode
+            ?: if (spellOnStack?.castFaceDown == true) FaceDownTurnUp.castMode(cardDef) else null
+        val faceDownHelperCardImageUri =
+            faceDownDisplayMode?.helperCardImageUri ?: MORPH_HELPER_CARD_IMAGE_URI
         val staticProtections = cardDef?.keywordAbilities
             ?.filterIsInstance<KeywordAbility.Protection>()
             ?.mapNotNull { (it.scope as? ProtectionScope.Color)?.color }
@@ -872,8 +884,9 @@ class ClientStateTransformer(
                     attachedTo = null,
                     attachments = emptyList(),
                     isFaceDown = true,
+                    faceDownMode = faceDownDisplayMode?.name,
                     morphCost = null,
-                    imageUri = "https://cards.scryfall.io/normal/front/e/9/e9375cbe-93c0-41a5-a6e3-fb4416f54a69.jpg",
+                    imageUri = faceDownHelperCardImageUri,
                     activeEffects = emptyList(),
                     revealedName = if (isRevealedToViewer) cardComponent.name else null,
                     revealedImageUri = if (isRevealedToViewer) (cardComponent.imageUri ?: cardDef?.metadata?.imageUri) else null
@@ -938,9 +951,9 @@ class ClientStateTransformer(
                 },
                 linkedExile = container.get<LinkedExileComponent>()?.exiledIds ?: emptyList(),
                 isFaceDown = true,
-                faceDownMode = container.get<FaceDownModeComponent>()?.mode?.name,
+                faceDownMode = faceDownDisplayMode?.name,
                 morphCost = null, // Opponent can't see morph cost
-                imageUri = "https://cards.scryfall.io/normal/front/e/9/e9375cbe-93c0-41a5-a6e3-fb4416f54a69.jpg", // Morph token from Commander 2019
+                imageUri = faceDownHelperCardImageUri,
                 activeEffects = buildCardActiveEffects(state, entityId),
                 revealedName = if (isRevealedToViewer) cardComponent.name else null,
                 revealedImageUri = if (isRevealedToViewer) (cardComponent.imageUri ?: cardDef?.metadata?.imageUri) else null
@@ -1367,7 +1380,7 @@ class ClientStateTransformer(
             attachments = attachments,
             linkedExile = linkedExile,
             isFaceDown = isFaceDown,
-            faceDownMode = if (isFaceDown) container.get<FaceDownModeComponent>()?.mode?.name else null,
+            faceDownMode = if (isFaceDown) faceDownDisplayMode?.name else null,
             isSuspected = projectedValues?.isSuspected == true,
             isSolved = container.has<com.wingedsheep.engine.state.components.battlefield.SolvedComponent>(),
             saddleRequirement = saddleRequirement,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownHelperCardVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/FaceDownHelperCardVisibilityTest.kt
@@ -1,0 +1,193 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.MANIFEST_HELPER_CARD_IMAGE_URI
+import com.wingedsheep.sdk.scripting.effects.MORPH_HELPER_CARD_IMAGE_URI
+import com.wingedsheep.sdk.scripting.effects.MYSTERIOUS_CREATURE_HELPER_CARD_IMAGE_URI
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Which helper card a face-down object is *drawn* as.
+ *
+ * Paper Magic prints one per mechanic — the helmeted Morph token, the Manifest token, and
+ * "A Mysterious Creature" for both disguise (CR 702.168) and cloak (CR 701.58) — and the client
+ * shows that card's art in place of the hidden one. The mode travels to the client on
+ * [ClientCard.faceDownMode], and the masked view (what an opponent or spectator gets, where the
+ * real art must never be sent) carries the helper card's own image in [ClientCard.imageUri].
+ *
+ * The interesting case is a spell **still on the stack**: `FaceDownModeComponent` is stamped when
+ * the permanent enters the battlefield, so while the spell is being cast the mode has to be derived
+ * from the keyword it was cast under. Without that, a creature cast with disguise was drawn as a
+ * *morph* for as long as it sat on the stack, and only became "A Mysterious Creature" on resolution.
+ */
+class FaceDownHelperCardVisibilityTest : FunSpec({
+
+    val disguiseBear = card("Disguised Bear") {
+        manaCost = "{2}{B}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+        disguise = "{2}{B}"
+    }
+
+    val morphBear = card("Morphing Bear") {
+        manaCost = "{2}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+        morph = "{2}{G}"
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(disguiseBear, morphBear))
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun transformer(d: GameTestDriver): ClientStateTransformer =
+        ClientStateTransformer(cardRegistry = d.cardRegistry)
+
+    /** Cast [cardName] face down for {3} and leave the spell on the stack. */
+    fun GameTestDriver.castFaceDown(playerId: EntityId, cardName: String): EntityId {
+        val card = putCardInHand(playerId, cardName)
+        giveMana(playerId, Color.BLACK, 3)
+        submit(
+            CastSpell(
+                playerId = playerId,
+                cardId = card,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        ).isSuccess shouldBe true
+        return card
+    }
+
+    /** Put [cardName] on the battlefield face down under [mode], as a real face-down entry does. */
+    fun GameTestDriver.putFaceDown(playerId: EntityId, cardName: String, mode: FaceDownMode): EntityId {
+        val id = putCreatureOnBattlefield(playerId, cardName)
+        val cardDef = cardRegistry.requireCard(cardName)
+        replaceState(
+            state.updateEntity(id) { container ->
+                var c = container.with(FaceDownComponent).with(FaceDownModeComponent(mode))
+                FaceDownTurnUp.dataFor(cardDef, cardName, mode)?.let { c = c.with(it) }
+                c
+            }
+        )
+        return id
+    }
+
+    context("a creature cast with disguise") {
+
+        test("is A Mysterious Creature to its opponent while the spell is on the stack") {
+            val d = driver()
+            val caster = d.activePlayer!!
+            val opponent = if (caster == d.player1) d.player2 else d.player1
+            val spell = d.castFaceDown(caster, "Disguised Bear")
+
+            val view = transformer(d).transform(d.state, viewingPlayerId = opponent)
+            val card = view.cards[spell].shouldNotBeNull()
+            card.isFaceDown shouldBe true
+            card.faceDownMode shouldBe FaceDownMode.DISGUISE.name
+            withClue("the opponent must get the helper card's art, never the hidden card's") {
+                card.imageUri shouldBe MYSTERIOUS_CREATURE_HELPER_CARD_IMAGE_URI
+            }
+            card.name shouldBe "Face-down creature"
+        }
+
+        test("is A Mysterious Creature to its caster while the spell is on the stack") {
+            val d = driver()
+            val caster = d.activePlayer!!
+            val spell = d.castFaceDown(caster, "Disguised Bear")
+
+            val view = transformer(d).transform(d.state, viewingPlayerId = caster)
+            val card = view.cards[spell].shouldNotBeNull()
+            card.isFaceDown shouldBe true
+            // The caster's own view keeps the real card's name and art (they may look at it); the
+            // mode is what tells the client to draw the helper card instead.
+            card.faceDownMode shouldBe FaceDownMode.DISGUISE.name
+            card.name shouldBe "Disguised Bear"
+        }
+
+        test("is still A Mysterious Creature once it has resolved") {
+            val d = driver()
+            val caster = d.activePlayer!!
+            val opponent = if (caster == d.player1) d.player2 else d.player1
+            val spell = d.castFaceDown(caster, "Disguised Bear")
+            d.bothPass()
+
+            val view = transformer(d).transform(d.state, viewingPlayerId = opponent)
+            val card = view.cards[spell].shouldNotBeNull()
+            card.faceDownMode shouldBe FaceDownMode.DISGUISE.name
+            card.imageUri shouldBe MYSTERIOUS_CREATURE_HELPER_CARD_IMAGE_URI
+        }
+    }
+
+    context("the other face-down mechanics keep their own helper card") {
+
+        test("a morph spell on the stack is the Morph token, not A Mysterious Creature") {
+            val d = driver()
+            val caster = d.activePlayer!!
+            val opponent = if (caster == d.player1) d.player2 else d.player1
+            val spell = d.castFaceDown(caster, "Morphing Bear")
+
+            val view = transformer(d).transform(d.state, viewingPlayerId = opponent)
+            val card = view.cards[spell].shouldNotBeNull()
+            card.faceDownMode shouldBe FaceDownMode.MORPH.name
+            card.imageUri shouldBe MORPH_HELPER_CARD_IMAGE_URI
+        }
+
+        test("a cloaked permanent is A Mysterious Creature — the card covers both mechanics") {
+            val d = driver()
+            val player = d.activePlayer!!
+            val opponent = if (player == d.player1) d.player2 else d.player1
+            val permanent = d.putFaceDown(player, "Grizzly Bears", FaceDownMode.CLOAK)
+
+            val view = transformer(d).transform(d.state, viewingPlayerId = opponent)
+            val card = view.cards[permanent].shouldNotBeNull()
+            card.faceDownMode shouldBe FaceDownMode.CLOAK.name
+            card.imageUri shouldBe MYSTERIOUS_CREATURE_HELPER_CARD_IMAGE_URI
+        }
+
+        test("a manifested permanent is the Manifest token") {
+            val d = driver()
+            val player = d.activePlayer!!
+            val opponent = if (player == d.player1) d.player2 else d.player1
+            val permanent = d.putFaceDown(player, "Grizzly Bears", FaceDownMode.MANIFEST)
+
+            val view = transformer(d).transform(d.state, viewingPlayerId = opponent)
+            val card = view.cards[permanent].shouldNotBeNull()
+            card.faceDownMode shouldBe FaceDownMode.MANIFEST.name
+            card.imageUri shouldBe MANIFEST_HELPER_CARD_IMAGE_URI
+        }
+
+        test("a face-down permanent with no mode recorded falls back to the Morph token") {
+            val d = driver()
+            val player = d.activePlayer!!
+            val opponent = if (player == d.player1) d.player2 else d.player1
+            val permanent = d.putCreatureOnBattlefield(player, "Grizzly Bears")
+            d.replaceState(d.state.updateEntity(permanent) { it.with(FaceDownComponent) })
+
+            val view = transformer(d).transform(d.state, viewingPlayerId = opponent)
+            val card = view.cards[permanent].shouldNotBeNull()
+            card.faceDownMode shouldBe null
+            card.imageUri shouldBe MORPH_HELPER_CARD_IMAGE_URI
+        }
+    }
+})

--- a/web-client/src/components/game/board/StackZone.tsx
+++ b/web-client/src/components/game/board/StackZone.tsx
@@ -5,7 +5,7 @@ import { useStackCards, selectGameState } from '@/store/selectors.ts'
 import { seatColor } from '@/styles/seatColors'
 import type { EntityId } from '@/types'
 import type { ClientAbilityIdentity, ClientCard } from '@/types/gameState'
-import { getCardImageUrl } from '@/utils/cardImages.ts'
+import { getCardImageUrl, faceDownImageUrl } from '@/utils/cardImages.ts'
 import { ActiveEffectBadges } from '../card/CardOverlays'
 import { AbilityText, ManaCost } from '../../ui/ManaSymbols'
 import { useOpenCardMenuOnTap } from '@/hooks/useOpenCardMenuOnTap.ts'
@@ -220,10 +220,17 @@ export function StackDisplay() {
           const dimmed = card.sourceZone === 'GRAVEYARD'
             ? { opacity: 0.7, filter: 'saturate(0.6)' }
             : {}
+          // A spell cast face down (morph, disguise) is drawn as its mechanic's helper card on the
+          // stack, the same as the permanent it becomes — the morph helmet, or "A Mysterious
+          // Creature" for disguise. Its controller still sees the real card on hover, exactly as
+          // for their own face-down permanents.
+          const faceDown = card.isFaceDown === true
           const image = (
             <img
-              src={getCardImageUrl(card.name, card.imageUri, 'small')}
-              alt={card.name}
+              src={faceDown
+                ? faceDownImageUrl(card.faceDownMode)
+                : getCardImageUrl(card.name, card.imageUri, 'small')}
+              alt={faceDown ? 'Face-down spell' : card.name}
               style={{
                 ...styles.stackItemImage,
                 ...(isLandscape
@@ -239,8 +246,8 @@ export function StackDisplay() {
                 cursor: isValidTarget || opts.onClick ? 'pointer' : 'default',
                 ...dimmed,
               }}
-              title={card.name}
-              onError={(e) => handleImageError(e, card.name, 'small')}
+              title={faceDown ? undefined : card.name}
+              onError={(e) => { if (!faceDown) handleImageError(e, card.name, 'small') }}
             />
           )
           if (!isLandscape) return image

--- a/web-client/src/utils/cardImages.ts
+++ b/web-client/src/utils/cardImages.ts
@@ -1,3 +1,7 @@
+// The three face-down helper cards below mirror `FaceDownMode.helperCardImageUri` in `mtg-sdk`: the
+// server sends the same URL as a masked face-down card's `imageUri`, and these constants cover the
+// surfaces the client draws from the mode alone. Keep the two lists in sync.
+
 /**
  * Standard MTG morph face-down card art from Scryfall.
  * This is the official morph token from Commander 2019 (TC19 #27) showing the distinctive helmet artwork.


### PR DESCRIPTION
## The bug

Paper Magic prints one helper card per face-down mechanic — the helmeted **Morph** token, the **Manifest** token, and **"A Mysterious Creature"** for both disguise (CR 702.168) and cloak (CR 701.58). The client already knew how to pick between them, from `ClientCard.faceDownMode`.

But that mode only existed once the permanent was on the battlefield: it's stamped as `FaceDownModeComponent` when the spell *resolves*. While a creature was being **cast** with disguise the field was null, so every surface fell back to the morph helmet — the stack pile, an opponent's hover preview, the exile pile. It turned into "A Mysterious Creature" only after it resolved.

The controller's own view had a second gap: the stack drew a face-down spell as the real card, even though the battlefield has always drawn a face-down permanent as its helper card.

## The fix

- **`FaceDownMode.helperCardImageUri`** — the mechanic's display card now sits next to the ward it also grants. The two hardcoded morph URLs in `ClientStateTransformer` are gone; a masked face-down card is sent its own mechanic's art (morph, manifest, or the Mysterious Creature).
- **`FaceDownTurnUp.castMode`** — the transformer derives the display mode for a spell still on the stack from the keyword it was cast under. That keyword-to-mode mapping already existed on `StackResolver`; it moved to the object that owns every other mode rule, and `StackResolver.faceDownCastMode` delegates to it. A permanent's stamped component still wins.
- **`StackZone`** draws a face-down spell as its helper card for *both* players, matching the battlefield. The controller still sees the real card on hover, as they do for their own face-down permanents.

## Verification

- New `FaceDownHelperCardVisibilityTest`: disguise on the stack (to caster and to opponent), after resolution, plus morph / cloak / manifest and the no-mode fallback each keeping their own helper card — 7 tests, green.
- `just test-rules` — engine tests + every card scenario, green.
- `tsc --noEmit` clean; the client's 626 vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)