### PR TITLE
Sneaky Snacker: the recursion trigger functions only in the graveyard

### DIFF
--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh3/cards/SneakySnacker.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh3/cards/SneakySnacker.kt
@@ -18,9 +18,13 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * When you draw your third card in a turn, return this card from your graveyard to the battlefield tapped.
  *
  * Uses [Triggers.NthCardDrawn]`(3)` (CR 121.2) for the third-draw trigger, and
- * [Effects.PutOntoBattlefield]`(Self, tapped = true)` — the same "return from graveyard tapped"
- * idiom as Persistent Specimen / Reassembling Skeleton / Teacher's Pest, but triggered rather than
- * activated.
+ * [Effects.PutOntoBattlefieldFromGraveyard]`(Self, tapped = true)` for the recursion — the same
+ * facade as Persistent Specimen / Reassembling Skeleton / Teacher's Pest, but triggered rather than
+ * activated. The facade's `fromZone = GRAVEYARD` is the guard the printed line names: a Snacker
+ * that has left the graveyard by the time the trigger resolves stays where it is.
+ *
+ * `triggerZones = {GRAVEYARD}` because the ability's effect moves the card out of the graveyard, so
+ * it functions only there (CR 113.6m) — a Snacker on the battlefield doesn't see your third draw.
  */
 val SneakySnacker = card("Sneaky Snacker") {
     manaCost = "{U}{B}"
@@ -34,8 +38,8 @@ val SneakySnacker = card("Sneaky Snacker") {
 
     triggeredAbility {
         trigger = Triggers.NthCardDrawn(3)
-        effect = Effects.PutOntoBattlefield(EffectTarget.Self, tapped = true)
-        triggerZones = setOf(Zone.BATTLEFIELD, Zone.GRAVEYARD)
+        effect = Effects.PutOntoBattlefieldFromGraveyard(EffectTarget.Self, tapped = true)
+        triggerZones = setOf(Zone.GRAVEYARD)
         description = "When you draw your third card in a turn, return this card from your graveyard to the battlefield tapped."
     }
 

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SneakySnackerScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SneakySnackerScenarioTest.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.Rarity
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sneaky Snacker (MH3 #205) — {U}{B} 2/1 Creature — Faerie Rogue.
+ *
+ * "Flying
+ *  When you draw your third card in a turn, return this card from your graveyard to the battlefield
+ *  tapped."
+ *
+ * The recursion trigger is graveyard-only: its effect moves the card out of the graveyard, so the
+ * ability functions only there (CR 113.6m). A Snacker already on the battlefield must not see the
+ * third draw — and the return itself carries the `fromZone = GRAVEYARD` guard, so a Snacker that
+ * left the graveyard before resolution stays gone.
+ */
+class SneakySnackerScenarioTest : FunSpec({
+
+    /** Local witness spell: one draw effect that crosses the third-card threshold on its own. */
+    val DrawThreeForSnacker = card("Draw Three For Snacker") {
+        manaCost = "{2}{U}"
+        colorIdentity = "U"
+        typeLine = "Sorcery"
+        oracleText = "Draw three cards."
+
+        spell {
+            effect = Effects.DrawCards(3)
+        }
+
+        metadata {
+            rarity = Rarity.COMMON
+            collectorNumber = "T01"
+        }
+    }
+
+    /** Local witness spell for the "only two cards drawn" case. */
+    val DrawTwoForSnacker = card("Draw Two For Snacker") {
+        manaCost = "{1}{U}"
+        colorIdentity = "U"
+        typeLine = "Sorcery"
+        oracleText = "Draw two cards."
+
+        spell {
+            effect = Effects.DrawCards(2)
+        }
+
+        metadata {
+            rarity = Rarity.COMMON
+            collectorNumber = "T02"
+        }
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DrawThreeForSnacker, DrawTwoForSnacker))
+        // Turn 1's active player skips their draw step (CR 103.7a), so the per-turn draw count
+        // starts at 0 and a single draw-three spell lands exactly on the third card.
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun castDrawSpell(driver: GameTestDriver, player: com.wingedsheep.sdk.model.EntityId, name: String, generic: Int) {
+        val spell = driver.putCardInHand(player, name)
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.giveColorlessMana(player, generic)
+        driver.castSpell(player, spell)
+        driver.bothPass()
+    }
+
+    test("drawing a third card returns the Snacker from the graveyard to the battlefield tapped") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val snacker = driver.putCardInGraveyard(player, "Sneaky Snacker")
+
+        castDrawSpell(driver, player, "Draw Three For Snacker", generic = 2)
+        // The draw spell has resolved; the recursion trigger is now on the stack.
+        driver.bothPass()
+        driver.isPaused shouldBe false
+
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(snacker) shouldBe true
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(snacker) shouldBe false
+        driver.isTapped(snacker) shouldBe true
+    }
+
+    test("drawing only two cards leaves the Snacker in the graveyard") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val snacker = driver.putCardInGraveyard(player, "Sneaky Snacker")
+
+        castDrawSpell(driver, player, "Draw Two For Snacker", generic = 1)
+        driver.isPaused shouldBe false
+
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(snacker) shouldBe true
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(snacker) shouldBe false
+    }
+
+    test("a Snacker already on the battlefield does not trigger on the third draw") {
+        // CR 113.6m: the ability moves the card out of the graveyard, so it functions only there.
+        // Before the guard the trigger fired from the battlefield too and tapped the Snacker.
+        val driver = newDriver()
+        val player = driver.player1
+
+        val snacker = driver.putCreatureOnBattlefield(player, "Sneaky Snacker")
+
+        castDrawSpell(driver, player, "Draw Three For Snacker", generic = 2)
+        driver.isPaused shouldBe false
+
+        driver.assertStackSize(0)
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(snacker) shouldBe true
+        driver.isTapped(snacker) shouldBe false
+    }
+
+    test("an opponent's third draw does not return your Snacker") {
+        val driver = newDriver()
+        val player = driver.player1
+        val opponent = driver.getOpponent(player)
+
+        val snacker = driver.putCardInGraveyard(player, "Sneaky Snacker")
+
+        // Hand the turn to the opponent, then have them draw three of their own cards. Their
+        // turn-based draw already counted as card #1, so a draw-two crosses their third.
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        castDrawSpell(driver, opponent, "Draw Two For Snacker", generic = 1)
+        driver.isPaused shouldBe false
+
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)).contains(snacker) shouldBe true
+        driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).contains(snacker) shouldBe false
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/MH3.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MH3.json
@@ -944,10 +944,10 @@
                     "type": "MoveToZone",
                     "target": "Self",
                     "destination": "Battlefield",
