### PR TITLE
Add 108 Assay-ready cards to Commander 2013

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/BasaltMonolith.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/BasaltMonolith.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.lea.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Basalt Monolith
+ * {3}
+ * Artifact
+ * This artifact doesn't untap during your untap step.
+ * {T}: Add {C}{C}{C}.
+ * {3}: Untap this artifact.
+ *
+ * "Doesn't untap" is the self-suppression flag [AbilityFlag.DOESNT_UNTAP], which the untap step
+ * filters on (cf. Colossus of Sardia). The mana ability is [Effects.AddColorlessMana] for 3 on
+ * [Costs.Tap] with [TimingRule.ManaAbility]; the pay-to-untap ability is a plain [Effects.Untap]
+ * on [EffectTarget.Self] for [Costs.Mana] "{3}" — unlike Colossus it carries no activation
+ * restriction, which is why it can be looped.
+ */
+val BasaltMonolith = card("Basalt Monolith") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "This artifact doesn't untap during your untap step.\n" +
+        "{T}: Add {C}{C}{C}.\n" +
+        "{3}: Untap this artifact."
+
+    flags(AbilityFlag.DOESNT_UNTAP)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(3)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}")
+        effect = Effects.Untap(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "231"
+        artist = "Jesper Myrfors"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/66a74c89-6f86-4ec8-af17-391cd5026054.jpg"
+        ruling("2020-08-07", "Basalt Monolith's last ability can untap it as often as you can pay for it. If you believe you've found a way to generate an unbounded amount of mana with it, you're probably right.")
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leb/cards/BasaltMonolithReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leb/cards/BasaltMonolithReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.leb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Basalt Monolith reprint in LEB. Canonical CardDefinition lives in its earliest set.
+ */
+val BasaltMonolithReprint = Printing(
+    oracleId = "6b8cf2a0-b045-4d91-9d91-c602d40c6237",
+    name = "Basalt Monolith",
+    setCode = "LEB",
+    collectorNumber = "232",
+    scryfallId = "81d73362-43c1-4dd0-87dd-9aa7ae13ff2f",
+    artist = "Jesper Myrfors",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/81d73362-43c1-4dd0-87dd-9aa7ae13ff2f.jpg",
+    releaseDate = "1993-10-04",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/Borrowing100000Arrows.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/Borrowing100000Arrows.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Borrowing 100,000 Arrows
+ * {2}{U}
+ * Sorcery
+ * Draw a card for each tapped creature target opponent controls.
+ *
+ * The count is a [DynamicAmount.AggregateBattlefield] over [Player.TargetOpponent] and
+ * `GameObjectFilter.Creature.tapped()` — the amount reads the targeted opponent's board on
+ * resolution, so the draw is never a snapshot taken at cast. The [TargetOpponent] requirement is
+ * what binds that player; the [Effects.DrawCards] itself is the ordinary controller-facing draw.
+ */
+val Borrowing100000Arrows = card("Borrowing 100,000 Arrows") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Draw a card for each tapped creature target opponent controls."
+
+    spell {
+        target("target", TargetOpponent())
+        effect = Effects.DrawCards(
+            DynamicAmount.AggregateBattlefield(
+                Player.TargetOpponent,
+                GameObjectFilter.Creature.tapped()
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "35"
+        artist = "Song Shikai"
+        flavorText = "Kongming and Lu Su tricked Wei troops into shooting over 100,000 arrows at them to later use against the Wei at Red Cliffs."
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96b5362a-bbca-4dc3-a320-3664609fe169.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/BrilliantPlan.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/BrilliantPlan.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brilliant Plan
+ * {4}{U}
+ * Sorcery
+ * Draw three cards.
+ *
+ * A one-line spell: a `spell { }` block whose whole effect is [Effects.DrawCards] at its default
+ * controller target. No target, no rider, nothing else to spell.
+ */
+val BrilliantPlan = card("Brilliant Plan") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Draw three cards."
+
+    spell {
+        effect = Effects.DrawCards(3)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "36"
+        artist = "Song Shikai"
+        flavorText = "At Red Cliffs, Kongming and Zhou Yu each wrote his plan for defeating the Wei on the palm of his hand. They laughed as they both revealed the same word, \"Fire.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6acae374-9d71-4f8d-ba75-a983756624c7.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/Famine.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/Famine.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Famine
+ * {3}{B}{B}
+ * Sorcery
+ * Famine deals 3 damage to each creature and each player.
+ *
+ * One printed sentence, two effects joined by [Effects.Composite]. The board half is
+ * [Effects.ForEachInGroup] over `GroupFilter(GameObjectFilter.Creature)` with the damage aimed at
+ * [EffectTarget.Self] — the current iteration entity. The player half is the corpus' spelling for a
+ * symmetric player sweep: [Effects.ForEachPlayer] over [Player.Each], each iteration rebinding the
+ * controller so [EffectTarget.Controller] is the player being processed.
+ */
+val Famine = card("Famine") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Famine deals 3 damage to each creature and each player."
+
+    spell {
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature),
+                Effects.DealDamage(3, EffectTarget.Self)
+            ),
+            Effects.ForEachPlayer(
+                Player.Each,
+                listOf(Effects.DealDamage(3, EffectTarget.Controller))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "75"
+        artist = "Sun Nan"
+        flavorText = "\"But it was a year of dearth. People were reduced to eating leaves of jujube trees. Corpses were seen everywhere in the countryside.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d6c10ca-f6d6-4322-aa17-7e874cb10bb1.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/KongmingSleepingDragon.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/KongmingSleepingDragon.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Kongming, "Sleeping Dragon"
+ * {2}{W}{W}
+ * Legendary Creature — Human Advisor
+ * 2/2
+ * Other creatures you control get +1/+1.
+ *
+ * The plain lord shape: a [ModifyStats] static over a [GroupFilter] of
+ * `GameObjectFilter.Creature.youControl()`. "Other" is the filter's `excludeSelf`, not a separate
+ * predicate — Kongming pumps the rest of the team and stays a 2/2 itself.
+ */
+val KongmingSleepingDragon = card("Kongming, \"Sleeping Dragon\"") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Advisor"
+    power = 2
+    toughness = 2
+    oracleText = "Other creatures you control get +1/+1."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl(), excludeSelf = true)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "9"
+        artist = "Gao Yan"
+        flavorText = "\"Such a lord as this—all virtues' height—Had never been, nor ever was again.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f4ae0a05-1870-4f4a-b8a2-bfb5381acacb.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sth/cards/StrongholdAssassin.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sth/cards/StrongholdAssassin.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.sth.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Stronghold Assassin
+ * {1}{B}{B}
+ * Creature — Phyrexian Zombie Assassin
+ * 2/1
+ * {T}, Sacrifice a creature: Destroy target nonblack creature.
+ *
+ * Two cost atoms in printed order — [Costs.Composite] of [Costs.Tap] (the `{T}` symbol, so
+ * summoning sickness applies) and [Costs.Sacrifice] over `GameObjectFilter.Creature`. The target
+ * is a [TargetCreature] narrowed with `TargetFilter.Creature.notColor(BLACK)`, which reads the
+ * creature's *current* colours off projected state, and [Effects.Destroy] is the facade for the
+ * `byDestruction` move to the graveyard (regeneration still applies — nothing here forbids it).
+ */
+val StrongholdAssassin = card("Stronghold Assassin") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Zombie Assassin"
+    power = 2
+    toughness = 1
+    oracleText = "{T}, Sacrifice a creature: Destroy target nonblack creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.Sacrifice(GameObjectFilter.Creature))
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.notColor(Color.BLACK)))
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "71"
+        artist = "Matthew D. Wilson"
+        flavorText = "The assassin sees only throats and hears only heartbeats."
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc0f043c-efb3-4392-ae25-b3ec180b0cb2.jpg"
+    }
+}

--- a/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pls/cards/CrosisSCharm.kt
+++ b/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pls/cards/CrosisSCharm.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.pls.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Crosis's Charm
+ * {U}{B}{R}
+ * Instant
+ *
+ * Choose one —
+ * • Return target permanent to its owner's hand.
+ * • Destroy target nonblack creature. It can't be regenerated.
+ * • Destroy target artifact.
+ *
+ * A plain choose-one `modal(chooseCount = 1)`, one target per mode. The bounce mode is
+ * [Effects.ReturnToHand] over an unfiltered [TargetPermanent]; the removal mode is
+ * [Effects.Destroy] with `noRegenerate = true` (the facade composes the "can't be regenerated"
+ * marker ahead of the destroy) over [TargetFilter.Creature]`.notColor(BLACK)`; the last mode is a
+ * bare [Effects.Destroy] on [Targets.Artifact].
+ */
+val CrosisSCharm = card("Crosis's Charm") {
+    manaCost = "{U}{B}{R}"
+    colorIdentity = "UBR"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Return target permanent to its owner's hand.\n" +
+        "• Destroy target nonblack creature. It can't be regenerated.\n" +
+        "• Destroy target artifact."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Return target permanent to its owner's hand") {
+                val t = target("target", TargetPermanent())
+                effect = Effects.ReturnToHand(t)
+            }
+            mode("Destroy target nonblack creature. It can't be regenerated") {
+                val t = target("target", TargetCreature(filter = TargetFilter.Creature.notColor(Color.BLACK)))
+                effect = Effects.Destroy(t, noRegenerate = true)
+            }
+            mode("Destroy target artifact") {
+                val t = target("target", Targets.Artifact)
+                effect = Effects.Destroy(t)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99"
+        artist = "David Martin"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b59a9e75-9988-4040-a718-b1655fc20d11.jpg"
+    }
+}

