### PR TITLE
Add 95 Assay-ready cards to Mercadian Masques

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/all/cards/DeadlyInsect.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/all/cards/DeadlyInsect.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.all.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deadly Insect
+ * {4}{G}
+ * Creature — Insect
+ * 6 / 1
+ */
+val DeadlyInsect = card("Deadly Insect") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect"
+    oracleText = "Shroud (This creature can't be the target of spells or abilities.)"
+    power = 6
+    toughness = 1
+
+    keywords(Keyword.SHROUD)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86a"
+        artist = "Scott Kirschner"
+        flavorText = "\"Beautiful, indeed—but one sting could fell a Giant in a heartbeat.\"\n" +
+            "—Taaveti of Kelsinko, Elvish Hunter"
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/add1b999-5c3f-4187-adac-ed1037406b3f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/MercadianMasquesSet.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/MercadianMasquesSet.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.mmq
 
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
@@ -22,11 +21,14 @@ object MercadianMasquesSet : MtgSet {
     override val displayName = "Mercadian Masques"
     override val releaseDate = "1999-10-04"
     override val block = "Masques"
-    override val basicLandsFallback = PortalSet
     override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/AerialCaravan.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/AerialCaravan.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aerial Caravan
+ * {4}{U}{U}
+ * Creature — Human Soldier
+ * 4 / 3
+ *
+ * The activated ability is the impulse-draw composition ([Patterns.Exile.impulse]) at count 1 with
+ * the default [com.wingedsheep.sdk.scripting.effects.MayPlayExpiry.EndOfTurn] expiry — gather the
+ * top card, move it to exile, grant "you may play it".
+ */
+val AerialCaravan = card("Aerial Caravan") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "Flying\n" +
+        "{1}{U}{U}: Exile the top card of your library. Until end of turn, you may play that card. (Reveal the card as you exile it.)"
+    power = 4
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{U}{U}")
+        effect = Patterns.Exile.impulse(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "58"
+        artist = "DiTerlizzi"
+        flavorText = "Successful delivery is *not* guaranteed."
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/adac91af-5165-4779-99f7-e75c83fa5d5d.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/AlabasterWall.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/AlabasterWall.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alabaster Wall
+ * {2}{W}
+ * Creature — Wall
+ * 0 / 4
+ *
+ * The plain Samite Healer shield ([Effects.PreventNextDamage]) on a Defender body — the
+ * `{T}` cost and an "any target" requirement, nothing else.
+ */
+val AlabasterWall = card("Alabaster Wall") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Wall"
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "{T}: Prevent the next 1 damage that would be dealt to any target this turn."
+    power = 0
+    toughness = 4
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", Targets.Any)
+        effect = Effects.PreventNextDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "2"
+        artist = "Randy Gallegos"
+        flavorText = "Its mortar is mixed with waters straight from the Fountain of Cho."
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9cf393a3-831e-4d3a-8404-ee83f60970aa.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BalloonPeddler.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BalloonPeddler.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Balloon Peddler
+ * {2}{U}
+ * Creature — Human Spellshaper
+ * 2 / 2
+ * {U}, {T}, Discard a card: Target creature gains flying until end of turn.
+ *
+ * The Spellshaper cost shape: mana, tap, discard a card — [Costs.DiscardCard] is the whole
+ * "Discard a card" atom, so no filter is needed.
+ */
+val BalloonPeddler = card("Balloon Peddler") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Spellshaper"
+    oracleText = "{U}, {T}, Discard a card: Target creature gains flying until end of turn."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap, Costs.DiscardCard)
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.FLYING, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "Paolo Parente"
+        flavorText = "The market festival turned out to be the high point of Jaffy's visit."
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c34963e6-850e-4ce4-b04f-5e623ce5b73f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BattleRampart.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BattleRampart.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Battle Rampart
+ * {2}{R}
+ * Creature — Wall
+ * 1 / 3
+ *
+ * A Wall that hands out haste — [Effects.GrantKeyword] at the default end-of-turn duration,
+ * so nothing but the keyword and the bound target is written.
+ */
+val BattleRampart = card("Battle Rampart") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Wall"
+    oracleText = "Defender\n" +
+        "{T}: Target creature gains haste until end of turn."
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.HASTE, target = t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "173"
+        artist = "Ron Spencer"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f27f6658-0f00-4934-8d12-cd0dda3958c9.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BattleSquadron.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BattleSquadron.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Battle Squadron
+ * {3}{R}{R}
+ * Creature — Goblin
+ * * / *
+ */
+val BattleSquadron = card("Battle Squadron") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin"
+    oracleText = "Flying\n" +
+        "Battle Squadron's power and toughness are each equal to the number of creatures you control."
+    power = 0
+    toughness = 0
+    dynamicStats(DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature))
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "174"
+        artist = "Mark Tedin"
+        flavorText = "The goblins made an unruly pile with military precision."
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/37d55504-ee04-4a5a-a952-9ec5dc2db413.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BlasterMage.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BlasterMage.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Blaster Mage
+ * {2}{R}
+ * Creature — Human Spellshaper
+ * 2 / 2
+ * {R}, {T}, Discard a card: Destroy target Wall.
+ *
+ * "Target Wall" is a bare tribal noun — any *permanent* with the Wall subtype, not
+ * `GameObjectFilter.Creature` (Dwarven Demolition Team uses the same filter).
+ */
+val BlasterMage = card("Blaster Mage") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Spellshaper"
+    oracleText = "{R}, {T}, Discard a card: Destroy target Wall."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Tap, Costs.DiscardCard)
+        val t = target("target", TargetPermanent(filter = TargetFilter(GameObjectFilter.Permanent.withSubtype("Wall"))))
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "175"
+        artist = "George Pratt"
+        flavorText = "\"Don't get up. I'll show myself out.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/0/801b0fd1-bbb2-47c0-a4c3-4129a67473b9.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BlockadeRunner.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BlockadeRunner.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blockade Runner
+ * {3}{U}
+ * Creature — Merfolk
+ * 2 / 2
+ */
+val BlockadeRunner = card("Blockade Runner") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk"
+    oracleText = "{U}: This creature can't be blocked this turn."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{U}")
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Carl Critchlow"
+        flavorText = "\"I need to get back to Mercadia City,\" said Sisay. \"We can get you there,\" the vizier answered. \"Easily.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/59e483df-b58a-401e-85bc-0afda4bf7cac.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BoaConstrictor.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BoaConstrictor.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Boa Constrictor
+ * {4}{G}
+ * Creature — Snake
+ * 3 / 3
+ * {T}: This creature gets +3/+3 until end of turn.
+ */
+val BoaConstrictor = card("Boa Constrictor") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Snake"
+    oracleText = "{T}: This creature gets +3/+3 until end of turn."
+    power = 3
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.ModifyStats(3, 3, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "231"
+        artist = "Carl Critchlow"
+        flavorText = "Its eyes are bigger than its stomach, but its mouth is larger still."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7369cbf-6986-4a39-b07c-a283b40aee40.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BogSmugglers.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BogSmugglers.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bog Smugglers
+ * {1}{B}{B}
+ * Creature — Human Mercenary
+ * 2 / 2
+ */
+val BogSmugglers = card("Bog Smugglers") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Mercenary"
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.SWAMPWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "117"
+        artist = "Mike Ploog"
+        flavorText = "They slide over the bog like oil across glass."
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2103a44-87e5-40cd-a0de-cd19456a8366.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BogWitch.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/BogWitch.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bog Witch
+ * {2}{B}
+ * Creature — Human Spellshaper
+ * 1 / 1
+ * {B}, {T}, Discard a card: Add {B}{B}{B}.
+ *
+ * A mana ability: it adds mana and requires no target, so `manaAbility = true`
+ * — which derives the timing rule; there is no separate `timing` to author.
+ */
+val BogWitch = card("Bog Witch") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Spellshaper"
+    oracleText = "{B}, {T}, Discard a card: Add {B}{B}{B}."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}"), Costs.Tap, Costs.DiscardCard)
+        effect = Effects.AddMana(Color.BLACK, 3)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Gao Yan"
+        flavorText = "The world is the body. The mana is the blood. The witch is the surgeon."
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6a926f9e-ee63-4b6e-8e5b-0650b74344a5.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Buoyancy.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Buoyancy.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Buoyancy
+ * {1}{U}
+ * Enchantment — Aura
+ *
+ * Flash
+ * Enchant creature
+ * Enchanted creature has flying.
+ *
+ * Mercadian Masques' flash-Aura cycle, the direct sibling of Prophecy's (Greel's Caress,
+ * Mageta's Boon, Alexis's Cloak): flash on an Aura needs nothing beyond the keyword — the
+ * cast-permission path reads it, and `auraTarget` supplies the "Enchant creature" restriction.
+ * The grant is the plain [GrantKeyword] whose default filter is the attached creature.
+ */
+val Buoyancy = card("Buoyancy") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\n" +
+        "Enchant creature\n" +
+        "Enchanted creature has flying."
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "63"
+        artist = "Jeff Miracola"
+        flavorText = "Saprazzan merfolk become legged on land, but some find it quicker to bring the water with them."
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b208dad2-a412-45fd-b19a-d370426ef5b8.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CateranBrute.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CateranBrute.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Cateran Brute
+ * {2}{B}
+ * Creature — Horror Mercenary
+ * 2 / 2
+ */
+val CateranBrute = card("Cateran Brute") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror Mercenary"
+    oracleText = "{2}, {T}: Search your library for a Mercenary permanent card with mana value 2 or less, put it onto the battlefield, then shuffle."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype("Mercenary").manaValueAtMost(2),
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "120"
+        artist = "Edward P. Beard, Jr."
+        flavorText = "The Cateran guild prefers to call them \"public relations.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73b6ce76-0ed0-4994-ae2c-d8e51ae09920.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CateranEnforcer.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CateranEnforcer.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Cateran Enforcer
+ * {3}{B}{B}
+ * Creature — Horror Mercenary
+ * 4 / 3
+ */
+val CateranEnforcer = card("Cateran Enforcer") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror Mercenary"
+    oracleText = "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\n" +
+        "{4}, {T}: Search your library for a Mercenary permanent card with mana value 4 or less, put it onto the battlefield, then shuffle."
+    power = 4
+    toughness = 3
+
+    keywords(Keyword.FEAR)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype("Mercenary").manaValueAtMost(4),
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "121"
+        artist = "Mike Ploog"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e9b6da8-39da-4fce-89cf-ea972f981331.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CateranKidnappers.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CateranKidnappers.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Cateran Kidnappers
+ * {2}{B}{B}
+ * Creature — Human Mercenary
+ * 4 / 2
+ */
+val CateranKidnappers = card("Cateran Kidnappers") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Mercenary"
+    oracleText = "{3}, {T}: Search your library for a Mercenary permanent card with mana value 3 or less, put it onto the battlefield, then shuffle."
+    power = 4
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype("Mercenary").manaValueAtMost(3),
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "122"
+        artist = "Carl Critchlow"
+        flavorText = "Recruits aren't always volunteers."
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/3768bdc1-4055-423a-a1cc-69b4c620e3e6.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CateranOverlord.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CateranOverlord.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cateran Overlord
+ * {4}{B}{B}{B}
+ * Creature — Horror Mercenary
+ * 7 / 5
+ */
+val CateranOverlord = card("Cateran Overlord") {
+    manaCost = "{4}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror Mercenary"
+    oracleText = "Sacrifice a creature: Regenerate this creature.\n" +
+        "{6}, {T}: Search your library for a Mercenary permanent card with mana value 6 or less, put it onto the battlefield, then shuffle."
+    power = 7
+    toughness = 5
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Creature)
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{6}"), Costs.Tap)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype("Mercenary").manaValueAtMost(6),
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "123"
+        artist = "Michael Sutfin"
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e8a1ffcb-40a7-423f-b28a-b5b4c1c9ffd0.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CateranPersuader.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CateranPersuader.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Cateran Persuader
+ * {B}{B}
+ * Creature — Human Mercenary
+ * 2 / 1
+ */
+val CateranPersuader = card("Cateran Persuader") {
+    manaCost = "{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Mercenary"
+    oracleText = "{1}, {T}: Search your library for a Mercenary permanent card with mana value 1 or less, put it onto the battlefield, then shuffle."
+    power = 2
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype("Mercenary").manaValueAtMost(1),
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "124"
+        artist = "Carl Critchlow"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a98bdbf1-32a6-4d9b-8e57-5d3aca6b05bc.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CateranSlaver.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CateranSlaver.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Cateran Slaver
+ * {4}{B}{B}
+ * Creature — Horror Mercenary
+ * 5 / 5
+ */
+val CateranSlaver = card("Cateran Slaver") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror Mercenary"
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\n" +
+        "{5}, {T}: Search your library for a Mercenary permanent card with mana value 5 or less, put it onto the battlefield, then shuffle."
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.SWAMPWALK)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype("Mercenary").manaValueAtMost(5),
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "125"
+        artist = "Carl Critchlow"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d293c51-714c-45b8-bfa4-fe35e8f3fbc1.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CaveSense.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CaveSense.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Cave Sense
+ * {1}{R}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets +1/+1 and has mountainwalk.
+ *
+ * Note there is **no** flash here — Cave Sense sits outside Mercadian Masques' flash-Aura cycle
+ * despite sharing the colour and the cost with [FlamingSword].
+ *
+ * Granted landwalk is engine-live: `BlockEvasionRules.LandwalkRule` reads the keyword out of
+ * projected state and maps `MOUNTAINWALK` to the Mountain subtype, so the grant works exactly as
+ * a printed one would. Same two-static shape as Cursed Flesh (`-1/-1` + fear).
+ */
+val CaveSense = card("Cave Sense") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +1/+1 and has mountainwalk. (It can't be blocked as long as defending player controls a Mountain.)"
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.MOUNTAINWALK)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "179"
+        artist = "Mark Romanoski"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d718421-c742-489c-a243-3adb19f6716a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CavernCrawler.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CavernCrawler.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cavern Crawler
+ * {2}{R}
+ * Creature — Insect
+ * 0 / 3
+ */
+val CavernCrawler = card("Cavern Crawler") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Insect"
+    oracleText = "Mountainwalk (This creature can't be blocked as long as defending player controls a Mountain.)\n" +
+        "{R}: This creature gets +1/-1 until end of turn."
+    power = 0
+    toughness = 3
+
+    keywords(Keyword.MOUNTAINWALK)
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, -1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "181"
+        artist = "Pete Venters"
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd0a8af9-2e86-4639-a6c9-209f115e95f8.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ChamberedNautilus.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ChamberedNautilus.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chambered Nautilus
+ * {2}{U}
+ * Creature — Nautilus Beast
+ * 2 / 2
+ *
+ * Whenever this creature becomes blocked, you may draw a card.
+ */
+val ChamberedNautilus = card("Chambered Nautilus") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Nautilus Beast"
+    oracleText = "Whenever this creature becomes blocked, you may draw a card."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        optional = true
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "64"
+        artist = "John Matson"
+        flavorText = "What's merely a home for the nautilus can become exquisite jewelry in the hands of Saprazzan artisans."
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/860c613d-d031-4c2a-922b-39f4eec04e18.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ChoArrimBruiser.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ChoArrimBruiser.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Cho-Arrim Bruiser
+ * {5}{W}
+ * Creature — Ogre Rebel
+ * 3 / 4
+ *
+ * "Up to two target creatures" is the target requirement's own `count`/`optional`; the effect only
+ * says "tap each of them" ([Effects.TapEachTarget], a `ForEach` over the chosen targets), so the
+ * number never gets duplicated on the effect. The printed "you may" is the ability's `optional`.
+ */
+val ChoArrimBruiser = card("Cho-Arrim Bruiser") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Ogre Rebel"
+    oracleText = "Whenever this creature attacks, you may tap up to two target creatures."
+    power = 3
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        optional = true
+        target("target", TargetCreature(count = 2, optional = true))
+        effect = Effects.TapEachTarget()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "9"
+        artist = "Paolo Parente"
+        flavorText = "He doesn't know why the Cho-Arrim fight the Mercadians, but he's happy to bash heads for them anyway."
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/26e98f06-ad8d-4a93-8ae6-3da42b63b5b5.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CloseQuarters.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CloseQuarters.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Close Quarters
+ * {2}{R}{R}
+ * Enchantment
+ *
+ * Whenever a creature you control becomes blocked, this enchantment deals 1 damage to any target.
+ *
+ * The Gustcloak Savior shape: the *filtered, ANY-binding* [Triggers.becomesBlocked] factory.
+ * `Triggers.BecomesBlocked` is its SELF-binding sibling and is wrong here — the enchantment is
+ * never itself the blocked creature, so a SELF binding would simply never fire.
+ *
+ * The trigger fires once per creature that becomes blocked (CR 509.1h), independent of how many
+ * blockers were assigned to it, and the damage target is chosen when the ability goes on the
+ * stack rather than at resolution.
+ */
+val CloseQuarters = card("Close Quarters") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a creature you control becomes blocked, this enchantment deals 1 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.becomesBlocked(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "184"
+        artist = "Ron Spencer"
+        flavorText = "The Mercadians' ineptitude in close combat sometimes accidentally pays off."
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b9131c7-4e46-4c01-80b3-a6b055439346.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CrenellatedWall.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CrenellatedWall.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crenellated Wall
+ * {4}
+ * Artifact Creature — Wall
+ * 0 / 4
+ */
+val CrenellatedWall = card("Crenellated Wall") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Wall"
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "{T}: Target creature gets +0/+4 until end of turn."
+    power = 0
+    toughness = 4
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(0, 4, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "290"
+        artist = "Arnie Swekel"
+        flavorText = "Mercadian soldiers excel at finding things to stand behind."
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d85ad08d-1120-411a-8bbe-ac93a56476bd.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CustomsDepot.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/CustomsDepot.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Customs Depot
+ * {1}{U}
+ * Enchantment
+ *
+ * Whenever you cast a creature spell, you may pay {1}. If you do, draw a card, then discard a
+ * card.
+ *
+ * "You may pay {1}. If you do, …" is an *optional cost rider on the triggered ability itself*
+ * ([MayPayManaEffect] → `Gate.MayPay`), not a reflexive trigger: the payment and the payoff both
+ * happen as this one ability resolves. Lightning Rift and Mind's Eye are the same shape.
+ * Affordability is checked before prompting, so a tapped-out controller is never offered an
+ * unpayable "yes".
+ *
+ * "Draw a card, then discard a card" is [Patterns.Hand].loot — draw, then the
+ * gather → select → move discard pipeline, in that order, so the drawn card is a legal discard.
+ */
+val CustomsDepot = card("Customs Depot") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you cast a creature spell, you may pay {1}. If you do, draw a card, then discard a card."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastCreature
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}"),
+            effect = Patterns.Hand.loot(draw = 1, discard = 1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "71"
+        artist = "Scott M. Fischer"
+        flavorText = "A bribe is always faster than filling out paperwork."
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/067d8c46-c334-4b00-af06-2e28b6086c58.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Dawnstrider.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Dawnstrider.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dawnstrider
+ * {1}{G}
+ * Creature — Dryad Spellshaper
+ * 1 / 1
+ * {G}, {T}, Discard a card: Prevent all combat damage that would be dealt this turn.
+ *
+ * A repeatable Fog on a body — the effect is the same [Effects.PreventAllCombatDamage] shield
+ * Fog installs (a turn-scoped `PreventionScope.CombatOnly`).
+ */
+val Dawnstrider = card("Dawnstrider") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dryad Spellshaper"
+    oracleText = "{G}, {T}, Discard a card: Prevent all combat damage that would be dealt this turn."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.Tap, Costs.DiscardCard)
+        effect = Effects.PreventAllCombatDamage()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "237"
+        artist = "rk post"
+        flavorText = "Morning's mists can hide many things."
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d193a35-8950-4a77-ace3-c4d4085727f4.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DeadlyInsectReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DeadlyInsectReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deadly Insect reprint in MMQ. Canonical CardDefinition lives in its earliest set.
+ */
+val DeadlyInsectReprint = Printing(
+    oracleId = "98273b0d-2b41-486b-9498-30a692c03982",
+    name = "Deadly Insect",
+    setCode = "MMQ",
+    collectorNumber = "238",
+    scryfallId = "46be78e6-13bb-4500-87db-5ed5cae0145e",
+    artist = "Randy Gallegos",
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/46be78e6-13bb-4500-87db-5ed5cae0145e.jpg",
+    releaseDate = "1999-10-04",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DeepwoodDrummer.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DeepwoodDrummer.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deepwood Drummer
+ * {1}{G}
+ * Creature — Human Spellshaper
+ * 1 / 1
+ * {G}, {T}, Discard a card: Target creature gets +2/+2 until end of turn.
+ */
+val DeepwoodDrummer = card("Deepwood Drummer") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Spellshaper"
+    oracleText = "{G}, {T}, Discard a card: Target creature gets +2/+2 until end of turn."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.Tap, Costs.DiscardCard)
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(2, 2, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "239"
+        artist = "Ron Spears"
+        flavorText = "His drums echo Deepwood's heartbeat."
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/acbed0f5-2ac0-48d8-b5ab-b4cd7176fde2.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DeepwoodTantiv.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DeepwoodTantiv.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deepwood Tantiv
+ * {4}{G}
+ * Creature — Beast
+ * 2 / 4
+ *
+ * Whenever this creature becomes blocked, you gain 2 life.
+ */
+val DeepwoodTantiv = card("Deepwood Tantiv") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    oracleText = "Whenever this creature becomes blocked, you gain 2 life."
+    power = 2
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "241"
+        artist = "Joel Biske"
+        flavorText = "A single tantiv is just as dangerous as a herd."
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bfa2028e-4e73-4ff2-a9e2-9ac347d67893.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DeepwoodWolverine.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DeepwoodWolverine.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Deepwood Wolverine
+ * {G}
+ * Creature — Wolverine
+ * 1 / 1
+ *
+ * Whenever this creature becomes blocked, it gets +2/+0 until end of turn.
+ */
+val DeepwoodWolverine = card("Deepwood Wolverine") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolverine"
+    oracleText = "Whenever this creature becomes blocked, it gets +2/+0 until end of turn."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "242"
+        artist = "Ray Lago"
+        flavorText = "The jhovalls are depleting its food sources, the Mercadians are eroding its home, and you're wondering why it's angry?"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db9a9a76-741a-4ba3-bd4b-0eb87d678253.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DevoutWitness.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DevoutWitness.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Devout Witness
+ * {2}{W}
+ * Creature — Human Spellshaper
+ * 2 / 2
+ * {1}{W}, {T}, Discard a card: Destroy target artifact or enchantment.
+ *
+ * A repeatable Disenchant — the same [TargetFilter.ArtifactOrEnchantment] single `Or` predicate.
+ */
+val DevoutWitness = card("Devout Witness") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Spellshaper"
+    oracleText = "{1}{W}, {T}, Discard a card: Destroy target artifact or enchantment."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}"), Costs.Tap, Costs.DiscardCard)
+        val t = target("target", TargetPermanent(filter = TargetFilter.ArtifactOrEnchantment))
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "17"
+        artist = "Don Hazeltine"
+        flavorText = "The Cho-Arrim fought Mercadia's decadence with more than just swords."
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48ca7aeb-09db-4409-9ba2-c5c5500ad72f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DiplomaticImmunity.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DiplomaticImmunity.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Diplomatic Immunity
+ * {1}{U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Shroud
+ * Enchanted creature has shroud.
+ *
+ * Shroud appears twice, in two different SDK positions, and the distinction is the whole card:
+ * the Aura's *own* shroud is a printed keyword on the enchantment (`keywords(...)`), while the
+ * enchanted creature's is a granted static ([GrantKeyword], default filter = the attached
+ * creature). Robe of Mirrors is the grant-only half of this; the printed half is what makes the
+ * Aura itself untargetable, so it can't be Disenchanted off with a targeted spell.
+ */
+val DiplomaticImmunity = card("Diplomatic Immunity") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Shroud (A permanent with shroud can't be the target of spells or abilities.)\n" +
+        "Enchanted creature has shroud."
+
+    keywords(Keyword.SHROUD)
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.SHROUD)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "75"
+        artist = "Terese Nielsen"
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb1e610e-a4a2-460b-8e4c-13674badbce3.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DrakeHatchling.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DrakeHatchling.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Drake Hatchling
+ * {2}{U}
+ * Creature — Drake
+ * 1 / 3
+ * Flying
+ * {U}: This creature gets +1/+0 until end of turn. Activate only once each turn.
+ *
+ * "Activate only once each turn" is [ActivationRestriction.OncePerTurn] — a per-turn activation
+ * cap, not a timing rule.
+ */
+val DrakeHatchling = card("Drake Hatchling") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    oracleText = "Flying\n" +
+        "{U}: This creature gets +1/+0 until end of turn. Activate only once each turn."
+    power = 1
+    toughness = 3
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{U}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "76"
+        artist = "Bradley Williams"
+        flavorText = "There is beauty in the space between learning to fly and taking it for granted."
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64ee32f9-6120-4f15-a692-89a4cd8167c6.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DustBowl.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/DustBowl.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Dust Bowl
+ *
+ * Land
+ *
+ * {T}: Add {C}.
+ * {3}, {T}, Sacrifice a land: Destroy target nonbasic land.
+ *
+ * The sacrifice is a plain [Costs.Sacrifice] over [GameObjectFilter.Land] — "a land", not
+ * "another land", so Dust Bowl itself is a legal sacrifice. The destroy ability is not a mana
+ * ability (it targets), so only the first ability carries `manaAbility`, which also settles its
+ * timing.
+ */
+val DustBowl = card("Dust Bowl") {
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{3}, {T}, Sacrifice a land: Destroy target nonbasic land."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{3}"),
+            Costs.Tap,
+            Costs.Sacrifice(GameObjectFilter.Land)
+        )
+        val land = target("target", TargetPermanent(filter = TargetFilter.NonbasicLand))
+        effect = Effects.Destroy(land)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "316"
+        artist = "Ben Thompson"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75b03c30-c2b8-4207-b675-26c59c40a7e5.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/EyeOfRamos.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/EyeOfRamos.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eye of Ramos
+ * {3}
+ * Artifact
+ *
+ * {T}: Add {U}.
+ * Sacrifice this artifact: Add {U}.
+ *
+ * One of the five "of Ramos" rocks, identical but for the colour: a tap-for-one ability and a
+ * sacrifice-for-one ability, both mana abilities (CR 605.1a), so neither uses the stack and both
+ * can be activated while paying a cost. `manaAbility` also settles each ability's timing.
+ */
+val EyeOfRamos = card("Eye of Ramos") {
+    manaCost = "{3}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {U}.\n" +
+        "Sacrifice this artifact: Add {U}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "294"
+        artist = "David Martin"
+        flavorText = "Ramos wept, and there were seas."
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/78d22400-39f6-444d-b508-783a7df7e945.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/FlamingSword.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/FlamingSword.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Flaming Sword
+ * {1}{R}
+ * Enchantment — Aura
+ *
+ * Flash
+ * Enchant creature
+ * Enchanted creature gets +1/+0 and has first strike.
+ *
+ * Same flash-Aura frame as [Buoyancy]. "gets +1/+0 **and** has first strike" is two statics, not
+ * one — [ModifyStats] lives in layer 7c and [GrantKeyword] in layer 6, so the SDK keeps them
+ * separate (Agility / Cursed Flesh shape). Both default their filter to the attached creature.
+ */
+val FlamingSword = card("Flaming Sword") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\n" +
+        "Enchant creature\n" +
+        "Enchanted creature gets +1/+0 and has first strike."
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(1, 0)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FIRST_STRIKE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "190"
+        artist = "Randy Gallegos"
+        flavorText = "\"It's not Talruum crystal, but I must admit—it gets the job done.\"\n" +
+            "—Tahngarth"
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/17ecd9ff-8c30-4e17-8cff-dd40d653c4af.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ForcedMarch.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ForcedMarch.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Forced March
+ * {X}{B}{B}{B}
+ * Sorcery
+ * Destroy all creatures with mana value X or less.
+ *
+ * The bound is part of the *filter*, not a count: [GameObjectFilter.manaValueAtMostX] adds
+ * `CardPredicate.ManaValueAtMostX`, which reads the {X} paid for this spell at resolution.
+ * Same idiom as Day of Black Sun's board wipe.
+ */
+val ForcedMarch = card("Forced March") {
+    manaCost = "{X}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all creatures with mana value X or less."
+
+    spell {
+        effect = Effects.DestroyAll(GameObjectFilter.Creature.manaValueAtMostX())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "136"
+        artist = "Greg Hildebrandt & Tim Hildebrandt"
+        flavorText = "The Caterans call it a screening process. The dead are in no condition to argue."
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/36eae0e1-7100-449d-a259-7abfcd429117.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/FuriousAssault.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/FuriousAssault.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Furious Assault
+ * {2}{R}
+ * Enchantment
+ *
+ * Whenever you cast a creature spell, this enchantment deals 1 damage to target player or
+ * planeswalker.
+ *
+ * [Triggers.YouCastCreature] is the cast trigger (an ANY-bound `SpellCastEvent` filtered to
+ * creature spells and to your own casts), so the ability goes on the stack *above* the creature
+ * spell and resolves first. The damage target is the errata'd modern wording —
+ * [Targets.PlayerOrPlaneswalker], not a bare player.
+ */
+val FuriousAssault = card("Furious Assault") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you cast a creature spell, this enchantment deals 1 damage to target player or planeswalker."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastCreature
+        val t = target("target", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "191"
+        artist = "Greg Staples"
+        flavorText = "\"Does it burn, Saprazzan? Do you wish you had never raised arms against us?\"\n" +
+            "—Kyren overseer"
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/27a07fae-0f34-45e7-b22d-97eea9031022.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/GerrardsIrregulars.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/GerrardsIrregulars.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gerrard's Irregulars
+ * {4}{R}
+ * Creature — Human Soldier
+ * 4 / 2
+ *
+ * Trample, haste
+ */
+val GerrardsIrregulars = card("Gerrard's Irregulars") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "Trample, haste"
+    power = 4
+    toughness = 2
+    keywords(Keyword.TRAMPLE, Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "192"
+        artist = "Eric Peterson"
+        flavorText = "Had Gerrard realized he'd end up fighting against them, he might not have trained them so well."
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8a88f507-3d78-4f7f-a91f-8489ad9250f2.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/GhoulsFeast.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/GhoulsFeast.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ghoul's Feast
+ * {1}{B}
+ * Instant
+ * Target creature gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
+ */
+val GhoulsFeast = card("Ghoul's Feast") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard."
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(
+            DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Creature),
+            DynamicAmount.Fixed(0),
+            creature
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "137"
+        artist = "Alan Pollack"
+        flavorText = "Mercadians not wealthy enough to buy a tomb are thrown into a bog called \"the Ghoul's Larder.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6a0054c1-6510-41dd-8695-9bf50296b615.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/GlowingAnemone.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/GlowingAnemone.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Glowing Anemone
+ * {3}{U}
+ * Creature — Jellyfish Beast
+ * 1 / 3
+ *
+ * The optional-ETB bounce frame: [Triggers.EntersBattlefield] with `optional = true` (the printed
+ * "you may") over a plain move-to-hand of the targeted land. "Its owner's hand" is the default
+ * destination owner, so no controller override is needed.
+ */
+val GlowingAnemone = card("Glowing Anemone") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Jellyfish Beast"
+    oracleText = "When this creature enters, you may return target land to its owner's hand."
+    power = 1
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val t = target("target", TargetPermanent(filter = TargetFilter.Land))
+        effect = Effects.Move(t, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "81"
+        artist = "Pete Venters"
+        flavorText = "Beautiful to behold, terrible to be held."
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/708593e6-787b-4f76-a86c-1d52857493ea.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/HammerMage.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/HammerMage.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Hammer Mage
+ * {1}{R}
+ * Creature — Human Spellshaper
+ * 1 / 1
+ * {X}{R}, {T}, Discard a card: Destroy all artifacts with mana value X or less.
+ *
+ * The X bound is a *predicate on the filter* — `manaValueAtMostX()` reads the X paid for this
+ * ability's own cost. It is never a count: `Effects.DestroyAll` takes no count at all.
+ */
+val HammerMage = card("Hammer Mage") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Spellshaper"
+    oracleText = "{X}{R}, {T}, Discard a card: Destroy all artifacts with mana value X or less."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{X}{R}"), Costs.Tap, Costs.DiscardCard)
+        effect = Effects.DestroyAll(GameObjectFilter.Artifact.manaValueAtMostX())
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "193"
+        artist = "Rebecca Guay"
+        flavorText = "When he's holding the hammers, everything looks like a nail."
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b959d7ad-a78e-439f-9225-4dbb89f490d7.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/HeartOfRamos.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/HeartOfRamos.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Heart of Ramos
+ * {3}
+ * Artifact
+ *
+ * {T}: Add {R}.
+ * Sacrifice this artifact: Add {R}.
+ *
+ * One of the five "of Ramos" rocks, identical but for the colour: a tap-for-one ability and a
+ * sacrifice-for-one ability, both mana abilities (CR 605.1a), so neither uses the stack and both
+ * can be activated while paying a cost. `manaAbility` also settles each ability's timing.
+ */
+val HeartOfRamos = card("Heart of Ramos") {
+    manaCost = "{3}"
+    colorIdentity = "R"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {R}.\n" +
+        "Sacrifice this artifact: Add {R}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "296"
+        artist = "David Martin"
+        flavorText = "Ramos bled, and there was fire."
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a0046226-7563-4345-aa4b-a2c732c2780a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/HengeGuardian.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/HengeGuardian.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Henge Guardian
+ * {5}
+ * Artifact Creature — Dragon Wurm
+ * 3 / 4
+ */
+val HengeGuardian = card("Henge Guardian") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Dragon Wurm"
+    oracleText = "{2}: This creature gains trample until end of turn."
+    power = 3
+    toughness = 4
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        effect = Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "297"
+        artist = "Chippy"
+        flavorText = "Like so many Thran relics, the wurm engine kept operating long after its creators were gone."
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/028e5e18-b639-4461-87e4-5306371440b5.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/HengeOfRamos.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/HengeOfRamos.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Henge of Ramos
+ *
+ * Land
+ *
+ * {T}: Add {C}.
+ * {2}, {T}: Add one mana of any color.
+ *
+ * Both abilities are mana abilities: the second one costs mana but adds it, so CR 605.1a still
+ * applies. "Add one mana of any color" is [Effects.AddAnyColorMana] with its default single mana.
+ */
+val HengeOfRamos = card("Henge of Ramos") {
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{2}, {T}: Add one mana of any color."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "318"
+        artist = "Edward P. Beard, Jr."
+        flavorText = "It is the hub. We are the wheel.\n" +
+            "—Dryad saying"
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/0582b42f-5ae5-4be2-ba2d-ed62b3cb20c5.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/HighMarket.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/HighMarket.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * High Market
+ *
+ * Land
+ *
+ * {T}: Add {C}.
+ * {T}, Sacrifice a creature: You gain 1 life.
+ *
+ * The sacrifice outlet is the whole point of the card, so the second ability's cost is
+ * `{T}` plus [Costs.Sacrifice] over [GameObjectFilter.Creature]; the life gain is the
+ * controller's by default.
+ */
+val HighMarket = card("High Market") {
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{T}, Sacrifice a creature: You gain 1 life."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.Sacrifice(GameObjectFilter.Creature)
+        )
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "320"
+        artist = "Carl Critchlow"
+        flavorText = "If it can't be had here, it can't be had on any world."
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f4c58683-65a6-4df9-8952-458e397b1374.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/HornOfRamos.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/HornOfRamos.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Horn of Ramos
+ * {3}
+ * Artifact
+ *
+ * {T}: Add {G}.
+ * Sacrifice this artifact: Add {G}.
+ *
+ * One of the five "of Ramos" rocks, identical but for the colour: a tap-for-one ability and a
+ * sacrifice-for-one ability, both mana abilities (CR 605.1a), so neither uses the stack and both
+ * can be activated while paying a cost. `manaAbility` also settles each ability's timing.
+ */
+val HornOfRamos = card("Horn of Ramos") {
+    manaCost = "{3}"
+    colorIdentity = "G"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {G}.\n" +
+        "Sacrifice this artifact: Add {G}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "299"
+        artist = "David Martin"
+        flavorText = "Ramos touched, and there was life."
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6b17f541-8e9d-43b0-b688-e3f2e7fa55c8.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Intimidation.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Intimidation.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Intimidation
+ * {2}{B}{B}{B}
+ * Enchantment
+ *
+ * Creatures you control have fear.
+ *
+ * Cover of Darkness with a controller scope instead of a chosen-type one: the printed phrase is
+ * "Creatures **you control**", so the [GroupFilter] carries the `youControl()` controller
+ * predicate rather than the default attached-creature scope [GrantKeyword] uses on Auras.
+ *
+ * Granted fear is engine-live — `BlockEvasionRules.FearRule` reads the keyword out of projected
+ * state, so the restriction applies to every creature the Aura-less enchantment covers, including
+ * ones that enter after it.
+ */
+val Intimidation = card("Intimidation") {
+    manaCost = "{2}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Creatures you control have fear. (They can't be blocked except by artifact creatures and/or black creatures.)"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FEAR, GroupFilter(GameObjectFilter.Creature.youControl()))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "142"
+        artist = "Terese Nielsen"
+        flavorText = "\"If they move, kill them. In fact, kill one now to make sure the other understands.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b9e1724-91cf-422e-909b-ddb69a6f9f76.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/IronLance.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/IronLance.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Iron Lance
+ * {2}
+ * Artifact
+ */
+val IronLance = card("Iron Lance") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{3}, {T}: Target creature gains first strike until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        val t = target("target", TargetCreature())
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "300"
+        artist = "Scott M. Fischer"
+        flavorText = "\"The only way to get Mercadians to fight on the front lines is to give them really long weapons.\"\n" +
+            "—Gerrard"
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/41f7d212-faf2-4a6f-a338-d9e5014b56d5.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/JhovallQueen.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/JhovallQueen.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jhovall Queen
+ * {4}{W}{W}
+ * Creature — Cat Rebel
+ * 4 / 7
+ *
+ * Vigilance
+ */
+val JhovallQueen = card("Jhovall Queen") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Rebel"
+    oracleText = "Vigilance"
+    power = 4
+    toughness = 7
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "25"
+        artist = "Michael Sutfin"
+        flavorText = "War-trained jhovalls eat twice their weight in war-trained soldiers daily."
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b8eb55cc-ddde-4f15-9262-b9aee28059d3.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/JhovallRider.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/JhovallRider.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jhovall Rider
+ * {4}{W}
+ * Creature — Human Rebel
+ * 3 / 3
+ *
+ * Trample
+ */
+val JhovallRider = card("Jhovall Rider") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Rebel"
+    oracleText = "Trample"
+    power = 3
+    toughness = 3
+    keywords(Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "26"
+        artist = "Scott M. Fischer"
+        flavorText = "Don't be fooled by the riders' fluid grace—it takes years of practice to ride these beasts."
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e1f7c51-0011-4ea5-b123-3c26293f5dab.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/KrisMage.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/KrisMage.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kris Mage
+ * {R}
+ * Creature — Human Spellshaper
+ * 1 / 1
+ */
+val KrisMage = card("Kris Mage") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Spellshaper"
+    oracleText = "{R}, {T}, Discard a card: This creature deals 1 damage to any target."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Tap, Costs.DiscardCard)
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "195"
+        artist = "Matthew D. Wilson"
+        flavorText = "Her blade draws blood without ever touching its target."
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/4389fbcd-182a-4cac-b14f-aa971948cf8e.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/KyrenGlider.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/KyrenGlider.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+
+/**
+ * Kyren Glider
+ * {1}{R}
+ * Creature — Goblin
+ * 1 / 1
+ */
+val KyrenGlider = card("Kyren Glider") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin"
+    oracleText = "Flying\n" +
+        "This creature can't block."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "196"
+        artist = "Daren Bader"
+        flavorText = "Mercadia's Kyren goblins are the opposite of Dominarian goblins: they're smart and cowardly."
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0bc55e01-342e-4856-937e-14561b8d165b.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/KyrenNegotiations.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/KyrenNegotiations.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Kyren Negotiations
+ * {2}{R}{R}
+ * Enchantment
+ */
+val KyrenNegotiations = card("Kyren Negotiations") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Tap an untapped creature you control: This enchantment deals 1 damage to target player or planeswalker."
+
+    activatedAbility {
+        cost = Costs.TapPermanents(count = 1, filter = GameObjectFilter.Creature)
+        val victim = target("target", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(1, victim)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "198"
+        artist = "Scott Hampton"
+        flavorText = "Kyren goblins always speak in questions and never allow wrong answers."
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c263a17-bbc2-433e-93f8-72e57b818322.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/LightningHounds.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/LightningHounds.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Hounds
+ * {2}{R}{R}
+ * Creature — Dog
+ * 3 / 2
+ *
+ * First strike
+ */
+val LightningHounds = card("Lightning Hounds") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dog"
+    oracleText = "First strike"
+    power = 3
+    toughness = 2
+    keywords(Keyword.FIRST_STRIKE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "201"
+        artist = "Andrew Robinson"
+        flavorText = "Quick enough to avoid jhovalls when alone and fierce enough to attack them in packs, the hounds were as at home in the mountains as the Mercadians were atop theirs."
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/38c82a1d-5db1-4090-b446-cc5bc6dc811d.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/LumberingSatyr.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/LumberingSatyr.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Lumbering Satyr
+ * {2}{G}{G}
+ * Creature — Satyr Beast
+ * 5 / 4
+ */
+val LumberingSatyr = card("Lumbering Satyr") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Satyr Beast"
+    oracleText = "All creatures have forestwalk. (They can't be blocked as long as defending player controls a Forest.)"
+    power = 5
+    toughness = 4
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.FORESTWALK,
+            filter = GroupFilter(GameObjectFilter.Creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "257"
+        artist = "Alan Pollack"
+        flavorText = "The satyr carves the path that all of Rushwood follows.\n" +
+            "—Cho-Arrim saying"
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d897088-0667-4864-91c3-5f0ac7f9b220.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/MaggotTherapy.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/MaggotTherapy.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Maggot Therapy
+ * {2}{B}
+ * Enchantment — Aura
+ *
+ * Flash
+ * Enchant creature
+ * Enchanted creature gets +2/-2.
+ *
+ * The black member of Mercadian Masques' flash-Aura cycle — Greel's Caress with the sign
+ * flipped onto toughness. A single [ModifyStats] static; the toughness reduction is a layer-7c
+ * modification, so a creature already at 2 toughness dies to the state-based action rather than
+ * to damage.
+ */
+val MaggotTherapy = card("Maggot Therapy") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\n" +
+        "Enchant creature\n" +
+        "Enchanted creature gets +2/-2."
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, -2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "145"
+        artist = "Jeff Easley"
+        flavorText = "\"If this is the cure, I'd hate to see the disease.\"\n" +
+            "—Orim"
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6ab963aa-2304-4ee6-a8c7-c485c5133b40.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/MercadianMasquesBasicLands.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/MercadianMasquesBasicLands.kt
@@ -1,0 +1,176 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Mercadian Masques Basic Lands
+ *
+ * Mercadian Masques printed four art variants of each basic land type (cards 331-350):
+ * Plains 331-334, Island 335-338, Swamp 339-342, Mountain 343-346, Forest 347-350.
+ */
+
+// =============================================================================
+// Plains (Cards 331-334)
+// =============================================================================
+
+val MmqPlains331 = basicLand("Plains") {
+    collectorNumber = "331"
+    artist = "Terry Springer"
+    imageUri = "https://cards.scryfall.io/normal/front/2/e/2edf5042-d185-424e-922d-c0bd4ce3e8b0.jpg?1783945905"
+}
+
+val MmqPlains332 = basicLand("Plains") {
+    collectorNumber = "332"
+    artist = "Scott Bailey"
+    imageUri = "https://cards.scryfall.io/normal/front/4/4/44214f36-8bb3-4a32-8046-3ecdfff8407b.jpg?1783945906"
+}
+
+val MmqPlains333 = basicLand("Plains") {
+    collectorNumber = "333"
+    artist = "Dana Knutson"
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e3e536cc-e724-43d4-9fe3-dfb4952613cb.jpg?1783945904"
+}
+
+val MmqPlains334 = basicLand("Plains") {
+    collectorNumber = "334"
+    artist = "Edward P. Beard, Jr."
+    imageUri = "https://cards.scryfall.io/normal/front/3/a/3a8fd867-8be1-4ee7-bb67-32c3f22db59e.jpg?1783945903"
+}
+
+// =============================================================================
+// Island (Cards 335-338)
+// =============================================================================
+
+val MmqIsland335 = basicLand("Island") {
+    collectorNumber = "335"
+    artist = "Terry Springer"
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5bae77e8-1230-4a6e-8c75-c99d2741a509.jpg?1783945903"
+}
+
+val MmqIsland336 = basicLand("Island") {
+    collectorNumber = "336"
+    artist = "Scott Bailey"
+    imageUri = "https://cards.scryfall.io/normal/front/9/a/9a38509a-2b74-42a0-af91-ed453e463b95.jpg?1783945902"
+}
+
+val MmqIsland337 = basicLand("Island") {
+    collectorNumber = "337"
+    artist = "Scott Bailey"
+    imageUri = "https://cards.scryfall.io/normal/front/b/2/b2d83856-2201-4c30-bfcf-9cab62545201.jpg?1783945902"
+}
+
+val MmqIsland338 = basicLand("Island") {
+    collectorNumber = "338"
+    artist = "Tony Szczudlo"
+    imageUri = "https://cards.scryfall.io/normal/front/e/0/e0fedd66-e547-492c-ad0d-9c7b527bdd17.jpg?1783945901"
+}
+
+// =============================================================================
+// Swamp (Cards 339-342)
+// =============================================================================
+
+val MmqSwamp339 = basicLand("Swamp") {
+    collectorNumber = "339"
+    artist = "Jeff Easley"
+    imageUri = "https://cards.scryfall.io/normal/front/7/2/72020810-bfa3-42d5-ad0d-6d02a6fe1b31.jpg?1783945901"
+}
+
+val MmqSwamp340 = basicLand("Swamp") {
+    collectorNumber = "340"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/c/2/c2436ceb-05c0-40e6-b370-a6f02f4adbe4.jpg?1783945902"
+}
+
+val MmqSwamp341 = basicLand("Swamp") {
+    collectorNumber = "341"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/1017347b-6b1a-4a2f-9147-98acad779616.jpg?1783945901"
+}
+
+val MmqSwamp342 = basicLand("Swamp") {
+    collectorNumber = "342"
+    artist = "Terry Springer"
+    imageUri = "https://cards.scryfall.io/normal/front/4/a/4a0243d2-5fde-489f-8113-4ece0511cb5c.jpg?1783945901"
+}
+
+// =============================================================================
+// Mountain (Cards 343-346)
+// =============================================================================
+
+val MmqMountain343 = basicLand("Mountain") {
+    collectorNumber = "343"
+    artist = "Terry Springer"
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/19b5fff1-7a60-4e50-893a-8177cd62bf82.jpg?1783945902"
+}
+
+val MmqMountain344 = basicLand("Mountain") {
+    collectorNumber = "344"
+    artist = "Scott Bailey"
+    imageUri = "https://cards.scryfall.io/normal/front/4/d/4dbd12ed-e512-43d8-919d-478b18674deb.jpg?1783945901"
+}
+
+val MmqMountain345 = basicLand("Mountain") {
+    collectorNumber = "345"
+    artist = "Dana Knutson"
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/1921ce16-8ed8-41d7-a2b4-9e62f44ac8d6.jpg?1783945900"
+}
+
+val MmqMountain346 = basicLand("Mountain") {
+    collectorNumber = "346"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/4/2/423f4311-9feb-4c63-8b4c-32ddd38382e0.jpg?1783945901"
+}
+
+// =============================================================================
+// Forest (Cards 347-350)
+// =============================================================================
+
+val MmqForest347 = basicLand("Forest") {
+    collectorNumber = "347"
+    artist = "Donato Giancola"
+    imageUri = "https://cards.scryfall.io/normal/front/6/9/695de19e-801f-4f08-b44c-b0726e4aced0.jpg?1783945900"
+}
+
+val MmqForest348 = basicLand("Forest") {
+    collectorNumber = "348"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a38e4ee7-6965-4e12-95d4-c9de1dbb014c.jpg?1783945899"
+}
+
+val MmqForest349 = basicLand("Forest") {
+    collectorNumber = "349"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c1973049-2d42-4091-9703-189ba374254d.jpg?1783945900"
+}
+
+val MmqForest350 = basicLand("Forest") {
+    collectorNumber = "350"
+    artist = "Terry Springer"
+    imageUri = "https://cards.scryfall.io/normal/front/9/8/98c4806b-a31a-4026-9876-eab4d0d1694b.jpg?1783945900"
+}
+
+/**
+ * All Mercadian Masques basic land variants.
+ */
+val MercadianMasquesBasicLands = listOf(
+    MmqPlains331,
+    MmqPlains332,
+    MmqPlains333,
+    MmqPlains334,
+    MmqIsland335,
+    MmqIsland336,
+    MmqIsland337,
+    MmqIsland338,
+    MmqSwamp339,
+    MmqSwamp340,
+    MmqSwamp341,
+    MmqSwamp342,
+    MmqMountain343,
+    MmqMountain344,
+    MmqMountain345,
+    MmqMountain346,
+    MmqForest347,
+    MmqForest348,
+    MmqForest349,
+    MmqForest350,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/MisshapenFiend.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/MisshapenFiend.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Misshapen Fiend
+ * {1}{B}
+ * Creature — Horror Mercenary
+ * 1 / 1
+ *
+ * Flying
+ */
+val MisshapenFiend = card("Misshapen Fiend") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror Mercenary"
+    oracleText = "Flying"
+    power = 1
+    toughness = 1
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "147"
+        artist = "Adam Rex"
+        flavorText = "You'd scarcely believe they could fly until they drop out of the sky onto you."
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a43cf59e-7583-4651-968a-2a7201c69b6b.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/MoltingHarpy.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/MoltingHarpy.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+
+/**
+ * Molting Harpy
+ * {B}
+ * Creature — Harpy Mercenary
+ * 2 / 1
+ *
+ * "Sacrifice this creature unless you pay {2}" is [PayOrSufferEffect] — the upkeep trigger offers
+ * the mana payment and the sacrifice is the unpaid branch. Same shape as Prophecy's Pit Raptor.
+ */
+val MoltingHarpy = card("Molting Harpy") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Harpy Mercenary"
+    oracleText = "Flying\n" +
+        "At the beginning of your upkeep, sacrifice this creature unless you pay {2}."
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = PayOrSufferEffect(cost = Costs.pay.Mana("{2}"), suffer = SacrificeSelfEffect)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "148"
+        artist = "Jeff Laubenstein"
+        flavorText = "Shed harpy feathers leave painful wounds—which explains the harpies' mood."
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/ddfe33fb-71d5-4552-bcd3-f07e4e3847e1.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/NightwindGlider.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/NightwindGlider.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Nightwind Glider
+ * {2}{W}
+ * Creature — Human Rebel
+ * 2 / 1
+ */
+val NightwindGlider = card("Nightwind Glider") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Rebel"
+    oracleText = "Flying, protection from black"
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.BLACK)))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "31"
+        artist = "Randy Gallegos"
+        flavorText = "Once you learn to float on the shadows, you'll never fear them again."
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/0968401d-522f-4def-92a1-d504471ac54e.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/NotoriousAssassin.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/NotoriousAssassin.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Notorious Assassin
+ * {3}{B}
+ * Creature — Human Spellshaper Assassin
+ * 2 / 2
+ */
+val NotoriousAssassin = card("Notorious Assassin") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Spellshaper Assassin"
+    oracleText = "{2}{B}, {T}, Discard a card: Destroy target nonblack creature. It can't be regenerated."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}"), Costs.Tap, Costs.DiscardCard)
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.notColor(Color.BLACK)))
+        effect = Effects.Destroy(t, noRegenerate = true)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "150"
+        artist = "Heather Hudson"
+        flavorText = "He wears his infamy like a fine silk shirt."
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/239e48d8-e2ba-4e25-88ef-301420c796b4.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Panacea.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Panacea.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Panacea
+ * {4}
+ * Artifact
+ *
+ * The `{X}{X}` shield: the announced X is the *cost*, so the prevented amount is
+ * [DynamicAmount.XValue] and the doubled symbol is nothing but the mana string.
+ */
+val Panacea = card("Panacea") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{X}{X}, {T}: Prevent the next X damage that would be dealt to any target this turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{X}{X}"), Costs.Tap)
+        val t = target("target", Targets.Any)
+        effect = Effects.PreventNextDamage(DynamicAmount.XValue, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "308"
+        artist = "Donato Giancola"
+        flavorText = "A drop numbs the tongue. A sip sends the heart racing. A draught reforges the body."
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/89414770-2a19-4baf-9b18-76104b7b0b9a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/PowerMatrix.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/PowerMatrix.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Power Matrix
+ * {4}
+ * Artifact
+ *
+ * One composite over the shared target: the +1/+1 pump plus one grant per keyword, each defaulting
+ * to `Duration.EndOfTurn`.
+ */
+val PowerMatrix = card("Power Matrix") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Target creature gets +1/+1 and gains flying, first strike, and trample until end of turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", TargetCreature())
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 1, t),
+            Effects.GrantKeyword(Keyword.FLYING, t),
+            Effects.GrantKeyword(Keyword.FIRST_STRIKE, t),
+            Effects.GrantKeyword(Keyword.TRAMPLE, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "309"
+        artist = "Alan Pollack"
+        flavorText = "As he repaired the ship's planeswalking engine, Karn saw for the first time how he could catalyze the *Weatherlight*'s evolution."
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a578599c-7d90-4881-b59a-9cf64b90d917.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RamosianCaptain.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RamosianCaptain.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Ramosian Captain
+ * {1}{W}{W}
+ * Creature — Human Rebel
+ * 2 / 2
+ */
+val RamosianCaptain = card("Ramosian Captain") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Rebel"
+    oracleText = "First strike\n" +
+        "{5}, {T}: Search your library for a Rebel permanent card with mana value 4 or less, put it onto the battlefield, then shuffle."
+    power = 2
+    toughness = 2
+    keywords(Keyword.FIRST_STRIKE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype("Rebel").manaValueAtMost(4),
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "35"
+        artist = "Matthew D. Wilson"
+        flavorText = "The Cho-Arrim believe in leading by example."
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0e9d2e2a-c608-4787-bbd9-e1871f681b58.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RamosianCommander.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RamosianCommander.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Ramosian Commander
+ * {2}{W}{W}
+ * Creature — Human Rebel
+ * 2 / 4
+ */
+val RamosianCommander = card("Ramosian Commander") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Rebel"
+    oracleText = "{6}, {T}: Search your library for a Rebel permanent card with mana value 5 or less, put it onto the battlefield, then shuffle."
+    power = 2
+    toughness = 4
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{6}"), Costs.Tap)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype("Rebel").manaValueAtMost(5),
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "36"
+        artist = "Scott Hampton"
+        flavorText = "\"Cho-Manno guides your spirit. I guide your sword.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/867f5d82-71c2-455f-ab16-5a32bba46986.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RamosianLieutenant.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RamosianLieutenant.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Ramosian Lieutenant
+ * {1}{W}
+ * Creature — Human Rebel
+ * 1 / 2
+ */
+val RamosianLieutenant = card("Ramosian Lieutenant") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Rebel"
+    oracleText = "{4}, {T}: Search your library for a Rebel permanent card with mana value 3 or less, put it onto the battlefield, then shuffle."
+    power = 1
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype("Rebel").manaValueAtMost(3),
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "37"
+        artist = "Alan Pollack"
+        flavorText = "\"Give me your hand and I will give you victory.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/debe840a-ebc9-43c4-9bf7-7eb292b65bf9.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RamosianSergeant.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RamosianSergeant.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Ramosian Sergeant
+ * {W}
+ * Creature — Human Rebel
+ * 1 / 1
+ */
+val RamosianSergeant = card("Ramosian Sergeant") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Rebel"
+    oracleText = "{3}, {T}: Search your library for a Rebel permanent card with mana value 2 or less, put it onto the battlefield, then shuffle."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype("Rebel").manaValueAtMost(2),
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Don Hazeltine"
+        flavorText = "Her commands are part rallying cry, part sermon, and wholly undeniable."
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/ef2b036d-5721-4a6e-bf43-69148b90da10.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RamosianSkyMarshal.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RamosianSkyMarshal.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Ramosian Sky Marshal
+ * {3}{W}{W}
+ * Creature — Human Rebel
+ * 3 / 3
+ */
+val RamosianSkyMarshal = card("Ramosian Sky Marshal") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Rebel"
+    oracleText = "Flying\n" +
+        "{7}, {T}: Search your library for a Rebel permanent card with mana value 6 or less, put it onto the battlefield, then shuffle."
+    power = 3
+    toughness = 3
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{7}"), Costs.Tap)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype("Rebel").manaValueAtMost(6),
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "40"
+        artist = "Matt Cavotta"
+        flavorText = "The Cho-Arrim fell from the sky onto Mercadia City like a vengeful rain."
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/16638976-8a78-4233-8ebc-42ea9bb49e0a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RampartCrawler.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RampartCrawler.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Rampart Crawler
+ * {B}
+ * Creature — Lizard Mercenary
+ * 1 / 1
+ *
+ * Juggernaut's / Bog Rats' blocking restriction, consumed by `CantBeBlockedByRule` in
+ * `BlockEvasionRules`. The blocker noun is the bare tribal "Walls", i.e. Wall *permanents* —
+ * `GameObjectFilter.Permanent.withSubtype`, not `.Creature` (which the older corpus cards use).
+ * `filter` is left at its `GroupFilter.source()` default: the restriction applies to this
+ * creature only.
+ */
+val RampartCrawler = card("Rampart Crawler") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Lizard Mercenary"
+    oracleText = "This creature can't be blocked by Walls."
+    power = 1
+    toughness = 1
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Permanent.withSubtype(Subtype.WALL))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "156"
+        artist = "Pete Venters"
+        flavorText = "\"Not even the magistrate in his lofty tower is out of our reach.\"\n" +
+            "—Cateran overlord"
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8b60f86f-c78a-4dfb-bb18-e9bcf21b26c4.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ReveredElder.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ReveredElder.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Revered Elder
+ * {2}{W}
+ * Creature — Human Cleric
+ * 1 / 2
+ *
+ * Samite Healer's shield pointed inward: "dealt to this creature" is
+ * [EffectTarget.Self], so the ability needs no target requirement at all.
+ */
+val ReveredElder = card("Revered Elder") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    oracleText = "{1}: Prevent the next 1 damage that would be dealt to this creature this turn."
+    power = 1
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        effect = Effects.PreventNextDamage(1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "43"
+        artist = "Donato Giancola"
+        flavorText = "The Cho-Arrim worship life and revere those who've experienced it longest."
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0793175-e56b-4ff8-9e22-3a96a698068c.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RishadanPort.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RishadanPort.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rishadan Port
+ *
+ * Land
+ *
+ * {T}: Add {C}.
+ * {1}, {T}: Tap target land.
+ *
+ * [Targets.Land] carries no controller predicate, matching the Oracle wording — the Port can tap
+ * any land, including one of yours. The tapping is [Effects.Tap] on the bound target; the `{T}` in
+ * the cost is the Port tapping itself. The second ability targets, so it is not a mana ability.
+ */
+val RishadanPort = card("Rishadan Port") {
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{1}, {T}: Tap target land."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        val land = target("target", Targets.Land)
+        effect = Effects.Tap(land)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "324"
+        artist = "Jerry Tiritilli"
+        flavorText = "Rishada is the gateway to free trade—but the key will cost you."
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/477a1f53-5cdf-4b45-b584-2e36b31a3fdb.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RushwoodElemental.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RushwoodElemental.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rushwood Elemental
+ * {G}{G}{G}{G}{G}
+ * Creature — Elemental
+ * 4 / 4
+ */
+val RushwoodElemental = card("Rushwood Elemental") {
+    manaCost = "{G}{G}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental"
+    oracleText = "Trample\n" +
+        "At the beginning of your upkeep, you may put a +1/+1 counter on this creature."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        optional = true
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "264"
+        artist = "Hannibal King"
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52128694-d9f5-4acb-b684-bb02a4e766b8.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RushwoodHerbalist.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/RushwoodHerbalist.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+
+/**
+ * Rushwood Herbalist
+ * {2}{G}
+ * Creature — Human Spellshaper
+ * 2 / 2
+ */
+val RushwoodHerbalist = card("Rushwood Herbalist") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Spellshaper"
+    oracleText = "{G}, {T}, Discard a card: Regenerate target creature."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.Tap, Costs.DiscardCard)
+        val t = target("target", Targets.Creature)
+        effect = RegenerateEffect(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "265"
+        artist = "Terese Nielsen"
+        flavorText = "When generals gather their armies, healers gather their herbs."
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9afde98f-a429-4eff-9d06-8582267ac74b.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SacredPrey.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SacredPrey.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sacred Prey
+ * {G}
+ * Creature — Horse
+ * 1 / 1
+ *
+ * Whenever this creature becomes blocked, you gain 1 life.
+ */
+val SacredPrey = card("Sacred Prey") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Horse"
+    oracleText = "Whenever this creature becomes blocked, you gain 1 life."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "268"
+        artist = "Rebecca Guay"
+        flavorText = "To see one is a good omen to the Cho-Arrim."
+        imageUri = "https://cards.scryfall.io/normal/front/e/9/e965d32c-3151-48e8-b256-0b7fa8a8a211.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SaprazzanHeir.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SaprazzanHeir.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Saprazzan Heir
+ * {1}{U}
+ * Creature — Merfolk
+ * 1 / 1
+ *
+ * Whenever this creature becomes blocked, you may draw three cards.
+ */
+val SaprazzanHeir = card("Saprazzan Heir") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk"
+    oracleText = "Whenever this creature becomes blocked, you may draw three cards."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        optional = true
+        effect = Effects.DrawCards(3)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "99"
+        artist = "Terese Nielsen"
+        flavorText = "Within the walls of the floating city, Saprazzan wealth is like Saprazzan water: abundant, free-flowing, and accessible to all."
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0e3d913d-2dcf-4747-8169-0c44ec895864.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SeismicMage.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SeismicMage.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seismic Mage
+ * {3}{R}
+ * Creature — Human Spellshaper
+ * 1 / 1
+ */
+val SeismicMage = card("Seismic Mage") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Spellshaper"
+    oracleText = "{2}{R}, {T}, Discard a card: Destroy target land."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}"), Costs.Tap, Costs.DiscardCard)
+        val t = target("target", Targets.Land)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "211"
+        artist = "Pete Venters"
+        flavorText = "The ground shakes when he walks. His customers shake if they're late with his fee."
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/9524432a-3186-4c7b-a780-28bdbe36053f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SilvergladeElemental.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SilvergladeElemental.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Silverglade Elemental
+ * {4}{G}
+ * Creature — Elemental
+ * 4 / 4
+ *
+ * Wood Elves' fetch under an optional ETB: [Patterns.Library.searchLibrary] supplies the gather /
+ * choose-up-to-one / put-onto-battlefield / shuffle sequence (`shuffleAfter` defaults to true, which
+ * is the printed "then shuffle").
+ */
+val SilvergladeElemental = card("Silverglade Elemental") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental"
+    oracleText = "When this creature enters, you may search your library for a Forest card, put that card onto the battlefield, then shuffle."
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Land.withSubtype(Subtype.FOREST),
+            destination = SearchDestination.BATTLEFIELD
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "269"
+        artist = "Chippy"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f222fe90-ac92-4ba9-b060-9b64075bf139.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Sizzle.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Sizzle.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sizzle
+ * {2}{R}
+ * Sorcery
+ * Sizzle deals 3 damage to each opponent.
+ */
+val Sizzle = card("Sizzle") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Sizzle deals 3 damage to each opponent."
+
+    spell {
+        effect = Effects.DealDamage(3, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "213"
+        artist = "Brian Snõddy"
+        flavorText = "Explosions ripped through the ship overhead, and those unfortunate enough to be directly below scrambled to find cover."
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f1ca1eee-d97d-48c6-84f1-7d1f972c3ca9.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SkullOfRamos.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SkullOfRamos.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skull of Ramos
+ * {3}
+ * Artifact
+ *
+ * {T}: Add {B}.
+ * Sacrifice this artifact: Add {B}.
+ *
+ * One of the five "of Ramos" rocks, identical but for the colour: a tap-for-one ability and a
+ * sacrifice-for-one ability, both mana abilities (CR 605.1a), so neither uses the stack and both
+ * can be activated while paying a cost. `manaAbility` also settles each ability's timing.
+ */
+val SkullOfRamos = card("Skull of Ramos") {
+    manaCost = "{3}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {B}.\n" +
+        "Sacrifice this artifact: Add {B}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "312"
+        artist = "David Martin"
+        flavorText = "Ramos fell, and there was night."
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f071957c-9bea-4d00-9ffd-30f98d57b8d2.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SnortingGahr.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SnortingGahr.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Snorting Gahr
+ * {2}{G}{G}
+ * Creature — Rhino Beast
+ * 3 / 3
+ *
+ * Whenever this creature becomes blocked, it gets +2/+2 until end of turn.
+ */
+val SnortingGahr = card("Snorting Gahr") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Rhino Beast"
+    oracleText = "Whenever this creature becomes blocked, it gets +2/+2 until end of turn."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "272"
+        artist = "Andrew Goldhawk"
+        flavorText = "There's little advantage to surprising the gahr."
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e568503e-a886-4c8b-9d46-8520c2cdda48.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SoothingBalm.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SoothingBalm.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soothing Balm
+ * {1}{W}
+ * Instant
+ * Target player gains 5 life.
+ */
+val SoothingBalm = card("Soothing Balm") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target player gains 5 life."
+
+    spell {
+        val player = target("target", Targets.Player)
+        effect = Effects.GainLife(5, player)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Scott M. Fischer"
+        flavorText = "Orim taught Ta-Karnst and the other Cho-Arrim healers a far less invasive method of healing."
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96b8f4be-9f4d-4373-8141-a03518ecd38a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SquallReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SquallReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Squall reprint in MMQ. Canonical CardDefinition lives in its earliest set.
+ */
+val SquallReprint = Printing(
+    oracleId = "16fe0abe-04fa-4023-8ee0-043a076e78bb",
+    name = "Squall",
+    setCode = "MMQ",
+    collectorNumber = "275",
+    scryfallId = "e5409b54-66ed-4add-bf43-cfeb074b1c50",
+    artist = "Val Mayerik",
+    imageUri = "https://cards.scryfall.io/normal/front/e/5/e5409b54-66ed-4add-bf43-cfeb074b1c50.jpg",
+    releaseDate = "1999-10-04",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SqueeGoblinNabob.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/SqueeGoblinNabob.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Squee, Goblin Nabob
+ * {2}{R}
+ * Legendary Creature — Goblin
+ * 1 / 1
+ *
+ * The ability functions from the graveyard, not the battlefield (CR 113.6b), so the trigger is
+ * zone-scoped with `triggerZone = Zone.GRAVEYARD` — the same arrangement as Gigapede. Without it
+ * the upkeep trigger would only be indexed while Squee is on the battlefield, where the ability
+ * can never do anything.
+ */
+val SqueeGoblinNabob = card("Squee, Goblin Nabob") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Goblin"
+    oracleText = "At the beginning of your upkeep, you may return this card from your graveyard to your hand."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        triggerZone = Zone.GRAVEYARD
+        optional = true
+        effect = Effects.Move(EffectTarget.Self, Zone.HAND, fromZone = Zone.GRAVEYARD)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "214"
+        artist = "David Monette"
+        flavorText = "\"General?!\" Tahngarth roared. \"General *nuisance*, maybe.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4ba8325a-1203-4125-9111-94d9e2b1f14b.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Squeeze.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Squeeze.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Squeeze
+ * {3}{U}
+ * Enchantment
+ * Sorcery spells cost {3} more to cast.
+ *
+ * Symmetrical tax — [SpellCostTarget.AnyCaster], so it hits its own controller too
+ * (cf. Thorn of Amethyst).
+ */
+val Squeeze = card("Squeeze") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Sorcery spells cost {3} more to cast."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.AnyCaster(GameObjectFilter.Sorcery),
+            modification = CostModification.IncreaseGeneric(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "105"
+        artist = "DiTerlizzi"
+        flavorText = "Any pirate would prefer Rishada's swift and cruel justice to Saprazzo's patient punishments."
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bbe63220-992b-459c-81ca-d4e2de273ce1.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/StingingBarrier.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/StingingBarrier.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stinging Barrier
+ * {2}{U}{U}
+ * Creature — Wall
+ * 0 / 4
+ *
+ * "This creature deals" is the ability's own source, which is the [Effects.DealDamage]
+ * default — no `damageSource` rider.
+ */
+val StingingBarrier = card("Stinging Barrier") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Wall"
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "{U}, {T}: This creature deals 1 damage to any target."
+    power = 0
+    toughness = 4
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap)
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "107"
+        artist = "Pat Lewis"
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/ca7f7cd5-4e91-474a-9f60-a66f3f462b1c.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/StrongarmThug.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/StrongarmThug.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Strongarm Thug
+ * {2}{B}
+ * Creature — Human Mercenary
+ * 1 / 1
+ *
+ * "Target Mercenary card" is the bare tribal noun, so the filter is permanent + subtype (never
+ * creature-only); the graveyard is on the [TargetFilter], and "your graveyard" is the owner
+ * predicate.
+ */
+val StrongarmThug = card("Strongarm Thug") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Mercenary"
+    oracleText = "When this creature enters, you may return target Mercenary card from your graveyard to your hand."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val t = target(
+            "target",
+            TargetObject(
+                filter = TargetFilter(
+                    baseFilter = GameObjectFilter.Permanent.withSubtype("Mercenary").ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.Move(t, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "165"
+        artist = "Rebecca Guay"
+        flavorText = "\"No, I insist—let *me* carry all that heavy jewelry.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/20aa9108-470c-484d-908a-c31cf6935765.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Sustenance.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Sustenance.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Sustenance
+ * {1}{G}
+ * Enchantment
+ * {1}, Sacrifice a land: Target creature gets +1/+1 until end of turn.
+ */
+val Sustenance = card("Sustenance") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "{1}, Sacrifice a land: Target creature gets +1/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Sacrifice(GameObjectFilter.Land))
+        val creature = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(1, 1, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "278"
+        artist = "Qiao Dafu"
+        flavorText = "Like the dryads, the forest itself willingly gives up some of its life for the sake of the future."
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5a61db44-80dc-4058-9c9d-65cd18e63fd4.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ThermalGlider.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ThermalGlider.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Thermal Glider
+ * {2}{W}
+ * Creature — Human Rebel
+ * 2 / 1
+ */
+val ThermalGlider = card("Thermal Glider") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Rebel"
+    oracleText = "Flying, protection from red"
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.RED)))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "53"
+        artist = "Mark Zug"
+        flavorText = "\"The Mercadians are too busy looking down on us to see us coming.\"\n" +
+            "—Cho-Arrim rebel"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd909c26-930d-4af0-b19a-c899847338b4.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ThrashingWumpus.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ThrashingWumpus.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Thrashing Wumpus
+ * {3}{B}{B}
+ * Creature — Beast
+ * 3 / 3
+ * {B}: This creature deals 1 damage to each creature and each player.
+ *
+ * "Each creature and each player" is two iterations, not one: a group pass over the creatures
+ * (`EffectTarget.Self` = the current iteration entity) and a player pass where each iteration
+ * rebinds the controller (`EffectTarget.Controller`). Same idiom as Inferno.
+ */
+val ThrashingWumpus = card("Thrashing Wumpus") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Beast"
+    oracleText = "{B}: This creature deals 1 damage to each creature and each player."
+    power = 3
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature),
+                Effects.DealDamage(1, EffectTarget.Self)
+            ),
+            Effects.ForEachPlayer(
+                Player.Each,
+                listOf(Effects.DealDamage(1, EffectTarget.Controller))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "166"
+        artist = "Jeff Miracola"
+        flavorText = "Young wumpuses are malevolent and vicious—but they grow out of it."
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/86bc07c6-2ba7-41f8-90ab-f9bbac86dd08.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/TigerClaws.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/TigerClaws.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Tiger Claws
+ * {2}{G}
+ * Enchantment — Aura
+ *
+ * Flash
+ * Enchant creature
+ * Enchanted creature gets +1/+1 and has trample.
+ *
+ * The green member of Mercadian Masques' flash-Aura cycle. Same two-static shape as
+ * [FlamingSword]: [ModifyStats] for the pump, [GrantKeyword] for the evasion word, both scoped
+ * by default to the attached creature.
+ */
+val TigerClaws = card("Tiger Claws") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\n" +
+        "Enchant creature\n" +
+        "Enchanted creature gets +1/+1 and has trample."
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "279"
+        artist = "Adam Rex"
+        flavorText = "Cho-Arrim martial artists emulate the beasts of their home."
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/0146a689-4817-4849-a90d-4cc64566960d.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/TonicPeddler.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/TonicPeddler.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tonic Peddler
+ * {1}{W}
+ * Creature — Human Spellshaper
+ * 1 / 1
+ */
+val TonicPeddler = card("Tonic Peddler") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Spellshaper"
+    oracleText = "{W}, {T}, Discard a card: Target player gains 3 life."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap, Costs.DiscardCard)
+        val t = target("target", Targets.Player)
+        effect = Effects.GainLife(3, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "54"
+        artist = "Adam Rex"
+        flavorText = "\"The price is written at the bottom of the cup.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/334bbd9d-3549-4352-9635-d772aab28503.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ToothOfRamos.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ToothOfRamos.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tooth of Ramos
+ * {3}
+ * Artifact
+ *
+ * {T}: Add {W}.
+ * Sacrifice this artifact: Add {W}.
+ *
+ * One of the five "of Ramos" rocks, identical but for the colour: a tap-for-one ability and a
+ * sacrifice-for-one ability, both mana abilities (CR 605.1a), so neither uses the stack and both
+ * can be activated while paying a cost. `manaAbility` also settles each ability's timing.
+ */
+val ToothOfRamos = card("Tooth of Ramos") {
+    manaCost = "{3}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {W}.\n" +
+        "Sacrifice this artifact: Add {W}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "313"
+        artist = "David Martin"
+        flavorText = "Ramos smiled, and there was day."
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9a3b999d-8e63-4647-a921-15e169022096.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/TradeRoutes.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/TradeRoutes.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Trade Routes
+ * {1}{U}
+ * Enchantment
+ * {1}: Return target land you control to its owner's hand.
+ * {1}, Discard a land card: Draw a card.
+ *
+ * Two independent activated abilities. The bounce targets a land you already control, so the
+ * "its owner's hand" wording is just the engine's default destination for a zone change to
+ * [com.wingedsheep.sdk.core.Zone.HAND]. The second ability's discard is a typed cost atom
+ * ([Costs.Discard] over [GameObjectFilter.Land]), not an effect.
+ */
+val TradeRoutes = card("Trade Routes") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "{1}: Return target land you control to its owner's hand.\n" +
+        "{1}, Discard a land card: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        val land = target("target", TargetPermanent(filter = TargetFilter.Land.youControl()))
+        effect = Effects.ReturnToHand(land)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Discard(GameObjectFilter.Land))
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "112"
+        artist = "Matt Cavotta"
+        flavorText = "Like the price of goods, the value of the routes was renegotiated daily."
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/eeaba189-b215-4d1c-9135-a86ce5ec955d.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Undertaker.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Undertaker.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Undertaker
+ * {1}{B}
+ * Creature — Human Spellshaper
+ * 1 / 1
+ */
+val Undertaker = card("Undertaker") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Spellshaper"
+    oracleText = "{B}, {T}, Discard a card: Return target creature card from your graveyard to your hand."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}"), Costs.Tap, Costs.DiscardCard)
+        val t = target("target", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.ReturnToHand(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "167"
+        artist = "Jeff Easley"
+        flavorText = "The weight of death is heavy but not immovable."
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f615f531-e8af-4f7b-a4ea-fb962149093f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/WallOfDistortion.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/WallOfDistortion.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Wall of Distortion
+ * {2}{B}{B}
+ * Creature — Wall
+ * 1 / 3
+ *
+ * "Activate only as a sorcery" is a *timing rule*, not an [com.wingedsheep.sdk.scripting.ActivationRestriction]:
+ * `ActivationRestriction` has no sorcery member, and `OnlyDuringYourTurn` would still permit
+ * instant speed on your own turn. `TimingRule.SorcerySpeed` is the one that says main phase,
+ * your turn, empty stack (`rules-engine/.../core/TurnManager.kt`).
+ *
+ * The discard itself is [Patterns.Hand]'s gather → select → move pipeline with the *target
+ * player* as both the hand's owner and the chooser.
+ */
+val WallOfDistortion = card("Wall of Distortion") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Wall"
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "{2}{B}, {T}: Target player discards a card. Activate only as a sorcery."
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}"), Costs.Tap)
+        val t = target("target", Targets.Player)
+        effect = Patterns.Hand.discardCards(1, t)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "171"
+        artist = "Mark Tedin"
+        flavorText = "It reflects only nightmares."
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d2b2d07a-9ea1-430d-b432-ae507f4fe73b.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/WaterfrontBouncer.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/WaterfrontBouncer.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Waterfront Bouncer
+ * {1}{U}
+ * Creature — Merfolk Spellshaper
+ * 1 / 1
+ */
+val WaterfrontBouncer = card("Waterfront Bouncer") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Spellshaper"
+    oracleText = "{U}, {T}, Discard a card: Return target creature to its owner's hand."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap, Costs.DiscardCard)
+        val t = target("target", Targets.Creature)
+        effect = Effects.ReturnToHand(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "114"
+        artist = "Paolo Parente"
+        flavorText = "Closing time comes earlier to some than to others."
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8dbdce9e-94fa-4ed5-9b97-d2026cffe7cb.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/Squall.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/Squall.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Squall
+ * {2}{G}
+ * Sorcery
+ * Squall deals 2 damage to each creature with flying.
+ *
+ * Hurricane without the player half: one [Effects.ForEachInGroup] over the flying creatures,
+ * with `EffectTarget.Self` naming the current iteration entity.
+ */
+val Squall = card("Squall") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Squall deals 2 damage to each creature with flying."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreatures.withKeyword(Keyword.FLYING),
+            Effects.DealDamage(2, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "143"
+        artist = "Carl Critchlow"
+        flavorText = "\"To-night the winds begin to rise . . . The rooks are blown about the skies . . . .\"\n" +
+            "—Alfred, Lord Tennyson, *In Memoriam*"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63c1b2f6-e47f-4f18-a94a-1d08eb009ef3.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/SqueeGoblinNabobReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/SqueeGoblinNabobReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.`10e`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Squee, Goblin Nabob reprint in 10E. Canonical CardDefinition lives in its earliest set.
+ */
+val SqueeGoblinNabobReprint = Printing(
+    oracleId = "0ef760f4-bbec-4735-8d60-fc24d973452a",
+    name = "Squee, Goblin Nabob",
+    setCode = "10E",
+    collectorNumber = "239",
+    scryfallId = "bd92bcec-ddfa-41bf-97e4-983d850fe32e",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/b/d/bd92bcec-ddfa-41bf-97e4-983d850fe32e.jpg",
+    releaseDate = "2007-07-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/SizzleReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/SizzleReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.`8ed`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sizzle reprint in 8ED. Canonical CardDefinition lives in its earliest set.
+ */
+val SizzleReprint = Printing(
+    oracleId = "938cc97f-3908-401e-94cd-32004aff1ef1",
+    name = "Sizzle",
+    setCode = "8ED",
+    collectorNumber = "224",
+    scryfallId = "dfdfe2a9-1323-4f15-b2ce-d8dd404b914d",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/d/f/dfdfe2a9-1323-4f15-b2ce-d8dd404b914d.jpg",
+    releaseDate = "2003-07-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/TradeRoutesReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/TradeRoutesReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.`8ed`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trade Routes reprint in 8ED. Canonical CardDefinition lives in its earliest set.
+ */
+val TradeRoutesReprint = Printing(
+    oracleId = "120fa67e-e5e0-4c23-9a78-d6171d357aee",
+    name = "Trade Routes",
+    setCode = "8ED",
+    collectorNumber = "109",
+    scryfallId = "f5a23417-3419-4edc-a722-b695e676a3ce",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/f/5/f5a23417-3419-4edc-a722-b695e676a3ce.jpg",
+    releaseDate = "2003-07-28",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/BogWitchReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/BogWitchReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bog Witch reprint in ARC. Canonical CardDefinition lives in its earliest set.
+ */
+val BogWitchReprint = Printing(
+    oracleId = "85573cba-07ae-4421-a167-a8569f85c0f7",
+    name = "Bog Witch",
+    setCode = "ARC",
+    collectorNumber = "11",
+    scryfallId = "92662394-c31d-4348-9b9c-0fe619949ea3",
+    artist = "Gao Yan",
+    imageUri = "https://cards.scryfall.io/normal/front/9/2/92662394-c31d-4348-9b9c-0fe619949ea3.jpg",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/HighMarketReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/HighMarketReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * High Market reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val HighMarketReprint = Printing(
+    oracleId = "86fb3749-37d6-48a6-8524-71e996850307",
+    name = "High Market",
+    setCode = "C15",
+    collectorNumber = "289",
+    scryfallId = "d80823f7-565a-4d0d-9fd1-24a8b8efcc24",
+    artist = "Carl Critchlow",
+    imageUri = "https://cards.scryfall.io/normal/front/d/8/d80823f7-565a-4d0d-9fd1-24a8b8efcc24.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/BattleRampartReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/BattleRampartReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Battle Rampart reprint in ROE. Canonical CardDefinition lives in its earliest set.
+ */
+val BattleRampartReprint = Printing(
+    oracleId = "ec187304-4c05-44da-8ad5-7c56f6b05212",
+    name = "Battle Rampart",
+    setCode = "ROE",
+    collectorNumber = "135",
+    scryfallId = "223ec005-e089-4dd4-85dc-2998bff56b75",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/2/2/223ec005-e089-4dd4-85dc-2998bff56b75.jpg",
+    releaseDate = "2010-04-23",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BattleSquadronReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BattleSquadronReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Battle Squadron reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val BattleSquadronReprint = Printing(
+    oracleId = "5783e71e-2497-4241-9d1a-8bced4745b1d",
+    name = "Battle Squadron",
+    setCode = "J22",
+    collectorNumber = "497",
+    scryfallId = "9ca05c60-edef-4107-bd86-31b7d4a38398",
+    artist = "Mark Tedin",
+    imageUri = "https://cards.scryfall.io/normal/front/9/c/9ca05c60-edef-4107-bd86-31b7d4a38398.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GhoulSFeastReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GhoulSFeastReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ghoul's Feast reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val GhoulSFeastReprint = Printing(
+    oracleId = "042e0533-faf4-475e-be7b-438d23c6e605",
+    name = "Ghoul's Feast",
+    setCode = "J22",
+    collectorNumber = "120",
+    scryfallId = "be82e102-b62d-4590-85d4-dd9b5811510d",
+    artist = "Ovidio Cartagena",
+    imageUri = "https://cards.scryfall.io/normal/front/b/e/be82e102-b62d-4590-85d4-dd9b5811510d.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/ALL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ALL.json
@@ -1,3 +1,27 @@
+// Deadly Insect
+{
+    "name": "Deadly Insect",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Shroud (This creature can't be the target of spells or abilities.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 1
+    },
+    "keywords": [
+        "SHROUD"
+    ],
+    "metadata": {
+        "collectorNumber": "86a",
+        "artist": "Scott Kirschner",
+        "flavorText": "\"Beautiful, indeed—but one sting could fell a Giant in a heartbeat.\"\n—Taaveti of Kelsinko, Elvish Hunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/add1b999-5c3f-4187-adac-ed1037406b3f.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Elvish Ranger
 {
     "name": "Elvish Ranger",

--- a/mtg-sets/src/test/resources/snapshots/cards/MMQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MMQ.json
@@ -1,3 +1,119 @@
+// Aerial Caravan
+{
+    "name": "Aerial Caravan",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Flying\n{1}{U}{U}: Exile the top card of your library. Until end of turn, you may play that card. (Reveal the card as you exile it.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "impulseExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "impulseExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "impulseExiled"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "rarity": "RARE",
+        "artist": "DiTerlizzi",
+        "flavorText": "Successful delivery is *not* guaranteed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/adac91af-5165-4779-99f7-e75c83fa5d5d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Alabaster Wall
+{
+    "name": "Alabaster Wall",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)\n{T}: Prevent the next 1 damage that would be dealt to any target this turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "artist": "Randy Gallegos",
+        "flavorText": "Its mortar is mixed with waters straight from the Fountain of Cho.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9cf393a3-831e-4d3a-8404-ee83f60970aa.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Arms Dealer
 {
     "name": "Arms Dealer",
@@ -203,6 +319,1074 @@
     ]
 }
 
+// Balloon Peddler
+{
+    "name": "Balloon Peddler",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Spellshaper",
+    "oracleText": "{U}, {T}, Discard a card: Target creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "artist": "Paolo Parente",
+        "flavorText": "The market festival turned out to be the high point of Jaffy's visit.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c34963e6-850e-4ce4-b04f-5e623ce5b73f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Battle Rampart
+{
+    "name": "Battle Rampart",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender\n{T}: Target creature gains haste until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "artist": "Ron Spencer",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f27f6658-0f00-4934-8d12-cd0dda3958c9.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Battle Squadron
+{
+    "name": "Battle Squadron",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Goblin",
+    "oracleText": "Flying\nBattle Squadron's power and toughness are each equal to the number of creatures you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature"
+            }
+        }
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "RARE",
+        "artist": "Mark Tedin",
+        "flavorText": "The goblins made an unruly pile with military precision.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/37d55504-ee04-4a5a-a952-9ec5dc2db413.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Blaster Mage
+{
+    "name": "Blaster Mage",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Spellshaper",
+    "oracleText": "{R}, {T}, Discard a card: Destroy target Wall.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent Wall"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "175",
+        "artist": "George Pratt",
+        "flavorText": "\"Don't get up. I'll show myself out.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/0/801b0fd1-bbb2-47c0-a4c3-4129a67473b9.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Blockade Runner
+{
+    "name": "Blockade Runner",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Merfolk",
+    "oracleText": "{U}: This creature can't be blocked this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "Carl Critchlow",
+        "flavorText": "\"I need to get back to Mercadia City,\" said Sisay. \"We can get you there,\" the vizier answered. \"Easily.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/59e483df-b58a-401e-85bc-0afda4bf7cac.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Boa Constrictor
+{
+    "name": "Boa Constrictor",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Snake",
+    "oracleText": "{T}: This creature gets +3/+3 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "rarity": "UNCOMMON",
+        "artist": "Carl Critchlow",
+        "flavorText": "Its eyes are bigger than its stomach, but its mouth is larger still.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7369cbf-6986-4a39-b07c-a283b40aee40.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Bog Smugglers
+{
+    "name": "Bog Smugglers",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Creature — Human Mercenary",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "117",
+        "artist": "Mike Ploog",
+        "flavorText": "They slide over the bog like oil across glass.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2103a44-87e5-40cd-a0de-cd19456a8366.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Bog Witch
+{
+    "name": "Bog Witch",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Spellshaper",
+    "oracleText": "{B}, {T}, Discard a card: Add {B}{B}{B}.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Gao Yan",
+        "flavorText": "The world is the body. The mana is the blood. The witch is the surgeon.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6a926f9e-ee63-4b6e-8e5b-0650b74344a5.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Buoyancy
+{
+    "name": "Buoyancy",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash\nEnchant creature\nEnchanted creature has flying.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "artist": "Jeff Miracola",
+        "flavorText": "Saprazzan merfolk become legged on land, but some find it quicker to bring the water with them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b208dad2-a412-45fd-b19a-d370426ef5b8.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Cateran Brute
+{
+    "name": "Cateran Brute",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Horror Mercenary",
+    "oracleText": "{2}, {T}: Search your library for a Mercenary permanent card with mana value 2 or less, put it onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "permanent Mercenary mv<=2"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "artist": "Edward P. Beard, Jr.",
+        "flavorText": "The Cateran guild prefers to call them \"public relations.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73b6ce76-0ed0-4994-ae2c-d8e51ae09920.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Cateran Enforcer
+{
+    "name": "Cateran Enforcer",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Horror Mercenary",
+    "oracleText": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\n{4}, {T}: Search your library for a Mercenary permanent card with mana value 4 or less, put it onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FEAR"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "permanent Mercenary mv<=4"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "UNCOMMON",
+        "artist": "Mike Ploog",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e9b6da8-39da-4fce-89cf-ea972f981331.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Cateran Kidnappers
+{
+    "name": "Cateran Kidnappers",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Human Mercenary",
+    "oracleText": "{3}, {T}: Search your library for a Mercenary permanent card with mana value 3 or less, put it onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "permanent Mercenary mv<=3"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "rarity": "UNCOMMON",
+        "artist": "Carl Critchlow",
+        "flavorText": "Recruits aren't always volunteers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/3768bdc1-4055-423a-a1cc-69b4c620e3e6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Cateran Overlord
+{
+    "name": "Cateran Overlord",
+    "manaCost": "{4}{B}{B}{B}",
+    "typeLine": "Creature — Horror Mercenary",
+    "oracleText": "Sacrifice a creature: Regenerate this creature.\n{6}, {T}: Search your library for a Mercenary permanent card with mana value 6 or less, put it onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "permanent Mercenary mv<=6"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "rarity": "RARE",
+        "artist": "Michael Sutfin",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/8/e8a1ffcb-40a7-423f-b28a-b5b4c1c9ffd0.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Cateran Persuader
+{
+    "name": "Cateran Persuader",
+    "manaCost": "{B}{B}",
+    "typeLine": "Creature — Human Mercenary",
+    "oracleText": "{1}, {T}: Search your library for a Mercenary permanent card with mana value 1 or less, put it onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "permanent Mercenary mv<=1"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "artist": "Carl Critchlow",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a98bdbf1-32a6-4d9b-8e57-5d3aca6b05bc.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Cateran Slaver
+{
+    "name": "Cateran Slaver",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Creature — Horror Mercenary",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\n{5}, {T}: Search your library for a Mercenary permanent card with mana value 5 or less, put it onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "permanent Mercenary mv<=5"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "RARE",
+        "artist": "Carl Critchlow",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d293c51-714c-45b8-bfa4-fe35e8f3fbc1.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Cave Sense
+{
+    "name": "Cave Sense",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +1/+1 and has mountainwalk. (It can't be blocked as long as defending player controls a Mountain.)",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "MOUNTAINWALK"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "artist": "Mark Romanoski",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d718421-c742-489c-a243-3adb19f6716a.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Cavern Crawler
+{
+    "name": "Cavern Crawler",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Mountainwalk (This creature can't be blocked as long as defending player controls a Mountain.)\n{R}: This creature gets +1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "keywords": [
+        "MOUNTAINWALK"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "181",
+        "artist": "Pete Venters",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd0a8af9-2e86-4639-a6c9-209f115e95f8.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Chambered Nautilus
+{
+    "name": "Chambered Nautilus",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Nautilus Beast",
+    "oracleText": "Whenever this creature becomes blocked, you may draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "64",
+        "rarity": "UNCOMMON",
+        "artist": "John Matson",
+        "flavorText": "What's merely a home for the nautilus can become exquisite jewelry in the hands of Saprazzan artisans.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/860c613d-d031-4c2a-922b-39f4eec04e18.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Cho-Arrim Bruiser
+{
+    "name": "Cho-Arrim Bruiser",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Ogre Rebel",
+    "oracleText": "Whenever this creature attacks, you may tap up to two target creatures.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ForEach",
+                        "space": "IterationSpace.Targets",
+                        "body": {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "RARE",
+        "artist": "Paolo Parente",
+        "flavorText": "He doesn't know why the Cho-Arrim fight the Mercadians, but he's happy to bash heads for them anyway.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/26e98f06-ad8d-4a93-8ae6-3da42b63b5b5.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Cinder Elemental
 {
     "name": "Cinder Elemental",
@@ -252,6 +1436,51 @@
         "artist": "Greg Staples",
         "flavorText": "Their rage can grow to such proportions that they explode in a cloud of fire.",
         "imageUri": "https://cards.scryfall.io/normal/front/8/0/80b39056-2ee8-4cfd-acbd-ba99f74e788d.jpg?1783945942"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Close Quarters
+{
+    "name": "Close Quarters",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a creature you control becomes blocked, this enchantment deals 1 damage to any target.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BecomesBlockedEvent",
+                    "filter": "creature ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "rarity": "UNCOMMON",
+        "artist": "Ron Spencer",
+        "flavorText": "The Mercadians' ineptitude in close combat sometimes accidentally pays off.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b9131c7-4e46-4c01-80b3-a6b055439346.jpg"
     },
     "colorIdentityOverride": [
         "RED"
@@ -326,6 +1555,61 @@
     ]
 }
 
+// Crenellated Wall
+{
+    "name": "Crenellated Wall",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)\n{T}: Target creature gets +0/+4 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "290",
+        "rarity": "UNCOMMON",
+        "artist": "Arnie Swekel",
+        "flavorText": "Mercadian soldiers excel at finding things to stand behind.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d85ad08d-1120-411a-8bbe-ac93a56476bd.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Crossbow Infantry
 {
     "name": "Crossbow Infantry",
@@ -388,6 +1672,216 @@
     ]
 }
 
+// Customs Depot
+{
+    "name": "Customs Depot",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you cast a creature spell, you may pay {1}. If you do, draw a card, then discard a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "rarity": "UNCOMMON",
+        "artist": "Scott M. Fischer",
+        "flavorText": "A bribe is always faster than filling out paperwork.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/067d8c46-c334-4b00-af06-2e28b6086c58.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Dawnstrider
+{
+    "name": "Dawnstrider",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Dryad Spellshaper",
+    "oracleText": "{G}, {T}, Discard a card: Prevent all combat damage that would be dealt this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "scope": "CombatOnly"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "RARE",
+        "artist": "rk post",
+        "flavorText": "Morning's mists can hide many things.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d193a35-8950-4a77-ace3-c4d4085727f4.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Deepwood Drummer
+{
+    "name": "Deepwood Drummer",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Spellshaper",
+    "oracleText": "{G}, {T}, Discard a card: Target creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "239",
+        "artist": "Ron Spears",
+        "flavorText": "His drums echo Deepwood's heartbeat.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/acbed0f5-2ac0-48d8-b5ab-b4cd7176fde2.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Deepwood Ghoul
 {
     "name": "Deepwood Ghoul",
@@ -427,6 +1921,442 @@
     ]
 }
 
+// Deepwood Tantiv
+{
+    "name": "Deepwood Tantiv",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Whenever this creature becomes blocked, you gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "rarity": "UNCOMMON",
+        "artist": "Joel Biske",
+        "flavorText": "A single tantiv is just as dangerous as a herd.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bfa2028e-4e73-4ff2-a9e2-9ac347d67893.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Deepwood Wolverine
+{
+    "name": "Deepwood Wolverine",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Wolverine",
+    "oracleText": "Whenever this creature becomes blocked, it gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "242",
+        "artist": "Ray Lago",
+        "flavorText": "The jhovalls are depleting its food sources, the Mercadians are eroding its home, and you're wondering why it's angry?",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db9a9a76-741a-4ba3-bd4b-0eb87d678253.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Devout Witness
+{
+    "name": "Devout Witness",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Spellshaper",
+    "oracleText": "{1}{W}, {T}, Discard a card: Destroy target artifact or enchantment.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact|enchantment"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "artist": "Don Hazeltine",
+        "flavorText": "The Cho-Arrim fought Mercadia's decadence with more than just swords.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48ca7aeb-09db-4409-9ba2-c5c5500ad72f.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Diplomatic Immunity
+{
+    "name": "Diplomatic Immunity",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nShroud (A permanent with shroud can't be the target of spells or abilities.)\nEnchanted creature has shroud.",
+    "keywords": [
+        "SHROUD"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "SHROUD"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "artist": "Terese Nielsen",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb1e610e-a4a2-460b-8e4c-13674badbce3.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Drake Hatchling
+{
+    "name": "Drake Hatchling",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying\n{U}: This creature gets +1/+0 until end of turn. Activate only once each turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "restrictions": [
+                    "OncePerTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "artist": "Bradley Williams",
+        "flavorText": "There is beauty in the space between learning to fly and taking it for granted.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/64ee32f9-6120-4f15-a692-89a4cd8167c6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Dust Bowl
+{
+    "name": "Dust Bowl",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{3}, {T}, Sacrifice a land: Destroy target nonbasic land.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "land"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsLand",
+                                    {
+                                        "type": "Not",
+                                        "predicate": "IsBasicLand"
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "316",
+        "rarity": "RARE",
+        "artist": "Ben Thompson",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75b03c30-c2b8-4207-b675-26c59c40a7e5.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Eye of Ramos
+{
+    "name": "Eye of Ramos",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {U}.\nSacrifice this artifact: Add {U}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "294",
+        "rarity": "RARE",
+        "artist": "David Martin",
+        "flavorText": "Ramos wept, and there were seas.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/78d22400-39f6-444d-b508-783a7df7e945.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Flaming Sword
+{
+    "name": "Flaming Sword",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash\nEnchant creature\nEnchanted creature gets +1/+0 and has first strike.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "190",
+        "artist": "Randy Gallegos",
+        "flavorText": "\"It's not Talruum crystal, but I must admit—it gets the job done.\"\n—Tahngarth",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/7/17ecd9ff-8c30-4e17-8cff-dd40d653c4af.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Forced March
+{
+    "name": "Forced March",
+    "manaCost": "{X}{B}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy all creatures with mana value X or less.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                "ManaValueAtMostX"
+                            ]
+                        }
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "RARE",
+        "artist": "Greg Hildebrandt & Tim Hildebrandt",
+        "flavorText": "The Caterans call it a screening process. The dead are in no condition to argue.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/36eae0e1-7100-449d-a259-7abfcd429117.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Fresh Volunteers
 {
     "name": "Fresh Volunteers",
@@ -444,6 +2374,177 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Furious Assault
+{
+    "name": "Furious Assault",
+    "manaCost": "{2}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you cast a creature spell, this enchantment deals 1 damage to target player or planeswalker.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayerOrPlaneswalker",
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "191",
+        "artist": "Greg Staples",
+        "flavorText": "\"Does it burn, Saprazzan? Do you wish you had never raised arms against us?\"\n—Kyren overseer",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/27a07fae-0f34-45e7-b22d-97eea9031022.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Gerrard's Irregulars
+{
+    "name": "Gerrard's Irregulars",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Trample, haste",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE",
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "192",
+        "artist": "Eric Peterson",
+        "flavorText": "Had Gerrard realized he'd end up fighting against them, he might not have trained them so well.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8a88f507-3d78-4f7f-a91f-8489ad9250f2.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ghoul's Feast
+{
+    "name": "Ghoul's Feast",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Count",
+                "player": "You",
+                "zone": "Graveyard",
+                "filter": "creature"
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 0
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "rarity": "UNCOMMON",
+        "artist": "Alan Pollack",
+        "flavorText": "Mercadians not wealthy enough to buy a tomb are thrown into a bog called \"the Ghoul's Larder.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6a0054c1-6510-41dd-8695-9bf50296b615.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Glowing Anemone
+{
+    "name": "Glowing Anemone",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Jellyfish Beast",
+    "oracleText": "When this creature enters, you may return target land to its owner's hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "land"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "rarity": "UNCOMMON",
+        "artist": "Pete Venters",
+        "flavorText": "Beautiful to behold, terrible to be held.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/708593e6-787b-4f76-a86c-1d52857493ea.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -500,6 +2601,268 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Hammer Mage
+{
+    "name": "Hammer Mage",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Spellshaper",
+    "oracleText": "{X}{R}, {T}, Discard a card: Destroy all artifacts with mana value X or less.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}{R}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsArtifact",
+                                        "ManaValueAtMostX"
+                                    ]
+                                }
+                            },
+                            "storeAs": "destroyAll_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "destroyAll_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "rarity": "UNCOMMON",
+        "artist": "Rebecca Guay",
+        "flavorText": "When he's holding the hammers, everything looks like a nail.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b959d7ad-a78e-439f-9225-4dbb89f490d7.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Heart of Ramos
+{
+    "name": "Heart of Ramos",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {R}.\nSacrifice this artifact: Add {R}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "296",
+        "rarity": "RARE",
+        "artist": "David Martin",
+        "flavorText": "Ramos bled, and there was fire.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a0046226-7563-4345-aa4b-a2c732c2780a.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Henge Guardian
+{
+    "name": "Henge Guardian",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Dragon Wurm",
+    "oracleText": "{2}: This creature gains trample until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "297",
+        "rarity": "UNCOMMON",
+        "artist": "Chippy",
+        "flavorText": "Like so many Thran relics, the wurm engine kept operating long after its creators were gone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/028e5e18-b639-4461-87e4-5306371440b5.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Henge of Ramos
+{
+    "name": "Henge of Ramos",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{2}, {T}: Add one mana of any color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "318",
+        "rarity": "UNCOMMON",
+        "artist": "Edward P. Beard, Jr.",
+        "flavorText": "It is the hub. We are the wheel.\n—Dryad saying",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/0582b42f-5ae5-4be2-ba2d-ed62b3cb20c5.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// High Market
+{
+    "name": "High Market",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{T}, Sacrifice a creature: You gain 1 life.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "320",
+        "rarity": "RARE",
+        "artist": "Carl Critchlow",
+        "flavorText": "If it can't be had here, it can't be had on any world.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4c58683-65a6-4df9-8952-458e397b1374.jpg"
+    },
+    "colorIdentityOverride": []
 }
 
 // Highway Robber
@@ -561,6 +2924,48 @@
     ]
 }
 
+// Horn of Ramos
+{
+    "name": "Horn of Ramos",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {G}.\nSacrifice this artifact: Add {G}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "299",
+        "rarity": "RARE",
+        "artist": "David Martin",
+        "flavorText": "Ramos touched, and there was life.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6b17f541-8e9d-43b0-b688-e3f2e7fa55c8.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Horned Troll
 {
     "name": "Horned Troll",
@@ -598,6 +3003,686 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Intimidation
+{
+    "name": "Intimidation",
+    "manaCost": "{2}{B}{B}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Creatures you control have fear. (They can't be blocked except by artifact creatures and/or black creatures.)",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FEAR",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "rarity": "UNCOMMON",
+        "artist": "Terese Nielsen",
+        "flavorText": "\"If they move, kill them. In fact, kill one now to make sure the other understands.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b9e1724-91cf-422e-909b-ddb69a6f9f76.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Iron Lance
+{
+    "name": "Iron Lance",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{3}, {T}: Target creature gains first strike until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "300",
+        "rarity": "UNCOMMON",
+        "artist": "Scott M. Fischer",
+        "flavorText": "\"The only way to get Mercadians to fight on the front lines is to give them really long weapons.\"\n—Gerrard",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/41f7d212-faf2-4a6f-a338-d9e5014b56d5.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Jhovall Queen
+{
+    "name": "Jhovall Queen",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Creature — Cat Rebel",
+    "oracleText": "Vigilance",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 7
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "25",
+        "rarity": "RARE",
+        "artist": "Michael Sutfin",
+        "flavorText": "War-trained jhovalls eat twice their weight in war-trained soldiers daily.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b8eb55cc-ddde-4f15-9262-b9aee28059d3.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Jhovall Rider
+{
+    "name": "Jhovall Rider",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Human Rebel",
+    "oracleText": "Trample",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "26",
+        "rarity": "UNCOMMON",
+        "artist": "Scott M. Fischer",
+        "flavorText": "Don't be fooled by the riders' fluid grace—it takes years of practice to ride these beasts.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e1f7c51-0011-4ea5-b123-3c26293f5dab.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Kris Mage
+{
+    "name": "Kris Mage",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Human Spellshaper",
+    "oracleText": "{R}, {T}, Discard a card: This creature deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "artist": "Matthew D. Wilson",
+        "flavorText": "Her blade draws blood without ever touching its target.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/4389fbcd-182a-4cac-b14f-aa971948cf8e.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Kyren Glider
+{
+    "name": "Kyren Glider",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin",
+    "oracleText": "Flying\nThis creature can't block.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            "CantBlock"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "196",
+        "artist": "Daren Bader",
+        "flavorText": "Mercadia's Kyren goblins are the opposite of Dominarian goblins: they're smart and cowardly.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0bc55e01-342e-4856-937e-14561b8d165b.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Kyren Negotiations
+{
+    "name": "Kyren Negotiations",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Tap an untapped creature you control: This enchantment deals 1 damage to target player or planeswalker.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayerOrPlaneswalker",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "rarity": "UNCOMMON",
+        "artist": "Scott Hampton",
+        "flavorText": "Kyren goblins always speak in questions and never allow wrong answers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c263a17-bbc2-433e-93f8-72e57b818322.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Lightning Hounds
+{
+    "name": "Lightning Hounds",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Dog",
+    "oracleText": "First strike",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "metadata": {
+        "collectorNumber": "201",
+        "artist": "Andrew Robinson",
+        "flavorText": "Quick enough to avoid jhovalls when alone and fierce enough to attack them in packs, the hounds were as at home in the mountains as the Mercadians were atop theirs.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/38c82a1d-5db1-4090-b446-cc5bc6dc811d.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Lumbering Satyr
+{
+    "name": "Lumbering Satyr",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Satyr Beast",
+    "oracleText": "All creatures have forestwalk. (They can't be blocked as long as defending player controls a Forest.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FORESTWALK",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "257",
+        "rarity": "UNCOMMON",
+        "artist": "Alan Pollack",
+        "flavorText": "The satyr carves the path that all of Rushwood follows.\n—Cho-Arrim saying",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d897088-0667-4864-91c3-5f0ac7f9b220.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Maggot Therapy
+{
+    "name": "Maggot Therapy",
+    "manaCost": "{2}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash\nEnchant creature\nEnchanted creature gets +2/-2.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": -2
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "artist": "Jeff Easley",
+        "flavorText": "\"If this is the cure, I'd hate to see the disease.\"\n—Orim",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6ab963aa-2304-4ee6-a8c7-c485c5133b40.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Misshapen Fiend
+{
+    "name": "Misshapen Fiend",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Horror Mercenary",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "147",
+        "artist": "Adam Rex",
+        "flavorText": "You'd scarcely believe they could fly until they drop out of the sky onto you.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a43cf59e-7583-4651-968a-2a7201c69b6b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Molting Harpy
+{
+    "name": "Molting Harpy",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Harpy Mercenary",
+    "oracleText": "Flying\nAt the beginning of your upkeep, sacrifice this creature unless you pay {2}.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{2}"
+                        }
+                    },
+                    "suffer": "SacrificeSelf"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "rarity": "UNCOMMON",
+        "artist": "Jeff Laubenstein",
+        "flavorText": "Shed harpy feathers leave painful wounds—which explains the harpies' mood.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/ddfe33fb-71d5-4552-bcd3-f07e4e3847e1.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Nightwind Glider
+{
+    "name": "Nightwind Glider",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Rebel",
+    "oracleText": "Flying, protection from black",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "BLACK"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "31",
+        "artist": "Randy Gallegos",
+        "flavorText": "Once you learn to float on the shadows, you'll never fear them again.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/0968401d-522f-4def-92a1-d504471ac54e.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Notorious Assassin
+{
+    "name": "Notorious Assassin",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Human Spellshaper Assassin",
+    "oracleText": "{2}{B}, {T}, Discard a card: Destroy target nonblack creature. It can't be regenerated.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CantBeRegenerated",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            },
+                            "destination": "Graveyard",
+                            "byDestruction": true
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotColor",
+                                        "color": "BLACK"
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "rarity": "RARE",
+        "artist": "Heather Hudson",
+        "flavorText": "He wears his infamy like a fine silk shirt.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/239e48d8-e2ba-4e25-88ef-301420c796b4.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Panacea
+{
+    "name": "Panacea",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "{X}{X}, {T}: Prevent the next X damage that would be dealt to any target this turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}{X}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "amount": "XValue"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "308",
+        "rarity": "UNCOMMON",
+        "artist": "Donato Giancola",
+        "flavorText": "A drop numbs the tongue. A sip sends the heart racing. A draught reforges the body.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/89414770-2a19-4baf-9b18-76104b7b0b9a.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Power Matrix
+{
+    "name": "Power Matrix",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Target creature gets +1/+1 and gains flying, first strike, and trample until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FLYING",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FIRST_STRIKE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "TRAMPLE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "309",
+        "rarity": "RARE",
+        "artist": "Alan Pollack",
+        "flavorText": "As he repaired the ship's planeswalking engine, Karn saw for the first time how he could catalyze the *Weatherlight*'s evolution.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a578599c-7d90-4881-b59a-9cf64b90d917.jpg"
+    },
+    "colorIdentityOverride": []
 }
 
 // Primeval Shambler
@@ -645,6 +3730,480 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Ramosian Captain
+{
+    "name": "Ramosian Captain",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Creature — Human Rebel",
+    "oracleText": "First strike\n{5}, {T}: Search your library for a Rebel permanent card with mana value 4 or less, put it onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "permanent Rebel mv<=4"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "35",
+        "rarity": "UNCOMMON",
+        "artist": "Matthew D. Wilson",
+        "flavorText": "The Cho-Arrim believe in leading by example.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0e9d2e2a-c608-4787-bbd9-e1871f681b58.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Ramosian Commander
+{
+    "name": "Ramosian Commander",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Human Rebel",
+    "oracleText": "{6}, {T}: Search your library for a Rebel permanent card with mana value 5 or less, put it onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "permanent Rebel mv<=5"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "UNCOMMON",
+        "artist": "Scott Hampton",
+        "flavorText": "\"Cho-Manno guides your spirit. I guide your sword.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/867f5d82-71c2-455f-ab16-5a32bba46986.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Ramosian Lieutenant
+{
+    "name": "Ramosian Lieutenant",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Rebel",
+    "oracleText": "{4}, {T}: Search your library for a Rebel permanent card with mana value 3 or less, put it onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "permanent Rebel mv<=3"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "artist": "Alan Pollack",
+        "flavorText": "\"Give me your hand and I will give you victory.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/debe840a-ebc9-43c4-9bf7-7eb292b65bf9.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Ramosian Sergeant
+{
+    "name": "Ramosian Sergeant",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Rebel",
+    "oracleText": "{3}, {T}: Search your library for a Rebel permanent card with mana value 2 or less, put it onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "permanent Rebel mv<=2"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "Don Hazeltine",
+        "flavorText": "Her commands are part rallying cry, part sermon, and wholly undeniable.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/ef2b036d-5721-4a6e-bf43-69148b90da10.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Ramosian Sky Marshal
+{
+    "name": "Ramosian Sky Marshal",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Human Rebel",
+    "oracleText": "Flying\n{7}, {T}: Search your library for a Rebel permanent card with mana value 6 or less, put it onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{7}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "permanent Rebel mv<=6"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "rarity": "RARE",
+        "artist": "Matt Cavotta",
+        "flavorText": "The Cho-Arrim fell from the sky onto Mercadia City like a vengeful rain.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/16638976-8a78-4233-8ebc-42ea9bb49e0a.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Rampart Crawler
+{
+    "name": "Rampart Crawler",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Lizard Mercenary",
+    "oracleText": "This creature can't be blocked by Walls.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsPermanent",
+                        {
+                            "type": "HasSubtype",
+                            "subtype": "Wall"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "156",
+        "artist": "Pete Venters",
+        "flavorText": "\"Not even the magistrate in his lofty tower is out of our reach.\"\n—Cateran overlord",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8b60f86f-c78a-4dfb-bb18-e9bcf21b26c4.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Revered Elder
+{
+    "name": "Revered Elder",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{1}: Prevent the next 1 damage that would be dealt to this creature this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": "Self",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "43",
+        "artist": "Donato Giancola",
+        "flavorText": "The Cho-Arrim worship life and revere those who've experienced it longest.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0793175-e56b-4ff8-9e22-3a96a698068c.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -726,6 +4285,71 @@
     ]
 }
 
+// Rishadan Port
+{
+    "name": "Rishadan Port",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{1}, {T}: Tap target land.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "324",
+        "rarity": "RARE",
+        "artist": "Jerry Tiritilli",
+        "flavorText": "Rishada is the gateway to free trade—but the key will cost you.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/477a1f53-5cdf-4b45-b584-2e36b31a3fdb.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Rock Badger
 {
     "name": "Rock Badger",
@@ -775,6 +4399,254 @@
     ]
 }
 
+// Rushwood Elemental
+{
+    "name": "Rushwood Elemental",
+    "manaCost": "{G}{G}{G}{G}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Trample\nAt the beginning of your upkeep, you may put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "264",
+        "rarity": "RARE",
+        "artist": "Hannibal King",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/52128694-d9f5-4acb-b684-bb02a4e766b8.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Rushwood Herbalist
+{
+    "name": "Rushwood Herbalist",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Spellshaper",
+    "oracleText": "{G}, {T}, Discard a card: Regenerate target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "265",
+        "artist": "Terese Nielsen",
+        "flavorText": "When generals gather their armies, healers gather their herbs.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9afde98f-a429-4eff-9d06-8582267ac74b.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Sacred Prey
+{
+    "name": "Sacred Prey",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Horse",
+    "oracleText": "Whenever this creature becomes blocked, you gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "268",
+        "artist": "Rebecca Guay",
+        "flavorText": "To see one is a good omen to the Cho-Arrim.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/9/e965d32c-3151-48e8-b256-0b7fa8a8a211.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Saprazzan Heir
+{
+    "name": "Saprazzan Heir",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk",
+    "oracleText": "Whenever this creature becomes blocked, you may draw three cards.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "rarity": "RARE",
+        "artist": "Terese Nielsen",
+        "flavorText": "Within the walls of the floating city, Saprazzan wealth is like Saprazzan water: abundant, free-flowing, and accessible to all.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0e3d913d-2dcf-4747-8169-0c44ec895864.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Seismic Mage
+{
+    "name": "Seismic Mage",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Spellshaper",
+    "oracleText": "{2}{R}, {T}, Discard a card: Destroy target land.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "RARE",
+        "artist": "Pete Venters",
+        "flavorText": "The ground shakes when he walks. His customers shake if they're late with his fee.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/9524432a-3186-4c7b-a780-28bdbe36053f.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Shock Troops
 {
     "name": "Shock Troops",
@@ -821,6 +4693,306 @@
     ]
 }
 
+// Silverglade Elemental
+{
+    "name": "Silverglade Elemental",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "When this creature enters, you may search your library for a Forest card, put that card onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "land Forest"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                }
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "269",
+        "artist": "Chippy",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f222fe90-ac92-4ba9-b060-9b64075bf139.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Sizzle
+{
+    "name": "Sizzle",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Sizzle deals 3 damage to each opponent.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "PlayerRef",
+                "player": "EachOpponent"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "213",
+        "artist": "Brian Snõddy",
+        "flavorText": "Explosions ripped through the ship overhead, and those unfortunate enough to be directly below scrambled to find cover.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f1ca1eee-d97d-48c6-84f1-7d1f972c3ca9.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Skull of Ramos
+{
+    "name": "Skull of Ramos",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {B}.\nSacrifice this artifact: Add {B}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "312",
+        "rarity": "RARE",
+        "artist": "David Martin",
+        "flavorText": "Ramos fell, and there was night.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f071957c-9bea-4d00-9ffd-30f98d57b8d2.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Snorting Gahr
+{
+    "name": "Snorting Gahr",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Rhino Beast",
+    "oracleText": "Whenever this creature becomes blocked, it gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "272",
+        "artist": "Andrew Goldhawk",
+        "flavorText": "There's little advantage to surprising the gahr.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e568503e-a886-4c8b-9d46-8520c2cdda48.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Soothing Balm
+{
+    "name": "Soothing Balm",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target player gains 5 life.",
+    "script": {
+        "spellEffect": {
+            "type": "GainLife",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "artist": "Scott M. Fischer",
+        "flavorText": "Orim taught Ta-Karnst and the other Cho-Arrim healers a far less invasive method of healing.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96b8f4be-9f4d-4373-8141-a03518ecd38a.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Squee, Goblin Nabob
+{
+    "name": "Squee, Goblin Nabob",
+    "manaCost": "{2}{R}",
+    "typeLine": "Legendary Creature — Goblin",
+    "oracleText": "At the beginning of your upkeep, you may return this card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Hand",
+                        "fromZone": "Graveyard"
+                    }
+                },
+                "activeZones": [
+                    "Graveyard"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "RARE",
+        "artist": "David Monette",
+        "flavorText": "\"General?!\" Tahngarth roared. \"General *nuisance*, maybe.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4ba8325a-1203-4125-9111-94d9e2b1f14b.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Squeeze
+{
+    "name": "Squeeze",
+    "manaCost": "{3}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Sorcery spells cost {3} more to cast.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "AnyCaster",
+                    "filter": "sorcery"
+                },
+                "modification": {
+                    "type": "IncreaseGeneric",
+                    "amount": 3
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "rarity": "RARE",
+        "artist": "DiTerlizzi",
+        "flavorText": "Any pirate would prefer Rishada's swift and cruel justice to Saprazzo's patient punishments.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bbe63220-992b-459c-81ca-d4e2de273ce1.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Steadfast Guard
 {
     "name": "Steadfast Guard",
@@ -842,6 +5014,293 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Stinging Barrier
+{
+    "name": "Stinging Barrier",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)\n{U}, {T}: This creature deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "artist": "Pat Lewis",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/ca7f7cd5-4e91-474a-9f60-a66f3f462b1c.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Strongarm Thug
+{
+    "name": "Strongarm Thug",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Mercenary",
+    "oracleText": "When this creature enters, you may return target Mercenary card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent Mercenary own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "UNCOMMON",
+        "artist": "Rebecca Guay",
+        "flavorText": "\"No, I insist—let *me* carry all that heavy jewelry.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/20aa9108-470c-484d-908a-c31cf6935765.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Sustenance
+{
+    "name": "Sustenance",
+    "manaCost": "{1}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "{1}, Sacrifice a land: Target creature gets +1/+1 until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "land"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "278",
+        "rarity": "UNCOMMON",
+        "artist": "Qiao Dafu",
+        "flavorText": "Like the dryads, the forest itself willingly gives up some of its life for the sake of the future.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5a61db44-80dc-4058-9c9d-65cd18e63fd4.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Thermal Glider
+{
+    "name": "Thermal Glider",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Rebel",
+    "oracleText": "Flying, protection from red",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "RED"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "53",
+        "artist": "Mark Zug",
+        "flavorText": "\"The Mercadians are too busy looking down on us to see us coming.\"\n—Cho-Arrim rebel",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd909c26-930d-4af0-b19a-c899847338b4.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Thrashing Wumpus
+{
+    "name": "Thrashing Wumpus",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "{B}: This creature deals 1 damage to each creature and each player.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature"
+                                }
+                            },
+                            "body": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": "Each"
+                            },
+                            "body": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": "Controller"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "166",
+        "rarity": "RARE",
+        "artist": "Jeff Miracola",
+        "flavorText": "Young wumpuses are malevolent and vicious—but they grow out of it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/86bc07c6-2ba7-41f8-90ab-f9bbac86dd08.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -867,6 +5326,291 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Tiger Claws
+{
+    "name": "Tiger Claws",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash\nEnchant creature\nEnchanted creature gets +1/+1 and has trample.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "279",
+        "artist": "Adam Rex",
+        "flavorText": "Cho-Arrim martial artists emulate the beasts of their home.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/0146a689-4817-4849-a90d-4cc64566960d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Tonic Peddler
+{
+    "name": "Tonic Peddler",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Spellshaper",
+    "oracleText": "{W}, {T}, Discard a card: Target player gains 3 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "rarity": "UNCOMMON",
+        "artist": "Adam Rex",
+        "flavorText": "\"The price is written at the bottom of the cup.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/334bbd9d-3549-4352-9635-d772aab28503.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Tooth of Ramos
+{
+    "name": "Tooth of Ramos",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {W}.\nSacrifice this artifact: Add {W}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "313",
+        "rarity": "RARE",
+        "artist": "David Martin",
+        "flavorText": "Ramos smiled, and there was day.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9a3b999d-8e63-4647-a921-15e169022096.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Trade Routes
+{
+    "name": "Trade Routes",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "{1}: Return target land you control to its owner's hand.\n{1}, Discard a land card: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land ctrl:you"
+                        },
+                        "id": "target"
+                    }
+                ]
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomDiscard",
+                                "filter": "land"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "RARE",
+        "artist": "Matt Cavotta",
+        "flavorText": "Like the price of goods, the value of the routes was renegotiated daily.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/eeaba189-b215-4d1c-9135-a86ce5ec955d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Undertaker
+{
+    "name": "Undertaker",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Spellshaper",
+    "oracleText": "{B}, {T}, Discard a card: Return target creature card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "artist": "Jeff Easley",
+        "flavorText": "The weight of death is heavy but not immovable.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f615f531-e8af-4f7b-a4ea-fb962149093f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -905,6 +5649,163 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Wall of Distortion
+{
+    "name": "Wall of Distortion",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)\n{2}{B}, {T}: Target player discards a card. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 1 card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "artist": "Mark Tedin",
+        "flavorText": "It reflects only nightmares.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d2b2d07a-9ea1-430d-b432-ae507f4fe73b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Waterfront Bouncer
+{
+    "name": "Waterfront Bouncer",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk Spellshaper",
+    "oracleText": "{U}, {T}, Discard a card: Return target creature to its owner's hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "artist": "Paolo Parente",
+        "flavorText": "Closing time comes earlier to some than to others.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8dbdce9e-94fa-4ed5-9b97-d2026cffe7cb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/S99.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/S99.json
@@ -139,6 +139,42 @@
     ]
 }
 
+// Squall
+{
+    "name": "Squall",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Squall deals 2 damage to each creature with flying.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature kw:flying"
+                }
+            },
+            "body": {
+                "type": "DealDamage",
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "artist": "Carl Critchlow",
+        "flavorText": "\"To-night the winds begin to rise . . . The rooks are blown about the skies . . . .\"\n—Alfred, Lord Tennyson, *In Memoriam*",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/63c1b2f6-e47f-4f18-a94a-1d08eb009ef3.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Thunder Dragon
 {
     "name": "Thunder Dragon",


### PR DESCRIPTION
Implements every Assay-ready card in Mercadian Masques — the cards Argentum Assay reads whole that
the set had not authored yet.

## The four-way split

| Bucket | Count | Work |
|---|---:|---|
| `original` | 93 | canonical authored in MMQ |
| `elsewhere` | 2 | Deadly Insect → ALL, Squall → S99, each plus a `Printing` row in MMQ |
| `basic` | 5 | `basicLand(...)` vals + the `basicLands` override |
| `row-only` | 0 | — |
| `unscaffolded` | 0 | — |
| **reprint tail** | 8 | `Printing` rows owed in 6 *other* scaffolded sets — invisible to `check-card-printing` until the canonicals existed |

The reprint tail: 8ED (Sizzle, Trade Routes), J22 (Battle Squadron, Ghoul's Feast), 10E (Squee,
Goblin Nabob), ARC (Bog Witch), C15 (High Market), ROE (Battle Rampart).

MMQ printed four art variants of each basic land type (cards 331–350), so the basics file carries
all 20 and `MercadianMasquesSet` drops its `basicLandsFallback = PortalSet` for a real
`basicLands` override.

## Numbers

| Gate | Before | After |
|---|---|---|
| MMQ Assay-ready | 100 | **0** |
| Differential compared | 4022 | 4117 |
| Differential confirmed | 3978 | 4073 |
| Differential divergent | 44 | **44** |

The divergence set is byte-identical to the baseline — no card in this PR introduces a divergence,
and none of the 44 pre-existing ones was masked. `just build` is green, `just check-card-printing`
passes for all 95 canonicals, and the three snapshot goldens moved by exactly +93 / +1 / +1 with
nothing removed.

## How the cards were authored

Every card was written against `oracle-assay compile <name>`'s JSON — the exact `CardDefinition`
Assay's grammar builds — rather than against the printed text, with the Scryfall set payload
supplying metadata. Each of the 95 briefs was then diffed back field-for-field against the written
file, scoped inside the `metadata { }` block: **zero metadata drift**.

A capability pre-flight traced every mechanic in the list to its `rules-engine` consumer *before*
any card was written, because a `Keyword.X` existing is not the engine reading it. All of MMQ's
mechanics came back live: landwalk (`BlockEvasionRules.kt:104`), fear (`:89`), shroud
(`TargetValidator.kt:479`), defender (`AttackRestrictionRules.kt:91`), damage prevention
(`PreventDamageExecutor.kt:41`), regeneration, `CantBeBlockedBy`, `CantBlock`, `OncePerTurn`,
`ModifySpellCost`, `TapPermanents` costs, `manaValueAtMost(X)`, CDA `dynamicStats`, `MayPay` gates,
`triggerZone = Zone.GRAVEYARD`, and `PayOrSufferEffect`.

The ten-card Rebel/Mercenary fetch chain was the one shape worth guarding: the "mana value N or
less" bound belongs on the *filter* via `.manaValueAtMost(N)`, while `searchLibrary`'s second
positional parameter is `count: Int = 1`. A past PR shipped four cards with that swap, so every
call in this PR passes `filter =` / `destination =` by name.

## Findings this sweep surfaced but did not fix

- **`GrantKeyword(Keyword.PROTECTION, …)` is display-only.** The only `rules-engine` reads of
  `Keyword.PROTECTION` are `view/ClientStateTransformer.kt:818` and `:914`, both pure view code —
  there is no combat, targeting, or damage consumer. `usg/cards/AbsoluteGrace.kt:27` ("All creatures
  have protection from black") is therefore mechanically inert as shipped. Granting protection needs
  the static ability `GrantProtection(color, filter)` (`StaticAbilityHandler.kt:823`) instead. No
  card in this PR grants protection — Nightwind Glider and Thermal Glider both have it printed — so
  nothing here is affected, but `AbsoluteGrace` is a live bug.
- **"can't be blocked by Walls" is spelled with the wrong noun in two shipped cards.** Assay's
  grammar builds `CantBeBlockedBy` from `Filters.plural`, so "Walls" is `IsPermanent` +
  `HasSubtype`, and Rampart Crawler was authored that way. `lea/cards/Juggernaut.kt:30` and
  `drk/cards/BogRats.kt` both use `.Creature` — and `Bog Rats [DRK]` is one of the 44 pre-existing
  divergences, which is that bug showing up in the gate.
- **Two errors in the sweep's own capability notes**, caught by the compile JSON rather than by
  review: `GroupFilter.self()` does not exist (the companion has `GroupFilter.source()`, which is
  `CantBlock`'s default), and `CostAtom.TapPermanents` already means "you control" — adding
  `.youControl()` to its filter would have been a divergence. Both are why "the JSON is the
  authority" is the rule.
- **Assay's `compile` output carries the provenance of whatever printing the Oracle bulk held**, not
  the canonical one: eleven of the 95 came back with a non-MMQ `setCode` and matching `imageUri`
  (Battle Squadron `DDT`, High Market `SOC`, Rishadan Port `A25`, Sizzle `8ED`, Trade Routes `9ED`,
  Squall `ME4`, Deadly Insect `MMQ`, and others). Metadata was taken from the set payload throughout,
  so no card is affected, but the field is not a placement claim and should not be read as one.

## Cards left out

None — all 95 Assay-ready cards are implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)