-                    "placement": "Tapped"
+                    "placement": "Tapped",
+                    "fromZone": "Graveyard"
                 },
                 "activeZones": [
-                    "Battlefield",
                     "Graveyard"
                 ],
                 "descriptionOverride": "When you draw your third card in a turn, return this card from your graveyard to the battlefield tapped."


### PR DESCRIPTION
Supersedes #1971. That PR found a real bug, then re-blessed the card snapshots against a stale `main` — the diff reverted goldens for ARN, ICE, LCI, LEG, MH2, MKM, MRD, ODY, ONS, PC2, SHM, SPM, ULG and VIS (deleting Zuran Orb and Greed outright, renaming `GainControlByMost` back to `GainControlByRank`, un-gating a Lost Caverns card), which is why `test (content)` failed and the branch went `CONFLICTING`. This branch is cut fresh from `main` and carries only the card fix, the re-blessed MH3 golden, and the scenario test the card never had.

## The bug

`Sneaky Snacker` — "When you draw your third card in a turn, return this card from your graveyard to the battlefield tapped." Two things were wrong:

1. **No graveyard guard on the return.** `Effects.PutOntoBattlefield(Self, tapped = true)` moves the card from wherever it is. `Effects.PutOntoBattlefieldFromGraveyard(Self, tapped = true)` is the facade that carries `fromZone = GRAVEYARD` — the guard the printed line names, and the one every sibling in this family already uses (Reassembling Skeleton, Persistent Specimen, Teacher's Pest, Haunted Dead, Tunnel Rats). #1971 reached past the facade for a raw `MoveToZoneEffect` instead; `AGENTS.md` asks cards to go through the facade.

2. **The ability functioned on the battlefield.** `triggerZones` listed `BATTLEFIELD` alongside `GRAVEYARD`. The ability's effect moves the card out of the graveyard, so it functions only there (CR 113.6m). With `BATTLEFIELD` in the set, a Snacker that was already on the battlefield when you drew your third card put its own trigger on the stack — and resolving it **tapped your own flier**. Probed directly on the pre-fix definition: `onBf=true tapped=true`.

## Fix

```kotlin
effect = Effects.PutOntoBattlefieldFromGraveyard(EffectTarget.Self, tapped = true)
triggerZones = setOf(Zone.GRAVEYARD)
```

Snapshot diff is exactly those two fields, on this card only:

```
-                    "placement": "Tapped"
+                    "placement": "Tapped",
+                    "fromZone": "Graveyard"
                 },
                 "activeZones": [
-                    "Battlefield",
                     "Graveyard"
```

## Test

New `SneakySnackerScenarioTest` (the card had none) — four cases:

- third draw returns it from the graveyard, tapped
- only two cards drawn → it stays in the graveyard
- an opponent's third draw doesn't return it (`Player.You` binding)
- **a Snacker already on the battlefield doesn't trigger** — this is the case that fails on the old definition (`Stack size mismatch: expected 0 but was 1`), verified by reverting the card and re-running

## Verification

| Gate | Result |
|---|---|
| `just test-class SneakySnackerScenarioTest` | 4/4 pass |
| `just test-scenarios 2024` | pass |
| `:mtg-sets:test` (FacadeBoundaryTest, CardLintTest, snapshots) | pass |
| `just rebless-cards` | only Sneaky Snacker moved |
| `just check-card-printing "Sneaky Snacker"` | canonical in MH3, its earliest printing |
| `just assay-differential --set MH3` | 7/7 confirmed, 0 divergent |

Oracle fields re-checked against Scryfall (`mh3` #205) — name, cost, type line, P/T, rarity, artist, flavour text and oracle text all already matched and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)