--- a/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pls/cards/DromarSCharm.kt
+++ b/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pls/cards/DromarSCharm.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.pls.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Dromar's Charm
+ * {W}{U}{B}
+ * Instant
+ *
+ * Choose one —
+ * • You gain 5 life.
+ * • Counter target spell.
+ * • Target creature gets -2/-2 until end of turn.
+ *
+ * A plain choose-one `modal(chooseCount = 1)`. The life mode is a targetless
+ * [Effects.GainLife] (its default target is already the controller); the counter mode is
+ * [Effects.CounterSpell] over the unfiltered [Targets.Spell]; the shrink mode is
+ * [Effects.ModifyStats]`(-2, -2)` on a [TargetCreature], which defaults to end of turn.
+ */
+val DromarSCharm = card("Dromar's Charm") {
+    manaCost = "{W}{U}{B}"
+    colorIdentity = "WUB"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• You gain 5 life.\n" +
+        "• Counter target spell.\n" +
+        "• Target creature gets -2/-2 until end of turn."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("You gain 5 life") {
+                effect = Effects.GainLife(5)
+            }
+            mode("Counter target spell") {
+                target("target", Targets.Spell)
+                effect = Effects.CounterSpell()
+            }
+            mode("Target creature gets -2/-2 until end of turn") {
+                val t = target("target", TargetCreature())
+                effect = Effects.ModifyStats(-2, -2, t)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "105"
+        artist = "David Martin"
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c7a1894c-af4e-4530-960f-2225916be8cb.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/AzamiLadyOfScrolls.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/AzamiLadyOfScrolls.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.chk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Azami, Lady of Scrolls
+ * {2}{U}{U}{U}
+ * Legendary Creature — Human Wizard
+ * 0/2
+ * Tap an untapped Wizard you control: Draw a card.
+ *
+ * The cost is [Costs.TapPermanents], not [Costs.Tap] — tapping as a cost rather than the `{T}`
+ * symbol, so summoning sickness (CR 302.6) never applies and only untapped permanents may be
+ * chosen (CR 701.26a). The bare tribal noun means *permanents*, hence
+ * `GameObjectFilter.Permanent.withSubtype("Wizard")`; "you control" is carried by the atom itself,
+ * and `excludeSelf` stays at its default `false` so Azami may tap herself. The payoff is the plain
+ * [Effects.DrawCards] facade at its default controller target.
+ */
+val AzamiLadyOfScrolls = card("Azami, Lady of Scrolls") {
+    manaCost = "{2}{U}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Wizard"
+    power = 0
+    toughness = 2
+    oracleText = "Tap an untapped Wizard you control: Draw a card."
+
+    activatedAbility {
+        cost = Costs.TapPermanents(1, GameObjectFilter.Permanent.withSubtype("Wizard"))
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "52"
+        artist = "Ittoku"
+        flavorText = "\"Choices belong to those with the luxuries of time and distance. We have neither. I recommend we proceed with the plan to destroy all shrines of the kami.\"\n—Lady Azami, letter to Sensei Hisoka"
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/15ea91b1-f2ff-4b99-8148-333aa27ea8cd.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fut/cards/NewBenalia.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fut/cards/NewBenalia.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.fut.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * New Benalia
+ *
+ * Land
+ *
+ * This land enters tapped.
+ * When this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ * {T}: Add {W}.
+ *
+ * The enters-tapped utility land the Theros "Temple" cycle later reprinted wholesale: an
+ * [EntersTapped] replacement effect for the printed first line, a [Triggers.EntersBattlefield]
+ * trigger carrying [Patterns.Library].scry(1), and one [Effects.AddMana] ability on [Costs.Tap]
+ * (`manaAbility = true` with [TimingRule.ManaAbility], so it resolves without using the stack).
+ * Scry is a compact SDK macro rather than a hand-rolled look-and-reorder pipeline, so the reminder
+ * text needs no separate wiring.
+ */
+val NewBenalia = card("New Benalia") {
+    manaCost = ""
+    colorIdentity = "W"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "When this land enters, scry 1. (Look at the top card of your library. You may put that " +
+        "card on the bottom.)\n" +
+        "{T}: Add {W}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.scry(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "172"
+        artist = "Richard Wright"
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/18bde721-8fa0-4f69-9909-b4864929e676.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/GrixisCharm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/GrixisCharm.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Grixis Charm
+ * {U}{B}{R}
+ * Instant
+ *
+ * Choose one —
+ * • Return target permanent to its owner's hand.
+ * • Target creature gets -4/-4 until end of turn.
+ * • Creatures you control get +2/+0 until end of turn.
+ *
+ * A plain choose-one `modal(chooseCount = 1)`. The bounce mode is [Effects.ReturnToHand] over an
+ * unfiltered [TargetPermanent]; the shrink mode is [Effects.ModifyStats]`(-4, -4)` on a
+ * [TargetCreature]; the team pump is [Patterns.Group]`.modifyStatsForAll` over
+ * [GroupFilter.AllCreaturesYouControl], which lowers to the same per-creature `ModifyStats` the
+ * group iteration expects — no group-only effect type needed.
+ */
+val GrixisCharm = card("Grixis Charm") {
+    manaCost = "{U}{B}{R}"
+    colorIdentity = "UBR"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Return target permanent to its owner's hand.\n" +
+        "• Target creature gets -4/-4 until end of turn.\n" +
+        "• Creatures you control get +2/+0 until end of turn."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Return target permanent to its owner's hand") {
+                val t = target("target", TargetPermanent())
+                effect = Effects.ReturnToHand(t)
+            }
+            mode("Target creature gets -4/-4 until end of turn") {
+                val t = target("target", TargetCreature())
+                effect = Effects.ModifyStats(-4, -4, t)
+            }
+            mode("Creatures you control get +2/+0 until end of turn") {
+                effect = Patterns.Group.modifyStatsForAll(2, 0, GroupFilter.AllCreaturesYouControl)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "171"
+        artist = "Lars Grant-West"
+        flavorText = "\"So many choices. Shall I choose loathing, hate, or malice today?\"\n—Eliza of the Keep"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a98a6695-44ce-445f-b476-e18a0b5dd8f2.jpg"
+        ruling("2008-10-01", "You can choose a mode only if you can choose legal targets for that mode. If you can’t choose legal targets for any of the modes, you can’t cast the spell.")
+        ruling("2008-10-01", "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don’t exist. You don’t choose targets for those modes.")
+        ruling("2008-10-01", "If this spell is copied, the copy will have the same mode as the original.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ObeliskOfEsper.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ObeliskOfEsper.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Obelisk of Esper
+ * {3}
+ * Artifact
+ * {T}: Add {W}, {U}, or {B}.
+ *
+ * One of the Alara shard obelisks. The printed "or" is a choice between three mana abilities, so
+ * it is authored as three separate [Effects.AddMana] abilities on [Costs.Tap] — the same shape as
+ * the shard tri-lands (cf. Arcane Sanctum) — each flagged `manaAbility` with
+ * [TimingRule.ManaAbility].
+ */
+val ObeliskOfEsper = card("Obelisk of Esper") {
+    manaCost = "{3}"
+    colorIdentity = "WUB"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {W}, {U}, or {B}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "213"
+        artist = "Francis Tsai"
+        flavorText = "It is a monument as austere, unyielding, and inscrutable as Esper itself."
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/19869e75-0925-45dc-b5d9-6968fbfb35b5.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ObeliskOfGrixis.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ObeliskOfGrixis.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Obelisk of Grixis
+ * {3}
+ * Artifact
+ * {T}: Add {U}, {B}, or {R}.
+ *
+ * One of the Alara shard obelisks. The printed "or" is a choice between three mana abilities, so
+ * it is authored as three separate [Effects.AddMana] abilities on [Costs.Tap] — the same shape as
+ * the shard tri-lands (cf. Crumbling Necropolis) — each flagged `manaAbility` with
+ * [TimingRule.ManaAbility].
+ */
+val ObeliskOfGrixis = card("Obelisk of Grixis") {
+    manaCost = "{3}"
+    colorIdentity = "UBR"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {U}, {B}, or {R}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "214"
+        artist = "Nils Hamm"
+        flavorText = "Like most features of Grixis, the obelisks that remain from the time of Alara now exist only for dark exploitation."
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/5200e41f-fe10-4c39-ab12-c6e13fb81a3d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ObeliskOfJund.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ObeliskOfJund.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Obelisk of Jund
+ * {3}
+ * Artifact
+ * {T}: Add {B}, {R}, or {G}.
+ *
+ * One of the Alara shard obelisks. The printed "or" is a choice between three mana abilities, so
+ * it is authored as three separate [Effects.AddMana] abilities on [Costs.Tap] — the same shape as
+ * the shard tri-lands (cf. Savage Lands) — each flagged `manaAbility` with
+ * [TimingRule.ManaAbility].
+ */
+val ObeliskOfJund = card("Obelisk of Jund") {
+    manaCost = "{3}"
+    colorIdentity = "BRG"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {B}, {R}, or {G}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "215"
+        artist = "Brandon Kitkouski"
+        flavorText = "Volcanic ash-winds batter it, climbing vines overwhelm it, dragonfire roasts it, and yet it still stands as a testament to a forgotten world."
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ffe1a49a-5c1c-4274-a2ed-9a8a44abfaa6.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/RakeclawGargantuan.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/RakeclawGargantuan.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Rakeclaw Gargantuan
+ * {2}{R}{G}{W}
+ * Creature — Beast
+ * 5 / 3
+ *
+ * {1}: Target creature with power 5 or greater gains first strike until end of turn.
+ *
+ * A plain [Costs.Mana] activated ability. The power threshold is a filter on the target itself —
+ * [TargetFilter.Creature].`powerAtLeast(5)` — so legality is checked on announcement and rechecked
+ * on resolution; the grant is [Effects.GrantKeyword] on the bound target, whose default
+ * `Duration.EndOfTurn` is exactly the printed "until end of turn".
+ */
+val RakeclawGargantuan = card("Rakeclaw Gargantuan") {
+    manaCost = "{2}{R}{G}{W}"
+    colorIdentity = "WRG"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 3
+    oracleText = "{1}: Target creature with power 5 or greater gains first strike until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.powerAtLeast(5)))
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "186"
+        artist = "Jesper Ejsing"
+        flavorText = "Naya teems with gargantuans, titanic monsters to whom both nature and civilization defer."
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d1995ab8-7382-4c2a-b8c7-8b9272cab4fb.jpg"
+        ruling("2008-10-01", "The ability checks the targeted creature’s power twice: when the creature becomes the target, and when the ability resolves. Once the ability resolves, it will continue to apply to the affected creature no matter what its power may become later in the turn.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SharuumTheHegemon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SharuumTheHegemon.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Sharuum the Hegemon
+ * {3}{W}{U}{B}
+ * Legendary Artifact Creature — Sphinx
+ * 5/5
+ * Flying
+ * When Sharuum enters, you may return target artifact card from your graveyard to the battlefield.
+ *
+ * The named target is a [TargetObject] over [TargetFilter] of `GameObjectFilter.Artifact.ownedByYou()`
+ * scoped to [Zone.GRAVEYARD], and the recursion is
+ * [Effects.PutOntoBattlefieldFromGraveyard] — the `fromZone`-guarded sibling of
+ * `PutOntoBattlefield`, so the move is skipped if the card has left the graveyard by resolution.
+ * `optional = true` lowers the printed "you may" into a
+ * [com.wingedsheep.sdk.scripting.effects.Gate.MayDecide] gate around it.
+ */
+val SharuumTheHegemon = card("Sharuum the Hegemon") {
+    manaCost = "{3}{W}{U}{B}"
+    colorIdentity = "WUB"
+    typeLine = "Legendary Artifact Creature — Sphinx"
+    power = 5
+    toughness = 5
+    oracleText = "Flying\n" +
+        "When Sharuum enters, you may return target artifact card from your graveyard to the battlefield."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "target",
+            TargetObject(
+                filter = TargetFilter(GameObjectFilter.Artifact.ownedByYou(), zone = Zone.GRAVEYARD)
+            )
+        )
+        optional = true
+        effect = Effects.PutOntoBattlefieldFromGraveyard(t)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "194"
+        artist = "Izzy"
+        flavorText = "To gain audience with the hegemon, one must bring a riddle she has not heard."
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/6589eaa8-95ec-4c97-8155-185487560ae6.jpg"
+        ruling("2020-08-07", "If Sharuum the Hegemon is put into your graveyard as a state-based action immediately after Sharuum the Hegemon enters the battlefield (most likely due to the \"legend rule\") it can be the artifact card targeted by its own ability.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SproutingThrinax.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SproutingThrinax.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sprouting Thrinax
+ * {B}{R}{G}
+ * Creature — Lizard
+ * 3/3
+ * When this creature dies, create three 1/1 green Saproling creature tokens.
+ *
+ * A plain [Triggers.Dies] (battlefield → graveyard, SELF binding) over a single
+ * [Effects.CreateToken] with `count = 3`; the three tokens are identical, so one effect with a
+ * count is the whole ability — no composition needed.
+ */
+val SproutingThrinax = card("Sprouting Thrinax") {
+    manaCost = "{B}{R}{G}"
+    colorIdentity = "BRG"
+    typeLine = "Creature — Lizard"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature dies, create three 1/1 green Saproling creature tokens."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling"),
+            count = 3
+        )
+        description = "When this creature dies, create three 1/1 green Saproling creature tokens."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "197"
+        artist = "Jarreau Wimberly"
+        flavorText = "The vast network of predation on Jund has actually caused some strange creatures to adapt to being eaten."
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/8950df86-1e27-4b6b-8b5c-25298a3bda85.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/TidehollowStrix.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/TidehollowStrix.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tidehollow Strix
+ * {U}{B}
+ * Artifact Creature — Bird
+ * 2 / 1
+ *
+ * Flying
+ * Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)
+ *
+ * Two evergreen keywords and nothing else: [Keyword.FLYING] and [Keyword.DEATHTOUCH] go on the
+ * card's keyword set, from which the builder derives one `Simple` keyword ability each. The
+ * reminder text is part of the printed oracle text, not a separate ability.
+ */
+val TidehollowStrix = card("Tidehollow Strix") {
+    manaCost = "{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Artifact Creature — Bird"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\n" +
+        "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)"
+
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "203"
+        artist = "Cyril Van Der Haegen"
+        flavorText = "The scullers beneath Esper keep strixes as trained pets, and set them loose when a fare refuses to pay."
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4aafc65d-faa8-4bfe-83ac-7714c969022b.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/TowerGargoyle.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/TowerGargoyle.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tower Gargoyle
+ * {1}{W}{U}{B}
+ * Artifact Creature — Gargoyle
+ * 4 / 4
+ *
+ * Flying
+ *
+ * A single evergreen keyword, so the whole script is one [Keyword.FLYING] entry on the card's
+ * keyword set — the builder derives the `Simple` keyword ability from it, and no triggered,
+ * activated or static ability is needed.
+ */
+val TowerGargoyle = card("Tower Gargoyle") {
+    manaCost = "{1}{W}{U}{B}"
+    colorIdentity = "WUB"
+    typeLine = "Artifact Creature — Gargoyle"
+    power = 4
+    toughness = 4
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "205"
+        artist = "Matt Cavotta"
+        flavorText = "\"Esper, like any work of art, can be truly appreciated only from a distance.\"\n—Tezzeret"
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/10504d1b-8d3e-411a-bf40-51a8e7a863a0.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/BehemothSledge.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/BehemothSledge.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.arb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Behemoth Sledge
+ * {1}{G}{W}
+ * Artifact — Equipment
+ * Equipped creature gets +2/+2 and has trample and lifelink.
+ * Equip {3}
+ *
+ * The standard Equipment shape: a [ModifyStats] static for the +2/+2 and one [GrantKeyword] static
+ * per granted keyword — the two keywords stay separate abilities rather than one composite, which is
+ * how the corpus (Loxodon Warhammer) and Argentum Assay both read the printed "has trample and
+ * lifelink". `equipAbility("{3}")` lowers the printed Equip line into the sorcery-speed activated
+ * ability targeting a creature you control.
+ */
+val BehemothSledge = card("Behemoth Sledge") {
+    manaCost = "{1}{G}{W}"
+    colorIdentity = "WG"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +2/+2 and has trample and lifelink.\n" +
+        "Equip {3}"
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.LIFELINK)
+    }
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "65"
+        artist = "Steve Prescott"
+        flavorText = "Those who worship the great gargantuans could hardly be expected to fight with a subtle weapon."
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/84e4a224-2db7-47d0-ba8b-98aeb50ad5d3.jpg"
+        ruling("2009-10-01", "Multiple instances of lifelink on the same creature are redundant. If a creature with multiple instances of lifelink deals damage, its controller still only gains life equal to the damage dealt.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/FiligreeAngel.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/FiligreeAngel.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.arb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Filigree Angel
+ * {5}{W}{W}{U}
+ * Artifact Creature — Angel
+ * 4/4
+ * Flying
+ * When this creature enters, you gain 3 life for each artifact you control.
+ *
+ * "3 life for each artifact you control" is a [DynamicAmount.Multiply] over a
+ * [DynamicAmount.AggregateBattlefield] count of [GameObjectFilter.Artifact] for [Player.You] — the
+ * player scopes the count, so the filter carries no controller predicate of its own. The count is
+ * *not* `excludeSelf`: Filigree Angel counts itself, per its own ruling. [Effects.GainLife]'s target
+ * defaults to the controller, so it is left unwritten.
+ */
+val FiligreeAngel = card("Filigree Angel") {
+    manaCost = "{5}{W}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Artifact Creature — Angel"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When this creature enters, you gain 3 life for each artifact you control."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(
+            DynamicAmount.Multiply(
+                DynamicAmount.AggregateBattlefield(
+                    player = Player.You,
+                    filter = GameObjectFilter.Artifact
+                ),
+                3
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "6"
+        artist = "Richard Whitters"
+        flavorText = "\"I craved enlightenment, and Crucius's etherium opened my eyes. I would share my sight with you, but first you must believe.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a0c7a2a-85c1-4b20-95b9-04aab0bd0d3b.jpg"
+        ruling("2009-05-01", "Filigree Angel's \"enters\" ability counts Filigree Angel itself, assuming that it's still on the battlefield and still an artifact by the time the ability resolves.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/SoulManipulation.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/SoulManipulation.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.arb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soul Manipulation
+ * {1}{U}{B}
+ * Instant
+ *
+ * Choose one or both —
+ * • Counter target creature spell.
+ * • Return target creature card from your graveyard to your hand.
+ *
+ * "Choose one or both" is `modal(chooseCount = 2, minChooseCount = 1)` — `chooseCount` is the
+ * maximum, `minChooseCount` the floor (CR 700.2). The first mode is [Effects.CounterSpell] over
+ * [Targets.CreatureSpell]; the second is [Effects.ReturnToHand] over
+ * [Targets.CreatureCardInYourGraveyard], whose requirement already carries the graveyard zone and
+ * the owned-by-you predicate.
+ */
+val SoulManipulation = card("Soul Manipulation") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Instant"
+    oracleText = "Choose one or both —\n" +
+        "• Counter target creature spell.\n" +
+        "• Return target creature card from your graveyard to your hand."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Counter target creature spell") {
+                target("target", Targets.CreatureSpell)
+                effect = Effects.CounterSpell()
+            }
+            mode("Return target creature card from your graveyard to your hand") {
+                val t = target("target", Targets.CreatureCardInYourGraveyard)
+                effect = Effects.ReturnToHand(t)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Carl Critchlow"
+        flavorText = "\"Birth and death are both reversible.\"\n—Nicol Bolas"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bcd3cb05-c6f9-435a-a0e7-1f85da4a36eb.jpg"
+        ruling("2009-05-01", "You may choose just the first mode (targeting a creature spell), just the second mode (targeting a creature card in your graveyard), or both modes (targeting a creature spell and a creature card in your graveyard). You can’t choose a mode unless there’s a legal target for it.")
+        ruling("2009-05-01", "If you choose both modes, you choose their targets at the same time. You can’t counter your own creature spell and then return that card from your graveyard to your hand.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/SphinxOfTheSteelWind.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/SphinxOfTheSteelWind.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.arb.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Sphinx of the Steel Wind
+ * {5}{W}{U}{B}
+ * Artifact Creature — Sphinx
+ * 6 / 6
+ *
+ * Flying, first strike, vigilance, lifelink, protection from red and from green
+ *
+ * - The four plain evergreen keywords are the card's keyword set ([Keyword.FLYING],
+ *   [Keyword.FIRST_STRIKE], [Keyword.VIGILANCE], [Keyword.LIFELINK]); the builder derives a
+ *   `Simple` keyword ability from each.
+ * - CR 702.16g: "protection from [quality A] and from [quality B]" is shorthand for two *separate*
+ *   protection abilities, so this is two [KeywordAbility.Protection] instances with a
+ *   single-colour [ProtectionScope.Color] each — not one [ProtectionScope.Colors] holding a set.
+ *   That matters when something removes or counts abilities individually.
+ */
+val SphinxOfTheSteelWind = card("Sphinx of the Steel Wind") {
+    manaCost = "{5}{W}{U}{B}"
+    colorIdentity = "WUB"
+    typeLine = "Artifact Creature — Sphinx"
+    power = 6
+    toughness = 6
+    oracleText = "Flying, first strike, vigilance, lifelink, protection from red and from green"
+
+    keywords(Keyword.FLYING, Keyword.FIRST_STRIKE, Keyword.VIGILANCE, Keyword.LIFELINK)
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.RED)))
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.GREEN)))
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "110"
+        artist = "Kev Walker"
+        flavorText = "No one has properly answered her favorite riddle: \"Why should I spare your life?\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c860cf0f-ef68-455f-9c71-a6dd25b51d71.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/WingedCoatl.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/WingedCoatl.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.arb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Winged Coatl
+ * {1}{G}{U}
+ * Creature — Snake
+ * 1 / 1
+ *
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * Flying
+ * Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)
+ *
+ * Three evergreen keywords and no other rules text: [Keyword.FLASH], [Keyword.FLYING] and
+ * [Keyword.DEATHTOUCH] go on the card's keyword set, which the builder turns into one `Simple`
+ * keyword ability apiece. Flash is read off that set by the casting-timing check, so no
+ * alternative-timing plumbing is needed here.
+ */
+val WingedCoatl = card("Winged Coatl") {
+    manaCost = "{1}{G}{U}"
+    colorIdentity = "UG"
+    typeLine = "Creature — Snake"
+    power = 1
+    toughness = 1
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "Flying\n" +
+        "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)"
+
+    keywords(Keyword.FLASH, Keyword.FLYING, Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Izzy"
+        flavorText = "The nacatl called this new species \"vetli,\" their word for poison arrows."
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd23ae2b-9f69-4d8d-87f9-ebcbccd67342.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/KazanduRefugeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/KazanduRefugeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kazandu Refuge reprint in ARC. Canonical CardDefinition lives in its earliest set.
+ */
+val KazanduRefugeReprint = Printing(
+    oracleId = "03332772-18b0-446a-a7e2-a4bdf38c4f0c",
+    name = "Kazandu Refuge",
+    setCode = "ARC",
+    collectorNumber = "126",
+    scryfallId = "fad380fe-6828-41a5-b198-3f56c76fa83f",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/f/a/fad380fe-6828-41a5-b198-3f56c76fa83f.jpg",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/KhalniGardenReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/KhalniGardenReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Khalni Garden reprint in ARC. Canonical CardDefinition lives in its earliest set.
+ */
+val KhalniGardenReprint = Printing(
+    oracleId = "b2d5ba45-8674-4428-89db-c2bbbf0bf5c5",
+    name = "Khalni Garden",
+    setCode = "ARC",
+    collectorNumber = "127",
+    scryfallId = "2aa510df-182c-47af-9cf2-97629215cc2f",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2aa510df-182c-47af-9cf2-97629215cc2f.jpg",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/ObeliskOfEsperReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/ObeliskOfEsperReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Obelisk of Esper reprint in ARC. Canonical CardDefinition lives in its earliest set.
+ */
+val ObeliskOfEsperReprint = Printing(
+    oracleId = "9da963f6-734b-4d3c-a3be-dd5cca2c7b19",
+    name = "Obelisk of Esper",
+    setCode = "ARC",
+    collectorNumber = "113",
+    scryfallId = "6e4ffc66-2a38-4622-8943-2bfc81830f5d",
+    artist = "Francis Tsai",
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6e4ffc66-2a38-4622-8943-2bfc81830f5d.jpg",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/MarrowBats.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/MarrowBats.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Marrow Bats
+ * {4}{B}
+ * Creature — Bat Skeleton
+ * 4/1
+ * Flying
+ * Pay 4 life: Regenerate this creature.
+ *
+ * Flying is a printed [Keyword]. The regeneration ability is the Deepwood Ghoul shape with a
+ * bigger price: a bare [Costs.PayLife] with no tap or mana beside it, and
+ * [RegenerateEffect] on [EffectTarget.Self]. `RegenerateEffect` has no `Effects` facade entry,
+ * so it is imported directly.
+ */
+val MarrowBats = card("Marrow Bats") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Bat Skeleton"
+    power = 4
+    toughness = 1
+    oracleText = "Flying\n" +
+        "Pay 4 life: Regenerate this creature."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.PayLife(4)
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "113"
+        artist = "Jason A. Engle"
+        flavorText = "\"No matter how far we push into Stensia, undeath will always remain in these lands.\"\n—Terhold, archmage of Drunau"
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/38dcbad0-267e-411f-8e99-5d90b537bf9b.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/RainOfThorns.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/RainOfThorns.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Rain of Thorns
+ * {4}{G}{G}
+ * Sorcery
+ * Choose one or more —
+ * • Destroy target artifact.
+ * • Destroy target enchantment.
+ * • Destroy target land.
+ *
+ * A choose-one-or-more modal spell — [modal] with `chooseCount = 3, minChooseCount = 1`, so any
+ * one, two, or all three modes may be picked. Each mode carries its own [TargetPermanent], filtered
+ * by [TargetFilter.Artifact], [TargetFilter.Enchantment] and [TargetFilter.Land] respectively, and
+ * each body is the plain [Effects.Destroy].
+ */
+val RainOfThorns = card("Rain of Thorns") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Choose one or more —\n" +
+        "• Destroy target artifact.\n" +
+        "• Destroy target enchantment.\n" +
+        "• Destroy target land."
+
+    spell {
+        modal(chooseCount = 3, minChooseCount = 1) {
+            mode("Destroy target artifact") {
+                val t = target("target", TargetPermanent(filter = TargetFilter.Artifact))
+                effect = Effects.Destroy(t)
+            }
+            mode("Destroy target enchantment") {
+                val t = target("target", TargetPermanent(filter = TargetFilter.Enchantment))
+                effect = Effects.Destroy(t)
+            }
+            mode("Destroy target land") {
+                val t = target("target", TargetPermanent(filter = TargetFilter.Land))
+                effect = Effects.Destroy(t)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "190"
+        artist = "Sam Burley"
+        flavorText = "When the forests became havens for evil, the archmages devised new ways to cleanse the wilds."
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd1cb530-b9d5-4386-b89e-2acecc8294c8.jpg"
+        ruling("2012-05-01", "You can choose just one mode, any two of the modes, or all three. You make this choice as you cast Rain of Thorns.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/AerieMysticsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/AerieMysticsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aerie Mystics reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val AerieMysticsReprint = Printing(
+    oracleId = "12134f7d-433a-416a-b668-c1a21984c94b",
+    name = "Aerie Mystics",
+    setCode = "C13",
+    collectorNumber = "2",
+    scryfallId = "23f0bae7-dceb-486d-8fdd-0a5666a9057b",
+    artist = "Mark Zug",
+    imageUri = "https://cards.scryfall.io/normal/front/2/3/23f0bae7-dceb-486d-8fdd-0a5666a9057b.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/AjaniSPridemateReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/AjaniSPridemateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ajani's Pridemate reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val AjaniSPridemateReprint = Printing(
+    oracleId = "95e94dea-5ac0-4d6f-adec-ca147aee861f",
+    name = "Ajani's Pridemate",
+    setCode = "C13",
+    collectorNumber = "3",
+    scryfallId = "24d4dbde-ff1f-4ffd-9fea-639b7a5bb50b",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/2/4/24d4dbde-ff1f-4ffd-9fea-639b7a5bb50b.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/AkoumRefugeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/AkoumRefugeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Akoum Refuge reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val AkoumRefugeReprint = Printing(
+    oracleId = "354fecd1-2371-49e3-81c6-7e47728dbb1f",
+    name = "Akoum Refuge",
+    setCode = "C13",
+    collectorNumber = "272",
+    scryfallId = "0b32023d-454a-456c-92fa-ebd591d2b854",
+    artist = "Fred Fields",
+    imageUri = "https://cards.scryfall.io/normal/front/0/b/0b32023d-454a-456c-92fa-ebd591d2b854.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ArcaneSanctumReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ArcaneSanctumReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arcane Sanctum reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val ArcaneSanctumReprint = Printing(
+    oracleId = "7d7cf15c-06b9-4062-a1eb-32614c458a3b",
+    name = "Arcane Sanctum",
+    setCode = "C13",
+    collectorNumber = "273",
+    scryfallId = "9ec9245a-bfd4-4fbd-83da-28c89abad011",
+    artist = "Anthony Francisco",
+    imageUri = "https://cards.scryfall.io/normal/front/9/e/9ec9245a-bfd4-4fbd-83da-28c89abad011.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ArchangelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ArchangelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Archangel reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val ArchangelReprint = Printing(
+    oracleId = "9971697b-2acc-4bc2-a44e-074d03a51df7",
+    name = "Archangel",
+    setCode = "C13",
+    collectorNumber = "5",
+    scryfallId = "85160859-9a2d-470b-a924-4b1b4caba860",
+    artist = "Quinton Hoover",
+    imageUri = "https://cards.scryfall.io/normal/front/8/5/85160859-9a2d-470b-a924-4b1b4caba860.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ArmillarySphereReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ArmillarySphereReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Armillary Sphere reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val ArmillarySphereReprint = Printing(
+    oracleId = "3963140c-da67-43e6-9514-fe9dc0a43c4d",
+    name = "Armillary Sphere",
+    setCode = "C13",
+    collectorNumber = "235",
+    scryfallId = "a87dd615-565d-4b79-a346-f8c6bb0a8340",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/a/8/a87dd615-565d-4b79-a346-f8c6bb0a8340.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/AzamiLadyOfScrollsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/AzamiLadyOfScrollsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Azami, Lady of Scrolls reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val AzamiLadyOfScrollsReprint = Printing(
+    oracleId = "0f8b97fe-3e5e-47c2-9a9d-7f77482aa159",
+    name = "Azami, Lady of Scrolls",
+    setCode = "C13",
+    collectorNumber = "31",
+    scryfallId = "cafda395-840f-4359-9314-e1cbf137cc66",
+    artist = "Ittoku",
+    imageUri = "https://cards.scryfall.io/normal/front/c/a/cafda395-840f-4359-9314-e1cbf137cc66.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/AzoriusGuildgateReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/AzoriusGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Azorius Guildgate reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val AzoriusGuildgateReprint = Printing(
+    oracleId = "ad1712d8-809f-410c-8b91-ffe6fb8a69a1",
+    name = "Azorius Guildgate",
+    setCode = "C13",
+    collectorNumber = "275",
+    scryfallId = "093bdc0f-bf04-48d3-91d1-28bc8a0f25be",
+    artist = "Drew Baker",
+    imageUri = "https://cards.scryfall.io/normal/front/0/9/093bdc0f-bf04-48d3-91d1-28bc8a0f25be.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BalothWoodcrasherReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BalothWoodcrasherReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Baloth Woodcrasher reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val BalothWoodcrasherReprint = Printing(
+    oracleId = "faaf9975-74df-4e9d-be0c-19a446cd507c",
+    name = "Baloth Woodcrasher",
+    setCode = "C13",
+    collectorNumber = "136",
+    scryfallId = "d8af1377-72bb-4d93-80bd-2c927b02cc73",
+    artist = "Zoltan Boros & Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/d/8/d8af1377-72bb-4d93-80bd-2c927b02cc73.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BarrenMoorReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BarrenMoorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barren Moor reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val BarrenMoorReprint = Printing(
+    oracleId = "326ba371-124c-4949-a048-3a0c8962e567",
+    name = "Barren Moor",
+    setCode = "C13",
+    collectorNumber = "277",
+    scryfallId = "80f4218e-b32e-415e-a240-79a466e04983",
+    artist = "Heather Hudson",
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/80f4218e-b32e-415e-a240-79a466e04983.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BasaltMonolithReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BasaltMonolithReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Basalt Monolith reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val BasaltMonolithReprint = Printing(
+    oracleId = "6b8cf2a0-b045-4d91-9d91-c602d40c6237",
+    name = "Basalt Monolith",
+    setCode = "C13",
+    collectorNumber = "237",
+    scryfallId = "7770e48e-72e1-4475-a4b5-c1c561a1beaa",
+    artist = "Yeong-Hao Han",
+    imageUri = "https://cards.scryfall.io/normal/front/7/7/7770e48e-72e1-4475-a4b5-c1c561a1beaa.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BehemothSledgeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BehemothSledgeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Behemoth Sledge reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val BehemothSledgeReprint = Printing(
+    oracleId = "00573e77-8ff6-4acb-8683-8827d965288f",
+    name = "Behemoth Sledge",
+    setCode = "C13",
+    collectorNumber = "178",
+    scryfallId = "1cf41508-64c0-48ce-8bd3-e1ec554d085f",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/1/c/1cf41508-64c0-48ce-8bd3-e1ec554d085f.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BloodRitesReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BloodRitesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blood Rites reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val BloodRitesReprint = Printing(
+    oracleId = "69757aaf-182e-41a0-a5b4-4404e4c81c45",
+    name = "Blood Rites",
+    setCode = "C13",
+    collectorNumber = "101",
+    scryfallId = "89d77b63-eeee-4d8a-9622-b1ea36dc70de",
+    artist = "Raymond Swanland",
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/89d77b63-eeee-4d8a-9622-b1ea36dc70de.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BorosCharmReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BorosCharmReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Boros Charm reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val BorosCharmReprint = Printing(
+    oracleId = "2679d0dd-ba30-4a1c-b6a0-b3ac6c790496",
+    name = "Boros Charm",
+    setCode = "C13",
+    collectorNumber = "179",
+    scryfallId = "2afdb457-a7e2-4e37-832a-dffefdb973e0",
+    artist = "Zoltan Boros",
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2afdb457-a7e2-4e37-832a-dffefdb973e0.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BorosGuildgateReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BorosGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Boros Guildgate reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val BorosGuildgateReprint = Printing(
+    oracleId = "73c423b7-cab8-4e69-8070-9edbf96a6c2c",
+    name = "Boros Guildgate",
+    setCode = "C13",
+    collectorNumber = "280",
+    scryfallId = "cd5bfeb1-22d5-434c-b379-6914aa007bdd",
+    artist = "Noah Bradley",
+    imageUri = "https://cards.scryfall.io/normal/front/c/d/cd5bfeb1-22d5-434c-b379-6914aa007bdd.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/Borrowing100000ArrowsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/Borrowing100000ArrowsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Borrowing 100,000 Arrows reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val Borrowing100000ArrowsReprint = Printing(
+    oracleId = "a3f10772-d055-419d-a535-4f094eaf437c",
+    name = "Borrowing 100,000 Arrows",
+    setCode = "C13",
+    collectorNumber = "33",
+    scryfallId = "90727520-1fab-4645-a05e-985e71b531cd",
+    artist = "Song Shikai",
+    imageUri = "https://cards.scryfall.io/normal/front/9/0/90727520-1fab-4645-a05e-985e71b531cd.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BrilliantPlanReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/BrilliantPlanReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brilliant Plan reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val BrilliantPlanReprint = Printing(
+    oracleId = "d83e1a42-11d1-412a-b66c-850c7a528777",
+    name = "Brilliant Plan",
+    setCode = "C13",
+    collectorNumber = "34",
+    scryfallId = "4fc6b5a0-9a0f-4934-8a43-a0e5364832ec",
+    artist = "Song Shikai",
+    imageUri = "https://cards.scryfall.io/normal/front/4/f/4fc6b5a0-9a0f-4934-8a43-a0e5364832ec.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/CarnageAltarReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/CarnageAltarReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Carnage Altar reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val CarnageAltarReprint = Printing(
+    oracleId = "aa05900f-0f04-407e-931c-fea8f91e78e3",
+    name = "Carnage Altar",
+    setCode = "C13",
+    collectorNumber = "238",
+    scryfallId = "c08486d3-3d94-49c7-b8c9-61eb8a3e6428",
+    artist = "James Paick",
+    imageUri = "https://cards.scryfall.io/normal/front/c/0/c08486d3-3d94-49c7-b8c9-61eb8a3e6428.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/Commander2013BasicLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/Commander2013BasicLands.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Commander 2013 Basic Lands
+ *
+ * C13 prints a single art for each basic land type (337, 341, 345, 349, 353).
+ */
+
+val Commander2013Plains = basicLand("Plains") {
+    collectorNumber = "337"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/503dfa54-a99e-40bc-a809-f1b7cb410eab.jpg"
+}
+
+val Commander2013Island = basicLand("Island") {
+    collectorNumber = "341"
+    artist = "Noah Bradley"
+    imageUri = "https://cards.scryfall.io/normal/front/c/a/caf4bd23-7fcd-47a9-9fc0-0f251299d7d0.jpg"
+}
+
+val Commander2013Swamp = basicLand("Swamp") {
+    collectorNumber = "345"
+    artist = "Mike Bierek"
+    imageUri = "https://cards.scryfall.io/normal/front/0/e/0e02d146-925e-47b4-ae9a-8e5fc542ea08.jpg"
+}
+
+val Commander2013Mountain = basicLand("Mountain") {
+    collectorNumber = "349"
+    artist = "Cliff Childs"
+    imageUri = "https://cards.scryfall.io/normal/front/d/a/daeda166-5add-4af1-bb6d-43ce5d754074.jpg"
+}
+
+val Commander2013Forest = basicLand("Forest") {
+    collectorNumber = "353"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/e/0/e005bfcd-5c99-4d92-99d9-4ba97b52af77.jpg"
+}
+
+/**
+ * All Commander 2013 basic land variants.
+ */
+val Commander2013BasicLands = listOf(
+    Commander2013Plains,
+    Commander2013Island,
+    Commander2013Swamp,
+    Commander2013Mountain,
+    Commander2013Forest,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ConjurerSClosetReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ConjurerSClosetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Conjurer's Closet reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val ConjurerSClosetReprint = Printing(
+    oracleId = "cd1eda60-53e4-44d0-9b2c-7a57395e291f",
+    name = "Conjurer's Closet",
+    setCode = "C13",
+    collectorNumber = "239",
+    scryfallId = "12de1008-9c1b-4072-8678-befce9a81cc7",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/1/2/12de1008-9c1b-4072-8678-befce9a81cc7.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/CrosisSCharmReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/CrosisSCharmReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crosis's Charm reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val CrosisSCharmReprint = Printing(
+    oracleId = "e59d70a2-40ac-45b0-995d-65b9caa290c8",
+    name = "Crosis's Charm",
+    setCode = "C13",
+    collectorNumber = "181",
+    scryfallId = "a586e329-b1e2-4b60-a914-7b9aa2c645c2",
+    artist = "Marco Nelor",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a586e329-b1e2-4b60-a914-7b9aa2c645c2.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/CrumblingNecropolisReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/CrumblingNecropolisReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crumbling Necropolis reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val CrumblingNecropolisReprint = Printing(
+    oracleId = "7190debf-708b-4f41-9714-0d0a5bd5a74e",
+    name = "Crumbling Necropolis",
+    setCode = "C13",
+    collectorNumber = "283",
+    scryfallId = "495ec48c-1352-4bbe-b27f-53bf8e823ce0",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/4/9/495ec48c-1352-4bbe-b27f-53bf8e823ce0.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/DarksteelIngotReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/DarksteelIngotReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Darksteel Ingot reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val DarksteelIngotReprint = Printing(
+    oracleId = "a2529491-7389-4cfa-92d2-145eda779603",
+    name = "Darksteel Ingot",
+    setCode = "C13",
+    collectorNumber = "241",
+    scryfallId = "251fc3c5-b2f0-4be3-aa65-bc6ef8112252",
+    artist = "Martina Pilcerova",
+    imageUri = "https://cards.scryfall.io/normal/front/2/5/251fc3c5-b2f0-4be3-aa65-bc6ef8112252.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/DeceiverExarchReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/DeceiverExarchReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deceiver Exarch reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val DeceiverExarchReprint = Printing(
+    oracleId = "3c939ea6-68b7-4965-b1d3-af1d3dc79778",
+    name = "Deceiver Exarch",
+    setCode = "C13",
+    collectorNumber = "37",
+    scryfallId = "b9c5761b-52f8-4f43-abfb-8d2366500f8f",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/b/9/b9c5761b-52f8-4f43-abfb-8d2366500f8f.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/DimirGuildgateReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/DimirGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dimir Guildgate reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val DimirGuildgateReprint = Printing(
+    oracleId = "52d14717-0cbc-4d7e-b546-54ea91580338",
+    name = "Dimir Guildgate",
+    setCode = "C13",
+    collectorNumber = "284",
+    scryfallId = "deba1271-ca49-4318-b94a-7a6598807dc8",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/d/e/deba1271-ca49-4318-b94a-7a6598807dc8.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/DriftingMeadowReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/DriftingMeadowReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Drifting Meadow reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val DriftingMeadowReprint = Printing(
+    oracleId = "c6eb2814-0021-4308-ad44-6c8cc59b0d1c",
+    name = "Drifting Meadow",
+    setCode = "C13",
+    collectorNumber = "285",
+    scryfallId = "6b2cb78c-c0d6-45e3-a957-71d634fc34b2",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/6/b/6b2cb78c-c0d6-45e3-a957-71d634fc34b2.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/DromarSCharmReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/DromarSCharmReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dromar's Charm reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val DromarSCharmReprint = Printing(
+    oracleId = "e9950393-8458-4132-9dc7-01246282a41a",
+    name = "Dromar's Charm",
+    setCode = "C13",
+    collectorNumber = "187",
+    scryfallId = "69f752d3-3f42-4275-be09-d257c89da70d",
+    artist = "Marco Nelor",
+    imageUri = "https://cards.scryfall.io/normal/front/6/9/69f752d3-3f42-4275-be09-d257c89da70d.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ElvishSkysweeperReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ElvishSkysweeperReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elvish Skysweeper reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val ElvishSkysweeperReprint = Printing(
+    oracleId = "f557697a-4c1b-44f6-a989-4879bbe26eb5",
+    name = "Elvish Skysweeper",
+    setCode = "C13",
+    collectorNumber = "143",
+    scryfallId = "ff4b950c-bd01-45e0-bd60-5b55640a50a8",
+    artist = "Mark Tedin",
+    imageUri = "https://cards.scryfall.io/normal/front/f/f/ff4b950c-bd01-45e0-bd60-5b55640a50a8.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/EndlessCockroachesReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/EndlessCockroachesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Endless Cockroaches reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val EndlessCockroachesReprint = Printing(
+    oracleId = "9f31dbb1-c350-46f8-bd1d-9f23a073d2f1",
+    name = "Endless Cockroaches",
+    setCode = "C13",
+    collectorNumber = "75",
+    scryfallId = "de7f26a4-da23-4508-b8b4-817a66d7852a",
+    artist = "Ron Spencer",
+    imageUri = "https://cards.scryfall.io/normal/front/d/e/de7f26a4-da23-4508-b8b4-817a66d7852a.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/EternalDragonReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/EternalDragonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eternal Dragon reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val EternalDragonReprint = Printing(
+    oracleId = "04d8615c-3883-4251-9790-1d8a4a40e142",
+    name = "Eternal Dragon",
+    setCode = "C13",
+    collectorNumber = "10",
+    scryfallId = "2a57191e-58a8-4ba9-8b5d-5a4e5a08b404",
+    artist = "Adam Rex",
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2a57191e-58a8-4ba9-8b5d-5a4e5a08b404.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/FamineReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/FamineReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Famine reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val FamineReprint = Printing(
+    oracleId = "1f82fe6b-1ec7-400b-a80d-40921b359723",
+    name = "Famine",
+    setCode = "C13",
+    collectorNumber = "77",
+    scryfallId = "a56410a7-6f99-4bdf-9385-f23571c263c3",
+    artist = "Karla Ortiz",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a56410a7-6f99-4bdf-9385-f23571c263c3.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/FiligreeAngelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/FiligreeAngelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Filigree Angel reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val FiligreeAngelReprint = Printing(
+    oracleId = "4a261c42-825d-4965-8ea7-80d50c43474e",
+    name = "Filigree Angel",
+    setCode = "C13",
+    collectorNumber = "189",
+    scryfallId = "46c0b36c-d2b8-4ed0-b523-3068584c1e71",
+    artist = "Richard Whitters",
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/46c0b36c-d2b8-4ed0-b523-3068584c1e71.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/FiresOfYavimayaReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/FiresOfYavimayaReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fires of Yavimaya reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val FiresOfYavimayaReprint = Printing(
+    oracleId = "e23d6f3b-0e18-423b-943b-15db7837255b",
+    name = "Fires of Yavimaya",
+    setCode = "C13",
+    collectorNumber = "190",
+    scryfallId = "82538d1b-7477-4d65-8aa2-e2b4ffec8d65",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/8/2/82538d1b-7477-4d65-8aa2-e2b4ffec8d65.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/FissureVentReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/FissureVentReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fissure Vent reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val FissureVentReprint = Printing(
+    oracleId = "f5bac25d-72e9-4655-8a04-3646fc10be27",
+    name = "Fissure Vent",
+    setCode = "C13",
+    collectorNumber = "107",
+    scryfallId = "c16cbb92-8d1e-44ec-a66a-57549042de19",
+    artist = "Philip Straub",
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c16cbb92-8d1e-44ec-a66a-57549042de19.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ForgottenCaveReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ForgottenCaveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Forgotten Cave reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val ForgottenCaveReprint = Printing(
+    oracleId = "394c6de5-7957-4a0b-a6b9-ee0c707cd022",
+    name = "Forgotten Cave",
+    setCode = "C13",
+    collectorNumber = "289",
+    scryfallId = "5b1535fc-8ace-4b5a-b492-a0ee09c42a9a",
+    artist = "Tony Szczudlo",
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5b1535fc-8ace-4b5a-b492-a0ee09c42a9a.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GoblinBombardmentReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GoblinBombardmentReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Bombardment reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val GoblinBombardmentReprint = Printing(
+    oracleId = "edad60c6-80de-4033-af1b-a703ac332983",
+    name = "Goblin Bombardment",
+    setCode = "C13",
+    collectorNumber = "110",
+    scryfallId = "cef7d5ac-d7a4-45a8-b780-6f19e2adc4c6",
+    artist = "Brian Snõddy",
+    imageUri = "https://cards.scryfall.io/normal/front/c/e/cef7d5ac-d7a4-45a8-b780-6f19e2adc4c6.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GolgariGuildgateReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GolgariGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Golgari Guildgate reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val GolgariGuildgateReprint = Printing(
+    oracleId = "fa2da325-6859-45bb-b185-35526b01bcc1",
+    name = "Golgari Guildgate",
+    setCode = "C13",
+    collectorNumber = "290",
+    scryfallId = "80658042-3998-49ca-88ef-f87320a5bd43",
+    artist = "Eytan Zana",
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/80658042-3998-49ca-88ef-f87320a5bd43.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GolgariGuildmageReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GolgariGuildmageReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Golgari Guildmage reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val GolgariGuildmageReprint = Printing(
+    oracleId = "46dad873-11f5-4269-8ec2-f126419fbd7d",
+    name = "Golgari Guildmage",
+    setCode = "C13",
+    collectorNumber = "229",
+    scryfallId = "890faae2-cf6a-400a-9f17-8772991b0eef",
+    artist = "Zoltan Boros & Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/890faae2-cf6a-400a-9f17-8772991b0eef.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GrazingGladehartReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GrazingGladehartReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grazing Gladehart reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val GrazingGladehartReprint = Printing(
+    oracleId = "f19f28e5-9cad-4398-b2d4-9e7fefb23cb4",
+    name = "Grazing Gladehart",
+    setCode = "C13",
+    collectorNumber = "147",
+    scryfallId = "fc1b8c33-05f5-426f-99eb-0e1e185c7862",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fc1b8c33-05f5-426f-99eb-0e1e185c7862.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GrixisCharmReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GrixisCharmReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grixis Charm reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val GrixisCharmReprint = Printing(
+    oracleId = "387ae7be-1cb5-4ae8-bb63-edf4941945a9",
+    name = "Grixis Charm",
+    setCode = "C13",
+    collectorNumber = "192",
+    scryfallId = "20332354-a294-4448-a66f-533e6b546df6",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/2/0/20332354-a294-4448-a66f-533e6b546df6.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GruulGuildgateReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GruulGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gruul Guildgate reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val GruulGuildgateReprint = Printing(
+    oracleId = "d38476e9-2e47-4c0c-8129-483c0bd09ec0",
+    name = "Gruul Guildgate",
+    setCode = "C13",
+    collectorNumber = "294",
+    scryfallId = "d5d7efbc-0863-4993-a6e9-58818378e8af",
+    artist = "Randy Gallegos",
+    imageUri = "https://cards.scryfall.io/normal/front/d/5/d5d7efbc-0863-4993-a6e9-58818378e8af.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GuttersnipeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/GuttersnipeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Guttersnipe reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val GuttersnipeReprint = Printing(
+    oracleId = "c6bdaf76-6a03-4695-9c4b-f040e73435af",
+    name = "Guttersnipe",
+    setCode = "C13",
+    collectorNumber = "112",
+    scryfallId = "bb4bd882-1fa6-41a4-b82b-ec9f8e7f9b11",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/b/b/bb4bd882-1fa6-41a4-b82b-ec9f8e7f9b11.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/HarmonizeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/HarmonizeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Harmonize reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val HarmonizeReprint = Printing(
+    oracleId = "7eff84f1-f772-497a-b350-bbc93d0230f7",
+    name = "Harmonize",
+    setCode = "C13",
+    collectorNumber = "148",
+    scryfallId = "83da2456-0c5c-4b2b-8183-20c332566127",
+    artist = "Paul Lee",
+    imageUri = "https://cards.scryfall.io/normal/front/8/3/83da2456-0c5c-4b2b-8183-20c332566127.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/InfestReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/InfestReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Infest reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val InfestReprint = Printing(
+    oracleId = "d6850616-7db5-4141-9ab0-ae8d1f08114f",
+    name = "Infest",
+    setCode = "C13",
+    collectorNumber = "81",
+    scryfallId = "df59c670-2deb-49ad-911d-6b7b182f0b1a",
+    artist = "Karl Kopinski",
+    imageUri = "https://cards.scryfall.io/normal/front/d/f/df59c670-2deb-49ad-911d-6b7b182f0b1a.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/IzzetGuildgateReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/IzzetGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Izzet Guildgate reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val IzzetGuildgateReprint = Printing(
+    oracleId = "bf75a3d1-f184-4b48-a913-21caee1db084",
+    name = "Izzet Guildgate",
+    setCode = "C13",
+    collectorNumber = "297",
+    scryfallId = "65caef6e-70f9-4841-8c4d-457748d292fa",
+    artist = "Noah Bradley",
+    imageUri = "https://cards.scryfall.io/normal/front/6/5/65caef6e-70f9-4841-8c4d-457748d292fa.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/JadeMageReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/JadeMageReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jade Mage reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val JadeMageReprint = Printing(
+    oracleId = "6daf3c59-7636-4d44-872b-67722b4868cb",
+    name = "Jade Mage",
+    setCode = "C13",
+    collectorNumber = "151",
+    scryfallId = "3d57bc86-7625-4669-9d33-b662263bd5bf",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3d57bc86-7625-4669-9d33-b662263bd5bf.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/JungleShrineReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/JungleShrineReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jungle Shrine reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val JungleShrineReprint = Printing(
+    oracleId = "2e69537c-c898-4e13-a72d-ce3957a90304",
+    name = "Jungle Shrine",
+    setCode = "C13",
+    collectorNumber = "299",
+    scryfallId = "025fb0fe-36f2-41bb-ab44-9afea7ef7818",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/0/2/025fb0fe-36f2-41bb-ab44-9afea7ef7818.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/JwarIsleRefugeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/JwarIsleRefugeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jwar Isle Refuge reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val JwarIsleRefugeReprint = Printing(
+    oracleId = "8b96f837-7c32-473a-b5ae-1d66527eaf7b",
+    name = "Jwar Isle Refuge",
+    setCode = "C13",
+    collectorNumber = "300",
+    scryfallId = "d748fbf3-ece2-4f48-9a7e-701a327dd749",
+    artist = "Cyril Van Der Haegen",
+    imageUri = "https://cards.scryfall.io/normal/front/d/7/d748fbf3-ece2-4f48-9a7e-701a327dd749.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/KazanduRefugeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/KazanduRefugeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kazandu Refuge reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val KazanduRefugeReprint = Printing(
+    oracleId = "03332772-18b0-446a-a7e2-a4bdf38c4f0c",
+    name = "Kazandu Refuge",
+    setCode = "C13",
+    collectorNumber = "301",
+    scryfallId = "94d5eb61-4f38-42a0-92b2-1f25019bd436",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/94d5eb61-4f38-42a0-92b2-1f25019bd436.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/KhalniGardenReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/KhalniGardenReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Khalni Garden reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val KhalniGardenReprint = Printing(
+    oracleId = "b2d5ba45-8674-4428-89db-c2bbbf0bf5c5",
+    name = "Khalni Garden",
+    setCode = "C13",
+    collectorNumber = "302",
+    scryfallId = "55d17634-db36-47e3-855f-7c3a8419cce7",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/55d17634-db36-47e3-855f-7c3a8419cce7.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/KongmingSleepingDragonReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/KongmingSleepingDragonReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kongming, "Sleeping Dragon" reprint in C13. Canonical CardDefinition lives in its earliest set
+ * (Portal Three Kingdoms, `ptk`).
+ *
+ * Hand-written rather than generated: `scripts/generate-reprints.py` matches cards by an exact-name
+ * Scryfall query, and this card's name embeds literal double quotes, which that query cannot express.
+ */
+val KongmingSleepingDragonReprint = Printing(
+    oracleId = "21e9e1a9-5d6d-473e-adab-6a1e8e2b0ebd",
+    name = "Kongming, \"Sleeping Dragon\"",
+    setCode = "C13",
+    collectorNumber = "16",
+    scryfallId = "5432b863-21cc-4898-9463-29049f939e51",
+    artist = "Gao Yan",
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/5432b863-21cc-4898-9463-29049f939e51.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/KrosanWarchiefReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/KrosanWarchiefReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Krosan Warchief reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val KrosanWarchiefReprint = Printing(
+    oracleId = "88350861-244c-4634-9bc9-e9a79401bd02",
+    name = "Krosan Warchief",
+    setCode = "C13",
+    collectorNumber = "155",
+    scryfallId = "0bfc9b24-6dbe-42df-a2c7-cb4845afb50f",
+    artist = "Greg Hildebrandt",
+    imageUri = "https://cards.scryfall.io/normal/front/0/b/0bfc9b24-6dbe-42df-a2c7-cb4845afb50f.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/LeoninBladetrapReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/LeoninBladetrapReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Leonin Bladetrap reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val LeoninBladetrapReprint = Printing(
+    oracleId = "ca21d597-40a5-4724-9d53-1ab6e6c6e767",
+    name = "Leonin Bladetrap",
+    setCode = "C13",
+    collectorNumber = "245",
+    scryfallId = "6eeac75d-22e8-42b1-99a2-6f6efb775515",
+    artist = "Randy Gallegos",
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6eeac75d-22e8-42b1-99a2-6f6efb775515.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/LonelySandbarReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/LonelySandbarReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lonely Sandbar reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val LonelySandbarReprint = Printing(
+    oracleId = "765863c8-1be0-4bb1-9e9c-db7701cffde3",
+    name = "Lonely Sandbar",
+    setCode = "C13",
+    collectorNumber = "305",
+    scryfallId = "a54cf217-263f-4872-91b2-d5fb808f64b7",
+    artist = "Heather Hudson",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a54cf217-263f-4872-91b2-d5fb808f64b7.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/MarrowBatsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/MarrowBatsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Marrow Bats reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val MarrowBatsReprint = Printing(
+    oracleId = "f20d96cc-3949-4888-a909-c7d67c4d31c7",
+    name = "Marrow Bats",
+    setCode = "C13",
+    collectorNumber = "82",
+    scryfallId = "a469e9a9-2498-4651-89fb-a86729d8c978",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/a/4/a469e9a9-2498-4651-89fb-a86729d8c978.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/NewBenaliaReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/NewBenaliaReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * New Benalia reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val NewBenaliaReprint = Printing(
+    oracleId = "6e743fbf-b5b6-4176-a4f2-6933f521f2fe",
+    name = "New Benalia",
+    setCode = "C13",
+    collectorNumber = "309",
+    scryfallId = "2ea41704-04e2-4cba-95c6-7cf827ad45af",
+    artist = "Richard Wright",
+    imageUri = "https://cards.scryfall.io/normal/front/2/e/2ea41704-04e2-4cba-95c6-7cf827ad45af.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ObeliskOfEsperReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ObeliskOfEsperReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Obelisk of Esper reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val ObeliskOfEsperReprint = Printing(
+    oracleId = "9da963f6-734b-4d3c-a3be-dd5cca2c7b19",
+    name = "Obelisk of Esper",
+    setCode = "C13",
+    collectorNumber = "250",
+    scryfallId = "70b347b1-9277-4ad0-88c8-faacace08827",
+    artist = "Francis Tsai",
+    imageUri = "https://cards.scryfall.io/normal/front/7/0/70b347b1-9277-4ad0-88c8-faacace08827.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ObeliskOfGrixisReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ObeliskOfGrixisReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Obelisk of Grixis reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val ObeliskOfGrixisReprint = Printing(
+    oracleId = "e193ae18-91a0-4870-b8a1-f8dedf744708",
+    name = "Obelisk of Grixis",
+    setCode = "C13",
+    collectorNumber = "251",
+    scryfallId = "e45bffc0-a12e-4c0e-81de-8d5b91109330",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/e/4/e45bffc0-a12e-4c0e-81de-8d5b91109330.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ObeliskOfJundReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ObeliskOfJundReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Obelisk of Jund reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val ObeliskOfJundReprint = Printing(
+    oracleId = "eb0be178-55f9-4743-8128-34bc86f134ec",
+    name = "Obelisk of Jund",
+    setCode = "C13",
+    collectorNumber = "252",
+    scryfallId = "1fe43306-f48f-4812-8d40-1903cc6f19d2",
+    artist = "Brandon Kitkouski",
+    imageUri = "https://cards.scryfall.io/normal/front/1/f/1fe43306-f48f-4812-8d40-1903cc6f19d2.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/OpportunityReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/OpportunityReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Opportunity reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val OpportunityReprint = Printing(
+    oracleId = "1f544a9f-c238-4858-be19-d6cd7d023dcc",
+    name = "Opportunity",
+    setCode = "C13",
+    collectorNumber = "51",
+    scryfallId = "bc0323fe-59a4-49f5-bdff-ba47229dd9d0",
+    artist = "Allen Williams",
+    imageUri = "https://cards.scryfall.io/normal/front/b/c/bc0323fe-59a4-49f5-bdff-ba47229dd9d0.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/OrzhovGuildgateReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/OrzhovGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Orzhov Guildgate reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val OrzhovGuildgateReprint = Printing(
+    oracleId = "57b37df5-fee4-4720-931f-f0cb0a8b338c",
+    name = "Orzhov Guildgate",
+    setCode = "C13",
+    collectorNumber = "312",
+    scryfallId = "1dd804d2-ae6c-4906-861b-16f6c976909f",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/1/d/1dd804d2-ae6c-4906-861b-16f6c976909f.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/PhyrexianReclamationReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/PhyrexianReclamationReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Phyrexian Reclamation reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val PhyrexianReclamationReprint = Printing(
+    oracleId = "647ca69e-cc01-4b2b-b376-bee2a98331e8",
+    name = "Phyrexian Reclamation",
+    setCode = "C13",
+    collectorNumber = "88",
+    scryfallId = "50186729-8ba7-47a5-8e82-2da78b9736f0",
+    artist = "rk post",
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/50186729-8ba7-47a5-8e82-2da78b9736f0.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/PilgrimSEyeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/PilgrimSEyeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pilgrim's Eye reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val PilgrimSEyeReprint = Printing(
+    oracleId = "66155010-cc2c-449a-85d5-92c95aade514",
+    name = "Pilgrim's Eye",
+    setCode = "C13",
+    collectorNumber = "253",
+    scryfallId = "ae9488d9-efeb-45a9-afcd-c5bb386847c8",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/a/e/ae9488d9-efeb-45a9-afcd-c5bb386847c8.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/PristineTalismanReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/PristineTalismanReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pristine Talisman reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val PristineTalismanReprint = Printing(
+    oracleId = "1b3d7fce-e9fe-4176-9d9a-472415826cdd",
+    name = "Pristine Talisman",
+    setCode = "C13",
+    collectorNumber = "255",
+    scryfallId = "ee345e13-cc0a-46ed-8379-61dabb6d3b5f",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/ee345e13-cc0a-46ed-8379-61dabb6d3b5f.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ProsperityReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ProsperityReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prosperity reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val ProsperityReprint = Printing(
+    oracleId = "c586312d-d04a-4bfb-bbb2-b41186ca178e",
+    name = "Prosperity",
+    setCode = "C13",
+    collectorNumber = "54",
+    scryfallId = "69ebc3a4-94b8-45aa-a3bf-21cd435ff5cf",
+    artist = "Nic Klein",
+    imageUri = "https://cards.scryfall.io/normal/front/6/9/69ebc3a4-94b8-45aa-a3bf-21cd435ff5cf.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/QuagmireDruidReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/QuagmireDruidReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Quagmire Druid reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val QuagmireDruidReprint = Printing(
+    oracleId = "560e1e81-6675-4d08-8e82-cdf1abd4b3d0",
+    name = "Quagmire Druid",
+    setCode = "C13",
+    collectorNumber = "90",
+    scryfallId = "ccb57a8b-1b2e-4119-a90e-b2b3de79e791",
+    artist = "Jaime Jones",
+    imageUri = "https://cards.scryfall.io/normal/front/c/c/ccb57a8b-1b2e-4119-a90e-b2b3de79e791.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/RainOfThornsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/RainOfThornsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rain of Thorns reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val RainOfThornsReprint = Printing(
+    oracleId = "363b0504-27bf-40df-96ec-9e3cb1e47588",
+    name = "Rain of Thorns",
+    setCode = "C13",
+    collectorNumber = "163",
+    scryfallId = "909fbbde-9db4-42fa-9d79-4f2b0568ae24",
+    artist = "Sam Burley",
+    imageUri = "https://cards.scryfall.io/normal/front/9/0/909fbbde-9db4-42fa-9d79-4f2b0568ae24.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/RakdosGuildgateReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/RakdosGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rakdos Guildgate reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val RakdosGuildgateReprint = Printing(
+    oracleId = "361f534b-39d1-4421-b5a8-d3813c62f86d",
+    name = "Rakdos Guildgate",
+    setCode = "C13",
+    collectorNumber = "314",
+    scryfallId = "e7c71a39-42a5-4a77-99fa-b7b59339818a",
+    artist = "Eytan Zana",
+    imageUri = "https://cards.scryfall.io/normal/front/e/7/e7c71a39-42a5-4a77-99fa-b7b59339818a.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/RakeclawGargantuanReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/RakeclawGargantuanReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rakeclaw Gargantuan reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val RakeclawGargantuanReprint = Printing(
+    oracleId = "8dbb4a8f-78e9-4ceb-824d-bb67bdf939db",
+    name = "Rakeclaw Gargantuan",
+    setCode = "C13",
+    collectorNumber = "205",
+    scryfallId = "a158bb17-d2e0-416d-840a-5e25fb5ac5c1",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a158bb17-d2e0-416d-840a-5e25fb5ac5c1.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/RampagingBalothsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/RampagingBalothsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rampaging Baloths reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val RampagingBalothsReprint = Printing(
+    oracleId = "2d3e6549-6cc6-434f-a189-ba3b55e64c34",
+    name = "Rampaging Baloths",
+    setCode = "C13",
+    collectorNumber = "164",
+    scryfallId = "6daaa97a-6864-4897-ad42-92a68dc6980d",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6daaa97a-6864-4897-ad42-92a68dc6980d.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/RavenousBalothReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/RavenousBalothReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ravenous Baloth reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val RavenousBalothReprint = Printing(
+    oracleId = "ee771e66-72f8-480f-9920-92c68ab93c3b",
+    name = "Ravenous Baloth",
+    setCode = "C13",
+    collectorNumber = "165",
+    scryfallId = "91ca66fc-2c65-4e31-8c9f-767d865b9d9c",
+    artist = "Todd Lockwood",
+    imageUri = "https://cards.scryfall.io/normal/front/9/1/91ca66fc-2c65-4e31-8c9f-767d865b9d9c.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/RecklessSpiteReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/RecklessSpiteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Reckless Spite reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val RecklessSpiteReprint = Printing(
+    oracleId = "a684df3a-5441-4daa-86d1-c47a91b35e6a",
+    name = "Reckless Spite",
+    setCode = "C13",
+    collectorNumber = "91",
+    scryfallId = "32bf8018-e5d8-4ddc-bf4f-26abe16de1d3",
+    artist = "Karl Kopinski",
+    imageUri = "https://cards.scryfall.io/normal/front/3/2/32bf8018-e5d8-4ddc-bf4f-26abe16de1d3.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/RuptureSpireReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/RuptureSpireReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rupture Spire reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val RuptureSpireReprint = Printing(
+    oracleId = "7eadffcb-1e15-44c1-b1db-78c71b8ec1ce",
+    name = "Rupture Spire",
+    setCode = "C13",
+    collectorNumber = "315",
+    scryfallId = "622087fc-4e34-43cd-a46f-fd2c339b3905",
+    artist = "Jaime Jones",
+    imageUri = "https://cards.scryfall.io/normal/front/6/2/622087fc-4e34-43cd-a46f-fd2c339b3905.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SavageLandsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SavageLandsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Savage Lands reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SavageLandsReprint = Printing(
+    oracleId = "a3292406-3f49-42d6-a547-e43dd5797f84",
+    name = "Savage Lands",
+    setCode = "C13",
+    collectorNumber = "317",
+    scryfallId = "34138230-30f6-4a5b-9ef6-16e51b8374f6",
+    artist = "Vance Kovacs",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/34138230-30f6-4a5b-9ef6-16e51b8374f6.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ScarlandThrinaxReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ScarlandThrinaxReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scarland Thrinax reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val ScarlandThrinaxReprint = Printing(
+    oracleId = "1a185f90-69eb-496b-8e38-8dcf241a84a4",
+    name = "Scarland Thrinax",
+    setCode = "C13",
+    collectorNumber = "209",
+    scryfallId = "8fb20f32-cdfa-43e3-8dbe-339bb03c0a00",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/8/f/8fb20f32-cdfa-43e3-8dbe-339bb03c0a00.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SecludedSteppeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SecludedSteppeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Secluded Steppe reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SecludedSteppeReprint = Printing(
+    oracleId = "8dec6fcf-1254-4b1b-ba23-7a3e492a7241",
+    name = "Secluded Steppe",
+    setCode = "C13",
+    collectorNumber = "319",
+    scryfallId = "bd3dc829-f296-43dc-a34a-41511de89445",
+    artist = "Heather Hudson",
+    imageUri = "https://cards.scryfall.io/normal/front/b/d/bd3dc829-f296-43dc-a34a-41511de89445.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SeerSSundialReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SeerSSundialReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seer's Sundial reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SeerSSundialReprint = Printing(
+    oracleId = "9929d7ba-cdc5-4099-a0ee-3a15073336f3",
+    name = "Seer's Sundial",
+    setCode = "C13",
+    collectorNumber = "256",
+    scryfallId = "4f6a4a8c-0b3e-4acf-8345-6ca73f3b675f",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/4/f/4f6a4a8c-0b3e-4acf-8345-6ca73f3b675f.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SejiriRefugeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SejiriRefugeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sejiri Refuge reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SejiriRefugeReprint = Printing(
+    oracleId = "73b3e242-075d-4c4d-9b09-6fef1633c348",
+    name = "Sejiri Refuge",
+    setCode = "C13",
+    collectorNumber = "320",
+    scryfallId = "65d1bf3c-f34a-4203-bae8-a17974f7800a",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/6/5/65d1bf3c-f34a-4203-bae8-a17974f7800a.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SelesnyaCharmReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SelesnyaCharmReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Selesnya Charm reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SelesnyaCharmReprint = Printing(
+    oracleId = "a1a49639-bcc4-4522-8862-c9fb13d40880",
+    name = "Selesnya Charm",
+    setCode = "C13",
+    collectorNumber = "211",
+    scryfallId = "5b01cfcd-fb1c-4f36-9cb7-79afabcdd766",
+    artist = "Zoltan Boros",
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5b01cfcd-fb1c-4f36-9cb7-79afabcdd766.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SelesnyaGuildgateReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SelesnyaGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Selesnya Guildgate reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SelesnyaGuildgateReprint = Printing(
+    oracleId = "75b235d3-595a-4859-be45-9559d8445db5",
+    name = "Selesnya Guildgate",
+    setCode = "C13",
+    collectorNumber = "321",
+    scryfallId = "44c9ebde-7af3-4390-a94a-3531e7d26c50",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/4/4/44c9ebde-7af3-4390-a94a-3531e7d26c50.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SelesnyaGuildmageReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SelesnyaGuildmageReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Selesnya Guildmage reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SelesnyaGuildmageReprint = Printing(
+    oracleId = "8fbdca3a-7aa3-4b5a-98d7-9168856045ac",
+    name = "Selesnya Guildmage",
+    setCode = "C13",
+    collectorNumber = "232",
+    scryfallId = "f251cd07-d3b8-4a22-a5fb-4a1a98cc6da4",
+    artist = "Mark Zug",
+    imageUri = "https://cards.scryfall.io/normal/front/f/2/f251cd07-d3b8-4a22-a5fb-4a1a98cc6da4.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SharuumTheHegemonReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SharuumTheHegemonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sharuum the Hegemon reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SharuumTheHegemonReprint = Printing(
+    oracleId = "037e7fc9-3aa6-484c-a2c8-43009e45f1d8",
+    name = "Sharuum the Hegemon",
+    setCode = "C13",
+    collectorNumber = "212",
+    scryfallId = "67a492b5-a392-497c-907d-29d3ede7e486",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/6/7/67a492b5-a392-497c-907d-29d3ede7e486.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SimicGuildgateReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SimicGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Simic Guildgate reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SimicGuildgateReprint = Printing(
+    oracleId = "e8705df9-6439-4930-91b6-229f818559af",
+    name = "Simic Guildgate",
+    setCode = "C13",
+    collectorNumber = "323",
+    scryfallId = "6dfe3527-fea7-4687-a311-7dc38080366d",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6dfe3527-fea7-4687-a311-7dc38080366d.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SlipperyKarstReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SlipperyKarstReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Slippery Karst reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SlipperyKarstReprint = Printing(
+    oracleId = "58bfd9a1-67ce-41d0-be38-f05addd1dd9e",
+    name = "Slippery Karst",
+    setCode = "C13",
+    collectorNumber = "324",
+    scryfallId = "9ae61670-9b39-4254-96c7-b2fb48d85a95",
+    artist = "Stephen Daniele",
+    imageUri = "https://cards.scryfall.io/normal/front/9/a/9ae61670-9b39-4254-96c7-b2fb48d85a95.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SmolderingCraterReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SmolderingCraterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Smoldering Crater reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SmolderingCraterReprint = Printing(
+    oracleId = "be09e83f-6486-4f42-8d2e-416cb95173f9",
+    name = "Smoldering Crater",
+    setCode = "C13",
+    collectorNumber = "325",
+    scryfallId = "eec84c7c-a6a5-4924-9ed2-160cace667ab",
+    artist = "Mark Tedin",
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/eec84c7c-a6a5-4924-9ed2-160cace667ab.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SolRingReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SolRingReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sol Ring reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SolRingReprint = Printing(
+    oracleId = "6ad8011d-3471-4369-9d68-b264cc027487",
+    name = "Sol Ring",
+    setCode = "C13",
+    collectorNumber = "259",
+    scryfallId = "1b59533a-3e38-495d-873e-2f89fbd08494",
+    artist = "Mike Bierek",
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1b59533a-3e38-495d-873e-2f89fbd08494.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SoulManipulationReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SoulManipulationReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soul Manipulation reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SoulManipulationReprint = Printing(
+    oracleId = "419c2ae1-fec7-4c27-a7a0-99f777abb4de",
+    name = "Soul Manipulation",
+    setCode = "C13",
+    collectorNumber = "215",
+    scryfallId = "fc30f6fb-bfdc-4914-9f7c-e4c00802b196",
+    artist = "Carl Critchlow",
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fc30f6fb-bfdc-4914-9f7c-e4c00802b196.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SphinxOfTheSteelWindReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SphinxOfTheSteelWindReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sphinx of the Steel Wind reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SphinxOfTheSteelWindReprint = Printing(
+    oracleId = "1c96772b-463c-4655-836b-cf6e9dc6319f",
+    name = "Sphinx of the Steel Wind",
+    setCode = "C13",
+    collectorNumber = "217",
+    scryfallId = "c1abede4-8c45-4016-9a1d-89131c428263",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c1abede4-8c45-4016-9a1d-89131c428263.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SpitebellowsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SpitebellowsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spitebellows reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SpitebellowsReprint = Printing(
+    oracleId = "fee18f57-4ae5-4df8-af3b-f82ed2157ac3",
+    name = "Spitebellows",
+    setCode = "C13",
+    collectorNumber = "120",
+    scryfallId = "d0ee0c68-8f00-447d-b36e-e2f6ce40f374",
+    artist = "Larry MacDougall",
+    imageUri = "https://cards.scryfall.io/normal/front/d/0/d0ee0c68-8f00-447d-b36e-e2f6ce40f374.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SproutingThrinaxReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/SproutingThrinaxReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sprouting Thrinax reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val SproutingThrinaxReprint = Printing(
+    oracleId = "ea74e89e-0724-4744-a6c9-e35c415624fb",
+    name = "Sprouting Thrinax",
+    setCode = "C13",
+    collectorNumber = "219",
+    scryfallId = "f9a7cf01-23d1-4006-8a71-e1e8e57e20bf",
+    artist = "Jarreau Wimberly",
+    imageUri = "https://cards.scryfall.io/normal/front/f/9/f9a7cf01-23d1-4006-8a71-e1e8e57e20bf.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/StrategicPlanningReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/StrategicPlanningReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Strategic Planning reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val StrategicPlanningReprint = Printing(
+    oracleId = "02b5acf3-47cb-4d39-9307-e02656f1879b",
+    name = "Strategic Planning",
+    setCode = "C13",
+    collectorNumber = "59",
+    scryfallId = "372993c8-8a55-4c40-a543-26ce6b827544",
+    artist = "Zhang Jiazhen",
+    imageUri = "https://cards.scryfall.io/normal/front/3/7/372993c8-8a55-4c40-a543-26ce6b827544.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/StrongholdAssassinReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/StrongholdAssassinReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stronghold Assassin reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val StrongholdAssassinReprint = Printing(
+    oracleId = "35826db0-b6ff-47b5-be16-c5b878d9e842",
+    name = "Stronghold Assassin",
+    setCode = "C13",
+    collectorNumber = "93",
+    scryfallId = "1de806b5-2263-42b4-a187-0cf8c9e15072",
+    artist = "Matthew D. Wilson",
+    imageUri = "https://cards.scryfall.io/normal/front/1/d/1de806b5-2263-42b4-a187-0cf8c9e15072.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/TempleOfTheFalseGodReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/TempleOfTheFalseGodReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Temple of the False God reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val TempleOfTheFalseGodReprint = Printing(
+    oracleId = "cfdd5dc6-593e-495a-8cfe-3a56b3c4c7df",
+    name = "Temple of the False God",
+    setCode = "C13",
+    collectorNumber = "327",
+    scryfallId = "5b25c648-34a7-4293-8f91-1295bcdeceb0",
+    artist = "Brian Snõddy",
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5b25c648-34a7-4293-8f91-1295bcdeceb0.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ThornwindFaeriesReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/ThornwindFaeriesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thornwind Faeries reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val ThornwindFaeriesReprint = Printing(
+    oracleId = "941a0e8d-c407-476b-9d0e-cffc1f8c6003",
+    name = "Thornwind Faeries",
+    setCode = "C13",
+    collectorNumber = "61",
+    scryfallId = "050280f0-97b2-446e-8166-21f434d06e4d",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/0/5/050280f0-97b2-446e-8166-21f434d06e4d.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/TidehollowStrixReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/TidehollowStrixReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tidehollow Strix reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val TidehollowStrixReprint = Printing(
+    oracleId = "19a39cc5-2134-4dee-932c-81389806c57b",
+    name = "Tidehollow Strix",
+    setCode = "C13",
+    collectorNumber = "222",
+    scryfallId = "17be4a4e-5f11-4c3e-b447-9feb5ccbc448",
+    artist = "Cyril Van Der Haegen",
+    imageUri = "https://cards.scryfall.io/normal/front/1/7/17be4a4e-5f11-4c3e-b447-9feb5ccbc448.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/TowerGargoyleReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/TowerGargoyleReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tower Gargoyle reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val TowerGargoyleReprint = Printing(
+    oracleId = "681ca1eb-2ef5-4d60-b834-58bd9b5a47b8",
+    name = "Tower Gargoyle",
+    setCode = "C13",
+    collectorNumber = "223",
+    scryfallId = "a49cbba1-09e9-4485-8dc8-1e3a786fa153",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/a/4/a49cbba1-09e9-4485-8dc8-1e3a786fa153.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/TowerOfFortunesReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/TowerOfFortunesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tower of Fortunes reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val TowerOfFortunesReprint = Printing(
+    oracleId = "dfb23df9-f912-4daa-9842-01bd12b4a72a",
+    name = "Tower of Fortunes",
+    setCode = "C13",
+    collectorNumber = "268",
+    scryfallId = "7622d6fe-73f2-417c-806c-8ca13192d271",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/7622d6fe-73f2-417c-806c-8ca13192d271.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/TranquilThicketReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/TranquilThicketReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tranquil Thicket reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val TranquilThicketReprint = Printing(
+    oracleId = "9f8fe514-77ed-41b4-a6f3-c6f095bb97be",
+    name = "Tranquil Thicket",
+    setCode = "C13",
+    collectorNumber = "329",
+    scryfallId = "7159ff50-904c-494e-a72b-6a8e36c51c59",
+    artist = "Heather Hudson",
+    imageUri = "https://cards.scryfall.io/normal/front/7/1/7159ff50-904c-494e-a72b-6a8e36c51c59.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/TransguildPromenadeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/TransguildPromenadeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Transguild Promenade reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val TransguildPromenadeReprint = Printing(
+    oracleId = "98334bfa-c516-4c20-bdc5-9e32e7127adc",
+    name = "Transguild Promenade",
+    setCode = "C13",
+    collectorNumber = "330",
+    scryfallId = "9f325665-43cd-4b6d-8878-e42a39178e3f",
+    artist = "Noah Bradley",
+    imageUri = "https://cards.scryfall.io/normal/front/9/f/9f325665-43cd-4b6d-8878-e42a39178e3f.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/VampireNighthawkReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/VampireNighthawkReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vampire Nighthawk reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val VampireNighthawkReprint = Printing(
+    oracleId = "feb244f8-bcb1-44cf-9940-2719221a7309",
+    name = "Vampire Nighthawk",
+    setCode = "C13",
+    collectorNumber = "97",
+    scryfallId = "88a78e21-e594-4051-bddb-a06beb087252",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/88a78e21-e594-4051-bddb-a06beb087252.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/VisceraSeerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/VisceraSeerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Viscera Seer reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val VisceraSeerReprint = Printing(
+    oracleId = "f82a4e85-526d-4456-b700-7760043a31be",
+    name = "Viscera Seer",
+    setCode = "C13",
+    collectorNumber = "99",
+    scryfallId = "535d8c19-c108-4fca-9918-2fcfc32e673d",
+    artist = "John Stanko",
+    imageUri = "https://cards.scryfall.io/normal/front/5/3/535d8c19-c108-4fca-9918-2fcfc32e673d.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/VituGhaziTheCityTreeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/VituGhaziTheCityTreeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vitu-Ghazi, the City-Tree reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val VituGhaziTheCityTreeReprint = Printing(
+    oracleId = "88fb9e82-28b9-4275-a1e2-cb3a9bfda127",
+    name = "Vitu-Ghazi, the City-Tree",
+    setCode = "C13",
+    collectorNumber = "332",
+    scryfallId = "b2d91432-f4f9-4dfb-8fc4-2579c82dcd50",
+    artist = "Martina Pilcerova",
+    imageUri = "https://cards.scryfall.io/normal/front/b/2/b2d91432-f4f9-4dfb-8fc4-2579c82dcd50.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/WalkerOfTheGroveReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/WalkerOfTheGroveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Walker of the Grove reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val WalkerOfTheGroveReprint = Printing(
+    oracleId = "02d69413-e040-46b1-8f58-69bde666329d",
+    name = "Walker of the Grove",
+    setCode = "C13",
+    collectorNumber = "175",
+    scryfallId = "3a4e30fa-c49a-4992-b029-5234a3063aee",
+    artist = "Todd Lockwood",
+    imageUri = "https://cards.scryfall.io/normal/front/3/a/3a4e30fa-c49a-4992-b029-5234a3063aee.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/WingedCoatlReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/WingedCoatlReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Winged Coatl reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val WingedCoatlReprint = Printing(
+    oracleId = "11369d8b-6443-43c3-a60f-dd920a4e8c08",
+    name = "Winged Coatl",
+    setCode = "C13",
+    collectorNumber = "226",
+    scryfallId = "9e54f4bc-eb76-4353-af2f-188a6c914db7",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/9/e/9e54f4bc-eb76-4353-af2f-188a6c914db7.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/WrathOfGodReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c13/cards/WrathOfGodReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wrath of God reprint in C13. Canonical CardDefinition lives in its earliest set.
+ */
+val WrathOfGodReprint = Printing(
+    oracleId = "34515b16-c9a4-4f98-8c77-416a7a523407",
+    name = "Wrath of God",
+    setCode = "C13",
+    collectorNumber = "27",
+    scryfallId = "b9042d0b-b96c-410c-b33d-16d0e94714f4",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/b/9/b9042d0b-b96c-410c-b33d-16d0e94714f4.jpg",
+    releaseDate = "2013-11-01",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/PristineTalismanReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/PristineTalismanReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pristine Talisman reprint in C14. Canonical CardDefinition lives in its earliest set.
+ */
+val PristineTalismanReprint = Printing(
+    oracleId = "1b3d7fce-e9fe-4176-9d9a-472415826cdd",
+    name = "Pristine Talisman",
+    setCode = "C14",
+    collectorNumber = "264",
+    scryfallId = "2fa0c4c8-5806-4835-8eca-3c0247b83083",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/2/f/2fa0c4c8-5806-4835-8eca-3c0247b83083.jpg",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SeerSSundialReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SeerSSundialReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seer's Sundial reprint in C14. Canonical CardDefinition lives in its earliest set.
+ */
+val SeerSSundialReprint = Printing(
+    oracleId = "9929d7ba-cdc5-4099-a0ee-3a15073336f3",
+    name = "Seer's Sundial",
+    setCode = "C14",
+    collectorNumber = "267",
+    scryfallId = "dff57990-c7dc-4b25-a1f8-58109da78053",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/d/f/dff57990-c7dc-4b25-a1f8-58109da78053.jpg",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SpitebellowsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SpitebellowsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spitebellows reprint in C14. Canonical CardDefinition lives in its earliest set.
+ */
+val SpitebellowsReprint = Printing(
+    oracleId = "fee18f57-4ae5-4df8-af3b-f82ed2157ac3",
+    name = "Spitebellows",
+    setCode = "C14",
+    collectorNumber = "181",
+    scryfallId = "1516163a-4c45-444d-8c71-3a09fb8804c8",
+    artist = "Larry MacDougall",
+    imageUri = "https://cards.scryfall.io/normal/front/1/5/1516163a-4c45-444d-8c71-3a09fb8804c8.jpg",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/BasaltMonolithReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/BasaltMonolithReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Basalt Monolith reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val BasaltMonolithReprint = Printing(
+    oracleId = "6b8cf2a0-b045-4d91-9d91-c602d40c6237",
+    name = "Basalt Monolith",
+    setCode = "C15",
+    collectorNumber = "244",
+    scryfallId = "e5951ebc-8fee-4305-a776-b2bd751c9818",
+    artist = "Yeong-Hao Han",
+    imageUri = "https://cards.scryfall.io/normal/front/e/5/e5951ebc-8fee-4305-a776-b2bd751c9818.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/NewBenaliaReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/NewBenaliaReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * New Benalia reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val NewBenaliaReprint = Printing(
+    oracleId = "6e743fbf-b5b6-4176-a4f2-6933f521f2fe",
+    name = "New Benalia",
+    setCode = "C15",
+    collectorNumber = "295",
+    scryfallId = "efb003a9-d6de-4d38-8431-c37346d70aa8",
+    artist = "Richard Wright",
+    imageUri = "https://cards.scryfall.io/normal/front/e/f/efb003a9-d6de-4d38-8431-c37346d70aa8.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/SeerSSundialReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/SeerSSundialReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seer's Sundial reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val SeerSSundialReprint = Printing(
+    oracleId = "9929d7ba-cdc5-4099-a0ee-3a15073336f3",
+    name = "Seer's Sundial",
+    setCode = "C15",
+    collectorNumber = "264",
+    scryfallId = "7ab9c2ec-34df-4866-aa2f-1ba4a9645187",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7ab9c2ec-34df-4866-aa2f-1ba4a9645187.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/FiligreeAngelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/FiligreeAngelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Filigree Angel reprint in C16. Canonical CardDefinition lives in its earliest set.
+ */
+val FiligreeAngelReprint = Printing(
+    oracleId = "4a261c42-825d-4965-8ea7-80d50c43474e",
+    name = "Filigree Angel",
+    setCode = "C16",
+    collectorNumber = "199",
+    scryfallId = "afee5684-e9ff-4451-b3e9-184c2e83fb36",
+    artist = "Richard Whitters",
+    imageUri = "https://cards.scryfall.io/normal/front/a/f/afee5684-e9ff-4451-b3e9-184c2e83fb36.jpg",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/SharuumTheHegemonReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/SharuumTheHegemonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sharuum the Hegemon reprint in C16. Canonical CardDefinition lives in its earliest set.
+ */
+val SharuumTheHegemonReprint = Printing(
+    oracleId = "037e7fc9-3aa6-484c-a2c8-43009e45f1d8",
+    name = "Sharuum the Hegemon",
+    setCode = "C16",
+    collectorNumber = "221",
+    scryfallId = "f8896272-4806-40ba-94fd-51310269aa07",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/f/8/f8896272-4806-40ba-94fd-51310269aa07.jpg",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/AkoumRefugeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/AkoumRefugeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Akoum Refuge reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val AkoumRefugeReprint = Printing(
+    oracleId = "354fecd1-2371-49e3-81c6-7e47728dbb1f",
+    name = "Akoum Refuge",
+    setCode = "CMD",
+    collectorNumber = "264",
+    scryfallId = "4c1c9068-6741-4137-a901-5492a2dcb535",
+    artist = "Fred Fields",
+    imageUri = "https://cards.scryfall.io/normal/front/4/c/4c1c9068-6741-4137-a901-5492a2dcb535.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/JwarIsleRefugeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/JwarIsleRefugeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jwar Isle Refuge reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val JwarIsleRefugeReprint = Printing(
+    oracleId = "8b96f837-7c32-473a-b5ae-1d66527eaf7b",
+    name = "Jwar Isle Refuge",
+    setCode = "CMD",
+    collectorNumber = "279",
+    scryfallId = "b997a8e1-814b-4780-ade8-bdcfc0021adf",
+    artist = "Cyril Van Der Haegen",
+    imageUri = "https://cards.scryfall.io/normal/front/b/9/b997a8e1-814b-4780-ade8-bdcfc0021adf.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/KazanduRefugeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/KazanduRefugeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kazandu Refuge reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val KazanduRefugeReprint = Printing(
+    oracleId = "03332772-18b0-446a-a7e2-a4bdf38c4f0c",
+    name = "Kazandu Refuge",
+    setCode = "CMD",
+    collectorNumber = "280",
+    scryfallId = "a1c7d053-8699-4fc4-a079-75cbcd661d8f",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a1c7d053-8699-4fc4-a079-75cbcd661d8f.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/SpitebellowsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/SpitebellowsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spitebellows reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val SpitebellowsReprint = Printing(
+    oracleId = "fee18f57-4ae5-4df8-af3b-f82ed2157ac3",
+    name = "Spitebellows",
+    setCode = "CMD",
+    collectorNumber = "135",
+    scryfallId = "95774d62-f5b8-4af7-861e-2f0ab2b38820",
+    artist = "Larry MacDougall",
+    imageUri = "https://cards.scryfall.io/normal/front/9/5/95774d62-f5b8-4af7-861e-2f0ab2b38820.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/AerieMystics.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/AerieMystics.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aerie Mystics
+ * {4}{W}
+ * Creature — Bird Wizard
+ * 3/3
+ * Flying
+ * {1}{G}{U}: Creatures you control gain shroud until end of turn. (They can't be the targets of spells or abilities.)
+ *
+ * Flying is a printed [Keyword]. The activated ability is one [Patterns.Group.grantKeywordToAll]
+ * over [Filters.Group.creaturesYouControl] — a single `ForEachInGroup` that names the group once
+ * and grants [Keyword.SHROUD] to each member; the pattern's default duration is already
+ * `Duration.EndOfTurn`, so the printed "until end of turn" needs no argument of its own.
+ */
+val AerieMystics = card("Aerie Mystics") {
+    manaCost = "{4}{W}"
+    colorIdentity = "WUG"
+    typeLine = "Creature — Bird Wizard"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "{1}{G}{U}: Creatures you control gain shroud until end of turn. (They can't be the targets of spells or abilities.)"
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{G}{U}")
+        effect = Patterns.Group.grantKeywordToAll(
+            keyword = Keyword.SHROUD,
+            filter = Filters.Group.creaturesYouControl
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "1"
+        artist = "Mark Zug"
+        flavorText = "They are cautious with their body language and facial expressions. Any stray movement could betray the positions of the troops they protect and cost many lives."
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/58e86a42-cc53-4731-819a-e76f203a742a.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ScarlandThrinax.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ScarlandThrinax.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Scarland Thrinax
+ * {B}{R}{G}
+ * Creature — Lizard
+ * 2/2
+ * Sacrifice a creature: Put a +1/+1 counter on this creature.
+ *
+ * "Sacrifice a creature" accepts any creature you control, this one included, so the cost is
+ * [Costs.Sacrifice] over [GameObjectFilter.Creature] rather than `SacrificeAnother` (cf.
+ * Falkenrath Torturer). The effect is [Effects.AddCounters] on [EffectTarget.Self]; there is no
+ * mana in the cost and no tap symbol, so the ability is repeatable as long as creatures last.
+ */
+val ScarlandThrinax = card("Scarland Thrinax") {
+    manaCost = "{B}{R}{G}"
+    colorIdentity = "BRG"
+    typeLine = "Creature — Lizard"
+    power = 2
+    toughness = 2
+    oracleText = "Sacrifice a creature: Put a +1/+1 counter on this creature."
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Creature)
+        effect = Effects.AddCounters("+1/+1", 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "123"
+        artist = "Daarken"
+        flavorText = "\"There is only one way of life in Jund: feed on the weak until you are cut down by something stronger.\"\n—Jorshu of Clan Nel Toth"
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2a179b9-e962-49a4-ad92-8cd0291296c1.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/VisceraSeer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/VisceraSeer.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Viscera Seer
+ * {B}
+ * Creature — Vampire Wizard
+ * 1/1
+ * Sacrifice a creature: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ *
+ * One activated ability whose whole cost is a single [Costs.Sacrifice] over
+ * `GameObjectFilter.Creature` — the sacrifice is the activation cost, not an effect, so nothing
+ * else is spelled. `excludeSelf` is left at its default `false`: the Seer may eat itself, which is
+ * what the printed ruling says. Scry rides the [Effects.Scry] facade (the `Patterns.Library.scry`
+ * composition behind it), never a hand-rolled look-and-reorder pipeline.
+ */
+val VisceraSeer = card("Viscera Seer") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "Sacrifice a creature: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Creature)
+        effect = Effects.Scry(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "120"
+        artist = "John Stanko"
+        flavorText = "In matters of life and death, he trusts his gut."
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/6179f847-e334-4f7f-9a4e-0013942a394f.jpg"
+        ruling("2010-08-15", "You can sacrifice Viscera Seer to activate its own ability.")
+        ruling("2010-08-15", "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/JadeMage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/JadeMage.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jade Mage
+ * {1}{G}
+ * Creature — Human Shaman
+ * 2/1
+ * {2}{G}: Create a 1/1 green Saproling creature token.
+ *
+ * A repeatable token maker: [Costs.Mana] plus the shared [Effects.CreateToken] facade, which spells
+ * the token entirely by its printed characteristics — P/T, [Color.GREEN], and the "Saproling"
+ * creature type. No bespoke token definition is needed.
+ */
+val JadeMage = card("Jade Mage") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Shaman"
+    power = 2
+    toughness = 1
+    oracleText = "{2}{G}: Create a 1/1 green Saproling creature token."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}")
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "181"
+        artist = "Izzy"
+        flavorText = "\"We are one with the wild things. Life blooms from our fingertips and nature responds to our summons.\"\n—Jade creed"
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/32d6c8d3-04a1-4b35-b7d1-18bed82beaf4.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/Spitebellows.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/Spitebellows.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.mor.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Spitebellows
+ * {5}{R}
+ * Creature — Elemental
+ * 6/1
+ * When this creature leaves the battlefield, it deals 6 damage to target creature.
+ * Evoke {1}{R}{R} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)
+ *
+ * Evoke is the first-class [card] field `evoke` (cf. Mulldrifter) — the engine supplies the
+ * "sacrificed when it enters" trigger itself, so none is written here. The damage rider is a
+ * [Triggers.LeavesBattlefield] trigger (not a dies trigger — it fires on exile and bounce too)
+ * over [Targets.Creature] with a fixed [Effects.DealDamage] of 6 on [EffectTarget.ContextTarget];
+ * the source is left implicit, so the engine attributes the damage to this creature's last known
+ * information, which is the only thing left of it by the time the ability resolves.
+ */
+val Spitebellows = card("Spitebellows") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 6
+    toughness = 1
+    oracleText = "When this creature leaves the battlefield, it deals 6 damage to target creature.\n" +
+        "Evoke {1}{R}{R} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)"
+
+    evoke = "{1}{R}{R}"
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        target = Targets.Creature
+        effect = Effects.DealDamage(6, EffectTarget.ContextTarget(0))
+        description = "When this creature leaves the battlefield, it deals 6 damage to target creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "105"
+        artist = "Larry MacDougall"
+        flavorText = "Disaster stalks with gaping jaws across unready lands."
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/43f2104d-aeff-493f-8227-cb95bf3e2eab.jpg"
+        ruling("2008-04-01", "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke.")
+        ruling("2008-04-01", "If a creature spell cast with evoke changes controllers before it enters, it will still be sacrificed when it enters. Similarly, if a creature cast with evoke changes controllers after it enters but before its sacrifice ability resolves, it will still be sacrificed. In both cases, the controller of the creature at the time it left the battlefield will control its leaves-the-battlefield ability.")
+        ruling("2008-04-01", "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead.")
+        ruling("2008-04-01", "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost.")
+        ruling("2008-04-01", "Whether evoke's sacrifice ability triggers when the creature enters depends on whether the spell's controller chose to pay the evoke cost, not whether they actually paid it (if it was reduced or otherwise altered by another ability, for example).")
+        ruling("2008-04-01", "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/WalkerOfTheGrove.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/WalkerOfTheGrove.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.mor.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Walker of the Grove
+ * {6}{G}{G}
+ * Creature — Elemental
+ * 7/7
+ * When this creature leaves the battlefield, create a 4/4 green Elemental creature token.
+ * Evoke {4}{G} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)
+ *
+ * Evoke is the first-class [card] field `evoke` (cf. Mulldrifter) — the engine supplies the
+ * "sacrificed when it enters" trigger itself, so none is written here. The token rider is a
+ * [Triggers.LeavesBattlefield] trigger (not a dies trigger — it also fires on exile and bounce)
+ * whose effect is a single [Effects.CreateToken] at the default count of one.
+ */
+val WalkerOfTheGrove = card("Walker of the Grove") {
+    manaCost = "{6}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental"
+    power = 7
+    toughness = 7
+    oracleText = "When this creature leaves the battlefield, create a 4/4 green Elemental creature token.\n" +
+        "Evoke {4}{G} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)"
+
+    evoke = "{4}{G}"
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.CreateToken(
+            power = 4,
+            toughness = 4,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Elemental")
+        )
+        description = "When this creature leaves the battlefield, create a 4/4 green Elemental creature token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "138"
+        artist = "Todd Lockwood"
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2675b8b-a321-4982-b1d9-5c55d27b9bfd.jpg"
+        ruling("2008-04-01", "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke.")
+        ruling("2008-04-01", "If a creature spell cast with evoke changes controllers before it enters, it will still be sacrificed when it enters. Similarly, if a creature cast with evoke changes controllers after it enters but before its sacrifice ability resolves, it will still be sacrificed. In both cases, the controller of the creature at the time it left the battlefield will control its leaves-the-battlefield ability.")
+        ruling("2008-04-01", "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead.")
+        ruling("2008-04-01", "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost.")
+        ruling("2008-04-01", "Whether evoke's sacrifice ability triggers when the creature enters depends on whether the spell's controller chose to pay the evoke cost, not whether they actually paid it (if it was reduced or otherwise altered by another ability, for example).")
+        ruling("2008-04-01", "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/DeceiverExarch.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/DeceiverExarch.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.nph.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Deceiver Exarch
+ * {2}{U}
+ * Creature — Phyrexian Cleric
+ * 1/4
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * When this creature enters, choose one —
+ * • Untap target permanent you control.
+ * • Tap target permanent an opponent controls.
+ *
+ * Flash is a printed [Keyword]. The enters trigger is a [ModalEffect.chooseOne] on
+ * [Triggers.EntersBattlefield], each mode carrying its own target — the mode is what decides
+ * *whose* permanent is legal, so both are [Mode.withTarget] over [Targets.PermanentYouControl] and
+ * [Targets.PermanentOpponentControls] rather than one shared requirement. The effects are the two
+ * halves of the same tap/untap atom, [Effects.Untap] and [Effects.Tap], each reading its own
+ * mode's slot.
+ */
+val DeceiverExarch = card("Deceiver Exarch") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Phyrexian Cleric"
+    power = 1
+    toughness = 4
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "When this creature enters, choose one —\n" +
+        "• Untap target permanent you control.\n" +
+        "• Tap target permanent an opponent controls."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect.chooseOne(
+            Mode.withTarget(
+                effect = Effects.Untap(EffectTarget.ContextTarget(0)),
+                target = Targets.PermanentYouControl,
+                description = "Untap target permanent you control."
+            ),
+            Mode.withTarget(
+                effect = Effects.Tap(EffectTarget.ContextTarget(0)),
+                target = Targets.PermanentOpponentControls,
+                description = "Tap target permanent an opponent controls."
+            )
+        )
+        description = "When this creature enters, choose one — Untap target permanent you control; " +
+            "or tap target permanent an opponent controls."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "33"
+        artist = "Izzy"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f123ad6-fe84-4fed-9c0f-6b41921e9c26.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/PristineTalisman.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/PristineTalisman.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.nph.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Pristine Talisman
+ * {3}
+ * Artifact
+ * {T}: Add {C}. You gain 1 life.
+ *
+ * A mana ability with a non-mana rider: one `manaAbility` on [Costs.Tap] whose effect is an
+ * [Effects.Composite] of [Effects.AddColorlessMana] and [Effects.GainLife] (cf. Talisman of
+ * Progress, which pairs its mana with damage instead). Because the whole ability is a mana
+ * ability it never uses the stack, so the life gain happens as part of the activation.
+ */
+val PristineTalisman = card("Pristine Talisman") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {C}. You gain 1 life."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.Composite(
+            Effects.AddColorlessMana(1),
+            Effects.GainLife(1)
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "151"
+        artist = "Matt Cavotta"
+        flavorText = "\"Tools and artisans can be destroyed, but the act of creation is inviolate.\"\n—Elspeth Tirel"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b31d96cf-7276-46c4-ad17-d6a5c85f1315.jpg"
+        ruling("2011-06-01", "Pristine Talisman has a mana ability. Its ability doesn't use the stack and can't be responded to.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/JwarIsleRefugeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/JwarIsleRefugeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jwar Isle Refuge reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val JwarIsleRefugeReprint = Printing(
+    oracleId = "8b96f837-7c32-473a-b5ae-1d66527eaf7b",
+    name = "Jwar Isle Refuge",
+    setCode = "PC2",
+    collectorNumber = "120",
+    scryfallId = "bbf7bc29-75b0-462b-901b-7c4a7a577780",
+    artist = "Cyril Van Der Haegen",
+    imageUri = "https://cards.scryfall.io/normal/front/b/b/bbf7bc29-75b0-462b-901b-7c4a7a577780.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/KazanduRefugeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/KazanduRefugeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kazandu Refuge reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val KazanduRefugeReprint = Printing(
+    oracleId = "03332772-18b0-446a-a7e2-a4bdf38c4f0c",
+    name = "Kazandu Refuge",
+    setCode = "PC2",
+    collectorNumber = "121",
+    scryfallId = "fcde6747-334c-4d4d-802a-4c17d5f8dd6f",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fcde6747-334c-4d4d-802a-4c17d5f8dd6f.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/KhalniGardenReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/KhalniGardenReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Khalni Garden reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val KhalniGardenReprint = Printing(
+    oracleId = "b2d5ba45-8674-4428-89db-c2bbbf0bf5c5",
+    name = "Khalni Garden",
+    setCode = "PC2",
+    collectorNumber = "122",
+    scryfallId = "3829a229-0594-4f0b-b441-226a038e3323",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/3/8/3829a229-0594-4f0b-b441-226a038e3323.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/BrilliantPlanReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/BrilliantPlanReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brilliant Plan reprint in PZ2. Canonical CardDefinition lives in its earliest set.
+ */
+val BrilliantPlanReprint = Printing(
+    oracleId = "d83e1a42-11d1-412a-b66c-850c7a528777",
+    name = "Brilliant Plan",
+    setCode = "PZ2",
+    collectorNumber = "70833",
+    scryfallId = "e9d45984-47c7-4d45-b3fa-a3aa951349ba",
+    artist = "Yutaka Li",
+    imageUri = "https://cards.scryfall.io/normal/front/e/9/e9d45984-47c7-4d45-b3fa-a3aa951349ba.jpg",
+    releaseDate = "2018-12-06",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/FissureVent.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/FissureVent.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Fissure Vent
+ * {3}{R}{R}
+ * Sorcery
+ * Choose one or both —
+ * • Destroy target artifact.
+ * • Destroy target nonbasic land.
+ *
+ * A choose-one-or-both modal spell — [modal] with `chooseCount = 2, minChooseCount = 1`, where
+ * `chooseCount` is the maximum. Each mode declares its own target, so the two halves are
+ * independent: [TargetPermanent] over [TargetFilter.Artifact] and over [TargetFilter.NonbasicLand].
+ * Both bodies are the plain [Effects.Destroy], which regeneration and indestructible still answer.
+ */
+val FissureVent = card("Fissure Vent") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Choose one or both —\n" +
+        "• Destroy target artifact.\n" +
+        "• Destroy target nonbasic land."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Destroy target artifact") {
+                val t = target("target", TargetPermanent(filter = TargetFilter.Artifact))
+                effect = Effects.Destroy(t)
+            }
+            mode("Destroy target nonbasic land") {
+                val t = target("target", TargetPermanent(filter = TargetFilter.NonbasicLand))
+                effect = Effects.Destroy(t)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "144"
+        artist = "Philip Straub"
+        flavorText = "\"Something down there has an appetite for what we're standing on. Let's hope it doesn't want seconds.\"\n—Samila, Murasa Expeditionary House"
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/15f4f813-f04c-4309-a007-b0549c00d6ab.jpg"
+        ruling("2010-06-15", "You may choose just the first mode (targeting an artifact), just the second mode (targeting a nonbasic land), or both modes (targeting an artifact and a nonbasic land). You can’t choose a mode unless there’s a legal target for it.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SelesnyaCharm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SelesnyaCharm.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Selesnya Charm
+ * {G}{W}
+ * Instant
+ *
+ * Choose one —
+ * • Target creature gets +2/+2 and gains trample until end of turn.
+ * • Exile target creature with power 5 or greater.
+ * • Create a 2/2 white Knight creature token with vigilance.
+ *
+ * A plain choose-one `modal(chooseCount = 1)`. The pump mode is an [Effects.Composite] of
+ * [Effects.ModifyStats]`(2, 2)` and [Effects.GrantKeyword]`(TRAMPLE)` on the same bound target,
+ * both defaulting to end of turn; the removal mode is [Effects.Exile] over
+ * [GameObjectFilter.Creature]`.powerAtLeast(5)`; the token mode is the plain [Effects.CreateToken]
+ * facade with the printed colour, subtype and keyword.
+ */
+val SelesnyaCharm = card("Selesnya Charm") {
+    manaCost = "{G}{W}"
+    colorIdentity = "WG"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Target creature gets +2/+2 and gains trample until end of turn.\n" +
+        "• Exile target creature with power 5 or greater.\n" +
+        "• Create a 2/2 white Knight creature token with vigilance."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Target creature gets +2/+2 and gains trample until end of turn") {
+                val t = target("target", TargetCreature())
+                effect = Effects.Composite(
+                    Effects.ModifyStats(2, 2, t),
+                    Effects.GrantKeyword(Keyword.TRAMPLE, t)
+                )
+            }
+            mode("Exile target creature with power 5 or greater") {
+                val t = target("target", TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.powerAtLeast(5))))
+                effect = Effects.Exile(t)
+            }
+            mode("Create a 2/2 white Knight creature token with vigilance") {
+                effect = Effects.CreateToken(
+                    power = 2,
+                    toughness = 2,
+                    colors = setOf(Color.WHITE),
+                    creatureTypes = setOf("Knight"),
+                    keywords = setOf(Keyword.VIGILANCE)
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "194"
+        artist = "Zoltan Boros"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9848eab-1d3a-4ab0-adf6-c20858aa3afb.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/KhalniGarden.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/KhalniGarden.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.wwk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Khalni Garden
+ *
+ * Land
+ *
+ * This land enters tapped.
+ * When this land enters, create a 0/1 green Plant creature token.
+ * {T}: Add {G}.
+ *
+ * The gainland shape with the life swapped for a body: an [EntersTapped] replacement effect for
+ * the printed first line, a [Triggers.EntersBattlefield] trigger, and a single [Effects.AddMana]
+ * ability on [Costs.Tap] (`manaAbility = true` with [TimingRule.ManaAbility], so it resolves
+ * without using the stack). The token is the plain [Effects.CreateToken] facade with the printed
+ * P/T, colour and creature type — no name or art is baked in here, so the Plant resolves through
+ * the set's own `tokenArt` layer.
+ */
+val KhalniGarden = card("Khalni Garden") {
+    manaCost = ""
+    colorIdentity = "G"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "When this land enters, create a 0/1 green Plant creature token.\n" +
+        "{T}: Add {G}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 0,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Plant"),
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "138"
+        artist = "Ryan Pancoast"
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1cc6a5e6-0b73-4488-8954-4b168ce7106d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/SeerSSundial.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/SeerSSundial.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.wwk.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+
+/**
+ * Seer's Sundial
+ * {4}
+ * Artifact
+ * Landfall — Whenever a land you control enters, you may pay {2}. If you do, draw a card.
+ *
+ * Landfall is [Triggers.LandYouControlEnters]. The "you may pay {2}. If you do, …" is an
+ * [OptionalCostEffect] — a [com.wingedsheep.sdk.scripting.effects.Gate.MayPay] gate whose cost is
+ * [PayManaCostEffect] and whose `ifPaid` branch is [Effects.DrawCards]. That is a different gate
+ * from the bare "you may" of a card like Grazing Gladehart: the consent here is the payment, so the
+ * draw is conditioned on the mana actually being spent rather than on a yes/no answer.
+ */
+val SeerSSundial = card("Seer's Sundial") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Landfall — Whenever a land you control enters, you may pay {2}. If you do, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = OptionalCostEffect(
+            cost = PayManaCostEffect(ManaCost.parse("{2}")),
+            ifPaid = Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "130"
+        artist = "Franz Vohwinkel"
+        flavorText = "\"The shadow travels toward the apex. I predict we will soon see the true measure of darkness.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/314cb009-bd0e-40eb-98ea-c6dea8d83dcf.jpg"
+        ruling("2024-11-08", "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control.")
+        ruling("2024-11-08", "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land.")
+        ruling("2024-11-08", "Whenever a land you control enters, each landfall ability of the permanents you control will trigger. You can put them   on the stack in any order. The last ability you put on the stack will be the first one to resolve (As a result, you can have those abilities resolve in the order of your choosing.).")
+        ruling("2010-03-01", "You choose whether to pay {2} as the ability resolves. You may pay {2} only once per resolution.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/AkoumRefuge.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/AkoumRefuge.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Akoum Refuge
+ *
+ * Land
+ *
+ * This land enters tapped.
+ * When this land enters, you gain 1 life.
+ * {T}: Add {B} or {R}.
+ *
+ * The Zendikar "Refuge" cycle is the original gainland shape that Khans of Tarkir later
+ * reprinted as [JungleHollow]: an [EntersTapped] replacement effect for the printed first
+ * line, a [Triggers.EntersBattlefield] trigger carrying [Effects.GainLife](1), and the dual
+ * mana line spelled as **two** [Effects.AddMana] abilities sharing a [Costs.Tap] cost rather
+ * than one choice effect — the majority SDK form for a plain "Add {B} or {R}." with no
+ * rider on the ability. Both mana abilities are `manaAbility = true` with
+ * [TimingRule.ManaAbility], so they resolve without using the stack.
+ */
+val AkoumRefuge = card("Akoum Refuge") {
+    manaCost = ""
+    colorIdentity = "BR"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "When this land enters, you gain 1 life.\n" +
+        "{T}: Add {B} or {R}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "210"
+        artist = "Fred Fields"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2ed95b4a-1452-4337-a4b2-e67e624d33df.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/CarnageAltar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/CarnageAltar.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Carnage Altar
+ * {2}
+ * Artifact
+ * {3}, Sacrifice a creature: Draw a card.
+ *
+ * A two-atom activation cost in the order the card prints it: [Costs.Composite] of
+ * [Costs.Mana] `{3}` and [Costs.Sacrifice] over `GameObjectFilter.Creature`. The payoff is the
+ * plain [Effects.DrawCards] facade at its default controller target.
+ */
+val CarnageAltar = card("Carnage Altar") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{3}, Sacrifice a creature: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Sacrifice(GameObjectFilter.Creature))
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "198"
+        artist = "James Paick"
+        flavorText = "\"In these bloodstains I will find the fingerprints of our oppressors.\"\n—Anowon, the Ruin Sage"
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52688a03-26a4-40ff-8a99-a268113a9802.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/GrazingGladehart.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/GrazingGladehart.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grazing Gladehart
+ * {2}{G}
+ * Creature — Antelope
+ * 2/2
+ * Landfall — Whenever a land you control enters, you may gain 2 life.
+ *
+ * Landfall is [Triggers.LandYouControlEnters] — the `ZoneChangeEvent` over
+ * `GameObjectFilter.Land.youControl()` with [com.wingedsheep.sdk.scripting.TriggerBinding.ANY].
+ * The printed "you may" is the builder's `optional = true`, which lowers to a
+ * [com.wingedsheep.sdk.scripting.effects.Gate.MayDecide] gate around [Effects.GainLife], so the
+ * consent lives on the gate rather than on a flag beside it.
+ */
+val GrazingGladehart = card("Grazing Gladehart") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Antelope"
+    power = 2
+    toughness = 2
+    oracleText = "Landfall — Whenever a land you control enters, you may gain 2 life."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        optional = true
+        effect = Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "163"
+        artist = "Ryan Pancoast"
+        flavorText = "\"Don't be fooled. If it were as docile as it looks, it would've died off long ago.\"\n—Yon Basrel, Oran-Rief survivalist"
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/078b5290-a613-496f-bd23-8fd109549f31.jpg"
+        ruling("2024-11-08", "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control.")
+        ruling("2024-11-08", "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land.")
+        ruling("2024-11-08", "Whenever a land you control enters, each landfall ability of the permanents you control will trigger. You can put them   on the stack in any order. The last ability you put on the stack will be the first one to resolve (As a result, you can have those abilities resolve in the order of your choosing.).")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/JwarIsleRefuge.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/JwarIsleRefuge.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Jwar Isle Refuge
+ *
+ * Land
+ *
+ * This land enters tapped.
+ * When this land enters, you gain 1 life.
+ * {T}: Add {U} or {B}.
+ *
+ * The Zendikar "Refuge" cycle is the original gainland shape that Khans of Tarkir later
+ * reprinted as [JungleHollow]: an [EntersTapped] replacement effect for the printed first
+ * line, a [Triggers.EntersBattlefield] trigger carrying [Effects.GainLife](1), and the dual
+ * mana line spelled as **two** [Effects.AddMana] abilities sharing a [Costs.Tap] cost rather
+ * than one choice effect — the majority SDK form for a plain "Add {U} or {B}." with no
+ * rider on the ability. Both mana abilities are `manaAbility = true` with
+ * [TimingRule.ManaAbility], so they resolve without using the stack.
+ */
+val JwarIsleRefuge = card("Jwar Isle Refuge") {
+    manaCost = ""
+    colorIdentity = "UB"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "When this land enters, you gain 1 life.\n" +
+        "{T}: Add {U} or {B}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "215"
+        artist = "Cyril Van Der Haegen"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/ddd9463f-d029-459d-a933-432b7bbd7a41.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/KazanduRefuge.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/KazanduRefuge.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Kazandu Refuge
+ *
+ * Land
+ *
+ * This land enters tapped.
+ * When this land enters, you gain 1 life.
+ * {T}: Add {R} or {G}.
+ *
+ * The Zendikar "Refuge" cycle is the original gainland shape that Khans of Tarkir later
+ * reprinted as [JungleHollow]: an [EntersTapped] replacement effect for the printed first
+ * line, a [Triggers.EntersBattlefield] trigger carrying [Effects.GainLife](1), and the dual
+ * mana line spelled as **two** [Effects.AddMana] abilities sharing a [Costs.Tap] cost rather
+ * than one choice effect — the majority SDK form for a plain "Add {R} or {G}." with no
+ * rider on the ability. Both mana abilities are `manaAbility = true` with
+ * [TimingRule.ManaAbility], so they resolve without using the stack.
+ */
+val KazanduRefuge = card("Kazandu Refuge") {
+    manaCost = ""
+    colorIdentity = "RG"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "When this land enters, you gain 1 life.\n" +
+        "{T}: Add {R} or {G}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "217"
+        artist = "Franz Vohwinkel"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8af66f9c-c90b-45e0-a54c-a76e7e1b9dff.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/SejiriRefuge.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/SejiriRefuge.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Sejiri Refuge
+ *
+ * Land
+ *
+ * This land enters tapped.
+ * When this land enters, you gain 1 life.
+ * {T}: Add {W} or {U}.
+ *
+ * The Zendikar "Refuge" cycle is the original gainland shape that Khans of Tarkir later
+ * reprinted as [JungleHollow]: an [EntersTapped] replacement effect for the printed first
+ * line, a [Triggers.EntersBattlefield] trigger carrying [Effects.GainLife](1), and the dual
+ * mana line spelled as **two** [Effects.AddMana] abilities sharing a [Costs.Tap] cost rather
+ * than one choice effect — the majority SDK form for a plain "Add {W} or {U}." with no
+ * rider on the ability. Both mana abilities are `manaAbility = true` with
+ * [TimingRule.ManaAbility], so they resolve without using the stack.
+ */
+val SejiriRefuge = card("Sejiri Refuge") {
+    manaCost = ""
+    colorIdentity = "WU"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "When this land enters, you gain 1 life.\n" +
+        "{T}: Add {W} or {U}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "224"
+        artist = "Ryan Pancoast"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1fd8cb0d-d651-44e7-ae14-4035b0f1aa77.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/AkoumRefugeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/AkoumRefugeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Akoum Refuge reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val AkoumRefugeReprint = Printing(
+    oracleId = "354fecd1-2371-49e3-81c6-7e47728dbb1f",
+    name = "Akoum Refuge",
+    setCode = "C17",
+    collectorNumber = "233",
+    scryfallId = "2745cd0e-086b-4456-9124-e7bf692fcc21",
+    artist = "Fred Fields",
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/2745cd0e-086b-4456-9124-e7bf692fcc21.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/AzamiLadyOfScrollsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/AzamiLadyOfScrollsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Azami, Lady of Scrolls reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val AzamiLadyOfScrollsReprint = Printing(
+    oracleId = "0f8b97fe-3e5e-47c2-9a9d-7f77482aa159",
+    name = "Azami, Lady of Scrolls",
+    setCode = "C17",
+    collectorNumber = "82",
+    scryfallId = "0ad06ad7-0545-4c6f-9b10-4a27fa2e827c",
+    artist = "Ittoku",
+    imageUri = "https://cards.scryfall.io/normal/front/0/a/0ad06ad7-0545-4c6f-9b10-4a27fa2e827c.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/BehemothSledgeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/BehemothSledgeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Behemoth Sledge reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val BehemothSledgeReprint = Printing(
+    oracleId = "00573e77-8ff6-4acb-8683-8827d965288f",
+    name = "Behemoth Sledge",
+    setCode = "C17",
+    collectorNumber = "162",
+    scryfallId = "c86f0453-f4ea-4f31-8076-e01c118b0f3d",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c86f0453-f4ea-4f31-8076-e01c118b0f3d.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/CrosisSCharmReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/CrosisSCharmReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crosis's Charm reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val CrosisSCharmReprint = Printing(
+    oracleId = "e59d70a2-40ac-45b0-995d-65b9caa290c8",
+    name = "Crosis's Charm",
+    setCode = "C17",
+    collectorNumber = "169",
+    scryfallId = "b5e1e94d-6876-4351-9c6e-98882e277ccc",
+    artist = "Marco Nelor",
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b5e1e94d-6876-4351-9c6e-98882e277ccc.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/JwarIsleRefugeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/JwarIsleRefugeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jwar Isle Refuge reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val JwarIsleRefugeReprint = Printing(
+    oracleId = "8b96f837-7c32-473a-b5ae-1d66527eaf7b",
+    name = "Jwar Isle Refuge",
+    setCode = "C17",
+    collectorNumber = "258",
+    scryfallId = "540f84af-f247-42a2-a4d5-bf3dab4da647",
+    artist = "Cyril Van Der Haegen",
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/540f84af-f247-42a2-a4d5-bf3dab4da647.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/RainOfThornsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/RainOfThornsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rain of Thorns reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val RainOfThornsReprint = Printing(
+    oracleId = "363b0504-27bf-40df-96ec-9e3cb1e47588",
+    name = "Rain of Thorns",
+    setCode = "C17",
+    collectorNumber = "156",
+    scryfallId = "afc3db76-2507-4a91-ab89-7bcdf4ac66b7",
+    artist = "Sam Burley",
+    imageUri = "https://cards.scryfall.io/normal/front/a/f/afc3db76-2507-4a91-ab89-7bcdf4ac66b7.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/SeerSSundialReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/SeerSSundialReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seer's Sundial reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val SeerSSundialReprint = Printing(
+    oracleId = "9929d7ba-cdc5-4099-a0ee-3a15073336f3",
+    name = "Seer's Sundial",
+    setCode = "CMR",
+    collectorNumber = "470",
+    scryfallId = "491b8613-d5cd-4749-9c1b-d27a388c616a",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/4/9/491b8613-d5cd-4749-9c1b-d27a388c616a.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/VisceraSeerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/VisceraSeerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Viscera Seer reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val VisceraSeerReprint = Printing(
+    oracleId = "f82a4e85-526d-4456-b700-7760043a31be",
+    name = "Viscera Seer",
+    setCode = "CMR",
+    collectorNumber = "158",
+    scryfallId = "d49203dd-89b6-4e91-b3ff-5f9f5ce981f8",
+    artist = "John Stanko",
+    imageUri = "https://cards.scryfall.io/normal/front/d/4/d49203dd-89b6-4e91-b3ff-5f9f5ce981f8.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/cards/BrilliantPlanReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/cards/BrilliantPlanReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.gs1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brilliant Plan reprint in GS1. Canonical CardDefinition lives in its earliest set.
+ */
+val BrilliantPlanReprint = Printing(
+    oracleId = "d83e1a42-11d1-412a-b66c-850c7a528777",
+    name = "Brilliant Plan",
+    setCode = "GS1",
+    collectorNumber = "17",
+    scryfallId = "115a5d53-8638-44a9-a889-f2d73a02e672",
+    artist = "Yutaka Li",
+    imageUri = "https://cards.scryfall.io/normal/front/1/1/115a5d53-8638-44a9-a889-f2d73a02e672.jpg",
+    releaseDate = "2018-06-22",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/SejiriRefugeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/SejiriRefugeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sejiri Refuge reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val SejiriRefugeReprint = Printing(
+    oracleId = "73b3e242-075d-4c4d-9b09-6fef1633c348",
+    name = "Sejiri Refuge",
+    setCode = "KHC",
+    collectorNumber = "118",
+    scryfallId = "b474bfdd-e0b2-4b96-b8eb-84ced9ac5a06",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b474bfdd-e0b2-4b96-b8eb-84ced9ac5a06.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/ALA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ALA.json
@@ -371,6 +371,118 @@
     ]
 }
 
+// Grixis Charm
+{
+    "name": "Grixis Charm",
+    "manaCost": "{U}{B}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Return target permanent to its owner's hand.\n• Target creature gets -4/-4 until end of turn.\n• Creatures you control get +2/+0 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "permanent"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Return target permanent to its owner's hand"
+                },
+                {
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -4
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": -4
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target creature gets -4/-4 until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Creatures you control get +2/+0 until end of turn"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "UNCOMMON",
+        "artist": "Lars Grant-West",
+        "flavorText": "\"So many choices. Shall I choose loathing, hate, or malice today?\"\n—Eliza of the Keep",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a98a6695-44ce-445f-b476-e18a0b5dd8f2.jpg",
+        "rulings": [
+            {
+                "date": "2008-10-01",
+                "text": "You can choose a mode only if you can choose legal targets for that mode. If you can’t choose legal targets for any of the modes, you can’t cast the spell."
+            },
+            {
+                "date": "2008-10-01",
+                "text": "While the spell is on the stack, treat it as though its only text is the chosen mode. The other two modes are treated as though they don’t exist. You don’t choose targets for those modes."
+            },
+            {
+                "date": "2008-10-01",
+                "text": "If this spell is copied, the copy will have the same mode as the original."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Incurable Ogre
 {
     "name": "Incurable Ogre",
@@ -460,6 +572,225 @@
         "artist": "Wayne Reynolds",
         "flavorText": "On Naya, ambition and treachery are scarce, hunted nearly to extinction by the awe owed to terrestrial gods.",
         "imageUri": "https://cards.scryfall.io/normal/front/e/4/e4f0d262-cbfe-42d2-9066-0b48a38995d6.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "RED",
+        "GREEN"
+    ]
+}
+
+// Obelisk of Esper
+{
+    "name": "Obelisk of Esper",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {W}, {U}, or {B}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "213",
+        "artist": "Francis Tsai",
+        "flavorText": "It is a monument as austere, unyielding, and inscrutable as Esper itself.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/19869e75-0925-45dc-b5d9-6968fbfb35b5.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK"
+    ]
+}
+
+// Obelisk of Grixis
+{
+    "name": "Obelisk of Grixis",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {U}, {B}, or {R}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "artist": "Nils Hamm",
+        "flavorText": "Like most features of Grixis, the obelisks that remain from the time of Alara now exist only for dark exploitation.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/5200e41f-fe10-4c39-ab12-c6e13fb81a3d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Obelisk of Jund
+{
+    "name": "Obelisk of Jund",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {B}, {R}, or {G}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "artist": "Brandon Kitkouski",
+        "flavorText": "Volcanic ash-winds batter it, climbing vines overwhelm it, dragonfire roasts it, and yet it still stands as a testament to a forgotten world.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ffe1a49a-5c1c-4274-a2ed-9a8a44abfaa6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED",
+        "GREEN"
+    ]
+}
+
+// Rakeclaw Gargantuan
+{
+    "name": "Rakeclaw Gargantuan",
+    "manaCost": "{2}{R}{G}{W}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "{1}: Target creature with power 5 or greater gains first strike until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow>=5"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Naya teems with gargantuans, titanic monsters to whom both nature and civilization defer.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1995ab8-7382-4c2a-b8c7-8b9272cab4fb.jpg",
+        "rulings": [
+            {
+                "date": "2008-10-01",
+                "text": "The ability checks the targeted creature’s power twice: when the creature becomes the target, and when the ability resolves. Once the ability resolves, it will continue to apply to the affected creature no matter what its power may become later in the turn."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "WHITE",
@@ -640,6 +971,176 @@
         "WHITE",
         "BLUE",
         "GREEN"
+    ]
+}
+
+// Sharuum the Hegemon
+{
+    "name": "Sharuum the Hegemon",
+    "manaCost": "{3}{W}{U}{B}",
+    "typeLine": "Legendary Artifact Creature — Sphinx",
+    "oracleText": "Flying\nWhen Sharuum enters, you may return target artifact card from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Battlefield",
+                        "fromZone": "Graveyard"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "rarity": "MYTHIC",
+        "artist": "Izzy",
+        "flavorText": "To gain audience with the hegemon, one must bring a riddle she has not heard.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/6589eaa8-95ec-4c97-8155-185487560ae6.jpg",
+        "rulings": [
+            {
+                "date": "2020-08-07",
+                "text": "If Sharuum the Hegemon is put into your graveyard as a state-based action immediately after Sharuum the Hegemon enters the battlefield (most likely due to the \"legend rule\") it can be the artifact card targeted by its own ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK"
+    ]
+}
+
+// Sprouting Thrinax
+{
+    "name": "Sprouting Thrinax",
+    "manaCost": "{B}{R}{G}",
+    "typeLine": "Creature — Lizard",
+    "oracleText": "When this creature dies, create three 1/1 green Saproling creature tokens.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Saproling"
+                    ]
+                },
+                "descriptionOverride": "When this creature dies, create three 1/1 green Saproling creature tokens."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "197",
+        "rarity": "UNCOMMON",
+        "artist": "Jarreau Wimberly",
+        "flavorText": "The vast network of predation on Jund has actually caused some strange creatures to adapt to being eaten.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/8950df86-1e27-4b6b-8b5c-25298a3bda85.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED",
+        "GREEN"
+    ]
+}
+
+// Tidehollow Strix
+{
+    "name": "Tidehollow Strix",
+    "manaCost": "{U}{B}",
+    "typeLine": "Artifact Creature — Bird",
+    "oracleText": "Flying\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "203",
+        "artist": "Cyril Van Der Haegen",
+        "flavorText": "The scullers beneath Esper keep strixes as trained pets, and set them loose when a fare refuses to pay.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4aafc65d-faa8-4bfe-83ac-7714c969022b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
+// Tower Gargoyle
+{
+    "name": "Tower Gargoyle",
+    "manaCost": "{1}{W}{U}{B}",
+    "typeLine": "Artifact Creature — Gargoyle",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "205",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Cavotta",
+        "flavorText": "\"Esper, like any work of art, can be truly appreciated only from a distance.\"\n—Tezzeret",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/10504d1b-8d3e-411a-bf40-51a8e7a863a0.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/ARB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARB.json
@@ -1,3 +1,76 @@
+// Behemoth Sledge
+{
+    "name": "Behemoth Sledge",
+    "manaCost": "{1}{G}{W}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +2/+2 and has trample and lifelink.\nEquip {3}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "LIFELINK"
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Prescott",
+        "flavorText": "Those who worship the great gargantuans could hardly be expected to fight with a subtle weapon.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/84e4a224-2db7-47d0-ba8b-98aeb50ad5d3.jpg",
+        "rulings": [
+            {
+                "date": "2009-10-01",
+                "text": "Multiple instances of lifelink on the same creature are redundant. If a creature with multiple instances of lifelink deals damage, its controller still only gains life equal to the damage dealt."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
 // Bloodbraid Elf
 {
     "name": "Bloodbraid Elf",
@@ -31,6 +104,61 @@
     "colorIdentityOverride": [
         "GREEN",
         "RED"
+    ]
+}
+
+// Filigree Angel
+{
+    "name": "Filigree Angel",
+    "manaCost": "{5}{W}{W}{U}",
+    "typeLine": "Artifact Creature — Angel",
+    "oracleText": "Flying\nWhen this creature enters, you gain 3 life for each artifact you control.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "artifact"
+                        },
+                        "multiplier": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "RARE",
+        "artist": "Richard Whitters",
+        "flavorText": "\"I craved enlightenment, and Crucius's etherium opened my eyes. I would share my sight with you, but first you must believe.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7a0c7a2a-85c1-4b20-95b9-04aab0bd0d3b.jpg",
+        "rulings": [
+            {
+                "date": "2009-05-01",
+                "text": "Filigree Angel's \"enters\" ability counts Filigree Angel itself, assuming that it's still on the battlefield and still an artifact by the time the ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
     ]
 }
 
@@ -187,6 +315,151 @@
     },
     "colorIdentityOverride": [
         "RED",
+        "GREEN"
+    ]
+}
+
+// Soul Manipulation
+{
+    "name": "Soul Manipulation",
+    "manaCost": "{1}{U}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one or both —\n• Counter target creature spell.\n• Return target creature card from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": "Counter",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature",
+                                "zone": "Stack"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Counter target creature spell"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature own:you",
+                                "zone": "Graveyard"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Return target creature card from your graveyard to your hand"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "artist": "Carl Critchlow",
+        "flavorText": "\"Birth and death are both reversible.\"\n—Nicol Bolas",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bcd3cb05-c6f9-435a-a0e7-1f85da4a36eb.jpg",
+        "rulings": [
+            {
+                "date": "2009-05-01",
+                "text": "You may choose just the first mode (targeting a creature spell), just the second mode (targeting a creature card in your graveyard), or both modes (targeting a creature spell and a creature card in your graveyard). You can’t choose a mode unless there’s a legal target for it."
+            },
+            {
+                "date": "2009-05-01",
+                "text": "If you choose both modes, you choose their targets at the same time. You can’t counter your own creature spell and then return that card from your graveyard to your hand."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
+// Sphinx of the Steel Wind
+{
+    "name": "Sphinx of the Steel Wind",
+    "manaCost": "{5}{W}{U}{B}",
+    "typeLine": "Artifact Creature — Sphinx",
+    "oracleText": "Flying, first strike, vigilance, lifelink, protection from red and from green",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING",
+        "FIRST_STRIKE",
+        "VIGILANCE",
+        "LIFELINK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "RED"
+            }
+        },
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "GREEN"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "110",
+        "rarity": "MYTHIC",
+        "artist": "Kev Walker",
+        "flavorText": "No one has properly answered her favorite riddle: \"Why should I spare your life?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c860cf0f-ef68-455f-9c71-a6dd25b51d71.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK"
+    ]
+}
+
+// Winged Coatl
+{
+    "name": "Winged Coatl",
+    "manaCost": "{1}{G}{U}",
+    "typeLine": "Creature — Snake",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING",
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Izzy",
+        "flavorText": "The nacatl called this new species \"vetli,\" their word for poison arrows.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd23ae2b-9f69-4d8d-87f9-ebcbccd67342.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
         "GREEN"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -1772,6 +1772,49 @@
     ]
 }
 
+// Marrow Bats
+{
+    "name": "Marrow Bats",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Bat Skeleton",
+    "oracleText": "Flying\nPay 4 life: Regenerate this creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomPayLife",
+                        "amount": 4
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "rarity": "UNCOMMON",
+        "artist": "Jason A. Engle",
+        "flavorText": "\"No matter how far we push into Stensia, undeath will always remain in these lands.\"\n—Terhold, archmage of Drunau",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/38dcbad0-267e-411f-8e99-5d90b537bf9b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Mist Raven
 {
     "name": "Mist Raven",
@@ -1973,6 +2016,102 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Rain of Thorns
+{
+    "name": "Rain of Thorns",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one or more —\n• Destroy target artifact.\n• Destroy target enchantment.\n• Destroy target land.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target artifact"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target enchantment"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "land"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target land"
+                }
+            ],
+            "chooseCount": 3,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "190",
+        "rarity": "UNCOMMON",
+        "artist": "Sam Burley",
+        "flavorText": "When the forests became havens for evil, the archmages devised new ways to cleanse the wilds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd1cb530-b9d5-4386-b89e-2acecc8294c8.jpg",
+        "rulings": [
+            {
+                "date": "2012-05-01",
+                "text": "You can choose just one mode, any two of the modes, or all three. You make this choice as you cast Rain of Thorns."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/CHK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CHK.json
@@ -93,6 +93,49 @@
     ]
 }
 
+// Azami, Lady of Scrolls
+{
+    "name": "Azami, Lady of Scrolls",
+    "manaCost": "{2}{U}{U}{U}",
+    "typeLine": "Legendary Creature — Human Wizard",
+    "oracleText": "Tap an untapped Wizard you control: Draw a card.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "permanent Wizard"
+                    }
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "rarity": "RARE",
+        "artist": "Ittoku",
+        "flavorText": "\"Choices belong to those with the luxuries of time and distance. We have neither. I recommend we proceed with the plan to destroy all shrines of the kami.\"\n—Lady Azami, letter to Sensei Hisoka",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/15ea91b1-f2ff-4b99-8148-333aa27ea8cd.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Ben-Ben, Akki Hermit
 {
     "name": "Ben-Ben, Akki Hermit",

--- a/mtg-sets/src/test/resources/snapshots/cards/CON_.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CON_.json
@@ -1,3 +1,58 @@
+// Aerie Mystics
+{
+    "name": "Aerie Mystics",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Bird Wizard",
+    "oracleText": "Flying\n{1}{G}{U}: Creatures you control gain shroud until end of turn. (They can't be the targets of spells or abilities.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "SHROUD",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Zug",
+        "flavorText": "They are cautious with their body language and facial expressions. Any stray movement could betray the positions of the troops they protect and cost many lives.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/58e86a42-cc53-4731-819a-e76f203a742a.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "GREEN"
+    ]
+}
+
 // Armillary Sphere
 {
     "name": "Armillary Sphere",
@@ -288,6 +343,50 @@
         "imageUri": "https://cards.scryfall.io/normal/front/5/6/568df642-3ad7-401c-a133-edb56970c3a1.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Scarland Thrinax
+{
+    "name": "Scarland Thrinax",
+    "manaCost": "{B}{R}{G}",
+    "typeLine": "Creature — Lizard",
+    "oracleText": "Sacrifice a creature: Put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "rarity": "UNCOMMON",
+        "artist": "Daarken",
+        "flavorText": "\"There is only one way of life in Jund: feed on the weak until you are cut down by something stronger.\"\n—Jorshu of Clan Nel Toth",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2a179b9-e962-49a4-ad92-8cd0291296c1.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED",
+        "GREEN"
+    ]
 }
 
 // Sigil of the Empty Throne

--- a/mtg-sets/src/test/resources/snapshots/cards/FUT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FUT.json
@@ -147,6 +147,53 @@
     ]
 }
 
+// New Benalia
+{
+    "name": "New Benalia",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\nWhen this land enters, scry 1. (Look at the top card of your library. You may put that card on the bottom.)\n{T}: Add {W}.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "172",
+        "rarity": "UNCOMMON",
+        "artist": "Richard Wright",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/18bde721-8fa0-4f69-9909-b4864929e676.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Thornweald Archer
 {
     "name": "Thornweald Archer",

--- a/mtg-sets/src/test/resources/snapshots/cards/LEA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LEA.json
@@ -139,6 +139,62 @@
     ]
 }
 
+// Basalt Monolith
+{
+    "name": "Basalt Monolith",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "This artifact doesn't untap during your untap step.\n{T}: Add {C}{C}{C}.\n{3}: Untap this artifact.",
+    "flags": [
+        "DOESNT_UNTAP"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "rarity": "UNCOMMON",
+        "artist": "Jesper Myrfors",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/66a74c89-6f86-4ec8-af17-391cd5026054.jpg",
+        "rulings": [
+            {
+                "date": "2020-08-07",
+                "text": "Basalt Monolith's last ability can untap it as often as you can pay for it. If you believe you've found a way to generate an unbounded amount of mana with it, you're probably right."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Bayou
 {
     "name": "Bayou",

--- a/mtg-sets/src/test/resources/snapshots/cards/M11.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M11.json
@@ -667,6 +667,55 @@
     ]
 }
 
+// Viscera Seer
+{
+    "name": "Viscera Seer",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Vampire Wizard",
+    "oracleText": "Sacrifice a creature: Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "artist": "John Stanko",
+        "flavorText": "In matters of life and death, he trusts his gut.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/6179f847-e334-4f7f-9a4e-0013942a394f.jpg",
+        "rulings": [
+            {
+                "date": "2010-08-15",
+                "text": "You can sacrifice Viscera Seer to activate its own ability."
+            },
+            {
+                "date": "2010-08-15",
+                "text": "If you sacrifice an attacking or blocking creature during the declare blockers step, it won't deal combat damage. If you wait until the combat damage step, but that creature is dealt lethal damage, it'll be destroyed before you get a chance to sacrifice it."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Wall of Vines
 {
     "name": "Wall of Vines",

--- a/mtg-sets/src/test/resources/snapshots/cards/M12.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M12.json
@@ -454,6 +454,53 @@
     ]
 }
 
+// Jade Mage
+{
+    "name": "Jade Mage",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "{2}{G}: Create a 1/1 green Saproling creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Saproling"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "181",
+        "rarity": "UNCOMMON",
+        "artist": "Izzy",
+        "flavorText": "\"We are one with the wild things. Life blooms from our fingertips and nature responds to our summons.\"\n—Jade creed",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/32d6c8d3-04a1-4b35-b7d1-18bed82beaf4.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Rune-Scarred Demon
 {
     "name": "Rune-Scarred Demon",

--- a/mtg-sets/src/test/resources/snapshots/cards/MOR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MOR.json
@@ -186,6 +186,92 @@
     ]
 }
 
+// Spitebellows
+{
+    "name": "Spitebellows",
+    "manaCost": "{5}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "When this creature leaves the battlefield, it deals 6 damage to target creature.\nEvoke {1}{R}{R} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 1
+    },
+    "keywords": [
+        "EVOKE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Evoke",
+            "cost": "{1}{R}{R}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 6
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    }
+                },
+                "descriptionOverride": "When this creature leaves the battlefield, it deals 6 damage to target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "rarity": "UNCOMMON",
+        "artist": "Larry MacDougall",
+        "flavorText": "Disaster stalks with gaping jaws across unready lands.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/43f2104d-aeff-493f-8227-cb95bf3e2eab.jpg",
+        "rulings": [
+            {
+                "date": "2008-04-01",
+                "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+            },
+            {
+                "date": "2008-04-01",
+                "text": "If a creature spell cast with evoke changes controllers before it enters, it will still be sacrificed when it enters. Similarly, if a creature cast with evoke changes controllers after it enters but before its sacrifice ability resolves, it will still be sacrificed. In both cases, the controller of the creature at the time it left the battlefield will control its leaves-the-battlefield ability."
+            },
+            {
+                "date": "2008-04-01",
+                "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
+            },
+            {
+                "date": "2008-04-01",
+                "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
+            },
+            {
+                "date": "2008-04-01",
+                "text": "Whether evoke's sacrifice ability triggers when the creature enters depends on whether the spell's controller chose to pay the evoke cost, not whether they actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+            },
+            {
+                "date": "2008-04-01",
+                "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Taurean Mauler
 {
     "name": "Taurean Mauler",
@@ -230,5 +316,84 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Walker of the Grove
+{
+    "name": "Walker of the Grove",
+    "manaCost": "{6}{G}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "When this creature leaves the battlefield, create a 4/4 green Elemental creature token.\nEvoke {4}{G} (You may cast this spell for its evoke cost. If you do, it's sacrificed when it enters.)",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "EVOKE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Evoke",
+            "cost": "{4}{G}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 4,
+                    "toughness": 4,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Elemental"
+                    ]
+                },
+                "descriptionOverride": "When this creature leaves the battlefield, create a 4/4 green Elemental creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "rarity": "UNCOMMON",
+        "artist": "Todd Lockwood",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2675b8b-a321-4982-b1d9-5c55d27b9bfd.jpg",
+        "rulings": [
+            {
+                "date": "2008-04-01",
+                "text": "Evoke doesn't change the timing of when you can cast the creature that has it. If you could cast that creature spell only when you could cast a sorcery, the same is true for cast it with evoke."
+            },
+            {
+                "date": "2008-04-01",
+                "text": "If a creature spell cast with evoke changes controllers before it enters, it will still be sacrificed when it enters. Similarly, if a creature cast with evoke changes controllers after it enters but before its sacrifice ability resolves, it will still be sacrificed. In both cases, the controller of the creature at the time it left the battlefield will control its leaves-the-battlefield ability."
+            },
+            {
+                "date": "2008-04-01",
+                "text": "When you cast a spell by paying its evoke cost, its mana cost doesn't change. You just pay the evoke cost instead."
+            },
+            {
+                "date": "2008-04-01",
+                "text": "Effects that cause you to pay more or less to cast a spell will cause you to pay that much more or less while casting it for its evoke cost, too. That's because they affect the total cost of the spell, not its mana cost."
+            },
+            {
+                "date": "2008-04-01",
+                "text": "Whether evoke's sacrifice ability triggers when the creature enters depends on whether the spell's controller chose to pay the evoke cost, not whether they actually paid it (if it was reduced or otherwise altered by another ability, for example)."
+            },
+            {
+                "date": "2008-04-01",
+                "text": "If you're casting a spell \"without paying its mana cost,\" you can't use its evoke ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/NPH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/NPH.json
@@ -29,6 +29,84 @@
     "colorIdentityOverride": []
 }
 
+// Deceiver Exarch
+{
+    "name": "Deceiver Exarch",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Phyrexian Cleric",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, choose one —\n• Untap target permanent you control.\n• Tap target permanent an opponent controls.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "TapUntap",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "tap": false
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "permanent ctrl:you"
+                                    }
+                                }
+                            ],
+                            "description": "Untap target permanent you control."
+                        },
+                        {
+                            "effect": {
+                                "type": "TapUntap",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "permanent ctrl:opponent"
+                                    }
+                                }
+                            ],
+                            "description": "Tap target permanent an opponent controls."
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, choose one — Untap target permanent you control; or tap target permanent an opponent controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "rarity": "UNCOMMON",
+        "artist": "Izzy",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f123ad6-fe84-4fed-9c0f-6b41921e9c26.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dismember
 {
     "name": "Dismember",
@@ -117,6 +195,56 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// Pristine Talisman
+{
+    "name": "Pristine Talisman",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {C}. You gain 1 life.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddColorlessMana",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "artist": "Matt Cavotta",
+        "flavorText": "\"Tools and artisans can be destroyed, but the act of creation is inviolate.\"\n—Elspeth Tirel",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b31d96cf-7276-46c4-ad17-d6a5c85f1315.jpg",
+        "rulings": [
+            {
+                "date": "2011-06-01",
+                "text": "Pristine Talisman has a mana ability. Its ability doesn't use the stack and can't be responded to."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Rotted Hystrix

--- a/mtg-sets/src/test/resources/snapshots/cards/PLS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/PLS.json
@@ -134,6 +134,114 @@
     ]
 }
 
+// Crosis's Charm
+{
+    "name": "Crosis's Charm",
+    "manaCost": "{U}{B}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Return target permanent to its owner's hand.\n• Destroy target nonblack creature. It can't be regenerated.\n• Destroy target artifact.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "permanent"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Return target permanent to its owner's hand"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "CantBeRegenerated",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            },
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        {
+                                            "type": "NotColor",
+                                            "color": "BLACK"
+                                        }
+                                    ]
+                                }
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target nonblack creature. It can't be regenerated"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target artifact"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "rarity": "UNCOMMON",
+        "artist": "David Martin",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b59a9e75-9988-4040-a718-b1655fc20d11.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Daring Leap
 {
     "name": "Daring Leap",
@@ -402,6 +510,81 @@
         "imageUri": "https://cards.scryfall.io/normal/front/7/6/76d1b5c5-cc47-465f-8549-4fd1ca4280df.jpg"
     },
     "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Dromar's Charm
+{
+    "name": "Dromar's Charm",
+    "manaCost": "{W}{U}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• You gain 5 life.\n• Counter target spell.\n• Target creature gets -2/-2 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 5
+                        }
+                    }
+                },
+                {
+                    "effect": "Counter",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {},
+                                "zone": "Stack"
+                            },
+                            "id": "target"
+                        }
+                    ]
+                },
+                {
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target creature gets -2/-2 until end of turn"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "rarity": "UNCOMMON",
+        "artist": "David Martin",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c7a1894c-af4e-4530-960f-2225916be8cb.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
         "BLACK"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/PTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/PTK.json
@@ -58,6 +58,67 @@
     ]
 }
 
+// Borrowing 100,000 Arrows
+{
+    "name": "Borrowing 100,000 Arrows",
+    "manaCost": "{2}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Draw a card for each tapped creature target opponent controls.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "AggregateBattlefield",
+                "player": "TargetOpponent",
+                "filter": "creature tapped"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponent",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "35",
+        "rarity": "UNCOMMON",
+        "artist": "Song Shikai",
+        "flavorText": "Kongming and Lu Su tricked Wei troops into shooting over 100,000 arrows at them to later use against the Wei at Red Cliffs.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96b5362a-bbca-4dc3-a320-3664609fe169.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Brilliant Plan
+{
+    "name": "Brilliant Plan",
+    "manaCost": "{4}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Draw three cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 3
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "UNCOMMON",
+        "artist": "Song Shikai",
+        "flavorText": "At Red Cliffs, Kongming and Zhou Yu each wrote his plan for defeating the Wei on the palm of his hand. They laughed as they both revealed the same word, \"Fire.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6acae374-9d71-4f8d-ba75-a983756624c7.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Corrupt Court Official
 {
     "name": "Corrupt Court Official",
@@ -138,6 +199,63 @@
     ]
 }
 
+// Famine
+{
+    "name": "Famine",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Famine deals 3 damage to each creature and each player.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "Each"
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": "Controller"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "UNCOMMON",
+        "artist": "Sun Nan",
+        "flavorText": "\"But it was a year of dearth. People were reduced to eating leaves of jujube trees. Corpses were seen everywhere in the countryside.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d6c10ca-f6d6-4322-aa17-7e874cb10bb1.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Forest Bear
 {
     "name": "Forest Bear",
@@ -175,6 +293,41 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Kongming, "Sleeping Dragon"
+{
+    "name": "Kongming, \"Sleeping Dragon\"",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Legendary Creature — Human Advisor",
+    "oracleText": "Other creatures you control get +1/+1.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "RARE",
+        "artist": "Gao Yan",
+        "flavorText": "\"Such a lord as this—all virtues' height—Had never been, nor ever was again.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4ae0a05-1870-4f4a-b8a2-bfb5381acacb.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/ROE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ROE.json
@@ -369,6 +369,88 @@
     "colorIdentityOverride": []
 }
 
+// Fissure Vent
+{
+    "name": "Fissure Vent",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one or both —\n• Destroy target artifact.\n• Destroy target nonbasic land.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target artifact"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsLand",
+                                        {
+                                            "type": "Not",
+                                            "predicate": "IsBasicLand"
+                                        }
+                                    ]
+                                }
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target nonbasic land"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "artist": "Philip Straub",
+        "flavorText": "\"Something down there has an appetite for what we're standing on. Let's hope it doesn't want seconds.\"\n—Samila, Murasa Expeditionary House",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/15f4f813-f04c-4309-a007-b0549c00d6ab.jpg",
+        "rulings": [
+            {
+                "date": "2010-06-15",
+                "text": "You may choose just the first mode (targeting an artifact), just the second mode (targeting a nonbasic land), or both modes (targeting an artifact and a nonbasic land). You can’t choose a mode unless there’s a legal target for it."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Fleeting Distraction
 {
     "name": "Fleeting Distraction",

--- a/mtg-sets/src/test/resources/snapshots/cards/RTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RTR.json
@@ -820,6 +820,107 @@
     "colorIdentityOverride": []
 }
 
+// Selesnya Charm
+{
+    "name": "Selesnya Charm",
+    "manaCost": "{G}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Target creature gets +2/+2 and gains trample until end of turn.\n• Exile target creature with power 5 or greater.\n• Create a 2/2 white Knight creature token with vigilance.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "TRAMPLE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target creature gets +2/+2 and gains trample until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Exile"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature pow>=5"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Exile target creature with power 5 or greater"
+                },
+                {
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 2,
+                        "toughness": 2,
+                        "colors": [
+                            "WHITE"
+                        ],
+                        "creatureTypes": [
+                            "Knight"
+                        ],
+                        "keywords": [
+                            "VIGILANCE"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a9848eab-1d3a-4ab0-adf6-c20858aa3afb.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
 // Selesnya Guildgate
 {
     "name": "Selesnya Guildgate",

--- a/mtg-sets/src/test/resources/snapshots/cards/STH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STH.json
@@ -421,6 +421,74 @@
     ]
 }
 
+// Stronghold Assassin
+{
+    "name": "Stronghold Assassin",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Creature — Phyrexian Zombie Assassin",
+    "oracleText": "{T}, Sacrifice a creature: Destroy target nonblack creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotColor",
+                                        "color": "BLACK"
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "rarity": "RARE",
+        "artist": "Matthew D. Wilson",
+        "flavorText": "The assassin sees only throats and hears only heartbeats.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc0f043c-efb3-4392-ae25-b3ec180b0cb2.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Wall of Blossoms
 {
     "name": "Wall of Blossoms",

--- a/mtg-sets/src/test/resources/snapshots/cards/WWK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WWK.json
@@ -211,6 +211,59 @@
     ]
 }
 
+// Khalni Garden
+{
+    "name": "Khalni Garden",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\nWhen this land enters, create a 0/1 green Plant creature token.\n{T}: Add {G}.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 0,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Plant"
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "artist": "Ryan Pancoast",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1cc6a5e6-0b73-4488-8954-4b168ce7106d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Kitesail
 {
     "name": "Kitesail",
@@ -510,4 +563,68 @@
         "RED",
         "GREEN"
     ]
+}
+
+// Seer's Sundial
+{
+    "name": "Seer's Sundial",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "Landfall — Whenever a land you control enters, you may pay {2}. If you do, draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{2}"
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "rarity": "RARE",
+        "artist": "Franz Vohwinkel",
+        "flavorText": "\"The shadow travels toward the apex. I predict we will soon see the true measure of darkness.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/314cb009-bd0e-40eb-98ea-c6dea8d83dcf.jpg",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Whenever a land you control enters, each landfall ability of the permanents you control will trigger. You can put them   on the stack in any order. The last ability you put on the stack will be the first one to resolve (As a result, you can have those abilities resolve in the order of your choosing.)."
+            },
+            {
+                "date": "2010-03-01",
+                "text": "You choose whether to pay {2} as the ability resolves. You may pay {2} only once per resolution."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
@@ -70,6 +70,67 @@
     "colorIdentityOverride": []
 }
 
+// Akoum Refuge
+{
+    "name": "Akoum Refuge",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {B} or {R}.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "rarity": "UNCOMMON",
+        "artist": "Fred Fields",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2ed95b4a-1452-4337-a4b2-e67e624d33df.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Arid Mesa
 {
     "name": "Arid Mesa",
@@ -448,6 +509,55 @@
     ]
 }
 
+// Carnage Altar
+{
+    "name": "Carnage Altar",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{3}, Sacrifice a creature: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "rarity": "UNCOMMON",
+        "artist": "James Paick",
+        "flavorText": "\"In these bloodstains I will find the fingerprints of our oppressors.\"\n—Anowon, the Ruin Sage",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/52688a03-26a4-40ff-8a99-a268113a9802.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Day of Judgment
 {
     "name": "Day of Judgment",
@@ -684,6 +794,65 @@
     ]
 }
 
+// Grazing Gladehart
+{
+    "name": "Grazing Gladehart",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Antelope",
+    "oracleText": "Landfall — Whenever a land you control enters, you may gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "artist": "Ryan Pancoast",
+        "flavorText": "\"Don't be fooled. If it were as docile as it looks, it would've died off long ago.\"\n—Yon Basrel, Oran-Rief survivalist",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/078b5290-a613-496f-bd23-8fd109549f31.jpg",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Whenever a land you control enters, each landfall ability of the permanents you control will trigger. You can put them   on the stack in any order. The last ability you put on the stack will be the first one to resolve (As a result, you can have those abilities resolve in the order of your choosing.)."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Into the Roil
 {
     "name": "Into the Roil",
@@ -741,6 +910,128 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Jwar Isle Refuge
+{
+    "name": "Jwar Isle Refuge",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {U} or {B}.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "UNCOMMON",
+        "artist": "Cyril Van Der Haegen",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/ddd9463f-d029-459d-a933-432b7bbd7a41.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
+// Kazandu Refuge
+{
+    "name": "Kazandu Refuge",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {R} or {G}.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "217",
+        "rarity": "UNCOMMON",
+        "artist": "Franz Vohwinkel",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8af66f9c-c90b-45e0-a54c-a76e7e1b9dff.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
     ]
 }
 
@@ -1380,6 +1671,67 @@
         "imageUri": "https://cards.scryfall.io/normal/front/3/2/327cf118-cc92-4073-85d0-94d2a0a6989a.jpg?1783942122"
     },
     "colorIdentityOverride": []
+}
+
+// Sejiri Refuge
+{
+    "name": "Sejiri Refuge",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\nWhen this land enters, you gain 1 life.\n{T}: Add {W} or {U}.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "rarity": "UNCOMMON",
+        "artist": "Ryan Pancoast",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1fd8cb0d-d651-44e7-ae14-4035b0f1aa77.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
 }
 
 // Shatterskull Giant

--- a/scripts/card-status
+++ b/scripts/card-status
@@ -69,8 +69,17 @@ STANDARD_LEGAL_RATIO = 0.5
 
 SET_CODE_RE = re.compile(r'override\s+val\s+code\s*=\s*"([^"]+)"')
 DISPLAY_NAME_RE = re.compile(r'override\s+val\s+displayName\s*=\s*"([^"]+)"')
-CARD_DSL_RE = re.compile(r'\b(?:card|basicLand)\(\s*"([^"]+)"')
-PRINTING_NAME_RE = re.compile(r'\bname\s*=\s*"([^"]+)"')
+# The `(?:[^"\\]|\\.)*` body (rather than `[^"]+`) is load-bearing: a handful of real card
+# names embed escaped double quotes — `card("Kongming, \\"Sleeping Dragon\\"")` — and a naive
+# `[^"]+` truncates at the first `\\"`, so the card reads as missing from a set that has it.
+# Captured values are Kotlin string literals; unescape them before comparing to Scryfall names.
+CARD_DSL_RE = re.compile(r'\b(?:card|basicLand)\(\s*"((?:[^"\\]|\\.)*)"')
+PRINTING_NAME_RE = re.compile(r'\bname\s*=\s*"((?:[^"\\]|\\.)*)"')
+
+
+def unescape_kotlin(literal: str) -> str:
+    """Turn the body of a Kotlin string literal back into the value it denotes."""
+    return re.sub(r'\\(.)', r'\1', literal)
 
 SKIP_FOLDERS = {"custom"}
 
@@ -170,8 +179,8 @@ def scan_implementations(cards_dir: Path) -> set[str]:
         return names
     for kt in cards_dir.glob("*.kt"):
         text = kt.read_text(encoding="utf-8")
-        names.update(CARD_DSL_RE.findall(text))
-        names.update(PRINTING_NAME_RE.findall(text))
+        names.update(unescape_kotlin(n) for n in CARD_DSL_RE.findall(text))
+        names.update(unescape_kotlin(n) for n in PRINTING_NAME_RE.findall(text))
     return names
 
 

--- a/scripts/check-card-printing.py
+++ b/scripts/check-card-printing.py
@@ -46,8 +46,17 @@ USER_AGENT = "argentum-engine-check-card-printing/1.0"
 REQUEST_DELAY_SEC = 0.15  # Scryfall asks for 50–100ms between requests
 CACHE_TTL_DAYS = 30
 
-CARD_DSL_RE = re.compile(r'\b(?:card|basicLand)\(\s*"([^"]+)"')
-PRINTING_NAME_RE = re.compile(r'\bname\s*=\s*"([^"]+)"')
+# The `(?:[^"\\]|\\.)*` body (rather than `[^"]+`) is load-bearing: a handful of real card
+# names embed escaped double quotes — `card("Kongming, \\"Sleeping Dragon\\"")` — and a naive
+# `[^"]+` truncates at the first `\\"`, so the card reports as having no declaration at all.
+# Captured values are Kotlin string literals; unescape them before comparing to Scryfall names.
+CARD_DSL_RE = re.compile(r'\b(?:card|basicLand)\(\s*"((?:[^"\\]|\\.)*)"')
+PRINTING_NAME_RE = re.compile(r'\bname\s*=\s*"((?:[^"\\]|\\.)*)"')
+
+
+def unescape_kotlin(literal: str) -> str:
+    """Turn the body of a Kotlin string literal back into the value it denotes."""
+    return re.sub(r'\\(.)', r'\1', literal)
 PRINTING_SETCODE_RE = re.compile(r'\bsetCode\s*=\s*"([^"]+)"')
 
 # Set types we expect to scaffold as a top-level set. Promo/token/memorabilia
@@ -153,7 +162,7 @@ def find_canonical(card_name: str) -> tuple[str, Path] | None:
     for kt in iter_card_files():
         text = kt.read_text(encoding="utf-8")
         for m in CARD_DSL_RE.finditer(text):
-            if m.group(1) in (card_name, front):
+            if unescape_kotlin(m.group(1)) in (card_name, front):
                 # definitions/<dir>/cards/<file>.kt
                 set_code = codes.get(kt.parts[-3], kt.parts[-3])
                 return (set_code, kt)
@@ -171,9 +180,9 @@ def find_reprint_rows(card_name: str) -> dict[str, Path]:
         text = kt.read_text(encoding="utf-8")
         if "Printing(" not in text:
             continue
-        if any(m.group(1) in (card_name, front) for m in CARD_DSL_RE.finditer(text)):
+        if any(unescape_kotlin(m.group(1)) in (card_name, front) for m in CARD_DSL_RE.finditer(text)):
             continue  # this file holds the CardDefinition, not a reprint row
-        if not any(n in (card_name, front) for n in PRINTING_NAME_RE.findall(text)):
+        if not any(unescape_kotlin(n) in (card_name, front) for n in PRINTING_NAME_RE.findall(text)):
             continue
         set_code = codes.get(kt.parts[-3], kt.parts[-3])
         result[set_code] = kt

--- a/scripts/missing-reprints.py
+++ b/scripts/missing-reprints.py
@@ -50,8 +50,17 @@ CACHE_TTL_DAYS = 30
 # Only `card(...)` declarations participate in the Printing-row reprint system.
 # Basic lands are defined per-set via `basicLand(...)` (each set scaffolds its
 # own art variants), never as shared `Printing(...)` rows — exclude them.
-CARD_DSL_RE = re.compile(r'\bcard\(\s*"([^"]+)"')
-PRINTING_NAME_RE = re.compile(r'\bname\s*=\s*"([^"]+)"')
+# The `(?:[^"\\]|\\.)*` body (rather than `[^"]+`) is load-bearing: a handful of real card
+# names embed escaped double quotes — `card("Kongming, \\"Sleeping Dragon\\"")` — and a naive
+# `[^"]+` truncates at the first `\\"`, so the card silently never matches its Scryfall name.
+# Captured values are Kotlin string literals; run them through [unescape_kotlin] before comparing.
+CARD_DSL_RE = re.compile(r'\bcard\(\s*"((?:[^"\\]|\\.)*)"')
+PRINTING_NAME_RE = re.compile(r'\bname\s*=\s*"((?:[^"\\]|\\.)*)"')
+
+
+def unescape_kotlin(literal: str) -> str:
+    """Turn the body of a Kotlin string literal back into the value it denotes."""
+    return re.sub(r'\\(.)', r'\1', literal)
 
 SCAFFOLDABLE_SET_TYPES = {
     "core", "expansion", "draft_innovation", "masters", "commander",
@@ -148,11 +157,12 @@ def scan_definitions() -> tuple[dict[str, str], dict[str, set[str]]]:
     for kt in iter_card_files():
         text = kt.read_text(encoding="utf-8")
         set_code = codes.get(kt.parts[-3], kt.parts[-3])
-        card_names = {m.group(1) for m in CARD_DSL_RE.finditer(text)}
+        card_names = {unescape_kotlin(m.group(1)) for m in CARD_DSL_RE.finditer(text)}
         for name in card_names:
             canonical[name] = set_code
         if "Printing(" in text:
-            for name in PRINTING_NAME_RE.findall(text):
+            for literal in PRINTING_NAME_RE.findall(text):
+                name = unescape_kotlin(literal)
                 if name not in card_names:  # reprint row, not the canonical file
                     reprints[name].add(set_code)
     return canonical, reprints


### PR DESCRIPTION
Commander 2013's ⚡ Assay-ready count, turned into merged cards. C13 is a **pure placement job** — 0 of its 109 Assay-ready cards are its own design, so every canonical belongs in an older set and C13 gets the `Printing` row.

## The four-way split

| Bucket | N | The work |
|---|---:|---|
| `original` | 0 | — C13 is a Commander product; none of its Assay-ready cards debut here |
| `elsewhere` | **44** | canonical authored in the earlier set + a `Printing` row here |
| `row-only` | **59** | canonical already in the corpus — a `Printing` row here |
| `basic` | **5** | `basicLand(...)` vals + the `basicLands` override — never `Printing` rows |
| held back | 1 | Valley Rannet — see *Findings* |

**Reprint tail:** the 44 new canonicals owe **30** further `Printing` rows across 12 other scaffolded sets (C17 6, CMD 4, ARC 3, C14 3, C15 3, PC2 3, C16 2, CMR 2, GS1 1, KHC 1, LEB 1, PZ2 1). Those are invisible to `check-card-printing` until the canonical exists, so they land here.

One extra C13 row rode along: **Conjurer's Closet**, whose canonical already existed and whose row C13 was simply missing.

Canonicals were authored across 18 sets: ALA 9, ZEN 6, ARB 5, PTK 4, AVR/CHK/CON/FUT/LEA/M11/M12/MOR/NPH/PLS/ROE/RTR/STH/WWK the rest.

## Results

**Assay-ready for C13: 109 → 1** (the 1 is Valley Rannet, held back deliberately). Missing overall: 325 → 216. Re-run on the branch, not inferred.

**Assay differential — zero new divergences:**

| | compared | confirmed | divergent |
|---|---:|---:|---:|
| baseline (main) | 3978 | 3934 | 44 |
| this branch | 4022 | 3978 | **44** |

+44 compared, +44 confirmed, divergent unchanged. All 44 divergent entries are pre-existing on main; **zero overlap** with the cards in this PR. Both numbers were taken with the same freshly-built binary.

Every card was authored to `oracle-assay compile`'s JSON rather than to the oracle text — that is why the differential moved by exactly the batch size.

## Verification

- `just build` — green.
- `just rebless-cards` — 18 goldens updated, exactly the 18 sets authored into. The diff is **2603 insertions, 0 deletions**: purely additive, no existing card entry moved.
- `just assay-differential` — 44 → 44 (above).
- `check-card-printing` — all 44 authored canonicals report `ok`.
- `just assay-ready C13` on the branch — 1 remaining.
- Every written file's `metadata { }` block was diffed back against its pre-fetched Scryfall brief (field-scoped inside the block, so a `CreateToken` `imageUri` can't be mistaken for the card's): all 44 match on collector number, artist, image URI, flavour text, rarity, colour identity, oracle text and ruling count.

## Findings

**1. Valley Rannet is blocked on an engine gap — deliberately left out.**
Its `Mountaincycling {2}, forestcycling {2}` needs *two* typecycling abilities, but the engine can only ever reach the first:

- `rules-engine/.../legalactions/enumerators/CyclingEnumerator.kt:33` — `cyclingAbilities.firstOrNull { it.searchFilter != null }`
- `rules-engine/.../handlers/actions/ability/TypecycleCardHandler.kt:276` — the same `firstOrNull`

The `TypecycleCard(playerId, cardId)` action carries **no discriminator** for which typecycling ability was chosen, so the second renders in the oracle text and is unreachable. No shipped card currently has two distinct typecycling abilities, so this is untested ground. Shipping it would ship a card that lies. The fix is a discriminated `TypecycleCard` across engine + client — `add-feature` territory, its own PR.

**2. A four-site card-name regex bug (fixed here).**
`[^"]+` in the card-name regexes truncates at the first escaped quote, so `card("Kongming, \"Sleeping Dragon\"")` matched nothing. Consequences, all silent:

- `generate-reprints.py` skipped the card with no mention in its summary
- `assay-ready.py` reported an implemented card as missing (`elsewhere`)
- `card-status` reported it missing from a set that has it
- `check-card-printing.py` claimed it had no declaration at all

Fixed in `scripts/missing-reprints.py`, `scripts/card-status` and `scripts/check-card-printing.py` by matching the full Kotlin string-literal body and unescaping it. Kongming is currently the **only** card in the corpus with an escaped-quote name, so the change is inert everywhere else — verified.

**3. `SupremeInquisitor` (ONS) may be a pre-existing divergence.** Assay compiles "Tap an untapped Wizard you control" to a *permanent* filter (`IsPermanent` + `HasSubtype`), per the house rule that a bare tribal noun means permanents. `SupremeInquisitor` uses `Creature.withSubtype("Wizard")`. Azami here follows the JSON. Not touched — flagging only. (Behaviourally both are safe: `CostPaymentService`'s `controlledUntapped` enforces "you control" and "untapped" structurally, which is why neither filter carries those predicates.)

**4. Assay may not build the `fromZone` guard inside a modal mode.** Soul Manipulation's "Return target creature card from your graveyard to your hand" compiles with **no** `fromZone`, which contradicts the `ReturnToHandFromGraveyard` KDoc ("Every card whose printed line names the graveyard should say so here; Argentum Assay builds this for the sentence"). Authored to the JSON, and the differential is clean — but worth a look, given the 18 cards the functional-zone band found missing this guard.

**5. Scope note.** Generating the tail rows surfaced **101** further `Printing` rows those 12 sets are missing for cards unrelated to this sweep (Lightning Greaves ×5, Loxodon Warhammer ×5, the Medallion cycle, the Guildgates, …). They were regenerated and removed to keep this PR scoped to C13's own tail; they remain outstanding debt in those sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
