### PR TITLE
Add 100 Assay-ready cards to Portal Three Kingdoms

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/RallyTheTroops.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/RallyTheTroops.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.YouWereAttackedThisStep
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rally the Troops
+ * {W}
+ * Instant
+ * Cast this spell only during the declare attackers step and only if you've been attacked this step.
+ * Untap all creatures you control.
+ *
+ * The Portal "combat trick" timing pair: [com.wingedsheep.sdk.dsl.SpellBuilder.castOnlyDuring] plus
+ * `castOnlyIf(YouWereAttackedThisStep)`. "All creatures you control" is [Effects.ForEachInGroup]
+ * with the untap aimed at [EffectTarget.Self] — the current iteration entity.
+ */
+val RallyTheTroops = card("Rally the Troops") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText =
+        "Cast this spell only during the declare attackers step and only if you've been attacked this step.\n" +
+        "Untap all creatures you control."
+
+    spell {
+        castOnlyDuring(Step.DECLARE_ATTACKERS)
+        castOnlyIf(YouWereAttackedThisStep)
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.Untap(EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "19"
+        artist = "Mark Poole"
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61d92577-c3e2-4129-8974-89eb896cdc2d.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/WarriorsStand.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/WarriorsStand.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.YouWereAttackedThisStep
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Warrior's Stand
+ * {1}{W}
+ * Instant
+ * Cast this spell only during the declare attackers step and only if you've been attacked this step.
+ * Creatures you control get +2/+2 until end of turn.
+ */
+val WarriorsStand = card("Warrior's Stand") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText =
+        "Cast this spell only during the declare attackers step and only if you've been attacked this step.\n" +
+        "Creatures you control get +2/+2 until end of turn."
+
+    spell {
+        castOnlyDuring(Step.DECLARE_ATTACKERS)
+        castOnlyIf(YouWereAttackedThisStep)
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.ModifyStats(2, 2, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "29"
+        artist = "Keith Parkinson"
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2a24f00c-7e2e-4609-b956-ca3d5fb365b2.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/PortalThreeKingdomsSet.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/PortalThreeKingdomsSet.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.ptk
 
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
@@ -21,11 +20,14 @@ object PortalThreeKingdomsSet : MtgSet {
     override val code = "PTK"
     override val displayName = "Portal Three Kingdoms"
     override val releaseDate = "1999-05-01"
-    override val basicLandsFallback = PortalSet
     override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/AlertShuInfantry.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/AlertShuInfantry.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alert Shu Infantry
+ * {2}{W}
+ * Creature — Human Soldier
+ * 2 / 2
+ *
+ * Vigilance
+ */
+val AlertShuInfantry = card("Alert Shu Infantry") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Vigilance"
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "1"
+        artist = "Solomon Au Yeung"
+        flavorText = "Kongming's predecessor helped Liu Bei win the battle of Fancheng by recognizing and defeating Cao Ren's use of the dreaded \"Eight Gold Locks\" formation."
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c94a92a9-060e-42d3-a8d1-49425defc08a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/BarbarianGeneral.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/BarbarianGeneral.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barbarian General
+ * {4}{R}
+ * Creature — Human Barbarian Soldier
+ * 3/2
+ *
+ * Horsemanship (This creature can't be blocked except by creatures with horsemanship.)
+ */
+val BarbarianGeneral = card("Barbarian General") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Barbarian Soldier"
+    power = 3
+    toughness = 2
+    oracleText = "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)"
+
+    keywords(Keyword.HORSEMANSHIP)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "100"
+        artist = "Kuang Sheng"
+        flavorText = "\"Barbarian tribes with their rulers are inferior to Chinese states without them.\"\n—Confucius, *The Analects* (trans. Lau)"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/060da652-03c7-45e3-ad83-f0a9fa9d1049.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/BorrowingTheEastWind.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/BorrowingTheEastWind.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Borrowing the East Wind
+ * {X}{G}{G}
+ * Sorcery
+ * Borrowing the East Wind deals X damage to each creature with horsemanship and each player.
+ *
+ * The Famine shape: one printed sentence, two halves joined by [Effects.Composite]. The board half
+ * is [Effects.ForEachInGroup] over the horsemanship creatures with the damage aimed at
+ * [EffectTarget.Self] — the current iteration entity — and the player half is the corpus' symmetric
+ * player sweep, [Effects.ForEachPlayer] over [Player.Each], each iteration rebinding the controller
+ * so [EffectTarget.Controller] is the player being processed.
+ */
+val BorrowingTheEastWind = card("Borrowing the East Wind") {
+    manaCost = "{X}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Borrowing the East Wind deals X damage to each creature with horsemanship and each player."
+
+    spell {
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature.withKeyword(Keyword.HORSEMANSHIP)),
+                Effects.DealDamage(DynamicAmount.XValue, EffectTarget.Self)
+            ),
+            Effects.ForEachPlayer(
+                Player.Each,
+                listOf(Effects.DealDamage(DynamicAmount.XValue, EffectTarget.Controller))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "133"
+        artist = "Gao Yan"
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96ba9014-d750-4924-aa6f-8b9f421807f9.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/BurningFields.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/BurningFields.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Burning Fields
+ * {4}{R}
+ * Sorcery
+ * Burning Fields deals 5 damage to target opponent or planeswalker.
+ *
+ * One sentence, one effect. The "opponent or planeswalker" half is a single target requirement
+ * ([Targets.OpponentOrPlaneswalker]) rather than two, so the damage aims at whichever the caster
+ * chose.
+ */
+val BurningFields = card("Burning Fields") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Burning Fields deals 5 damage to target opponent or planeswalker."
+
+    spell {
+        val victim = target("target", Targets.OpponentOrPlaneswalker)
+        effect = Effects.DealDamage(5, victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "Yang Hong"
+        flavorText = "\"In raiding and plundering, be like fire, in immovability like a mountain.\"\n—Sun Tzu, *Art of War* (trans. Giles)"
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/dee12f01-581e-4a3c-a8b5-41bef2516781.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/CaoRenWeiCommander.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/CaoRenWeiCommander.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cao Ren, Wei Commander
+ * {2}{B}{B}
+ * Legendary Creature — Human Soldier Warrior
+ */
+val CaoRenWeiCommander = card("Cao Ren, Wei Commander") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Soldier Warrior"
+    power = 3
+    toughness = 3
+    oracleText =
+        "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)\n" +
+        "When Cao Ren enters, you lose 3 life."
+
+    keywords(Keyword.HORSEMANSHIP)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.LoseLife(3, EffectTarget.Controller)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "69"
+        artist = "Junko Taguchi"
+        flavorText = "Cao Cao's cousin, Cao Ren was known throughout the three kingdoms as the fiercest of warriors."
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f7e8366-82ba-4df0-b9df-7d0aa9b972eb.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ChampionsVictory.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ChampionsVictory.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.YouWereAttackedThisStep
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Champion's Victory
+ * {U}
+ * Instant
+ * Cast this spell only during the declare attackers step and only if you've been attacked this step.
+ * Return target attacking creature to its owner's hand.
+ *
+ * The Portal-era combat-trick timing pair: `castOnlyDuring(DECLARE_ATTACKERS)` for the step and
+ * `castOnlyIf(YouWereAttackedThisStep)` for the "you've been attacked" half — two separate cast
+ * restrictions, because the step alone would let the attacking player cast it too.
+ */
+val ChampionsVictory = card("Champion's Victory") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText =
+        "Cast this spell only during the declare attackers step and only if you've been attacked this step.\n" +
+        "Return target attacking creature to its owner's hand."
+
+    spell {
+        castOnlyDuring(Step.DECLARE_ATTACKERS)
+        castOnlyIf(YouWereAttackedThisStep)
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.attacking()))
+        effect = Effects.Move(t, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "39"
+        artist = "Hong Yan"
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/451ef657-8590-497a-9d98-a732d4de6165.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/CorruptEunuchs.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/CorruptEunuchs.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Corrupt Eunuchs
+ * {3}{R}
+ * Creature — Human Advisor
+ * 2/2
+ * When this creature enters, it deals 2 damage to target creature.
+ */
+val CorruptEunuchs = card("Corrupt Eunuchs") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Advisor"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, it deals 2 damage to target creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "106"
+        artist = "Li Yousong"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e084664-2faf-4f7a-9068-d58d3f4b8456.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/CouncilOfAdvisors.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/CouncilOfAdvisors.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Council of Advisors
+ * {2}{U}
+ * Creature — Human Advisor
+ * 1/1
+ * When this creature enters, draw a card.
+ */
+val CouncilOfAdvisors = card("Council of Advisors") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Advisor"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature enters, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "40"
+        artist = "Liu Shangying"
+        flavorText = "Sun Quan's long and successful rule in the years 199 to 251 was due to his ability to choose and foster talented advisors and generals."
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c59f45b-46fa-4494-9b25-cf9d3e462539.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/DesertSandstorm.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/DesertSandstorm.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Desert Sandstorm
+ * {2}{R}
+ * Sorcery
+ * Desert Sandstorm deals 1 damage to each creature.
+ */
+val DesertSandstorm = card("Desert Sandstorm") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Desert Sandstorm deals 1 damage to each creature."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreatures,
+            Effects.DealDamage(1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "107"
+        artist = "Xu Tan"
+        flavorText = "While pursuing the remnants of Yuan Shao's forces into the Wuhan Desert, Cao Cao was temporarily turned back by a fierce sandstorm."
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/588ad2bf-405d-4c36-b485-e415c22f2703.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/DesperateCharge.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/DesperateCharge.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Desperate Charge
+ * {2}{B}
+ * Sorcery
+ *
+ * The mass-pump shape: one [Effects.ForEachInGroup] over the creatures you control, whose
+ * per-member body is a [Effects.ModifyStats] on `EffectTarget.Self` — the iterated member, not the
+ * spell's controller. The +2/+0 lasts until end of turn, which is `ModifyStats`' default duration.
+ */
+val DesperateCharge = card("Desperate Charge") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Creatures you control get +2/+0 until end of turn."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.ModifyStats(2, 0, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "74"
+        artist = "Chen Weidong"
+        flavorText = "\"Lieutenants dishonored, corpses carted home; The general raises troops again to take revenge.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a5587089-b17e-4187-97aa-1c3eec070a0b.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/EightfoldMaze.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/EightfoldMaze.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.YouWereAttackedThisStep
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Eightfold Maze
+ * {2}{W}
+ * Instant
+ * Cast this spell only during the declare attackers step and only if you've been attacked this step.
+ * Destroy target attacking creature.
+ */
+val EightfoldMaze = card("Eightfold Maze") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText =
+        "Cast this spell only during the declare attackers step and only if you've been attacked this step.\n" +
+        "Destroy target attacking creature."
+
+    spell {
+        castOnlyDuring(Step.DECLARE_ATTACKERS)
+        castOnlyIf(YouWereAttackedThisStep)
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.attacking()))
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "2"
+        artist = "Shang Huitong"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc8c377a-82c4-46ee-94c2-b970160a3205.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/FalseDefeat.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/FalseDefeat.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * False Defeat
+ * {3}{W}
+ * Sorcery
+ *
+ * Return target creature card from your graveyard to the battlefield.
+ */
+val FalseDefeat = card("False Defeat") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature card from your graveyard to the battlefield."
+
+    spell {
+        val creature = target("target", TargetObject(filter = TargetFilter.CreatureInYourGraveyard))
+        effect = Effects.Move(creature, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "4"
+        artist = "Li Wang"
+        flavorText = "\"All warfare is based on deception.\"\n—Sun Tzu, *Art of War* (trans. Giles)"
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5ca71ce3-8633-428a-8d9e-9b807b77a8e2.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/FireAmbush.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/FireAmbush.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Fire Ambush
+ * {1}{R}
+ * Sorcery
+ * Fire Ambush deals 3 damage to any target.
+ */
+val FireAmbush = card("Fire Ambush") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Fire Ambush deals 3 damage to any target."
+
+    spell {
+        val t = target("target", AnyTarget())
+        effect = Effects.DealDamage(3, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "Tang Xiaogu"
+        flavorText = "\"With fire he broke the battle at Bowang . . . . Striking fear deep into Cao Cao's soul, thus Kongming scored a coup at his debut.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4dd8bdbd-99c9-4fa7-936a-acc7f4238507.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/FireBowman.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/FireBowman.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Fire Bowman
+ * {R}
+ * Creature — Human Soldier Archer
+ * 1/1
+ * Sacrifice this creature: It deals 1 damage to any target. Activate only during your turn,
+ * before attackers are declared.
+ *
+ * The Portal timing rider is two [ActivationRestriction]s, not one: [ActivationRestriction.OnlyDuringYourTurn]
+ * for "during your turn" and [ActivationRestriction.BeforeStep] for "before attackers are declared".
+ */
+val FireBowman = card("Fire Bowman") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier Archer"
+    power = 1
+    toughness = 1
+    oracleText = "Sacrifice this creature: It deals 1 damage to any target. Activate only during your turn, before attackers are declared."
+
+    activatedAbility {
+        cost = AbilityCost.SacrificeSelf
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)
+        )
+        val victim = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, victim)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "112"
+        artist = "Cai Tingting"
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/18acc721-e9ae-4ba4-b435-754e41fb541e.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/FlankingTroops.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/FlankingTroops.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flanking Troops
+ * {2}{W}{W}
+ * Creature — Human Soldier
+ */
+val FlankingTroops = card("Flanking Troops") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature attacks, you may tap target creature."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        optional = true
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Tap(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "5"
+        artist = "Li Wang"
+        flavorText = "Following the battle of Redcliffs, both Liu Bei and Sun Quan coveted the province of Jingzhou. After Sun Quan's troops failed to capture it, Liu Bei's succeeded."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a219a031-2466-4850-b646-79a09e30cf18.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ForcedRetreat.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ForcedRetreat.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Forced Retreat
+ * {2}{U}
+ * Sorcery
+ * Put target creature on top of its owner's library.
+ */
+val ForcedRetreat = card("Forced Retreat") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Put target creature on top of its owner's library."
+
+    spell {
+        val t = target("target", TargetCreature())
+        effect = Effects.Move(t, Zone.LIBRARY, ZonePlacement.Top)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "44"
+        artist = "Huang Qishi"
+        flavorText = "\"Leadership, not numbers, determines victory.\"\n—A Wu commander, before his 5,000 troops forced 15,000 Wei troops to retreat from Ruxu"
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/9753d211-3436-4a9b-86d9-54a541770ec2.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/GhostlyVisit.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/GhostlyVisit.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Ghostly Visit
+ * {2}{B}
+ * Sorcery
+ * Destroy target nonblack creature.
+ */
+val GhostlyVisit = card("Ghostly Visit") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target nonblack creature."
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.notColor(Color.BLACK)))
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "76"
+        artist = "Kang Yu"
+        flavorText = "Cao Cao was haunted to death by the ghosts of the empresses and other high courtiers he had murdered."
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/06f6938a-229a-4521-b5d5-7999ce5fb372.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/GuanYus1000LiMarch.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/GuanYus1000LiMarch.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Guan Yu's 1,000-Li March
+ * {4}{W}{W}
+ * Sorcery
+ * Destroy all tapped creatures.
+ */
+val GuanYus1000LiMarch = card("Guan Yu's 1,000-Li March") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all tapped creatures."
+
+    spell {
+        effect = Effects.DestroyAll(Filters.Creature.tapped())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "7"
+        artist = "Yang Guangmai"
+        flavorText = "\"He [Guan Yu] covered the ground on a thousand-*li* horse; / With dragon blade he took each pass by force.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8fa7526a-7a4e-4b3d-b96e-91f2bbf1c7bd.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/HeavyFog.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/HeavyFog.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.YouWereAttackedThisStep
+
+/**
+ * Heavy Fog
+ * {1}{G}
+ * Instant
+ * Cast this spell only during the declare attackers step and only if you've been attacked this step.
+ * Prevent all damage that would be dealt to you this turn by attacking creatures.
+ */
+val HeavyFog = card("Heavy Fog") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText =
+        "Cast this spell only during the declare attackers step and only if you've been attacked this step.\n" +
+        "Prevent all damage that would be dealt to you this turn by attacking creatures."
+
+    spell {
+        castOnlyDuring(Step.DECLARE_ATTACKERS)
+        castOnlyIf(YouWereAttackedThisStep)
+        effect = Effects.PreventDamageFromAttackingCreatures()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "136"
+        artist = "Liu Shangying"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/499fee7b-1942-4eb9-b1d0-806a1f6c0cd8.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/HuangZhongShuGeneral.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/HuangZhongShuGeneral.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
+
+/**
+ * Huang Zhong, Shu General
+ * {2}{W}{W}
+ * Legendary Creature — Human Soldier
+ * 2/3
+ *
+ * The blocker-cap evasion: [CantBeBlockedByMoreThan] with the default `GroupFilter.source()`, so
+ * the restriction scopes to Huang Zhong himself rather than to a group.
+ */
+val HuangZhongShuGeneral = card("Huang Zhong, Shu General") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 2
+    toughness = 3
+    oracleText = "Huang Zhong can't be blocked by more than one creature."
+
+    staticAbility {
+        ability = CantBeBlockedByMoreThan(maxBlockers = 1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "8"
+        artist = "Quan Xuejun"
+        flavorText = "\"Virile in war, he kept the north in fear; His prodigies subdued the western sphere.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c079037c-f4cf-423f-ad15-ee57136d6148.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ImperialRecruiter.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ImperialRecruiter.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Imperial Recruiter
+ * {2}{R}
+ * Creature — Human Advisor
+ * 1 / 1
+ *
+ * When this creature enters, search your library for a creature card with power 2 or less,
+ * reveal it, put it into your hand, then shuffle.
+ */
+val ImperialRecruiter = card("Imperial Recruiter") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Advisor"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature enters, search your library for a creature card with power 2 or less, reveal it, put it into your hand, then shuffle."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Creature.powerAtMost(2),
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "113"
+        artist = "Mitsuaki Sagiri"
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1c473253-3992-4cc1-8b46-5d1da308c537.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ImperialSeal.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ImperialSeal.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Imperial Seal
+ * {B}
+ * Sorcery
+ *
+ * Search your library for a card, then shuffle and put that card on top. You lose 2 life.
+ *
+ * The search half is the shared `Patterns.Library.searchLibrary` pipeline with
+ * [SearchDestination.TOP_OF_LIBRARY], which shuffles before placing the found card on top.
+ */
+val ImperialSeal = card("Imperial Seal") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Search your library for a card, then shuffle and put that card on top. You lose 2 life."
+
+    spell {
+        effect = Effects.Composite(
+            Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Any,
+                destination = SearchDestination.TOP_OF_LIBRARY,
+            ),
+            Effects.LoseLife(2, EffectTarget.Controller),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "78"
+        artist = "Li Tie"
+        flavorText = "\"If Heaven has placed it in your hands, it means that the throne is destined to be yours.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/822e30db-40c5-4099-868b-185ad9b7c7dc.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/LadyZhurongWarriorQueen.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/LadyZhurongWarriorQueen.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Lady Zhurong, Warrior Queen
+ * {4}{G}
+ * Legendary Creature — Human Soldier Warrior
+ * 4/3
+ * Horsemanship
+ */
+val LadyZhurongWarriorQueen = card("Lady Zhurong, Warrior Queen") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Human Soldier Warrior"
+    power = 4
+    toughness = 3
+    oracleText = "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)"
+
+    keywordAbility(KeywordAbility.Simple(Keyword.HORSEMANSHIP))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "139"
+        artist = "Miao Aili"
+        flavorText = "\"A man, and such a fool! I, a woman, will fight them for you.\"\n—Lady Zhurong to her husband Meng Huo, before leading an army against the Shu"
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/009661e7-c704-43a1-82e3-7da0b609844e.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/LuBuMasterAtArms.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/LuBuMasterAtArms.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lu Bu, Master-at-Arms
+ * {5}{R}
+ * Legendary Creature — Human Soldier Warrior
+ * 4/3
+ * Haste; horsemanship (This creature can't be blocked except by creatures with horsemanship.)
+ *
+ * Two parameterless keywords printed on one semicolon-joined line.
+ */
+val LuBuMasterAtArms = card("Lu Bu, Master-at-Arms") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Soldier Warrior"
+    power = 4
+    toughness = 3
+    oracleText = "Haste; horsemanship (This creature can't be blocked except by creatures with horsemanship.)"
+
+    keywords(Keyword.HASTE, Keyword.HORSEMANSHIP)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "115"
+        artist = "Gao Jianzhang"
+        flavorText = "\"Dong Zhuo's man, Lu Bu, warrior without peer, / Far surpassed the champions of his sphere.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/07d60c27-8625-48eb-a3f0-1e26d6930ae7.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/LuMengWuGeneral.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/LuMengWuGeneral.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lu Meng, Wu General
+ * {3}{U}{U}
+ * Legendary Creature — Human Soldier
+ */
+val LuMengWuGeneral = card("Lu Meng, Wu General") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 4
+    toughness = 4
+    oracleText = "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)"
+
+    keywords(Keyword.HORSEMANSHIP)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "46"
+        artist = "Gao Yan"
+        flavorText = "As the Wu chief commander, Lu Meng conquered Shu-held Jingzhou in 219 by disguising soldiers as merchants on boats filled with hiding troops."
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/77a8b376-eda5-4bf9-9093-9518c09e50e8.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/LuSuWuAdvisor.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/LuSuWuAdvisor.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Lu Su, Wu Advisor
+ * {3}{U}{U}
+ * Legendary Creature — Human Advisor
+ * 1/2
+ * {T}: Draw a card. Activate only during your turn, before attackers are declared.
+ *
+ * The Portal-era "before attackers are declared" window is two activation restrictions:
+ * [ActivationRestriction.OnlyDuringYourTurn] plus [ActivationRestriction.BeforeStep] on the
+ * declare-attackers step.
+ */
+val LuSuWuAdvisor = card("Lu Su, Wu Advisor") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Advisor"
+    power = 1
+    toughness = 2
+    oracleText = "{T}: Draw a card. Activate only during your turn, before attackers are declared."
+
+    activatedAbility {
+        cost = Costs.Tap
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "47"
+        artist = "Zhao Tan"
+        flavorText = "Lu Su served as an intermediary between the Wu and Shu kingdoms until Zhou Yu's death in 210, when he became Wu's supreme commander."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d361823-31ce-42c4-997d-3d3b52c0599a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/MengHuoBarbarianKing.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/MengHuoBarbarianKing.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Meng Huo, Barbarian King
+ * {3}{G}{G}
+ * Legendary Creature — Human Barbarian Soldier
+ * 4/4
+ * Other green creatures you control get +1/+1.
+ *
+ * The lord shape: "other" is the [GroupFilter]'s `excludeSelf`, not a predicate — Meng Huo is green
+ * himself and would otherwise pump his own stats.
+ */
+val MengHuoBarbarianKing = card("Meng Huo, Barbarian King") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Human Barbarian Soldier"
+    power = 4
+    toughness = 4
+    oracleText = "Other green creatures you control get +1/+1."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withColor(Color.GREEN).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "142"
+        artist = "Yang Guangmai"
+        flavorText = "The stubborn Meng Huo was captured and released by Kongming seven times before finally surrendering."
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e340647c-fb6d-45a6-9f42-235390b40337.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/MisfortunesGain.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/MisfortunesGain.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.OwnerGainsLifeEffect
+
+/**
+ * Misfortune's Gain
+ * {3}{W}
+ * Sorcery
+ * Destroy target creature. Its owner gains 4 life.
+ */
+val MisfortunesGain = card("Misfortune's Gain") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature. Its owner gains 4 life."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.Destroy(t),
+            OwnerGainsLifeEffect(4)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "13"
+        artist = "Jiaming"
+        flavorText = "The mourning families of commanders and generals were often given land, valuables, or money to compensate for their losses."
+        imageUri = "https://cards.scryfall.io/normal/front/8/0/80abd7c1-8f7a-4279-b76f-251a02624345.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/MountainBandit.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/MountainBandit.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mountain Bandit
+ * {R}
+ * Creature — Human Soldier Rogue
+ * 1/1
+ * Haste
+ */
+val MountainBandit = card("Mountain Bandit") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "Haste"
+
+    keywords(Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "117"
+        artist = "Xu Xiaoming"
+        flavorText = "Penniless and far from home, many former Yellow Scarves and other soldiers became bandits to survive."
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/34fd541d-9956-4595-9527-a83db4c5f74f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/PangTongYoungPhoenix.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/PangTongYoungPhoenix.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Pang Tong, "Young Phoenix"
+ * {1}{W}{W}
+ * Legendary Creature — Human Advisor
+ * 1/2
+ *
+ * The Portal "combat trick on a stick" shape (Stern Marshal's cycle): a tap ability whose timing
+ * clause is two [ActivationRestriction]s — [ActivationRestriction.OnlyDuringYourTurn] plus
+ * [ActivationRestriction.BeforeStep] on the declare-attackers step.
+ */
+val PangTongYoungPhoenix = card("Pang Tong, \"Young Phoenix\"") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Advisor"
+    power = 1
+    toughness = 2
+    oracleText = "{T}: Target creature gets +0/+2 until end of turn. Activate only during your turn, before attackers are declared."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)
+        )
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.ModifyStats(0, 2, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "14"
+        artist = "Li Tie"
+        flavorText = "\". . . It was Pang Tong's boat-connecting scheme That let Zhou Yu accomplish his great deed.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f484d47a-fb1d-4746-8f1d-dd9d24e67c1a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/PoisonArrow.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/PoisonArrow.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Poison Arrow
+ * {4}{B}{B}
+ * Sorcery
+ * Destroy target nonblack creature. You gain 3 life.
+ */
+val PoisonArrow = card("Poison Arrow") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target nonblack creature. You gain 3 life."
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.notColor(Color.BLACK)))
+        effect = Effects.Composite(
+            Effects.Destroy(t),
+            Effects.GainLife(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "80"
+        artist = "Li Tie"
+        flavorText = "In ancient China, not wearing armor could be a fatal mistake. Guan Yu, Zhou Yu, Sun Ce, and other heros were struck by poison arrows."
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6b7b5f34-c250-484e-9bae-94789b2a87fb.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/PortalThreeKingdomsBasicLands.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/PortalThreeKingdomsBasicLands.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Portal Three Kingdoms Basic Lands
+ *
+ * Portal Three Kingdoms contains 3 art variants of each basic land type.
+ * Cards 166-180 (Plains 166-168, Island 169-171, Swamp 172-174, Mountain 175-177, Forest 178-180)
+ */
+
+// =============================================================================
+// Plains (Cards 166-168)
+// =============================================================================
+
+val PortalThreeKingdomsPlains166 = basicLand("Plains") {
+    collectorNumber = "166"
+    artist = "He Jiancheng"
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/ed82f466-ee1c-4942-9b4d-a8bffd548b30.jpg"
+}
+
+val PortalThreeKingdomsPlains167 = basicLand("Plains") {
+    collectorNumber = "167"
+    artist = "He Jiancheng"
+    imageUri = "https://cards.scryfall.io/normal/front/2/f/2fe3d8c0-1640-42bb-bb15-0b82c553976f.jpg"
+}
+
+val PortalThreeKingdomsPlains168 = basicLand("Plains") {
+    collectorNumber = "168"
+    artist = "He Jiancheng"
+    imageUri = "https://cards.scryfall.io/normal/front/4/8/4801e24d-7c45-4d23-9461-0c7771eddd91.jpg"
+}
+
+// =============================================================================
+// Island (Cards 169-171)
+// =============================================================================
+
+val PortalThreeKingdomsIsland169 = basicLand("Island") {
+    collectorNumber = "169"
+    artist = "Ku Xueming"
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/76033c90-1e06-473b-ba44-a94e16ac5348.jpg"
+}
+
+val PortalThreeKingdomsIsland170 = basicLand("Island") {
+    collectorNumber = "170"
+    artist = "Ku Xueming"
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/899cfba6-9131-43ef-9e8d-803a0e64d0b0.jpg"
+}
+
+val PortalThreeKingdomsIsland171 = basicLand("Island") {
+    collectorNumber = "171"
+    artist = "Ku Xueming"
+    imageUri = "https://cards.scryfall.io/normal/front/e/7/e74b6430-0ddb-4433-b3bc-6f0ab42560e6.jpg"
+}
+
+// =============================================================================
+// Swamp (Cards 172-174)
+// =============================================================================
+
+val PortalThreeKingdomsSwamp172 = basicLand("Swamp") {
+    collectorNumber = "172"
+    artist = "Wang Chuxiong"
+    imageUri = "https://cards.scryfall.io/normal/front/1/7/17b4a8a4-caa8-472d-bf90-ee70250bc0ab.jpg"
+}
+
+val PortalThreeKingdomsSwamp173 = basicLand("Swamp") {
+    collectorNumber = "173"
+    artist = "Wang Chuxiong"
+    imageUri = "https://cards.scryfall.io/normal/front/9/f/9fc74272-8dc7-4a07-85e3-e7a13573345e.jpg"
+}
+
+val PortalThreeKingdomsSwamp174 = basicLand("Swamp") {
+    collectorNumber = "174"
+    artist = "Wang Chuxiong"
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7a6447bb-fffc-41c8-91cb-e526ed727b3e.jpg"
+}
+
+// =============================================================================
+// Mountain (Cards 175-177)
+// =============================================================================
+
+val PortalThreeKingdomsMountain175 = basicLand("Mountain") {
+    collectorNumber = "175"
+    artist = "Qin Jun"
+    imageUri = "https://cards.scryfall.io/normal/front/9/5/95046649-bc6d-46f5-8dbc-85d3fa5097c4.jpg"
+}
+
+val PortalThreeKingdomsMountain176 = basicLand("Mountain") {
+    collectorNumber = "176"
+    artist = "Qin Jun"
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/80a6f28b-6910-416e-86e1-bd428360bb27.jpg"
+}
+
+val PortalThreeKingdomsMountain177 = basicLand("Mountain") {
+    collectorNumber = "177"
+    artist = "Qin Jun"
+    imageUri = "https://cards.scryfall.io/normal/front/0/0/00f0ab3f-86c5-49f6-948b-ace35bc03889.jpg"
+}
+
+// =============================================================================
+// Forest (Cards 178-180)
+// =============================================================================
+
+val PortalThreeKingdomsForest178 = basicLand("Forest") {
+    collectorNumber = "178"
+    artist = "Ji Yong"
+    imageUri = "https://cards.scryfall.io/normal/front/6/6/6677baa6-a38f-48f2-9ff2-2e3321b22959.jpg"
+}
+
+val PortalThreeKingdomsForest179 = basicLand("Forest") {
+    collectorNumber = "179"
+    artist = "Ji Yong"
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c5c94d6c-ed6d-4544-8565-35f1ea8bfc26.jpg"
+}
+
+val PortalThreeKingdomsForest180 = basicLand("Forest") {
+    collectorNumber = "180"
+    artist = "Ji Yong"
+    imageUri = "https://cards.scryfall.io/normal/front/8/4/84722185-dffb-498e-8ce7-f50236b716f5.jpg"
+}
+
+/**
+ * All Portal Three Kingdoms basic land variants.
+ */
+val PortalThreeKingdomsBasicLands = listOf(
+    PortalThreeKingdomsPlains166, PortalThreeKingdomsPlains167, PortalThreeKingdomsPlains168,
+    PortalThreeKingdomsIsland169, PortalThreeKingdomsIsland170, PortalThreeKingdomsIsland171,
+    PortalThreeKingdomsSwamp172, PortalThreeKingdomsSwamp173, PortalThreeKingdomsSwamp174,
+    PortalThreeKingdomsMountain175, PortalThreeKingdomsMountain176, PortalThreeKingdomsMountain177,
+    PortalThreeKingdomsForest178, PortalThreeKingdomsForest179, PortalThreeKingdomsForest180
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/PreemptiveStrike.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/PreemptiveStrike.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Preemptive Strike
+ * {1}{U}
+ * Instant
+ *
+ * Counter target creature spell.
+ */
+val PreemptiveStrike = card("Preemptive Strike") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target creature spell."
+
+    spell {
+        target("target", Targets.CreatureSpell)
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "Jiaming"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2314bf1-b22d-48c2-860f-e1081f56296b.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RallyTheTroopsReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RallyTheTroopsReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rally the Troops reprint in PTK. Canonical CardDefinition lives in its earliest set (P02).
+ */
+val RallyTheTroopsReprint = Printing(
+    oracleId = "555927b3-bbc8-48b7-9a04-e8ebaabccf3e",
+    name = "Rally the Troops",
+    setCode = "PTK",
+    collectorNumber = "16",
+    artist = "Shang Huitong",
+    imageUri = "https://cards.scryfall.io/normal/front/0/4/04ee74d6-bd06-48e5-89de-f926e0c9413f.jpg",
+    releaseDate = "1999-05-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RavagesOfWar.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RavagesOfWar.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Ravages of War
+ * {3}{W}
+ * Sorcery
+ * Destroy all lands.
+ *
+ * The white Armageddon. [Effects.DestroyAll] is the wrath *pipeline* — gather the matching
+ * battlefield cards first, then move the whole collection at once — so every land leaves
+ * simultaneously and the leaves-the-battlefield triggers all see the same board.
+ */
+val RavagesOfWar = card("Ravages of War") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all lands."
+
+    spell {
+        effect = Effects.DestroyAll(GameObjectFilter.Land)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "17"
+        artist = "Fang Yue"
+        flavorText = "\"Thorn bushes spring up wherever the army has passed. Lean years follow in the wake of a great war.\"\n—Lao Tzu, *Tao Te Ching* (trans. Feng and English)"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11dca9ba-b27f-4af8-9962-3794e743886f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RavagingHorde.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RavagingHorde.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ravaging Horde
+ * {3}{R}{R}
+ * Creature — Human Soldier
+ */
+val RavagingHorde = card("Ravaging Horde") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, destroy target land."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val land = target("target", Targets.Land)
+        effect = Effects.Destroy(land)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "118"
+        artist = "Liu Jianjian"
+        flavorText = "Upon his return to the capitol after taking soldiers to loot a nearby peaceful town, the prime minister, Dong Zhou, boasted of it as a victory over bandits."
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/6278d679-fc54-4527-ab16-90735574ab9b.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RedCliffsArmada.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RedCliffsArmada.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+
+/**
+ * Red Cliffs Armada
+ * {4}{U}
+ * Creature — Human Soldier
+ * 5/4
+ * This creature can't attack unless defending player controls an Island.
+ *
+ * The Island Fish Jasconius attack clause: `DefendingPlayerControlsLandType` resolves against the
+ * player actually being attacked, not any opponent, so it stays correct in multiplayer.
+ */
+val RedCliffsArmada = card("Red Cliffs Armada") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier"
+    power = 5
+    toughness = 4
+    oracleText = "This creature can't attack unless defending player controls an Island."
+
+    staticAbility {
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "51"
+        artist = "Zhang Jiazhen"
+        flavorText = "By the battle of Red Cliffs in the year 208, the Wu kingdom controlled more than 7,000 warships on the Yangtze."
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c8fe0f33-35c7-439b-bece-4a9461b92352.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RenegadeTroops.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RenegadeTroops.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Renegade Troops
+ * {4}{R}
+ * Creature — Human Soldier
+ * 4/2
+ * Haste
+ */
+val RenegadeTroops = card("Renegade Troops") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    power = 4
+    toughness = 2
+    oracleText = "Haste"
+
+    keywords(Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "120"
+        artist = "Liu Jianjian"
+        flavorText = "\"Across the land rebellions seethed and swarmed / As vicious war lords swooped down on all sides.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a75095f4-a77f-4237-ae25-2e6f2f8788c1.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ReturnToBattle.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ReturnToBattle.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Return to Battle
+ * {B}
+ * Sorcery
+ * Return target creature card from your graveyard to your hand.
+ */
+val ReturnToBattle = card("Return to Battle") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature card from your graveyard to your hand."
+
+    spell {
+        val t = target("target", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.Move(t, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "81"
+        artist = "Ding Songjian"
+        flavorText = "\"Swallowing his eye, the valiant Xiahou Dun fought on; / But Cao Cao's vanguard, its commander wounded, could not hold out for long.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/1841e615-fdcd-4187-bd69-d07abde0e1ae.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RidingRedHare.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RidingRedHare.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Riding Red Hare
+ * {2}{W}
+ * Sorcery
+ * Target creature gets +3/+3 and gains horsemanship until end of turn.
+ */
+val RidingRedHare = card("Riding Red Hare") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Target creature gets +3/+3 and gains horsemanship until end of turn. (It can't be blocked except by creatures with horsemanship.)"
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 3, t),
+            Effects.GrantKeyword(Keyword.HORSEMANSHIP, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Qi Baocheng"
+        flavorText = "One of the greatest steeds in the empire, Red Hare could travel a thousand *li* a day and climb hills as if running on flat ground."
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c0504a24-4b92-471a-8da4-02ec57eb43be.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RockslideAmbush.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RockslideAmbush.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Rockslide Ambush
+ * {1}{R}
+ * Sorcery
+ *
+ * Spitting Earth's shape: the damage amount is a battlefield tally
+ * ([DynamicAmount.AggregateBattlefield]) over the lands you control carrying the Mountain subtype.
+ */
+val RockslideAmbush = card("Rockslide Ambush") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Rockslide Ambush deals damage to target creature equal to the number of Mountains you control."
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.DealDamage(
+            DynamicAmount.AggregateBattlefield(
+                Player.You,
+                GameObjectFilter.Land.withSubtype(Subtype.MOUNTAIN)
+            ),
+            t
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "121"
+        artist = "Inoue Junichi"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04e5faf1-25c9-46c0-88f2-c59e7b9c08c5.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RollingEarthquake.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/RollingEarthquake.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rolling Earthquake
+ * {X}{R}
+ * Sorcery
+ * Rolling Earthquake deals X damage to each creature without horsemanship and each player.
+ *
+ * The horsemanship-blind cousin of Earthquake: one sentence, two halves joined by
+ * [Effects.Composite]. The board half is [Effects.ForEachInGroup] over every creature that lacks
+ * [Keyword.HORSEMANSHIP], with the damage aimed at [EffectTarget.Self] — the current iteration
+ * entity. The player half is [Effects.ForEachPlayer] over [Player.Each], each iteration rebinding
+ * the controller so [EffectTarget.Controller] is the player being processed.
+ */
+val RollingEarthquake = card("Rolling Earthquake") {
+    manaCost = "{X}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Rolling Earthquake deals X damage to each creature without horsemanship and each player."
+
+    spell {
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                Filters.Group.allCreatures.withoutKeyword(Keyword.HORSEMANSHIP),
+                Effects.DealXDamage(EffectTarget.Self)
+            ),
+            Effects.ForEachPlayer(
+                Player.Each,
+                listOf(Effects.DealXDamage(EffectTarget.Controller))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "122"
+        artist = "Yang Hong"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c1bf210-ecdb-4b49-8504-51360c269e66.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/SagesKnowledge.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/SagesKnowledge.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Sage's Knowledge
+ * {2}{U}
+ * Sorcery
+ *
+ * Return target sorcery card from your graveyard to your hand.
+ */
+val SagesKnowledge = card("Sage's Knowledge") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Return target sorcery card from your graveyard to your hand."
+
+    spell {
+        val sorcery = target(
+            "target",
+            TargetObject(
+                filter = TargetFilter(GameObjectFilter.Sorcery.ownedByYou(), zone = Zone.GRAVEYARD)
+            )
+        )
+        effect = Effects.ReturnToHand(sorcery)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Ding Songjian"
+        flavorText = "\"Those who know do not talk. Those who talk do not know.\"\n—Lao Tzu, *Tao Te Ching*\n(trans. Feng and English)"
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/156d7c70-6c6d-4052-9d44-029ba1bb66e4.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuCavalry.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuCavalry.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Shu Cavalry
+ * {2}{W}
+ * Creature — Human Soldier
+ * 2/2
+ * Horsemanship
+ */
+val ShuCavalry = card("Shu Cavalry") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)"
+
+    keywordAbility(KeywordAbility.Simple(Keyword.HORSEMANSHIP))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Li Xiaohua"
+        flavorText = "In establishing the Shu kingdom, Liu Bei's forces fought against Ma Chao at Chengdu. Eventually, Ma Chao surrendered and became one of Liu Bei's Tiger Generals."
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/0433bee7-406d-4dd3-8d1b-dfd6cb64d038.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuDefender.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuDefender.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shu Defender
+ * {2}{W}
+ * Creature — Human Soldier
+ * 2/2
+ * Whenever this creature blocks, it gets +0/+2 until end of turn.
+ */
+val ShuDefender = card("Shu Defender") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature blocks, it gets +0/+2 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ModifyStats(0, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "Sun Nan"
+        flavorText = "Confronting Cao Cao's army at Steepslope Bridge, Zhang Fei bellowed, \"I am Zhang Fei of Yan! Who dares fight me to the death?\" Cao Cao's army cowered and fled."
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/ee57a9ab-c385-4a51-aff7-6a654f5d7611.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuEliteCompanions.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuEliteCompanions.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shu Elite Companions
+ * {4}{W}
+ * Creature — Human Soldier
+ */
+val ShuEliteCompanions = card("Shu Elite Companions") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)"
+
+    keywords(Keyword.HORSEMANSHIP)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "21"
+        artist = "Qiao Dafu"
+        flavorText = "Throughout the three kingdoms, important generals were often guarded by small groups of expert soldiers known as \"elite companions.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11ac63f6-cd61-4334-902a-777410311b2d.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuFarmer.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuFarmer.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Shu Farmer
+ * {1}{W}
+ * Creature — Human
+ * 1/1
+ * {T}: You gain 1 life. Activate only during your turn, before attackers are declared.
+ */
+val ShuFarmer = card("Shu Farmer") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: You gain 1 life. Activate only during your turn, before attackers are declared."
+
+    activatedAbility {
+        cost = Costs.Tap
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)
+        )
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "23"
+        artist = "Li Xiaohua"
+        flavorText = "\"The common folk are ceaselessly active. The fields are fertile and the soil productive, and neither flood nor drought plagues us.\"\n—A Shu diplomat"
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc6d6524-d8bd-4eb9-9222-747443492b8c.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuGeneral.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuGeneral.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shu General
+ * {3}{W}
+ * Creature — Human Soldier
+ * 2/2
+ * Vigilance; horsemanship
+ */
+val ShuGeneral = card("Shu General") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Vigilance; horsemanship (This creature can't be blocked except by creatures with horsemanship.)"
+
+    keywords(Keyword.VIGILANCE, Keyword.HORSEMANSHIP)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "25"
+        artist = "Li Xiaohua"
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c9c3be7a-82a8-411c-bfe2-16749ada1244.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuGrainCaravan.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuGrainCaravan.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shu Grain Caravan
+ * {2}{W}
+ * Creature — Human Soldier
+ * 2/2
+ * When this creature enters, you gain 2 life.
+ */
+val ShuGrainCaravan = card("Shu Grain Caravan") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, you gain 2 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "26"
+        artist = "Li Wang"
+        flavorText = "Keeping a million-man army fed was no easy task. Grain and rice caravans were the lifeblood of the empire."
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7bf26eb7-8a31-4022-87bb-67394653f06a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuSoldierFarmers.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuSoldierFarmers.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shu Soldier-Farmers
+ * {4}{W}
+ * Creature — Human Soldier
+ * 2/4
+ * When this creature enters, you gain 4 life.
+ */
+val ShuSoldierFarmers = card("Shu Soldier-Farmers") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 4
+    oracleText = "When this creature enters, you gain 4 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(4)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "27"
+        artist = "Li Xiaohua"
+        flavorText = "During Kongming's campaigns against the Wei, his Shu troops rotated from the battlefront to the fields every hundred days."
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/edb576e9-98ba-4bd1-9d1e-e316acf2e7f5.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/SimaYiWeiFieldMarshal.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/SimaYiWeiFieldMarshal.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sima Yi, Wei Field Marshal
+ * {5}{B}
+ * Legendary Creature — Human Soldier
+ * Power is the number of Swamps you control; toughness 4.
+ *
+ * A characteristic-defining ability: the power lives in `creatureStats`, not in a static ability,
+ * so it applies in every zone. `dynamicPower` with a zero offset builds the plain
+ * `CharacteristicValue.Dynamic` over the Swamps you control.
+ */
+val SimaYiWeiFieldMarshal = card("Sima Yi, Wei Field Marshal") {
+    manaCost = "{5}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Soldier"
+    dynamicPower(
+        DynamicAmount.AggregateBattlefield(
+            Player.You,
+            GameObjectFilter.Land.withSubtype(Subtype.SWAMP)
+        )
+    )
+    toughness = 4
+    oracleText = "Sima Yi's power is equal to the number of Swamps you control."
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "82"
+        artist = "Gao Yan"
+        flavorText = "Sima Yi fought for four generations of the Cao family before his own grandson became emperor and united the three kingdoms."
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/6500b690-d601-4c6d-baea-552e366ea242.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/SlashingTiger.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/SlashingTiger.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Slashing Tiger
+ * {2}{G}{G}
+ * Creature — Cat
+ * 3 / 3
+ *
+ * Whenever this creature becomes blocked, it gets +2/+2 until end of turn.
+ */
+val SlashingTiger = card("Slashing Tiger") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever this creature becomes blocked, it gets +2/+2 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "145"
+        artist = "Yang Jun Kwon"
+        flavorText = "\"Unless you enter the tiger's lair, you cannot get hold of the tiger's cubs.\"\n—Sun Tzu, *Art of War* (trans. Giles)"
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4fbedd66-457a-4e1c-a9f3-fa37dec81c7a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/SpringOfEternalPeace.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/SpringOfEternalPeace.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spring of Eternal Peace
+ * {3}{G}{G}
+ * Sorcery
+ *
+ * You gain 8 life.
+ */
+val SpringOfEternalPeace = card("Spring of Eternal Peace") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "You gain 8 life."
+
+    spell {
+        effect = Effects.GainLife(8)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Wang Yuqun"
+        flavorText = "Bathing in this spring could cure ailments of body and mind alike."
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6862d7a-04ee-48ac-a5b3-46a4e8694d5b.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/StolenGrain.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/StolenGrain.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stolen Grain
+ * {4}{B}{B}
+ * Sorcery
+ * Stolen Grain deals 5 damage to target opponent or planeswalker. You gain 5 life.
+ */
+val StolenGrain = card("Stolen Grain") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Stolen Grain deals 5 damage to target opponent or planeswalker. You gain 5 life."
+
+    spell {
+        val t = target("target", Targets.OpponentOrPlaneswalker)
+        effect = Effects.Composite(
+            Effects.DealDamage(5, t),
+            Effects.GainLife(5)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "83"
+        artist = "LHQ"
+        flavorText = "At the battle of Guandu, Cao Cao defeated Yuan Shao by raiding his grain depot, leaving him with no way to feed his troops."
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e1f08862-5107-46a0-8c14-a961a5c4b135.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/SunCeYoungConquerer.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/SunCeYoungConquerer.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Sun Ce, Young Conquerer
+ * {3}{U}{U}
+ * Legendary Creature — Human Soldier
+ * 3/3
+ * Horsemanship (This creature can't be blocked except by creatures with horsemanship.)
+ * When Sun Ce enters, you may return target creature to its owner's hand.
+ *
+ * The target is mandatory at announcement — the trigger carries a `targetRequirement`, so a
+ * creature is chosen when the ability goes on the stack — and the printed "you may" is only the
+ * resolution-time yes/no (`optional = true` lowers to a `Gate.MayDecide`).
+ */
+val SunCeYoungConquerer = card("Sun Ce, Young Conquerer") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 3
+    toughness = 3
+    oracleText =
+        "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)\n" +
+        "When Sun Ce enters, you may return target creature to its owner's hand."
+
+    keywords(Keyword.HORSEMANSHIP)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val victim = target("target", TargetObject(filter = TargetFilter.Creature))
+        effect = Effects.ReturnToHand(victim)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "55"
+        artist = "Yang Guangmai"
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/16114a68-58d1-4aad-9b3a-890e9c84b253.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/SunQuanLordOfWu.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/SunQuanLordOfWu.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Sun Quan, Lord of Wu
+ * {4}{U}{U}
+ * Legendary Creature — Human Soldier
+ */
+val SunQuanLordOfWu = card("Sun Quan, Lord of Wu") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 4
+    toughness = 4
+    oracleText = "Creatures you control have horsemanship. (They can't be blocked except by creatures with horsemanship.)"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.HORSEMANSHIP, GroupFilter.AllCreaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "56"
+        artist = "Xu Xiaoming"
+        flavorText = "\"One score and four he reigned, the Southland king: / A dragon coiled, a tiger poised below the mighty Yangtze.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6def4492-3f67-4cdb-8a25-c3ddebd125c7.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/TaoistHermit.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/TaoistHermit.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Taoist Hermit
+ * {2}{G}
+ * Creature — Human Mystic
+ * 2/2
+ * Hexproof (This creature can't be the target of spells or abilities your opponents control.)
+ */
+val TaoistHermit = card("Taoist Hermit") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Mystic"
+    power = 2
+    toughness = 2
+    oracleText = "Hexproof (This creature can't be the target of spells or abilities your opponents control.)"
+
+    keywords(Keyword.HEXPROOF)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "150"
+        artist = "Wang Yuqun"
+        flavorText = "Taoists chose to be hermits for many reasons, but all shared one unchanging goal: to follow the Tao."
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d818c231-8d66-4024-91de-fe29f8622902.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/TaoistMystic.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/TaoistMystic.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Taoist Mystic
+ * {2}{G}
+ * Creature — Human Mystic
+ * 2/2
+ * This creature can't be blocked by creatures with horsemanship.
+ */
+val TaoistMystic = card("Taoist Mystic") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Mystic"
+    power = 2
+    toughness = 2
+    oracleText = "This creature can't be blocked by creatures with horsemanship."
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.withKeyword(Keyword.HORSEMANSHIP))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "151"
+        artist = "Qu Xin"
+        flavorText = "By appearing in places miles apart at the same time, Zuo Ci exhibited the mystic's ability to \"shrink the land.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/023ae64a-7888-4ad2-b879-0649d8e341ac.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/TauntingChallenge.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/TauntingChallenge.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MustBeBlockedEffect
+
+/**
+ * Taunting Challenge
+ * {1}{G}{G}
+ * Sorcery
+ * All creatures able to block target creature this turn do so.
+ */
+val TauntingChallenge = card("Taunting Challenge") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "All creatures able to block target creature this turn do so."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = MustBeBlockedEffect(t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "152"
+        artist = "Gao Yan"
+        flavorText = "Incensed by their opponents' unrelenting taunts, even wise generals were known to rashly lead their troops into battle—often to disastrous defeats."
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/4620867c-a3a6-4c81-b923-24007367132e.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/TrainedCheetah.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/TrainedCheetah.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Trained Cheetah
+ * {2}{G}
+ * Creature — Cat
+ * 2/2
+ * Whenever this creature becomes blocked, it gets +1/+1 until end of turn.
+ */
+val TrainedCheetah = card("Trained Cheetah") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature becomes blocked, it gets +1/+1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "154"
+        artist = "Fang Yue"
+        flavorText = "\"[King Mulu's cheetahs] came riding on the winds, charging, with fangs bared and claws flexed.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab242eab-5cab-41a0-bcf8-93a6919e4558.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/TripWire.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/TripWire.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Trip Wire
+ * {2}{G}
+ * Sorcery
+ *
+ * Portal Three Kingdoms' answer to horsemanship: a plain destroy whose target filter carries the
+ * keyword predicate.
+ */
+val TripWire = card("Trip Wire") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature with horsemanship."
+
+    spell {
+        val t = target(
+            "target",
+            TargetCreature(
+                filter = TargetFilter(GameObjectFilter.Creature.withKeyword(Keyword.HORSEMANSHIP))
+            )
+        )
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "156"
+        artist = "Hong Yan"
+        flavorText = "Trip wire, hooked poles, and sunken pits were commonly used to unhorse riders during the Three Kingdoms period."
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4eb1e16f-002e-4a81-ba41-cfe41f3a9071.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/VirtuousCharge.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/VirtuousCharge.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Virtuous Charge
+ * {2}{W}
+ * Sorcery
+ * Creatures you control get +1/+1 until end of turn.
+ *
+ * The board-wide pump is [Effects.ForEachInGroup] over `creaturesYouControl` with the modifier aimed
+ * at [EffectTarget.Self] — the current iteration entity.
+ */
+val VirtuousCharge = card("Virtuous Charge") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Creatures you control get +1/+1 until end of turn."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            Filters.Group.creaturesYouControl,
+            Effects.ModifyStats(1, 1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Qu Xin"
+        flavorText = "\"The empire belongs to no one man but to all in the empire. He who has virtue shall possess it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72ad4c79-a85d-4fc6-95ab-5a6d6d667579.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WarriorsOath.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WarriorsOath.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Warrior's Oath
+ * {R}{R}
+ * Sorcery
+ *
+ * Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.
+ *
+ * The "you lose the game" rider is the `loseAtEndStep` flag on the extra-turn effect (Final
+ * Fortune's shape), scoped to the extra turn this spell creates.
+ */
+val WarriorsOath = card("Warrior's Oath") {
+    manaCost = "{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game."
+
+    spell {
+        effect = Effects.TakeExtraTurn(loseAtEndStep = true)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "124"
+        artist = "Mitsuaki Sagiri"
+        flavorText = "\"If I fail, my head is yours.\"\n—Warrior's oath common during the Three Kingdoms period"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d582861a-ca6e-4b74-adf0-3eb588ea5ed2.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WarriorsStandReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WarriorsStandReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Warrior's Stand reprint in PTK. Canonical CardDefinition lives in its earliest set (P02).
+ */
+val WarriorsStandReprint = Printing(
+    oracleId = "1f08072d-7dec-4f0d-b465-dda62eb17630",
+    name = "Warrior's Stand",
+    setCode = "PTK",
+    collectorNumber = "31",
+    artist = "Qiao Dafu",
+    imageUri = "https://cards.scryfall.io/normal/front/5/3/53bffc2e-67b6-4eb0-9742-e2a5918cc8d8.jpg",
+    releaseDate = "1999-05-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WeiAmbushForce.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WeiAmbushForce.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wei Ambush Force
+ * {1}{B}
+ * Creature — Human Soldier
+ * 1/1
+ * Whenever this creature attacks, it gets +2/+0 until end of turn.
+ */
+val WeiAmbushForce = card("Wei Ambush Force") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever this creature attacks, it gets +2/+0 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "85"
+        artist = "Ku Xueming"
+        flavorText = "The battle of Puyang marked the beginning of the end for Lu Bu. He lost the city—and later his life—to Cao Cao."
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b241ba4-cff5-48ce-83bd-d70fb5e20ff4.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WeiEliteCompanions.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WeiEliteCompanions.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wei Elite Companions
+ * {4}{B}
+ * Creature — Human Soldier
+ */
+val WeiEliteCompanions = card("Wei Elite Companions") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)"
+
+    keywords(Keyword.HORSEMANSHIP)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "87"
+        artist = "Li Youliang"
+        flavorText = "Cao Cao was more concerned with capabilities than lineage. He excelled at recruiting and retaining men of talent to serve him."
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/843cbf18-60ac-4d97-b156-874735db61c6.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WeiScout.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WeiScout.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wei Scout
+ * {1}{B}
+ * Creature — Human Soldier Scout
+ * 1/1
+ * Horsemanship (This creature can't be blocked except by creatures with horsemanship.)
+ */
+val WeiScout = card("Wei Scout") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Soldier Scout"
+    power = 1
+    toughness = 1
+    oracleText = "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)"
+
+    keywords(Keyword.HORSEMANSHIP)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "90"
+        artist = "Jiang Zhuqing"
+        flavorText = "\"He will win who, prepared himself, waits to take the enemy unprepared.\"\n—Sun Tzu, *Art of War* (trans. Giles)"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a11d58fb-fb70-4e8f-8f64-232ad2c1f59b.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WeiStrikeForce.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WeiStrikeForce.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wei Strike Force
+ * {2}{B}
+ * Creature — Human Soldier
+ * 2/1
+ * Horsemanship
+ */
+val WeiStrikeForce = card("Wei Strike Force") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 1
+    oracleText = "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)"
+
+    keywords(Keyword.HORSEMANSHIP)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "91"
+        artist = "Tang Xiaogu"
+        flavorText = "At the battle of Chang'an, Ma Chao defeated the two generals Cao Cao sent to guard the pass but was forced to flee when Cao Cao's trickery turned his own ally against him."
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6eae8ce1-b21f-4d64-91ff-e98bf6a4548a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WieldingTheGreenDragon.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WieldingTheGreenDragon.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wielding the Green Dragon
+ * {1}{G}
+ * Sorcery
+ * Target creature gets +4/+4 until end of turn.
+ */
+val WieldingTheGreenDragon = card("Wielding the Green Dragon") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Target creature gets +4/+4 until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(4, 4, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "157"
+        artist = "Quan Xuejun"
+        flavorText = "Named for the eastern part of the sky, the source of energy and renewal, Guan Yu's crescent-moon blade weighed over 100 pounds."
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2b138167-8129-4109-a58b-af26c95577e4.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WuAdmiral.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WuAdmiral.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Wu Admiral
+ * {4}{U}
+ * Creature — Human Soldier
+ * 3/3
+ * This creature gets +1/+1 as long as an opponent controls an Island.
+ */
+val WuAdmiral = card("Wu Admiral") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "This creature gets +1/+1 as long as an opponent controls an Island."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(1, 1, Filters.Self),
+            condition = Exists(
+                Player.EachOpponent,
+                Zone.BATTLEFIELD,
+                GameObjectFilter.Land.withSubtype(Subtype.ISLAND)
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "57"
+        artist = "Zhang Jiazhen"
+        flavorText = "The Wu kingdom's well-trained admirals were integral to the Southlands' victory at Red Cliffs as well as the kingdom's defense."
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/499ae191-80ac-42bf-b49d-db343803bd56.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WuEliteCavalry.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WuEliteCavalry.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wu Elite Cavalry
+ * {3}{U}
+ * Creature — Human Soldier
+ * 2/3
+ */
+val WuEliteCavalry = card("Wu Elite Cavalry") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 3
+    oracleText = "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)"
+
+    keywords(Keyword.HORSEMANSHIP)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "58"
+        artist = "Li Wang"
+        flavorText = "At the second battle of Ruxu, the brave Wu general Gan Ning raided Cao Cao's camp of 400,000 men with only 100 cavalry. Not a single man or horse was lost."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7cf562e2-be8e-4514-b2c8-3268dc1ab0db.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WuLightCavalry.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WuLightCavalry.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wu Light Cavalry
+ * {1}{U}
+ * Creature — Human Soldier
+ * 1 / 2
+ *
+ * Horsemanship (This creature can't be blocked except by creatures with horsemanship.)
+ */
+val WuLightCavalry = card("Wu Light Cavalry") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 2
+    oracleText = "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)"
+
+    keywords(Keyword.HORSEMANSHIP)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Huang Qishi"
+        flavorText = "A cunning strategist, Cao Ren tricked Zhou Yu by letting him enter Nanjun. Zhou Yu thought he was capturing the city until Cao Ren's arrows rained down upon him."
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60e55b25-fde2-4b57-b5db-65b75262ff3d.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WuLongbowman.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WuLongbowman.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Wu Longbowman
+ * {2}{U}
+ * Creature — Human Soldier Archer
+ * 1/1
+ *
+ * {T}: This creature deals 1 damage to any target. Activate only during your turn, before
+ * attackers are declared.
+ */
+val WuLongbowman = card("Wu Longbowman") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier Archer"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: This creature deals 1 damage to any target. Activate only during your turn, before attackers are declared."
+
+    activatedAbility {
+        cost = Costs.Tap
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)
+        )
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "61"
+        artist = "Xu Tan"
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/28e68635-b0ed-4a56-8b18-679f95db12b6.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WuScout.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WuScout.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.LookAtTargetHandEffect
+
+/**
+ * Wu Scout
+ * {1}{U}
+ * Creature — Human Soldier Scout
+ * 1/1
+ * Horsemanship
+ * When this creature enters, look at target opponent's hand.
+ */
+val WuScout = card("Wu Scout") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier Scout"
+    power = 1
+    toughness = 1
+    oracleText =
+        "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)\n" +
+        "When this creature enters, look at target opponent's hand."
+
+    keywordAbility(KeywordAbility.Simple(Keyword.HORSEMANSHIP))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Opponent)
+        effect = LookAtTargetHandEffect(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "62"
+        artist = "Jiaming"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d13330f-6e07-451f-b17a-4e1606a74c3f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WuWarship.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WuWarship.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+
+/**
+ * Wu Warship
+ * {2}{U}
+ * Creature — Human Soldier
+ * 3/3
+ * This creature can't attack unless defending player controls an Island.
+ *
+ * The same [CantAttackUnless] shape as Goblin Rock Sled, aimed at the *defending* player's
+ * Islands — a nonbasic land with the Island type counts, which is why the condition is a land
+ * subtype test rather than a basic-land one.
+ */
+val WuWarship = card("Wu Warship") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "This creature can't attack unless defending player controls an Island."
+
+    staticAbility {
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType(Subtype.ISLAND.value))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "64"
+        artist = "Jiang Zhuqing"
+        flavorText = "Both Wu and Wei warships patrolled the Yangtze River, the natural border between the two kingdoms."
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e211d47-dab4-429a-a90b-5b8489441886.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/XunYuWeiAdvisor.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/XunYuWeiAdvisor.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Xun Yu, Wei Advisor
+ * {1}{B}{B}
+ * Legendary Creature — Human Advisor
+ */
+val XunYuWeiAdvisor = card("Xun Yu, Wei Advisor") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Advisor"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Target creature you control gets +2/+0 until end of turn. Activate only during your turn, before attackers are declared."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)
+        )
+        val creature = target("target", Targets.CreatureYouControl)
+        effect = Effects.ModifyStats(2, 0, creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "93"
+        artist = "Jack Wei"
+        flavorText = "\"A splendid talent, admired of all men! His folly lay in serving Cao Cao's power.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8f0a25ea-b414-423c-94a6-8a4795d60b46.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/YellowScarvesCavalry.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/YellowScarvesCavalry.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+
+/**
+ * Yellow Scarves Cavalry
+ * {1}{R}
+ * Creature — Human Soldier
+ * 1/1
+ * Horsemanship (This creature can't be blocked except by creatures with horsemanship.)
+ * This creature can't block.
+ */
+val YellowScarvesCavalry = card("Yellow Scarves Cavalry") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 1
+    oracleText =
+        "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)\n" +
+        "This creature can't block."
+
+    keywords(Keyword.HORSEMANSHIP)
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "125"
+        artist = "Chen Weidong"
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/84460666-4f6b-422c-b20e-dc1651c66e15.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/YellowScarvesGeneral.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/YellowScarvesGeneral.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+
+/**
+ * Yellow Scarves General
+ * {3}{R}
+ * Creature — Human Soldier
+ * 2/2
+ * Horsemanship
+ * This creature can't block.
+ */
+val YellowScarvesGeneral = card("Yellow Scarves General") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText =
+        "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)\n" +
+        "This creature can't block."
+
+    keywords(Keyword.HORSEMANSHIP)
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "126"
+        artist = "Chen Weidong"
+        flavorText = "Zhang Jue, leader of the Yellow Scarves rebellion, was a Taoist master and tutored his soldiers in those arts."
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/06e98691-6227-41f2-a3f4-3131b07a3a6f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/YellowScarvesTroops.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/YellowScarvesTroops.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+
+/**
+ * Yellow Scarves Troops
+ * {1}{R}
+ * Creature — Human Soldier
+ * 2/2
+ * This creature can't block.
+ */
+val YellowScarvesTroops = card("Yellow Scarves Troops") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "This creature can't block."
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "127"
+        artist = "Chen Weidong"
+        flavorText = "Over 500,000 commoners followed Zhang Jue, General of Heaven, in his attempt to overthrow the corrupt Han dynasty."
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3ca36a8d-ca44-485e-a219-85814f160c4d.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/YoungWeiRecruits.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/YoungWeiRecruits.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+
+/**
+ * Young Wei Recruits
+ * {1}{B}
+ * Creature — Human Soldier
+ * 2/2
+ * This creature can't block.
+ */
+val YoungWeiRecruits = card("Young Wei Recruits") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "This creature can't block."
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "94"
+        artist = "Li Youliang"
+        flavorText = "\"To send the common people to war untrained is to throw them away.\"\n—Confucius, *The Analects* (trans. Lau)"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11431c4c-b0bb-4747-a34a-4a90238ec9c6.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZhangFeiFierceWarrior.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZhangFeiFierceWarrior.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zhang Fei, Fierce Warrior
+ * {4}{W}{W}
+ * Legendary Creature — Human Soldier Warrior
+ * 4/4
+ */
+val ZhangFeiFierceWarrior = card("Zhang Fei, Fierce Warrior") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Soldier Warrior"
+    power = 4
+    toughness = 4
+    oracleText = "Vigilance; horsemanship (This creature can't be blocked except by creatures with horsemanship.)"
+
+    keywords(Keyword.VIGILANCE, Keyword.HORSEMANSHIP)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "32"
+        artist = "Qiao Dafu"
+        flavorText = "Zhang Fei's uncharacteristic alliance with a defeated Riverlands general, Yan Yan, allowed Shu forces to advance through forty-five Riverlands strongpoints with no casualties."
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2a58ec38-f1dc-4c69-9d26-a4599bce586a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZhaoZilongTigerGeneral.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZhaoZilongTigerGeneral.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Zhao Zilong, Tiger General
+ * {3}{W}{W}
+ * Legendary Creature — Human Soldier Warrior
+ * 3 / 3
+ *
+ * Horsemanship (This creature can't be blocked except by creatures with horsemanship.)
+ * Whenever Zhao Zilong blocks, it gets +1/+1 until end of turn.
+ */
+val ZhaoZilongTigerGeneral = card("Zhao Zilong, Tiger General") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Soldier Warrior"
+    power = 3
+    toughness = 3
+    oracleText =
+        "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)\n" +
+        "Whenever Zhao Zilong blocks, it gets +1/+1 until end of turn."
+
+    keywords(Keyword.HORSEMANSHIP)
+
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "33"
+        artist = "Quan Xuejun"
+        flavorText = "Zhao Zilong was a brave and noble warrior. Twice he rescued Liu Bei's son, Liu Shan."
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d16cf1d-a7c3-4038-a648-299c1bedae99.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZhouYuChiefCommander.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZhouYuChiefCommander.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+
+/**
+ * Zhou Yu, Chief Commander
+ * {5}{U}{U}
+ * Legendary Creature — Human Soldier
+ * 8/8
+ *
+ * Zhou Yu can't attack unless defending player controls an Island.
+ */
+val ZhouYuChiefCommander = card("Zhou Yu, Chief Commander") {
+    manaCost = "{5}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 8
+    toughness = 8
+    oracleText = "Zhou Yu can't attack unless defending player controls an Island."
+
+    staticAbility {
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "65"
+        artist = "Xu Xiaoming"
+        flavorText = "\"After making me, Zhou Yu, did you have to make Kongming?\"\n—Zhou Yu crying to heaven on his deathbed"
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6e2cf83b-417d-41ca-8e65-86aa65180c40.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZhugeJinWuStrategist.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZhugeJinWuStrategist.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Zhuge Jin, Wu Strategist
+ * {1}{U}{U}
+ * Legendary Creature — Human Advisor
+ * 1/1
+ * {T}: Target creature can't be blocked this turn. Activate only during your turn, before attackers
+ * are declared.
+ */
+val ZhugeJinWuStrategist = card("Zhuge Jin, Wu Strategist") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Advisor"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Target creature can't be blocked this turn. Activate only during your turn, before attackers are declared."
+
+    activatedAbility {
+        cost = Costs.Tap
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)
+        )
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "66"
+        artist = "Song Shikai"
+        flavorText = "When Zhuge Jin proposed the marriage of Guan Yu's daugher and Sun Quan's heir, Guan Yu's arrogant refusal led to disaster."
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60790b07-53da-41fa-b9e0-e7ce22fdcb11.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacDog.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacDog.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zodiac Dog
+ * {2}{R}
+ * Creature — Dog
+ * 2/2
+ * Mountainwalk (This creature can't be blocked as long as defending player controls a Mountain.)
+ */
+val ZodiacDog = card("Zodiac Dog") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dog"
+    power = 2
+    toughness = 2
+    oracleText = "Mountainwalk (This creature can't be blocked as long as defending player controls a Mountain.)"
+
+    keywords(Keyword.MOUNTAINWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Qi Baocheng"
+        flavorText = "\". . . Jiang Wei alone still strove with might and main: / Nine times more he fought the north—in vain. . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc61aa62-25ee-40a4-9b6e-d6277316b464.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacGoat.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacGoat.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zodiac Goat
+ * {R}
+ * Creature — Goat
+ */
+val ZodiacGoat = card("Zodiac Goat") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goat"
+    power = 1
+    toughness = 1
+    oracleText = "Mountainwalk (This creature can't be blocked as long as defending player controls a Mountain.)"
+
+    keywords(Keyword.MOUNTAINWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "132"
+        artist = "Qi Baocheng"
+        flavorText = "\". . . Near death in Baidi, having reigned three years, / Bei sadly placed his son in Kongming's care. . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52510462-2802-4e16-87d4-da376ee2e3be.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacHorse.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacHorse.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zodiac Horse
+ * {3}{G}
+ * Creature — Horse
+ * 3/3
+ * Islandwalk (This creature can't be blocked as long as defending player controls an Island.)
+ */
+val ZodiacHorse = card("Zodiac Horse") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Horse"
+    power = 3
+    toughness = 3
+    oracleText = "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)"
+
+    keywords(Keyword.ISLANDWALK)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "159"
+        artist = "Ai Desheng"
+        flavorText = "\". . . 'First take Jingzhou, next the Riverlands; / On that rich region, base your own royal stand.' . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb24cb19-3409-45f7-b0e0-7c652064d2dd.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacMonkey.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacMonkey.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zodiac Monkey
+ * {1}{G}
+ * Creature — Monkey
+ * 2/1
+ * Forestwalk
+ */
+val ZodiacMonkey = card("Zodiac Monkey") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Monkey"
+    power = 2
+    toughness = 1
+    oracleText = "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)"
+
+    keywords(Keyword.FORESTWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "160"
+        artist = "Ai Desheng"
+        flavorText = "\". . . By six offensives from the hills of Qi Kongming sought to change Han's destiny. . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e98eb0b-c3b5-4561-b8a2-f22bd0fe1115.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacOx.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacOx.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zodiac Ox
+ * {3}{G}
+ * Creature — Ox
+ * 3/3
+ * Swampwalk
+ */
+val ZodiacOx = card("Zodiac Ox") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ox"
+    power = 3
+    toughness = 3
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)"
+
+    keywords(Keyword.SWAMPWALK)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "161"
+        artist = "Ai Desheng"
+        flavorText = "\". . . Cao's abdication changed the face of all; / No mighty battles marked the Southland's fall. . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a731b3a-0065-448d-841c-28700d78a4fd.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacPig.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacPig.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zodiac Pig
+ * {3}{B}
+ * Creature — Boar
+ * 3/3
+ * Swampwalk
+ */
+val ZodiacPig = card("Zodiac Pig") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Boar"
+    power = 3
+    toughness = 3
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)"
+
+    keywords(Keyword.SWAMPWALK)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "97"
+        artist = "Qi Baocheng"
+        flavorText = "\". . . Zhong Hui and Deng Ai next led armies west: / And to the Cao, Han's hills and streams now passed. . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52e364b5-55ca-4df5-8755-6643218b0969.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacRabbit.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacRabbit.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zodiac Rabbit
+ * {G}
+ * Creature — Rabbit
+ * 1/1
+ */
+val ZodiacRabbit = card("Zodiac Rabbit") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Rabbit"
+    power = 1
+    toughness = 1
+    oracleText = "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)"
+
+    keywords(Keyword.FORESTWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "162"
+        artist = "Ai Desheng"
+        flavorText = "\". . . The world's affairs rush on, an endless stream; / A sky-told fate, infinite in reach, dooms all. . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab4211d0-deef-4113-84e0-47ce0df7a5c6.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacRat.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacRat.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zodiac Rat
+ * {B}
+ * Creature — Rat
+ * 1 / 1
+ *
+ * Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)
+ */
+val ZodiacRat = card("Zodiac Rat") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Rat"
+    power = 1
+    toughness = 1
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)"
+
+    keywords(Keyword.SWAMPWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "98"
+        artist = "Qi Baocheng"
+        flavorText = "\" . . . Cao Pi, Cao Rui, Fang, Mao, and briefly, Huan— / The Sima took the empire in their turn. . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb6e5814-e1b5-48d2-9c4f-62b5727f333f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacRooster.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacRooster.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zodiac Rooster
+ * {1}{G}
+ * Creature — Bird
+ * 2/1
+ *
+ * Plainswalk (This creature can't be blocked as long as defending player controls a Plains.)
+ */
+val ZodiacRooster = card("Zodiac Rooster") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Bird"
+    power = 2
+    toughness = 1
+    oracleText = "Plainswalk (This creature can't be blocked as long as defending player controls a Plains.)"
+
+    keywords(Keyword.PLAINSWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "163"
+        artist = "Ai Desheng"
+        flavorText = "\". . . But the time of Han had run—could he [Kongming] not tell?— / That night his master star fell past the hills. . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/81dd362e-42f6-4eeb-9fe7-0d9cbeb4f21e.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacSnake.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacSnake.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Zodiac Snake
+ * {2}{B}
+ * Creature — Snake
+ * 2/2
+ * Swampwalk
+ */
+val ZodiacSnake = card("Zodiac Snake") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Snake"
+    power = 2
+    toughness = 2
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)"
+
+    keywordAbility(KeywordAbility.Simple(Keyword.SWAMPWALK))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "99"
+        artist = "Qi Baocheng"
+        flavorText = "\"Thrice Xuande's ardent quest led to Nanyang, / Where Sleeping Dragon unveiled Han's partition: . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6d30d6f0-ca4c-4442-a47f-ecdf52088ecc.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacTiger.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZodiacTiger.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zodiac Tiger
+ * {2}{G}{G}
+ * Creature — Cat
+ * 3/4
+ * Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)
+ */
+val ZodiacTiger = card("Zodiac Tiger") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat"
+    power = 3
+    toughness = 4
+    oracleText = "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)"
+
+    keywords(Keyword.FORESTWALK)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "164"
+        artist = "Ai Desheng"
+        flavorText = "\". . . Three kings no more—Chenliu, Guiming, Anle. / The fiefs and posts must now be filled anew. . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aafd78d5-df9f-46a3-a634-ebf7634a6358.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZuoCiTheMockingSage.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ZuoCiTheMockingSage.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Zuo Ci, the Mocking Sage
+ * {1}{G}{G}
+ * Legendary Creature — Human Advisor
+ */
+val ZuoCiTheMockingSage = card("Zuo Ci, the Mocking Sage") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Human Advisor"
+    power = 1
+    toughness = 2
+    oracleText =
+        "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\n" +
+        "Zuo Ci can't be blocked by creatures with horsemanship."
+
+    keywords(Keyword.HEXPROOF)
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.withKeyword(Keyword.HORSEMANSHIP))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "165"
+        artist = "Wang Yuqun"
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e3425241-efdc-4261-a2bb-58fbf4a9fe8c.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HorsemanshipScenarioTest.kt
+++ b/mtg-sets/1993-1999/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HorsemanshipScenarioTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ptk.cards.ShuCavalry
+import com.wingedsheep.mtg.sets.definitions.ptk.cards.ShuDefender
+import com.wingedsheep.mtg.sets.definitions.ptk.cards.WuLightCavalry
+import com.wingedsheep.mtg.sets.definitions.ptk.cards.ZuoCiTheMockingSage
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine coverage for horsemanship (CR 702.31) — Portal Three Kingdoms' signature evasion keyword.
+ *
+ * `Keyword.HORSEMANSHIP` and [com.wingedsheep.engine.mechanics.combat.rules.HorsemanshipRule] both
+ * predate this test, but until the PTK sweep **no card in the corpus declared the keyword**, so
+ * nothing ever exercised the rule end to end. That is the display-only-keyword failure mode
+ * (cascade, modular, annihilator): the line renders and the engine ignores it. These tests prove
+ * horsemanship is live in both directions.
+ *
+ * Zuo Ci is the mirror case — a static "can't be blocked by creatures with horsemanship" rather
+ * than the keyword itself, and the only PTK card that reads the keyword off a *blocker*.
+ */
+class HorsemanshipScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(WuLightCavalry)
+        driver.registerCard(ShuCavalry)
+        driver.registerCard(ShuDefender)
+        driver.registerCard(ZuoCiTheMockingSage)
+        return driver
+    }
+
+    test("a horsemanship attacker can only be blocked by a creature with horsemanship") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val attacker = driver.putCreatureOnBattlefield(me, "Wu Light Cavalry")
+        driver.removeSummoningSickness(attacker)
+        val plainBlocker = driver.putCreatureOnBattlefield(opponent, "Shu Defender")
+        val horseBlocker = driver.putCreatureOnBattlefield(opponent, "Shu Cavalry")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(attacker), opponent).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        withClue("Shu Defender has no horsemanship, so it cannot block Wu Light Cavalry") {
+            driver.declareBlockers(opponent, mapOf(plainBlocker to listOf(attacker))).isSuccess shouldBe false
+        }
+        withClue("Shu Cavalry does have horsemanship, so the block is legal") {
+            driver.declareBlockers(opponent, mapOf(horseBlocker to listOf(attacker))).isSuccess shouldBe true
+        }
+    }
+
+    test("horsemanship restricts nothing when the attacker lacks it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val attacker = driver.putCreatureOnBattlefield(me, "Shu Defender")
+        driver.removeSummoningSickness(attacker)
+        val horseBlocker = driver.putCreatureOnBattlefield(opponent, "Shu Cavalry")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(attacker), opponent).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        withClue("a horsemanship creature may block anything; the keyword only gates the attacker") {
+            driver.declareBlockers(opponent, mapOf(horseBlocker to listOf(attacker))).isSuccess shouldBe true
+        }
+    }
+
+    test("Zuo Ci inverts it: a horsemanship creature is the one that cannot block") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val attacker = driver.putCreatureOnBattlefield(me, "Zuo Ci, the Mocking Sage")
+        driver.removeSummoningSickness(attacker)
+        val horseBlocker = driver.putCreatureOnBattlefield(opponent, "Shu Cavalry")
+        val plainBlocker = driver.putCreatureOnBattlefield(opponent, "Shu Defender")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(attacker), opponent).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        withClue("Zuo Ci can't be blocked by creatures with horsemanship") {
+            driver.declareBlockers(opponent, mapOf(horseBlocker to listOf(attacker))).isSuccess shouldBe false
+        }
+        withClue("a creature without horsemanship blocks Zuo Ci normally") {
+            driver.declareBlockers(opponent, mapOf(plainBlocker to listOf(attacker))).isSuccess shouldBe true
+        }
+    }
+})

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/CaoRenWeiCommanderReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/CaoRenWeiCommanderReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cao Ren, Wei Commander reprint in PZ2. Canonical CardDefinition lives in its earliest set.
+ */
+val CaoRenWeiCommanderReprint = Printing(
+    oracleId = "99cbc054-2757-4c07-ad04-9ac67dad4abc",
+    name = "Cao Ren, Wei Commander",
+    setCode = "PZ2",
+    collectorNumber = "65817",
+    scryfallId = "3fb72119-4b7c-4008-ac09-dfdcc6d5f5be",
+    artist = "Junko Taguchi",
+    imageUri = "https://cards.scryfall.io/normal/front/3/f/3fb72119-4b7c-4008-ac09-dfdcc6d5f5be.jpg",
+    releaseDate = "2016-11-16",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/HuangZhongShuGeneralReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/HuangZhongShuGeneralReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Huang Zhong, Shu General reprint in PZ2. Canonical CardDefinition lives in its earliest set.
+ */
+val HuangZhongShuGeneralReprint = Printing(
+    oracleId = "7d6c4290-d46d-4b98-805c-3f537462c4c8",
+    name = "Huang Zhong, Shu General",
+    setCode = "PZ2",
+    collectorNumber = "65801",
+    scryfallId = "1ebf9dea-b4f8-4955-9824-7da5bbba91e9",
+    artist = "Quan Xuejun",
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1ebf9dea-b4f8-4955-9824-7da5bbba91e9.jpg",
+    releaseDate = "2016-11-16",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/LadyZhurongWarriorQueenReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/LadyZhurongWarriorQueenReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lady Zhurong, Warrior Queen reprint in PZ2. Canonical CardDefinition lives in its earliest set.
+ */
+val LadyZhurongWarriorQueenReprint = Printing(
+    oracleId = "531e6ffb-28e0-4e8e-ad88-2f3a243789cf",
+    name = "Lady Zhurong, Warrior Queen",
+    setCode = "PZ2",
+    collectorNumber = "65811",
+    scryfallId = "307858f0-f8db-40b3-870b-b7e6d6833d01",
+    artist = "Miao Aili",
+    imageUri = "https://cards.scryfall.io/normal/front/3/0/307858f0-f8db-40b3-870b-b7e6d6833d01.jpg",
+    releaseDate = "2016-11-16",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/LuSuWuAdvisorReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/LuSuWuAdvisorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lu Su, Wu Advisor reprint in PZ2. Canonical CardDefinition lives in its earliest set.
+ */
+val LuSuWuAdvisorReprint = Printing(
+    oracleId = "59238ba1-fde4-4e43-9f24-b24125e59de0",
+    name = "Lu Su, Wu Advisor",
+    setCode = "PZ2",
+    collectorNumber = "65809",
+    scryfallId = "d132e6c8-293f-4f7b-94c9-c97cc01cdda9",
+    artist = "Zhao Tan",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d132e6c8-293f-4f7b-94c9-c97cc01cdda9.jpg",
+    releaseDate = "2016-11-16",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/PangTongYoungPhoenixReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/PangTongYoungPhoenixReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pang Tong, "Young Phoenix" reprint in PZ2. Canonical CardDefinition lives in its earliest set.
+ *
+ * Hand-written rather than generated: `scripts/missing-reprints.py` scans for `card("Name")` with a
+ * regex that stops at the first `"`, so a card name containing escaped quotes is invisible to it.
+ */
+val PangTongYoungPhoenixReprint = Printing(
+    oracleId = "6d9dc632-414e-480c-85ef-c2b98a6460ad",
+    name = "Pang Tong, \"Young Phoenix\"",
+    setCode = "PZ2",
+    collectorNumber = "65813",
+    scryfallId = "dd0d76db-0521-440f-94e5-db1544a8c7ea",
+    artist = "Li Tie",
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/dd0d76db-0521-440f-94e5-db1544a8c7ea.jpg",
+    releaseDate = "2016-11-16",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/SimaYiWeiFieldMarshalReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/SimaYiWeiFieldMarshalReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sima Yi, Wei Field Marshal reprint in PZ2. Canonical CardDefinition lives in its earliest set.
+ */
+val SimaYiWeiFieldMarshalReprint = Printing(
+    oracleId = "eefa9a94-9915-4dcd-b5dc-7f8e9aa621a7",
+    name = "Sima Yi, Wei Field Marshal",
+    setCode = "PZ2",
+    collectorNumber = "65815",
+    scryfallId = "0fa7239c-a833-4a8f-8010-d55386c1b057",
+    artist = "Gao Yan",
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0fa7239c-a833-4a8f-8010-d55386c1b057.jpg",
+    releaseDate = "2016-11-16",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/XunYuWeiAdvisorReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/XunYuWeiAdvisorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Xun Yu, Wei Advisor reprint in PZ2. Canonical CardDefinition lives in its earliest set.
+ */
+val XunYuWeiAdvisorReprint = Printing(
+    oracleId = "fb5fea4a-1b04-45c6-a207-e2e8493ea968",
+    name = "Xun Yu, Wei Advisor",
+    setCode = "PZ2",
+    collectorNumber = "65799",
+    scryfallId = "3156d253-e38f-4d2b-b899-6119d9e1cb31",
+    artist = "Jack Wei",
+    imageUri = "https://cards.scryfall.io/normal/front/3/1/3156d253-e38f-4d2b-b899-6119d9e1cb31.jpg",
+    releaseDate = "2016-11-16",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/ZuoCiTheMockingSageReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/ZuoCiTheMockingSageReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zuo Ci, the Mocking Sage reprint in PZ2. Canonical CardDefinition lives in its earliest set.
+ */
+val ZuoCiTheMockingSageReprint = Printing(
+    oracleId = "ae8773a3-05f2-4074-9a53-033b0c127235",
+    name = "Zuo Ci, the Mocking Sage",
+    setCode = "PZ2",
+    collectorNumber = "65805",
+    scryfallId = "5c4c2944-30f0-4928-87fb-4b4ccad9e72f",
+    artist = "Wang Yuqun",
+    imageUri = "https://cards.scryfall.io/normal/front/5/c/5c4c2944-30f0-4928-87fb-4b4ccad9e72f.jpg",
+    releaseDate = "2016-11-16",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ImperialRecruiterReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh2/cards/ImperialRecruiterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mh2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Imperial Recruiter reprint in MH2. Canonical CardDefinition lives in its earliest set.
+ */
+val ImperialRecruiterReprint = Printing(
+    oracleId = "4d6a1391-817a-4ddc-840d-886b138eeb3f",
+    name = "Imperial Recruiter",
+    setCode = "MH2",
+    collectorNumber = "281",
+    scryfallId = "05bd329b-5707-42fc-af1c-084cc604e805",
+    artist = "Zack Stella",
+    imageUri = "https://cards.scryfall.io/normal/front/0/5/05bd329b-5707-42fc-af1c-084cc604e805.jpg",
+    releaseDate = "2021-06-18",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/TauntingChallengeReprint.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/TauntingChallengeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.tle.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Taunting Challenge reprint in TLE. Canonical CardDefinition lives in its earliest set.
+ */
+val TauntingChallengeReprint = Printing(
+    oracleId = "50c52320-9f84-4655-a91a-e09b71f9025c",
+    name = "Taunting Challenge",
+    setCode = "TLE",
+    collectorNumber = "46",
+    scryfallId = "769a8758-6638-45f6-b3a0-1f161f80983d",
+    artist = "Viacom",
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/769a8758-6638-45f6-b3a0-1f161f80983d.jpg",
+    releaseDate = "2025-11-21",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/P02.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/P02.json
@@ -470,6 +470,49 @@
     ]
 }
 
+// Rally the Troops
+{
+    "name": "Rally the Troops",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nUntap all creatures you control.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "TapUntap",
+                "target": "Self",
+                "tap": false
+            }
+        },
+        "castRestrictions": [
+            {
+                "type": "OnlyDuringStep",
+                "step": "DECLARE_ATTACKERS"
+            },
+            {
+                "type": "CastOnlyIfCondition",
+                "condition": "YouWereAttackedThisStep"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Poole",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61d92577-c3e2-4129-8974-89eb896cdc2d.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ravenous Rats
 {
     "name": "Ravenous Rats",
@@ -712,6 +755,56 @@
         "artist": "Keith Parkinson",
         "flavorText": "People fight hardest on their own soil.",
         "imageUri": "https://cards.scryfall.io/normal/front/d/e/de307b2e-9a1c-4f95-887f-14c9d99577aa.jpg?1783946489"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Warrior's Stand
+{
+    "name": "Warrior's Stand",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nCreatures you control get +2/+2 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "target": "Self"
+            }
+        },
+        "castRestrictions": [
+            {
+                "type": "OnlyDuringStep",
+                "step": "DECLARE_ATTACKERS"
+            },
+            {
+                "type": "CastOnlyIfCondition",
+                "condition": "YouWereAttackedThisStep"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "rarity": "UNCOMMON",
+        "artist": "Keith Parkinson",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2a24f00c-7e2e-4609-b956-ca3d5fb365b2.jpg"
     },
     "colorIdentityOverride": [
         "WHITE"

--- a/mtg-sets/src/test/resources/snapshots/cards/PTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/PTK.json
@@ -1,3 +1,28 @@
+// Alert Shu Infantry
+{
+    "name": "Alert Shu Infantry",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Vigilance",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "UNCOMMON",
+        "artist": "Solomon Au Yeung",
+        "flavorText": "Kongming's predecessor helped Liu Bei win the battle of Fancheng by recognizing and defeating Cao Ren's use of the dreaded \"Eight Gold Locks\" formation.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c94a92a9-060e-42d3-a8d1-49425defc08a.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ambition's Cost
 {
     "name": "Ambition's Cost",
@@ -35,6 +60,31 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Barbarian General
+{
+    "name": "Barbarian General",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Human Barbarian Soldier",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "metadata": {
+        "collectorNumber": "100",
+        "rarity": "UNCOMMON",
+        "artist": "Kuang Sheng",
+        "flavorText": "\"Barbarian tribes with their rulers are inferior to Chinese states without them.\"\n—Confucius, *The Analects* (trans. Lau)",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/060da652-03c7-45e3-ad83-f0a9fa9d1049.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -92,6 +142,56 @@
     ]
 }
 
+// Borrowing the East Wind
+{
+    "name": "Borrowing the East Wind",
+    "manaCost": "{X}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Borrowing the East Wind deals X damage to each creature with horsemanship and each player.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature kw:horsemanship"
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": "XValue",
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "Each"
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": "XValue",
+                        "target": "Controller"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "rarity": "RARE",
+        "artist": "Gao Yan",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96ba9014-d750-4924-aa6f-8b9f421807f9.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Brilliant Plan
 {
     "name": "Brilliant Plan",
@@ -113,6 +213,132 @@
         "artist": "Song Shikai",
         "flavorText": "At Red Cliffs, Kongming and Zhou Yu each wrote his plan for defeating the Wei on the palm of his hand. They laughed as they both revealed the same word, \"Fire.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/6/a/6acae374-9d71-4f8d-ba75-a983756624c7.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Burning Fields
+{
+    "name": "Burning Fields",
+    "manaCost": "{4}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Burning Fields deals 5 damage to target opponent or planeswalker.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponentOrPlaneswalker",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "Yang Hong",
+        "flavorText": "\"In raiding and plundering, be like fire, in immovability like a mountain.\"\n—Sun Tzu, *Art of War* (trans. Giles)",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/dee12f01-581e-4a3c-a8b5-41bef2516781.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Cao Ren, Wei Commander
+{
+    "name": "Cao Ren, Wei Commander",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Legendary Creature — Human Soldier Warrior",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)\nWhen Cao Ren enters, you lose 3 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": "Controller"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "rarity": "RARE",
+        "artist": "Junko Taguchi",
+        "flavorText": "Cao Cao's cousin, Cao Ren was known throughout the three kingdoms as the fiercest of warriors.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f7e8366-82ba-4df0-b9df-7d0aa9b972eb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Champion's Victory
+{
+    "name": "Champion's Victory",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nReturn target attacking creature to its owner's hand.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature attacking"
+                },
+                "id": "target"
+            }
+        ],
+        "castRestrictions": [
+            {
+                "type": "OnlyDuringStep",
+                "step": "DECLARE_ATTACKERS"
+            },
+            {
+                "type": "CastOnlyIfCondition",
+                "condition": "YouWereAttackedThisStep"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "UNCOMMON",
+        "artist": "Hong Yan",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/451ef657-8590-497a-9d98-a732d4de6165.jpg"
     },
     "colorIdentityOverride": [
         "BLUE"
@@ -199,6 +425,258 @@
     ]
 }
 
+// Corrupt Eunuchs
+{
+    "name": "Corrupt Eunuchs",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Advisor",
+    "oracleText": "When this creature enters, it deals 2 damage to target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "rarity": "UNCOMMON",
+        "artist": "Li Yousong",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e084664-2faf-4f7a-9068-d58d3f4b8456.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Council of Advisors
+{
+    "name": "Council of Advisors",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Advisor",
+    "oracleText": "When this creature enters, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "rarity": "UNCOMMON",
+        "artist": "Liu Shangying",
+        "flavorText": "Sun Quan's long and successful rule in the years 199 to 251 was due to his ability to choose and foster talented advisors and generals.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c59f45b-46fa-4494-9b25-cf9d3e462539.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Desert Sandstorm
+{
+    "name": "Desert Sandstorm",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Desert Sandstorm deals 1 damage to each creature.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            },
+            "body": {
+                "type": "DealDamage",
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "artist": "Xu Tan",
+        "flavorText": "While pursuing the remnants of Yuan Shao's forces into the Wuhan Desert, Cao Cao was temporarily turned back by a fierce sandstorm.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/588ad2bf-405d-4c36-b485-e415c22f2703.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Desperate Charge
+{
+    "name": "Desperate Charge",
+    "manaCost": "{2}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Creatures you control get +2/+0 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 0
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "rarity": "UNCOMMON",
+        "artist": "Chen Weidong",
+        "flavorText": "\"Lieutenants dishonored, corpses carted home; The general raises troops again to take revenge.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a5587089-b17e-4187-97aa-1c3eec070a0b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Eightfold Maze
+{
+    "name": "Eightfold Maze",
+    "manaCost": "{2}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nDestroy target attacking creature.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature attacking"
+                },
+                "id": "target"
+            }
+        ],
+        "castRestrictions": [
+            {
+                "type": "OnlyDuringStep",
+                "step": "DECLARE_ATTACKERS"
+            },
+            {
+                "type": "CastOnlyIfCondition",
+                "condition": "YouWereAttackedThisStep"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "RARE",
+        "artist": "Shang Huitong",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc8c377a-82c4-46ee-94c2-b970160a3205.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// False Defeat
+{
+    "name": "False Defeat",
+    "manaCost": "{3}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target creature card from your graveyard to the battlefield.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Battlefield",
+            "fromZone": "Graveyard"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "artist": "Li Wang",
+        "flavorText": "\"All warfare is based on deception.\"\n—Sun Tzu, *Art of War* (trans. Giles)",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5ca71ce3-8633-428a-8d9e-9b807b77a8e2.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Famine
 {
     "name": "Famine",
@@ -256,6 +734,180 @@
     ]
 }
 
+// Fire Ambush
+{
+    "name": "Fire Ambush",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Fire Ambush deals 3 damage to any target.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "artist": "Tang Xiaogu",
+        "flavorText": "\"With fire he broke the battle at Bowang . . . . Striking fear deep into Cao Cao's soul, thus Kongming scored a coup at his debut.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4dd8bdbd-99c9-4fa7-936a-acc7f4238507.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Fire Bowman
+{
+    "name": "Fire Bowman",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Human Soldier Archer",
+    "oracleText": "Sacrifice this creature: It deals 1 damage to any target. Activate only during your turn, before attackers are declared.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    {
+                        "type": "BeforeStep",
+                        "step": "DECLARE_ATTACKERS"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "UNCOMMON",
+        "artist": "Cai Tingting",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/18acc721-e9ae-4ba4-b435-754e41fb541e.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Flanking Troops
+{
+    "name": "Flanking Troops",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Whenever this creature attacks, you may tap target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "UNCOMMON",
+        "artist": "Li Wang",
+        "flavorText": "Following the battle of Redcliffs, both Liu Bei and Sun Quan coveted the province of Jingzhou. After Sun Quan's troops failed to capture it, Liu Bei's succeeded.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a219a031-2466-4850-b646-79a09e30cf18.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Forced Retreat
+{
+    "name": "Forced Retreat",
+    "manaCost": "{2}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Put target creature on top of its owner's library.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Library",
+            "placement": "Top"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "artist": "Huang Qishi",
+        "flavorText": "\"Leadership, not numbers, determines victory.\"\n—A Wu commander, before his 5,000 troops forced 15,000 Wei troops to retreat from Ruxu",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/9753d211-3436-4a9b-86d9-54a541770ec2.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Forest Bear
 {
     "name": "Forest Bear",
@@ -273,6 +925,294 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Ghostly Visit
+{
+    "name": "Ghostly Visit",
+    "manaCost": "{2}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target nonblack creature.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotColor",
+                                "color": "BLACK"
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "artist": "Kang Yu",
+        "flavorText": "Cao Cao was haunted to death by the ghosts of the empresses and other high courtiers he had murdered.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/06f6938a-229a-4521-b5d5-7999ce5fb372.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Guan Yu's 1,000-Li March
+{
+    "name": "Guan Yu's 1,000-Li March",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy all tapped creatures.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "creature tapped"
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "rarity": "RARE",
+        "artist": "Yang Guangmai",
+        "flavorText": "\"He [Guan Yu] covered the ground on a thousand-*li* horse; / With dragon blade he took each pass by force.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8fa7526a-7a4e-4b3d-b96e-91f2bbf1c7bd.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Heavy Fog
+{
+    "name": "Heavy Fog",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Cast this spell only during the declare attackers step and only if you've been attacked this step.\nPrevent all damage that would be dealt to you this turn by attacking creatures.",
+    "script": {
+        "spellEffect": {
+            "type": "PreventDamageShield",
+            "sourceFilter": "AttackingCreatures"
+        },
+        "castRestrictions": [
+            {
+                "type": "OnlyDuringStep",
+                "step": "DECLARE_ATTACKERS"
+            },
+            {
+                "type": "CastOnlyIfCondition",
+                "condition": "YouWereAttackedThisStep"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "UNCOMMON",
+        "artist": "Liu Shangying",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/499fee7b-1942-4eb9-b1d0-806a1f6c0cd8.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Huang Zhong, Shu General
+{
+    "name": "Huang Zhong, Shu General",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Legendary Creature — Human Soldier",
+    "oracleText": "Huang Zhong can't be blocked by more than one creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedByMoreThan",
+                "maxBlockers": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "rarity": "RARE",
+        "artist": "Quan Xuejun",
+        "flavorText": "\"Virile in war, he kept the north in fear; His prodigies subdued the western sphere.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c079037c-f4cf-423f-ad15-ee57136d6148.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Imperial Recruiter
+{
+    "name": "Imperial Recruiter",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Advisor",
+    "oracleText": "When this creature enters, search your library for a creature card with power 2 or less, reveal it, put it into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "creature pow<=2"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "rarity": "UNCOMMON",
+        "artist": "Mitsuaki Sagiri",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1c473253-3992-4cc1-8b46-5d1da308c537.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Imperial Seal
+{
+    "name": "Imperial Seal",
+    "manaCost": "{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        "ShuffleLibrary",
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            }
+                        },
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Controller"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "rarity": "RARE",
+        "artist": "Li Tie",
+        "flavorText": "\"If Heaven has placed it in your hands, it means that the throne is destined to be yours.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/822e30db-40c5-4099-868b-185ad9b7c7dc.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -331,6 +1271,132 @@
     ]
 }
 
+// Lady Zhurong, Warrior Queen
+{
+    "name": "Lady Zhurong, Warrior Queen",
+    "manaCost": "{4}{G}",
+    "typeLine": "Legendary Creature — Human Soldier Warrior",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Simple",
+            "keyword": "HORSEMANSHIP"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "139",
+        "rarity": "RARE",
+        "artist": "Miao Aili",
+        "flavorText": "\"A man, and such a fool! I, a woman, will fight them for you.\"\n—Lady Zhurong to her husband Meng Huo, before leading an army against the Shu",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/009661e7-c704-43a1-82e3-7da0b609844e.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Lu Bu, Master-at-Arms
+{
+    "name": "Lu Bu, Master-at-Arms",
+    "manaCost": "{5}{R}",
+    "typeLine": "Legendary Creature — Human Soldier Warrior",
+    "oracleText": "Haste; horsemanship (This creature can't be blocked except by creatures with horsemanship.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "HASTE",
+        "HORSEMANSHIP"
+    ],
+    "metadata": {
+        "collectorNumber": "115",
+        "rarity": "RARE",
+        "artist": "Gao Jianzhang",
+        "flavorText": "\"Dong Zhuo's man, Lu Bu, warrior without peer, / Far surpassed the champions of his sphere.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/07d60c27-8625-48eb-a3f0-1e26d6930ae7.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Lu Meng, Wu General
+{
+    "name": "Lu Meng, Wu General",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Legendary Creature — Human Soldier",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "RARE",
+        "artist": "Gao Yan",
+        "flavorText": "As the Wu chief commander, Lu Meng conquered Shu-held Jingzhou in 219 by disguising soldiers as merchants on boats filled with hiding troops.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/77a8b376-eda5-4bf9-9093-9518c09e50e8.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Lu Su, Wu Advisor
+{
+    "name": "Lu Su, Wu Advisor",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Legendary Creature — Human Advisor",
+    "oracleText": "{T}: Draw a card. Activate only during your turn, before attackers are declared.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    {
+                        "type": "BeforeStep",
+                        "step": "DECLARE_ATTACKERS"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "47",
+        "rarity": "RARE",
+        "artist": "Zhao Tan",
+        "flavorText": "Lu Su served as an intermediary between the Wu and Shu kingdoms until Zhou Yu's death in 210, when he became Wu's supreme commander.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d361823-31ce-42c4-997d-3d3b52c0599a.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Meng Huo's Horde
 {
     "name": "Meng Huo's Horde",
@@ -348,6 +1414,172 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Meng Huo, Barbarian King
+{
+    "name": "Meng Huo, Barbarian King",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Legendary Creature — Human Barbarian Soldier",
+    "oracleText": "Other green creatures you control get +1/+1.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature green ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "rarity": "RARE",
+        "artist": "Yang Guangmai",
+        "flavorText": "The stubborn Meng Huo was captured and released by Kongming seven times before finally surrendering.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e340647c-fb6d-45a6-9f42-235390b40337.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Misfortune's Gain
+{
+    "name": "Misfortune's Gain",
+    "manaCost": "{3}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature. Its owner gains 4 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "OwnerGainsLife",
+                    "amount": 4
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "artist": "Jiaming",
+        "flavorText": "The mourning families of commanders and generals were often given land, valuables, or money to compensate for their losses.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/0/80abd7c1-8f7a-4279-b76f-251a02624345.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Mountain Bandit
+{
+    "name": "Mountain Bandit",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Human Soldier Rogue",
+    "oracleText": "Haste",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "117",
+        "artist": "Xu Xiaoming",
+        "flavorText": "Penniless and far from home, many former Yellow Scarves and other soldiers became bandits to survive.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/4/34fd541d-9956-4595-9527-a83db4c5f74f.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Pang Tong, "Young Phoenix"
+{
+    "name": "Pang Tong, \"Young Phoenix\"",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Legendary Creature — Human Advisor",
+    "oracleText": "{T}: Target creature gets +0/+2 until end of turn. Activate only during your turn, before attackers are declared.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    {
+                        "type": "BeforeStep",
+                        "step": "DECLARE_ATTACKERS"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "rarity": "RARE",
+        "artist": "Li Tie",
+        "flavorText": "\". . . It was Pang Tong's boat-connecting scheme That let Zhou Yu accomplish his great deed.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f484d47a-fb1d-4746-8f1d-dd9d24e67c1a.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -383,6 +1615,568 @@
     ]
 }
 
+// Poison Arrow
+{
+    "name": "Poison Arrow",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target nonblack creature. You gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotColor",
+                                "color": "BLACK"
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "rarity": "UNCOMMON",
+        "artist": "Li Tie",
+        "flavorText": "In ancient China, not wearing armor could be a fatal mistake. Guan Yu, Zhou Yu, Sun Ce, and other heros were struck by poison arrows.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6b7b5f34-c250-484e-9bae-94789b2a87fb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Preemptive Strike
+{
+    "name": "Preemptive Strike",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target creature spell.",
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature",
+                    "zone": "Stack"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "Jiaming",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2314bf1-b22d-48c2-860f-e1081f56296b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Ravages of War
+{
+    "name": "Ravages of War",
+    "manaCost": "{3}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy all lands.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "land"
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "RARE",
+        "artist": "Fang Yue",
+        "flavorText": "\"Thorn bushes spring up wherever the army has passed. Lean years follow in the wake of a great war.\"\n—Lao Tzu, *Tao Te Ching* (trans. Feng and English)",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11dca9ba-b27f-4af8-9962-3794e743886f.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Ravaging Horde
+{
+    "name": "Ravaging Horde",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "When this creature enters, destroy target land.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "land"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "rarity": "UNCOMMON",
+        "artist": "Liu Jianjian",
+        "flavorText": "Upon his return to the capitol after taking soldiers to loot a nearby peaceful town, the prime minister, Dong Zhou, boasted of it as a victory over bandits.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/6278d679-fc54-4527-ab16-90735574ab9b.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Red Cliffs Armada
+{
+    "name": "Red Cliffs Armada",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "This creature can't attack unless defending player controls an Island.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnless",
+                "condition": {
+                    "type": "Exists",
+                    "player": "DefendingPlayer",
+                    "zone": "Battlefield",
+                    "filter": "land Island"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "UNCOMMON",
+        "artist": "Zhang Jiazhen",
+        "flavorText": "By the battle of Red Cliffs in the year 208, the Wu kingdom controlled more than 7,000 warships on the Yangtze.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c8fe0f33-35c7-439b-bece-4a9461b92352.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Renegade Troops
+{
+    "name": "Renegade Troops",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Haste",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "120",
+        "rarity": "UNCOMMON",
+        "artist": "Liu Jianjian",
+        "flavorText": "\"Across the land rebellions seethed and swarmed / As vicious war lords swooped down on all sides.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a75095f4-a77f-4237-ae25-2e6f2f8788c1.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Return to Battle
+{
+    "name": "Return to Battle",
+    "manaCost": "{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target creature card from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "artist": "Ding Songjian",
+        "flavorText": "\"Swallowing his eye, the valiant Xiahou Dun fought on; / But Cao Cao's vanguard, its commander wounded, could not hold out for long.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/1841e615-fdcd-4187-bd69-d07abde0e1ae.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Riding Red Hare
+{
+    "name": "Riding Red Hare",
+    "manaCost": "{2}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target creature gets +3/+3 and gains horsemanship until end of turn. (It can't be blocked except by creatures with horsemanship.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HORSEMANSHIP",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Qi Baocheng",
+        "flavorText": "One of the greatest steeds in the empire, Red Hare could travel a thousand *li* a day and climb hills as if running on flat ground.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c0504a24-4b92-471a-8da4-02ec57eb43be.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Rockslide Ambush
+{
+    "name": "Rockslide Ambush",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Rockslide Ambush deals damage to target creature equal to the number of Mountains you control.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land Mountain"
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "UNCOMMON",
+        "artist": "Inoue Junichi",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/04e5faf1-25c9-46c0-88f2-c59e7b9c08c5.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Rolling Earthquake
+{
+    "name": "Rolling Earthquake",
+    "manaCost": "{X}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Rolling Earthquake deals X damage to each creature without horsemanship and each player.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotKeyword",
+                                        "keyword": "HORSEMANSHIP"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": "XValue",
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "Each"
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": "XValue",
+                        "target": "Controller"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "rarity": "RARE",
+        "artist": "Yang Hong",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3c1bf210-ecdb-4b49-8504-51360c269e66.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Sage's Knowledge
+{
+    "name": "Sage's Knowledge",
+    "manaCost": "{2}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target sorcery card from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "sorcery own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Ding Songjian",
+        "flavorText": "\"Those who know do not talk. Those who talk do not know.\"\n—Lao Tzu, *Tao Te Ching*\n(trans. Feng and English)",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/156d7c70-6c6d-4052-9d44-029ba1bb66e4.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Shu Cavalry
+{
+    "name": "Shu Cavalry",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Simple",
+            "keyword": "HORSEMANSHIP"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Li Xiaohua",
+        "flavorText": "In establishing the Shu kingdom, Liu Bei's forces fought against Ma Chao at Chengdu. Eventually, Ma Chao surrendered and became one of Liu Bei's Tiger Generals.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/0433bee7-406d-4dd3-8d1b-dfd6cb64d038.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Shu Defender
+{
+    "name": "Shu Defender",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Whenever this creature blocks, it gets +0/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "Sun Nan",
+        "flavorText": "Confronting Cao Cao's army at Steepslope Bridge, Zhang Fei bellowed, \"I am Zhang Fei of Yan! Who dares fight me to the death?\" Cao Cao's army cowered and fled.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/ee57a9ab-c385-4a51-aff7-6a654f5d7611.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Shu Elite Companions
+{
+    "name": "Shu Elite Companions",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "metadata": {
+        "collectorNumber": "21",
+        "rarity": "UNCOMMON",
+        "artist": "Qiao Dafu",
+        "flavorText": "Throughout the three kingdoms, important generals were often guarded by small groups of expert soldiers known as \"elite companions.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11ac63f6-cd61-4334-902a-777410311b2d.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Shu Elite Infantry
 {
     "name": "Shu Elite Infantry",
@@ -397,6 +2191,49 @@
         "artist": "Song Shikai",
         "flavorText": "Kongming's first campaign against the Wei kingdom was a rousing success until an arrogant Shu general, Ma Su, foolishly lost the city of Jieting.",
         "imageUri": "https://cards.scryfall.io/normal/front/3/6/36bcd751-1142-4e72-9d87-7a25c74c038b.jpg?1783946128"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Shu Farmer
+{
+    "name": "Shu Farmer",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human",
+    "oracleText": "{T}: You gain 1 life. Activate only during your turn, before attackers are declared.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    {
+                        "type": "BeforeStep",
+                        "step": "DECLARE_ATTACKERS"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "artist": "Li Xiaohua",
+        "flavorText": "\"The common folk are ceaselessly active. The fields are fertile and the soil productive, and neither flood nor drought plagues us.\"\n—A Shu diplomat",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc6d6524-d8bd-4eb9-9222-747443492b8c.jpg"
     },
     "colorIdentityOverride": [
         "WHITE"
@@ -423,6 +2260,181 @@
     ]
 }
 
+// Shu General
+{
+    "name": "Shu General",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Vigilance; horsemanship (This creature can't be blocked except by creatures with horsemanship.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE",
+        "HORSEMANSHIP"
+    ],
+    "metadata": {
+        "collectorNumber": "25",
+        "rarity": "UNCOMMON",
+        "artist": "Li Xiaohua",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c9c3be7a-82a8-411c-bfe2-16749ada1244.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Shu Grain Caravan
+{
+    "name": "Shu Grain Caravan",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "When this creature enters, you gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "artist": "Li Wang",
+        "flavorText": "Keeping a million-man army fed was no easy task. Grain and rice caravans were the lifeblood of the empire.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7bf26eb7-8a31-4022-87bb-67394653f06a.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Shu Soldier-Farmers
+{
+    "name": "Shu Soldier-Farmers",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "When this creature enters, you gain 4 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "27",
+        "rarity": "UNCOMMON",
+        "artist": "Li Xiaohua",
+        "flavorText": "During Kongming's campaigns against the Wei, his Shu troops rotated from the battlefront to the fields every hundred days.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/edb576e9-98ba-4bd1-9d1e-e316acf2e7f5.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Sima Yi, Wei Field Marshal
+{
+    "name": "Sima Yi, Wei Field Marshal",
+    "manaCost": "{5}{B}",
+    "typeLine": "Legendary Creature — Human Soldier",
+    "oracleText": "Sima Yi's power is equal to the number of Swamps you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "land Swamp"
+            }
+        },
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "rarity": "RARE",
+        "artist": "Gao Yan",
+        "flavorText": "Sima Yi fought for four generations of the Cao family before his own grandson became emperor and united the three kingdoms.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/6500b690-d601-4c6d-baea-552e366ea242.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Slashing Tiger
+{
+    "name": "Slashing Tiger",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Whenever this creature becomes blocked, it gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "rarity": "RARE",
+        "artist": "Yang Jun Kwon",
+        "flavorText": "\"Unless you enter the tiger's lair, you cannot get hold of the tiger's cubs.\"\n—Sun Tzu, *Art of War* (trans. Giles)",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4fbedd66-457a-4e1c-a9f3-fa37dec81c7a.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Southern Elephant
 {
     "name": "Southern Elephant",
@@ -440,6 +2452,81 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Spring of Eternal Peace
+{
+    "name": "Spring of Eternal Peace",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "You gain 8 life.",
+    "script": {
+        "spellEffect": {
+            "type": "GainLife",
+            "amount": {
+                "type": "Fixed",
+                "amount": 8
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "artist": "Wang Yuqun",
+        "flavorText": "Bathing in this spring could cure ailments of body and mind alike.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6862d7a-04ee-48ac-a5b3-46a4e8694d5b.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Stolen Grain
+{
+    "name": "Stolen Grain",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Stolen Grain deals 5 damage to target opponent or planeswalker. You gain 5 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponentOrPlaneswalker",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "UNCOMMON",
+        "artist": "LHQ",
+        "flavorText": "At the battle of Guandu, Cao Cao defeated Yuan Shao by raiding his grain depot, leaving him with no way to feed his troops.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e1f08862-5107-46a0-8c14-a961a5c4b135.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -530,6 +2617,192 @@
     ]
 }
 
+// Sun Ce, Young Conquerer
+{
+    "name": "Sun Ce, Young Conquerer",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Legendary Creature — Human Soldier",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)\nWhen Sun Ce enters, you may return target creature to its owner's hand.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "rarity": "RARE",
+        "artist": "Yang Guangmai",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/16114a68-58d1-4aad-9b3a-890e9c84b253.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Sun Quan, Lord of Wu
+{
+    "name": "Sun Quan, Lord of Wu",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Legendary Creature — Human Soldier",
+    "oracleText": "Creatures you control have horsemanship. (They can't be blocked except by creatures with horsemanship.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "HORSEMANSHIP",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "rarity": "RARE",
+        "artist": "Xu Xiaoming",
+        "flavorText": "\"One score and four he reigned, the Southland king: / A dragon coiled, a tiger poised below the mighty Yangtze.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6def4492-3f67-4cdb-8a25-c3ddebd125c7.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Taoist Hermit
+{
+    "name": "Taoist Hermit",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Mystic",
+    "oracleText": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HEXPROOF"
+    ],
+    "metadata": {
+        "collectorNumber": "150",
+        "rarity": "UNCOMMON",
+        "artist": "Wang Yuqun",
+        "flavorText": "Taoists chose to be hermits for many reasons, but all shared one unchanging goal: to follow the Tao.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d818c231-8d66-4024-91de-fe29f8622902.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Taoist Mystic
+{
+    "name": "Taoist Mystic",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Mystic",
+    "oracleText": "This creature can't be blocked by creatures with horsemanship.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasKeyword",
+                            "keyword": "HORSEMANSHIP"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "RARE",
+        "artist": "Qu Xin",
+        "flavorText": "By appearing in places miles apart at the same time, Zuo Ci exhibited the mystic's ability to \"shrink the land.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/023ae64a-7888-4ad2-b879-0649d8e341ac.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Taunting Challenge
+{
+    "name": "Taunting Challenge",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "All creatures able to block target creature this turn do so.",
+    "script": {
+        "spellEffect": {
+            "type": "MustBeBlocked",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "rarity": "RARE",
+        "artist": "Gao Yan",
+        "flavorText": "Incensed by their opponents' unrelenting taunts, even wise generals were known to rashly lead their troops into battle—often to disastrous defeats.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/4620867c-a3a6-4c81-b923-24007367132e.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Three Visits
 {
     "name": "Three Visits",
@@ -585,6 +2858,48 @@
     ]
 }
 
+// Trained Cheetah
+{
+    "name": "Trained Cheetah",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Whenever this creature becomes blocked, it gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "rarity": "UNCOMMON",
+        "artist": "Fang Yue",
+        "flavorText": "\"[King Mulu's cheetahs] came riding on the winds, charging, with fangs bared and claws flexed.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab242eab-5cab-41a0-bcf8-93a6919e4558.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Trained Jackal
 {
     "name": "Trained Jackal",
@@ -602,6 +2917,174 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Trip Wire
+{
+    "name": "Trip Wire",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature with horsemanship.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature kw:horsemanship"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "156",
+        "rarity": "UNCOMMON",
+        "artist": "Hong Yan",
+        "flavorText": "Trip wire, hooked poles, and sunken pits were commonly used to unhorse riders during the Three Kingdoms period.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4eb1e16f-002e-4a81-ba41-cfe41f3a9071.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Virtuous Charge
+{
+    "name": "Virtuous Charge",
+    "manaCost": "{2}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Creatures you control get +1/+1 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "artist": "Qu Xin",
+        "flavorText": "\"The empire belongs to no one man but to all in the empire. He who has virtue shall possess it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72ad4c79-a85d-4fc6-95ab-5a6d6d667579.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Warrior's Oath
+{
+    "name": "Warrior's Oath",
+    "manaCost": "{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
+    "script": {
+        "spellEffect": {
+            "type": "TakeExtraTurn",
+            "loseAtEndStep": true
+        }
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "rarity": "RARE",
+        "artist": "Mitsuaki Sagiri",
+        "flavorText": "\"If I fail, my head is yours.\"\n—Warrior's oath common during the Three Kingdoms period",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d582861a-ca6e-4b74-adf0-3eb588ea5ed2.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Wei Ambush Force
+{
+    "name": "Wei Ambush Force",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Whenever this creature attacks, it gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "artist": "Ku Xueming",
+        "flavorText": "The battle of Puyang marked the beginning of the end for Lu Bu. He lost the city—and later his life—to Cao Cao.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b241ba4-cff5-48ce-83bd-d70fb5e20ff4.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Wei Elite Companions
+{
+    "name": "Wei Elite Companions",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "metadata": {
+        "collectorNumber": "87",
+        "rarity": "UNCOMMON",
+        "artist": "Li Youliang",
+        "flavorText": "Cao Cao was more concerned with capabilities than lineage. He excelled at recruiting and retaining men of talent to serve him.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/843cbf18-60ac-4d97-b156-874735db61c6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -625,6 +3108,165 @@
     ]
 }
 
+// Wei Scout
+{
+    "name": "Wei Scout",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Soldier Scout",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "metadata": {
+        "collectorNumber": "90",
+        "artist": "Jiang Zhuqing",
+        "flavorText": "\"He will win who, prepared himself, waits to take the enemy unprepared.\"\n—Sun Tzu, *Art of War* (trans. Giles)",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a11d58fb-fb70-4e8f-8f64-232ad2c1f59b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Wei Strike Force
+{
+    "name": "Wei Strike Force",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "metadata": {
+        "collectorNumber": "91",
+        "artist": "Tang Xiaogu",
+        "flavorText": "At the battle of Chang'an, Ma Chao defeated the two generals Cao Cao sent to guard the pass but was forced to flee when Cao Cao's trickery turned his own ally against him.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/e/6eae8ce1-b21f-4d64-91ff-e98bf6a4548a.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Wielding the Green Dragon
+{
+    "name": "Wielding the Green Dragon",
+    "manaCost": "{1}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target creature gets +4/+4 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "artist": "Quan Xuejun",
+        "flavorText": "Named for the eastern part of the sky, the source of energy and renewal, Guan Yu's crescent-moon blade weighed over 100 pounds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2b138167-8129-4109-a58b-af26c95577e4.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Wu Admiral
+{
+    "name": "Wu Admiral",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "This creature gets +1/+1 as long as an opponent controls an Island.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "EachOpponent",
+                    "zone": "Battlefield",
+                    "filter": "land Island"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "rarity": "UNCOMMON",
+        "artist": "Zhang Jiazhen",
+        "flavorText": "The Wu kingdom's well-trained admirals were integral to the Southlands' victory at Red Cliffs as well as the kingdom's defense.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/499ae191-80ac-42bf-b49d-db343803bd56.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Wu Elite Cavalry
+{
+    "name": "Wu Elite Cavalry",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "metadata": {
+        "collectorNumber": "58",
+        "artist": "Li Wang",
+        "flavorText": "At the second battle of Ruxu, the brave Wu general Gan Ning raided Cao Cao's camp of 400,000 men with only 100 cavalry. Not a single man or horse was lost.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7cf562e2-be8e-4514-b2c8-3268dc1ab0db.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Wu Infantry
 {
     "name": "Wu Infantry",
@@ -642,5 +3284,812 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Wu Light Cavalry
+{
+    "name": "Wu Light Cavalry",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "Huang Qishi",
+        "flavorText": "A cunning strategist, Cao Ren tricked Zhou Yu by letting him enter Nanjun. Zhou Yu thought he was capturing the city until Cao Ren's arrows rained down upon him.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/60e55b25-fde2-4b57-b5db-65b75262ff3d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Wu Longbowman
+{
+    "name": "Wu Longbowman",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Soldier Archer",
+    "oracleText": "{T}: This creature deals 1 damage to any target. Activate only during your turn, before attackers are declared.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    {
+                        "type": "BeforeStep",
+                        "step": "DECLARE_ATTACKERS"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "rarity": "UNCOMMON",
+        "artist": "Xu Tan",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/28e68635-b0ed-4a56-8b18-679f95db12b6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Wu Scout
+{
+    "name": "Wu Scout",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Soldier Scout",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)\nWhen this creature enters, look at target opponent's hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Simple",
+            "keyword": "HORSEMANSHIP"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "LookAtTargetHand",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "artist": "Jiaming",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d13330f-6e07-451f-b17a-4e1606a74c3f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Wu Warship
+{
+    "name": "Wu Warship",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "This creature can't attack unless defending player controls an Island.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnless",
+                "condition": {
+                    "type": "Exists",
+                    "player": "DefendingPlayer",
+                    "zone": "Battlefield",
+                    "filter": "land Island"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "64",
+        "artist": "Jiang Zhuqing",
+        "flavorText": "Both Wu and Wei warships patrolled the Yangtze River, the natural border between the two kingdoms.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e211d47-dab4-429a-a90b-5b8489441886.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Xun Yu, Wei Advisor
+{
+    "name": "Xun Yu, Wei Advisor",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Legendary Creature — Human Advisor",
+    "oracleText": "{T}: Target creature you control gets +2/+0 until end of turn. Activate only during your turn, before attackers are declared.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    {
+                        "type": "BeforeStep",
+                        "step": "DECLARE_ATTACKERS"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "93",
+        "rarity": "RARE",
+        "artist": "Jack Wei",
+        "flavorText": "\"A splendid talent, admired of all men! His folly lay in serving Cao Cao's power.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8f0a25ea-b414-423c-94a6-8a4795d60b46.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Yellow Scarves Cavalry
+{
+    "name": "Yellow Scarves Cavalry",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)\nThis creature can't block.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "script": {
+        "staticAbilities": [
+            "CantBlock"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "artist": "Chen Weidong",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/84460666-4f6b-422c-b20e-dc1651c66e15.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Yellow Scarves General
+{
+    "name": "Yellow Scarves General",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)\nThis creature can't block.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "script": {
+        "staticAbilities": [
+            "CantBlock"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "126",
+        "rarity": "RARE",
+        "artist": "Chen Weidong",
+        "flavorText": "Zhang Jue, leader of the Yellow Scarves rebellion, was a Taoist master and tutored his soldiers in those arts.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/06e98691-6227-41f2-a3f4-3131b07a3a6f.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Yellow Scarves Troops
+{
+    "name": "Yellow Scarves Troops",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "This creature can't block.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            "CantBlock"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "artist": "Chen Weidong",
+        "flavorText": "Over 500,000 commoners followed Zhang Jue, General of Heaven, in his attempt to overthrow the corrupt Han dynasty.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3ca36a8d-ca44-485e-a219-85814f160c4d.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Young Wei Recruits
+{
+    "name": "Young Wei Recruits",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "This creature can't block.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            "CantBlock"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "artist": "Li Youliang",
+        "flavorText": "\"To send the common people to war untrained is to throw them away.\"\n—Confucius, *The Analects* (trans. Lau)",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11431c4c-b0bb-4747-a34a-4a90238ec9c6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Zhang Fei, Fierce Warrior
+{
+    "name": "Zhang Fei, Fierce Warrior",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Legendary Creature — Human Soldier Warrior",
+    "oracleText": "Vigilance; horsemanship (This creature can't be blocked except by creatures with horsemanship.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE",
+        "HORSEMANSHIP"
+    ],
+    "metadata": {
+        "collectorNumber": "32",
+        "rarity": "RARE",
+        "artist": "Qiao Dafu",
+        "flavorText": "Zhang Fei's uncharacteristic alliance with a defeated Riverlands general, Yan Yan, allowed Shu forces to advance through forty-five Riverlands strongpoints with no casualties.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2a58ec38-f1dc-4c69-9d26-a4599bce586a.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Zhao Zilong, Tiger General
+{
+    "name": "Zhao Zilong, Tiger General",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Legendary Creature — Human Soldier Warrior",
+    "oracleText": "Horsemanship (This creature can't be blocked except by creatures with horsemanship.)\nWhenever Zhao Zilong blocks, it gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "HORSEMANSHIP"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "rarity": "RARE",
+        "artist": "Quan Xuejun",
+        "flavorText": "Zhao Zilong was a brave and noble warrior. Twice he rescued Liu Bei's son, Liu Shan.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d16cf1d-a7c3-4038-a648-299c1bedae99.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Zhou Yu, Chief Commander
+{
+    "name": "Zhou Yu, Chief Commander",
+    "manaCost": "{5}{U}{U}",
+    "typeLine": "Legendary Creature — Human Soldier",
+    "oracleText": "Zhou Yu can't attack unless defending player controls an Island.",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnless",
+                "condition": {
+                    "type": "Exists",
+                    "player": "DefendingPlayer",
+                    "zone": "Battlefield",
+                    "filter": "land Island"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "RARE",
+        "artist": "Xu Xiaoming",
+        "flavorText": "\"After making me, Zhou Yu, did you have to make Kongming?\"\n—Zhou Yu crying to heaven on his deathbed",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/e/6e2cf83b-417d-41ca-8e65-86aa65180c40.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Zhuge Jin, Wu Strategist
+{
+    "name": "Zhuge Jin, Wu Strategist",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Legendary Creature — Human Advisor",
+    "oracleText": "{T}: Target creature can't be blocked this turn. Activate only during your turn, before attackers are declared.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    {
+                        "type": "BeforeStep",
+                        "step": "DECLARE_ATTACKERS"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "RARE",
+        "artist": "Song Shikai",
+        "flavorText": "When Zhuge Jin proposed the marriage of Guan Yu's daugher and Sun Quan's heir, Guan Yu's arrogant refusal led to disaster.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/60790b07-53da-41fa-b9e0-e7ce22fdcb11.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Zodiac Dog
+{
+    "name": "Zodiac Dog",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Dog",
+    "oracleText": "Mountainwalk (This creature can't be blocked as long as defending player controls a Mountain.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "MOUNTAINWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "130",
+        "artist": "Qi Baocheng",
+        "flavorText": "\". . . Jiang Wei alone still strove with might and main: / Nine times more he fought the north—in vain. . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc61aa62-25ee-40a4-9b6e-d6277316b464.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Zodiac Goat
+{
+    "name": "Zodiac Goat",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goat",
+    "oracleText": "Mountainwalk (This creature can't be blocked as long as defending player controls a Mountain.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "MOUNTAINWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "132",
+        "artist": "Qi Baocheng",
+        "flavorText": "\". . . Near death in Baidi, having reigned three years, / Bei sadly placed his son in Kongming's care. . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/52510462-2802-4e16-87d4-da376ee2e3be.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Zodiac Horse
+{
+    "name": "Zodiac Horse",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Horse",
+    "oracleText": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "ISLANDWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "159",
+        "rarity": "UNCOMMON",
+        "artist": "Ai Desheng",
+        "flavorText": "\". . . 'First take Jingzhou, next the Riverlands; / On that rich region, base your own royal stand.' . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb24cb19-3409-45f7-b0e0-7c652064d2dd.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Zodiac Monkey
+{
+    "name": "Zodiac Monkey",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Monkey",
+    "oracleText": "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FORESTWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "160",
+        "artist": "Ai Desheng",
+        "flavorText": "\". . . By six offensives from the hills of Qi Kongming sought to change Han's destiny. . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e98eb0b-c3b5-4561-b8a2-f22bd0fe1115.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Zodiac Ox
+{
+    "name": "Zodiac Ox",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Ox",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "161",
+        "rarity": "UNCOMMON",
+        "artist": "Ai Desheng",
+        "flavorText": "\". . . Cao's abdication changed the face of all; / No mighty battles marked the Southland's fall. . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a731b3a-0065-448d-841c-28700d78a4fd.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Zodiac Pig
+{
+    "name": "Zodiac Pig",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Boar",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "97",
+        "rarity": "UNCOMMON",
+        "artist": "Qi Baocheng",
+        "flavorText": "\". . . Zhong Hui and Deng Ai next led armies west: / And to the Cao, Han's hills and streams now passed. . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/52e364b5-55ca-4df5-8755-6643218b0969.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Zodiac Rabbit
+{
+    "name": "Zodiac Rabbit",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Rabbit",
+    "oracleText": "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FORESTWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "162",
+        "artist": "Ai Desheng",
+        "flavorText": "\". . . The world's affairs rush on, an endless stream; / A sky-told fate, infinite in reach, dooms all. . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab4211d0-deef-4113-84e0-47ce0df7a5c6.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Zodiac Rat
+{
+    "name": "Zodiac Rat",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Rat",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "98",
+        "artist": "Qi Baocheng",
+        "flavorText": "\" . . . Cao Pi, Cao Rui, Fang, Mao, and briefly, Huan— / The Sima took the empire in their turn. . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb6e5814-e1b5-48d2-9c4f-62b5727f333f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Zodiac Rooster
+{
+    "name": "Zodiac Rooster",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Plainswalk (This creature can't be blocked as long as defending player controls a Plains.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "PLAINSWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "163",
+        "artist": "Ai Desheng",
+        "flavorText": "\". . . But the time of Han had run—could he [Kongming] not tell?— / That night his master star fell past the hills. . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/1/81dd362e-42f6-4eeb-9fe7-0d9cbeb4f21e.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Zodiac Snake
+{
+    "name": "Zodiac Snake",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Snake",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Simple",
+            "keyword": "SWAMPWALK"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "99",
+        "artist": "Qi Baocheng",
+        "flavorText": "\"Thrice Xuande's ardent quest led to Nanyang, / Where Sleeping Dragon unveiled Han's partition: . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6d30d6f0-ca4c-4442-a47f-ecdf52088ecc.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Zodiac Tiger
+{
+    "name": "Zodiac Tiger",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Forestwalk (This creature can't be blocked as long as defending player controls a Forest.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FORESTWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "164",
+        "rarity": "UNCOMMON",
+        "artist": "Ai Desheng",
+        "flavorText": "\". . . Three kings no more—Chenliu, Guiming, Anle. / The fiefs and posts must now be filled anew. . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aafd78d5-df9f-46a3-a634-ebf7634a6358.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Zuo Ci, the Mocking Sage
+{
+    "name": "Zuo Ci, the Mocking Sage",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Legendary Creature — Human Advisor",
+    "oracleText": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nZuo Ci can't be blocked by creatures with horsemanship.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "HEXPROOF"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasKeyword",
+                            "keyword": "HORSEMANSHIP"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "RARE",
+        "artist": "Wang Yuqun",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e3425241-efdc-4261-a2bb-58fbf4a9fe8c.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }


### PR DESCRIPTION
Sweeps every card Argentum Assay reads whole that Portal Three Kingdoms had not authored. **PTK goes 100 → 0 Assay-ready**, re-run on this branch (never inferred).

## The four-way split

| Bucket | Count | What landed |
|---|---:|---|
| `original` | **93** | canonical `card(...)` in `definitions/ptk/cards/` — PTK is the earliest real printing |
| `elsewhere` | **2** | Rally the Troops, Warrior's Stand — canonical authored in **P02** (Portal Second Age), `Printing` row here |
| `basic` | **5** | `PortalThreeKingdomsBasicLands.kt` — 15 `basicLand(...)` vals (3 art variants each, 166–180) plus the `basicLands` override on the set |
| `unscaffolded` | 0 | — |

The stage-0 report listed 92 originals + 1 `unknown`. The unknown was `Pang Tong, "Young Phoenix"`: its printings fetch 404s because the exact-name query `!"Pang Tong, "Young Phoenix""` is unparseable to Scryfall. Resolved by an `oracleid:` lookup — 2 printings, PTK earliest — so it is an `original`, giving 93.

## The reprint tail — 9 rows in 3 other sets

Invisible to `check-card-printing` until the canonicals existed:

- **PZ2** (8): Cao Ren, Huang Zhong, Lady Zhurong, Lu Su, Pang Tong, Sima Yi, Xun Yu, Zuo Ci
- **MH2** (1): Imperial Recruiter
- **TLE** (1): Taunting Challenge

Generated with `scripts/generate-reprints.py` after refreshing all 95 printing caches (the script silently drops any card whose cache is past its 30-day TTL). Pang Tong's PZ2 row is hand-written — see the tooling findings below. Six further rows the generator offered (Ash Barrens in PZ2; Lightning Bolt, Meteorite, Mirrorwing Dragon, Prosperity, Sol Ring in TLE) are **pre-existing debt unrelated to this sweep** and were left out.

## Differential

| | compared | confirmed | divergent |
|---|---:|---:|---:|
| before | 4156 | 4110 | 46 |
| after | **4246** | **4200** | **46** |

**+90 compared, +90 confirmed, zero new divergences.** None of the 46 is a PTK or P02 card — all are the pre-existing baseline. Both readings use the same freshly-built binary in this checkout.

Every card was authored to `oracle-assay compile`'s JSON rather than to the oracle text, which is why the divergence delta is zero across 95 cards.

## Horsemanship was a display-only keyword in practice

`Keyword.HORSEMANSHIP` (`Keyword.kt:20`) and `HorsemanshipRule` (`BlockEvasionRules.kt:57`, registered at :690) both predate this PR, but **no card in the corpus had ever declared the keyword**, so nothing exercised the rule end to end. That is the exact shape of the cascade / modular / annihilator failure — the line renders and the engine ignores it. 19 cards in this sweep declare it, so `HorsemanshipScenarioTest` now proves it live in three directions:

1. a horsemanship attacker cannot be blocked by a creature without it;
2. it *can* be blocked by one with it;
3. Zuo Ci, the Mocking Sage inverts it — a horsemanship creature is the one that cannot block.

The rule turned out to be correctly implemented; the gap was coverage, not behaviour. (One authoring agent independently concluded from a `mtg-sdk`-only grep that horsemanship was display-only. It isn't — the consumer lives in `rules-engine`, which is why the Stage 1 pre-flight has to grep both.)

## Verification

- `just build` — green
- `just rebless-cards` — P02 +2, PTK +93 card blocks; **zero pre-existing entries changed** (verified by diffing per-card blocks, not line counts)
- `just assay-differential` — 46 → 46, no new divergences
- `just check-card-printing` — all 95 canonicals report "canonical is in the card's earliest real printing and all scaffolded reprints have rows"
- `just test-class HorsemanshipScenarioTest` — 3/3
- `just assay-ready PTK` — **0 Assay-ready** (42 remaining are `LINE_DECLINED`: grammar work, not authoring work)

Metadata was checked mechanically rather than by eye: every `collectorNumber` / `artist` / `imageUri` / `flavorText` / `rarity` was diffed back against the pre-fetched Scryfall payload with the field match scoped inside the `metadata { }` block. **0 mismatches across 95 cards.**

## Findings this sweep surfaced but did not fix

*Revised after tracing each one to source — the first was filed against the wrong script, and the second and third turn out not to be defects.*

**1. `scripts/generate-reprints.py` silently drops any card whose name contains escaped quotes.** Its
lines 50–51 carry naive `card\(\s*"([^"]+)"` / `name\s*=\s*"([^"]+)"` copies of the scanners, and no
`unescape_kotlin` call. `card("Pang Tong, \"Young Phoenix\"")` truncates to the key `Pang Tong, \`,
which slugifies to `pang-tong`, misses the printings cache, and lands in the "no fresh cache" bucket —
so the card is reported as *stale*, never as owing rows. Two corpus names hit it: `Pang Tong, "Young
Phoenix"` and `Kongming, "Sleeping Dragon"`. Both happen to be fully covered today (I hand-wrote Pang
Tong's PZ2 row in this PR; Kongming's C13 row predates it), so no row is missing right now — it is a
latent silent-drop, the same failure mode as the 30-day-TTL skip already documented in that file.

`scripts/missing-reprints.py` is **not** affected — my original note blamed it, wrongly. It has the
correct `(?:[^"\\]|\\.)*` bodies at lines 57–58, a comment at 54–56 explaining exactly why, and
`unescape_kotlin` applied at 160/165. The fix was made in one script and never propagated to its
sibling; the sibling should import the constants rather than re-declare them.

The same names also break `just check-card-printing "…"` (the `*ARGS` re-enter `sh -c` — the documented
`just assay compile` trap) and `fetch_printings`' `!"…"` Scryfall query, which 404s. Both have clean
workarounds (call `scripts/check-card-printing.py` directly; search by `oracleid:`), and `assay-ready`
already reports such a card as `unknown` rather than as a decline.

**2. The `fromZone` asymmetry is deliberate and corpus-backed — withdrawn.** I flagged that Assay gives
False Defeat's graveyard→battlefield move a `fromZone` guard while Sage's Knowledge's graveyard→hand
move gets none, from the same printed "from your graveyard". Tracing it: the two rows of
`Graveyard.graveyardStep` use different facades on purpose — `Effects.Move(it, Zone.HAND)` versus
`Effects.PutOntoBattlefieldFromGraveyard(it)`, which sets the guard. The corpus agrees decisively:
**194 of 196** hand-written "return target … from your graveyard to your hand" cards write no
`fromZone` (the 2 exceptions are self-returns, a different rule). The battlefield row's KDoc already
records that dropping its guard was tried and fixed 3 cards while breaking 6. Nothing to change; at
most the to-hand row deserves a one-line KDoc so the next sweep doesn't re-raise it.

**3. Zhuge Jin's "daugher" is Scryfall's own spelling — withdrawn.** Verified against both the cached
PTK payload and a live `cards/named` fetch: Scryfall carries `"…the marriage of Guan Yu's daugher and
Sun Quan's heir…"`. Copying it verbatim is correct, and "correcting" it would break the field
verification the `verify-set` skill runs. Noted only so nobody else re-files it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
