### PR TITLE
Complete Duel Decks: Blessed vs. Cursed — the last five cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -8745,7 +8745,10 @@ composite abilities).
   (`Scope.SoulbondPair`) — "both creatures" / "each of those creatures". That scope resolves to `{source, partner}` while
   paired and to the **empty set** while unpaired, so "as long as this creature is paired with another creature" is
   self-enforcing and needs no `condition =` gate: Lightning Mauler is just
-  `GrantKeyword(Keyword.HASTE, GroupFilter.soulbondPair())`, and Deadeye Navigator is
+  `GrantKeyword(Keyword.HASTE, GroupFilter.soulbondPair())`, Spectral Gateguards is the same with `VIGILANCE`,
+  Tandem Lookout is `GrantTriggeredAbility(<whenever this creature deals damage to an opponent, draw a card>,
+  GroupFilter.soulbondPair())` — hosted on *each* half, so `TriggerBinding.SELF` makes "this creature" mean whichever
+  one dealt the damage — and Deadeye Navigator is
   `GrantActivatedAbility(<{1}{U}: blink self>, GroupFilter.soulbondPair())` — a granted ability's `EffectTarget.Self`
   binds to the permanent that *has* it (CR 113.7), so activating it on the partner blinks the partner.
   Pairing state lives in the engine, not the SDK: `PairWithSourceExecutor` stamps a symmetric `PairedComponent` on both
@@ -11314,6 +11317,7 @@ All `ReplacementEffect` subtypes inherit the following virtual properties from t
 
 - `restrictions: List<Condition>` (default empty) — when non-empty, the replacement only applies if every condition passes; a uniform gating mechanism used by `PreventDamage`, `DoubleDamage`, `ModifyLifeLoss`, `LifeLossFloor`, and others. In the `ReplacementEffectProcessor` (the draw domain today) each condition is evaluated with the **player the event affects** as `EffectContext.controllerId` — so `Player.You` inside a restriction reads as the drawing player, not the source's controller. The two coincide for a `Player.You` `appliesTo`; for `Player.EachOpponent` they don't, and such a card needs a source-relative condition instead.
 - `optional: Boolean` (default `false`) — when `true`, the player affected by the event may decline the replacement (e.g. "you may draw a card instead").
+- `activeZones: Set<Zone>` (default `{BATTLEFIELD}`) — the zones the effect functions from (CR 113.6), the replacement-effect twin of `TriggeredAbility.activeZones`. Declaring another zone is a *move*, not an addition: `EntersWithReplacements` sweeps the battlefield for `BATTLEFIELD` sources and every graveyard for `GRAVEYARD` ones, so `{GRAVEYARD}` switches the effect **on** in the graveyard and **off** on the battlefield. That is the whole of "as long as this creature is in your graveyard, …" (Dearly Departed) — no condition, no duration. Currently a constructor parameter on `EntersWithDynamicCounters` only; other subtypes take the interface default until a card needs otherwise. "You" for a graveyard source resolves to the graveyard's **owner** (a card outside the battlefield has no controller, CR 108.3), and the sweep visits every card, so two copies in one graveyard stack.
 - `priorityGroup: ReplacementPriorityGroup` (default `ReplacementPriorityGroup.ANY`) — the CR 616.1a–f priority tier. Declared as an *override on the subtype*, never as a card-facing constructor parameter, so the engine processor never pattern-matches on SDK types and a card can't accidentally promote itself out of the affected player's 616.1e choice. Today only `EntersAsCopy` overrides it (`COPY`).
 
 The priority groups are (CR 616.1a–f):
@@ -11332,6 +11336,20 @@ The priority groups are (CR 616.1a–f):
   `restrictions: List<Condition>` (default empty) gates the prevention on extra conditions evaluated
   against the source's controller — the same pattern as `ModifyLifeLoss.restrictions`. Use it for
   "as long as …, prevent …" statics (Spirit of Resistance: a five-distinct-colors `Compare` gate).
+- `ReplacementEffect.PreventDamageByRemovingCounter(counterType = PlusOnePlusOne, appliesTo = DamageEvent(recipient = Self))`
+  — "If this creature would be dealt damage, prevent that damage and remove a +1/+1 counter from it"
+  (Unbreathing Horde). The printed twin of the shield counter's prevention half (CR 122.1c), wired at
+  the same two chokepoints (`DamageUtils.dealDamageToTarget` and
+  `CombatDamageManager.applyShieldCountersToCombatDamage`) and inheriting its scoping: exactly **one**
+  counter per damage *event*, however large the damage and however many counters are on the permanent —
+  a creature blocking two attackers is dealt damage once (CR 510.2), and the first-strike and regular
+  damage steps are two events. One deliberate difference from the shield counter: the prevention does
+  **not** depend on having a counter to spend, because it is a printed ability rather than a rule made
+  of counters. A separate type rather than a flag on `PreventDamage` — the counter removal is what the
+  ability *is*, and it needs a state-returning application path where plain prevention is pure
+  arithmetic. Only self-recipient patterns are honoured; a card shielding *other* permanents this way
+  would need a battlefield-wide scan. A permanent carrying both this and a shield counter spends only
+  the shield counter (once the shield prevents the damage there is nothing left to replace).
 - `CapDamage(maxAmount, appliesTo)` — clamp matching damage to `maxAmount` (a *replacement* distinct
   from prevent/modify; applied after all amplification). Divine Presence: `CapDamage(3, DamageEvent(recipient = Any))`.
 - `SetMinimumDamage(minAmount = 0, dynamicMinimum?, appliesTo)` — the **floor** mirror of `CapDamage`:
@@ -11559,7 +11577,7 @@ The priority groups are (CR 616.1a–f):
   characteristics — a "whenever a Mountain enters" trigger won't see the type a Multiversal Passage
   just chose. Both entry paths behave the same way here, so it is consistent, not path-dependent.
 - `EntersWithCounters(counterType?, count, selfOnly?, condition?, otherOnly?, appliesTo?)` /
-  `EntersWithDynamicCounters(counterType?, count, otherOnly?, appliesTo?)` — "[permanent] enters with
+  `EntersWithDynamicCounters(counterType?, count, otherOnly?, appliesTo?, activeZones?)` — "[permanent] enters with
   N counters." `EntersWithCounters` takes a fixed `count: Int` (Master Biomancer, Metallic Mimic);
   `EntersWithDynamicCounters` takes a `count: DynamicAmount` (Stag Beetle; the SOS Converge "Archaic"
   cycle via `convergeEntersWithCounters()` → `count = DistinctColorsManaSpent`). `appliesTo` defaults
@@ -11567,6 +11585,11 @@ The priority groups are (CR 616.1a–f):
   - **Self** (default) — applies to the permanent that owns the replacement. Reserve a *dynamic* count
     for "this creature enters with a counter for each color of mana spent to cast **it**" / "for each X
     it has".
+  - **`activeZones = {GRAVEYARD}`** (dynamic variant) — the source hands out its counters from the
+    *graveyard* instead of the battlefield (Dearly Departed: "as long as this creature is in your
+    graveyard, each Human creature you control enters with an additional +1/+1 counter on it"). Pair it
+    with `otherOnly = true`, which is what routes the effect through the global sweep; the source can
+    never be live for its own entry anyway, since entering the battlefield is leaving the graveyard.
   - **`otherOnly = true`** (both variants) — applies to *other* matching creatures entering (Metallic
     Mimic: "each **other** creature you control of the chosen type enters with an additional +1/+1
     counter"; Gev, Scaled Scorch:

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -104,6 +104,29 @@ sealed interface ReplacementEffect : TextReplaceable<ReplacementEffect> {
     val priorityGroup: ReplacementPriorityGroup get() = ReplacementPriorityGroup.ANY
 
     /**
+     * The zones from which this replacement effect functions (CR 113.6).
+     *
+     * Default `{BATTLEFIELD}` — a permanent's abilities function only while it is on the
+     * battlefield, which is every replacement effect the corpus prints except the ones that say
+     * otherwise in so many words. A card whose printed line scopes itself to another zone declares
+     * that zone instead: Dearly Departed's "As long as this creature is in your graveyard, each
+     * Human creature you control enters with an additional +1/+1 counter on it" is
+     * `activeZones = setOf(Zone.GRAVEYARD)`.
+     *
+     * This is the replacement-effect twin of [TriggeredAbility.activeZones], and it is read the
+     * same way: the *scanner* filters by it. [com.wingedsheep.engine.handlers.effects.EntersWithReplacements]
+     * sweeps the battlefield for `BATTLEFIELD` sources and every graveyard for `GRAVEYARD` ones, so
+     * declaring `{GRAVEYARD}` both switches the effect **on** in the graveyard and switches it
+     * **off** on the battlefield — a Dearly Departed you cast does nothing until it dies, which is
+     * what the card says.
+     *
+     * Only the "as long as this card is in <zone>" *static* zone is expressed here. It is not a
+     * duration and not a condition: the effect is live for exactly as long as the card sits in one
+     * of these zones.
+     */
+    val activeZones: Set<Zone> get() = setOf(Zone.BATTLEFIELD)
+
+    /**
      * Additional [Condition]s gating when this replacement applies.
      *
      * Evaluated with the **player the event affects** as `EffectContext.controllerId`, not the
@@ -553,7 +576,8 @@ data class EntersWithDynamicCounters(
     override val appliesTo: EventPattern = EventPattern.ZoneChangeEvent(
         filter = GameObjectFilter.Creature.youControl(),
         to = Zone.BATTLEFIELD
-    )
+    ),
+    override val activeZones: Set<Zone> = setOf(Zone.BATTLEFIELD),
 ) : ReplacementEffect {
     override val description: String =
         "If ${appliesTo.description}, it enters with ${count.description} ${counterType.description} counters"
@@ -655,6 +679,47 @@ data class PreventDamage(
         val anyChanged = newAppliesTo !== appliesTo ||
             newRestrictions.zip(restrictions).any { (n, o) -> n !== o }
         return if (anyChanged) copy(appliesTo = newAppliesTo, restrictions = newRestrictions) else this
+    }
+}
+
+/**
+ * Prevent damage that would be dealt to this permanent and remove one counter of [counterType]
+ * from it — the printed twin of the shield counter's prevention half (CR 122.1c).
+ *
+ * Models Unbreathing Horde: "If this creature would be dealt damage, prevent that damage and
+ * remove a +1/+1 counter from it."
+ *
+ * Distinct from `PreventDamage` rather than a flag on it, because the counter removal is not a
+ * parameter of the prevention — it is what the ability *is*, and it makes the effect need a
+ * state-returning application path where plain prevention is a pure arithmetic reduction.
+ *
+ * Two rules the printed rulings pin down, both shared with shield counters:
+ *
+ * - **Exactly one counter per damage event**, however large the damage and however many counters
+ *   are on the permanent. A creature blocking two attackers is dealt combat damage once (CR 510.2),
+ *   so it spends one counter and prevents all of it; the first-strike and regular damage steps are
+ *   separate events and each cost a counter.
+ * - **The prevention does not depend on having a counter.** With no counters left the damage is
+ *   still prevented — there is simply nothing to remove. (Unbreathing Horde only survives that way
+ *   while something else is holding its toughness above 0.)
+ *
+ * [appliesTo] defaults to "any damage that would be dealt to this permanent"; narrow its
+ * `damageType`, `source` or `amount` for a card that only shields part of the picture.
+ */
+@SerialName("PreventDamageByRemovingCounter")
+@Serializable
+data class PreventDamageByRemovingCounter(
+    val counterType: CounterTypeFilter = CounterTypeFilter.PlusOnePlusOne,
+    override val appliesTo: EventPattern = EventPattern.DamageEvent(
+        recipient = RecipientFilter.Self
+    )
+) : ReplacementEffect {
+    override val description: String =
+        "If ${appliesTo.description}, prevent that damage and remove a ${counterType.description} counter from it"
+
+    override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
+        val newAppliesTo = appliesTo.applyTextReplacement(replacer)
+        return if (newAppliesTo !== appliesTo) copy(appliesTo = newAppliesTo) else this
     }
 }
 

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/SpectralGateguards.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/SpectralGateguards.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.soulbond
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Spectral Gateguards
+ * {4}{W}
+ * Creature — Spirit Soldier
+ * 2/5
+ * Soulbond (You may pair this creature with another unpaired creature when either enters. They
+ * remain paired for as long as you control both of them.)
+ * As long as this creature is paired with another creature, both creatures have vigilance.
+ *
+ * The white half of [LightningMauler]'s shape: a plain [GrantKeyword] over
+ * `GroupFilter.soulbondPair()`, which covers "both creatures" and is empty while unpaired, so
+ * "as long as this creature is paired" needs no condition of its own (CR 702.95b/e).
+ */
+val SpectralGateguards = card("Spectral Gateguards") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit Soldier"
+    oracleText = "Soulbond (You may pair this creature with another unpaired creature when either " +
+        "enters. They remain paired for as long as you control both of them.)\n" +
+        "As long as this creature is paired with another creature, both creatures have vigilance."
+    power = 2
+    toughness = 5
+
+    soulbond()
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter.soulbondPair())
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "37"
+        artist = "Wayne England"
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f774e0eb-5c05-4a9e-8ab7-9ee4c7741591.jpg?1783940729"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/TandemLookout.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/TandemLookout.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.soulbond
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Tandem Lookout
+ * {2}{U}
+ * Creature — Human Scout
+ * 2/1
+ * Soulbond (You may pair this creature with another unpaired creature when either enters. They
+ * remain paired for as long as you control both of them.)
+ * As long as Tandem Lookout is paired with another creature, each of those creatures has
+ * "Whenever this creature deals damage to an opponent, draw a card."
+ *
+ * [DeadeyeNavigator]'s shape with a triggered ability instead of an activated one:
+ * [GrantTriggeredAbility] over `GroupFilter.soulbondPair()` — the Lookout *and* its partner, and
+ * nobody at all while unpaired (CR 702.95b/e).
+ *
+ * The trigger is [DamageType.Any], not combat only — the printed line says "deals damage", so a
+ * partner that pings an opponent with an activated ability draws too. [RecipientFilter.Opponent]
+ * resolves against the *host* creature's controller, which is the same player for both halves of a
+ * soulbond pair (CR 702.95a requires you control both), so either half firing draws for you.
+ *
+ * `TriggerBinding.SELF` is what makes "this creature" mean the half that dealt the damage rather
+ * than the Lookout: the engine hosts a granted trigger on the *receiving* permanent (CR 113.7), so
+ * each creature's copy watches its own damage.
+ */
+val TandemLookout = card("Tandem Lookout") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Scout"
+    oracleText = "Soulbond (You may pair this creature with another unpaired creature when either " +
+        "enters. They remain paired for as long as you control both of them.)\n" +
+        "As long as Tandem Lookout is paired with another creature, each of those creatures has " +
+        "\"Whenever this creature deals damage to an opponent, draw a card.\""
+    power = 2
+    toughness = 1
+
+    soulbond()
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.dealsDamage(recipient = RecipientFilter.Opponent).event,
+                binding = Triggers.dealsDamage(recipient = RecipientFilter.Opponent).binding,
+                effect = Effects.DrawCards(1),
+                descriptionOverride = "Whenever this creature deals damage to an opponent, draw a card"
+            ),
+            filter = GroupFilter.soulbondPair()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "80"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/83564e67-2677-4955-a3b9-3b221dbb100b.jpg?1783940709"
+        ruling("2017-03-14", "If Tandem Lookout or the creature it's paired with is dealt lethal damage at the same time that either deals damage to an opponent, its ability triggers. You'll draw a card even though that creature no longer has the ability.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DearlyDepartedReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DearlyDepartedReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Dearly Departed reprint in DDQ. Canonical def lives in ISD. */
+val DearlyDepartedReprint = Printing(
+    oracleId = "539be0f3-0863-4d44-87ee-5912dd003475",
+    name = "Dearly Departed",
+    setCode = "DDQ",
+    collectorNumber = "6",
+    scryfallId = "16e88d15-26b3-4782-a7f9-231f23905fb5",
+    artist = "Daniel Ljunggren",
+    imageUri = "https://cards.scryfall.io/normal/front/1/6/16e88d15-26b3-4782-a7f9-231f23905fb5.jpg?1783937860",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/RelentlessSkaabsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/RelentlessSkaabsReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Relentless Skaabs reprint in DDQ. Canonical def lives in DKA. */
+val RelentlessSkaabsReprint = Printing(
+    oracleId = "5089cd0f-1338-4ecd-bb1b-664d7e72f8fc",
+    name = "Relentless Skaabs",
+    setCode = "DDQ",
+    collectorNumber = "46",
+    scryfallId = "7cf48c1a-5709-4e24-8a85-8292a4457150",
+    artist = "Karl Kopinski",
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7cf48c1a-5709-4e24-8a85-8292a4457150.jpg?1783937843",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/SpectralGateguardsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/SpectralGateguardsReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Spectral Gateguards reprint in DDQ. Canonical def lives in AVR. */
+val SpectralGateguardsReprint = Printing(
+    oracleId = "334f7cd5-6c7b-4592-b564-8a0edac4a1b4",
+    name = "Spectral Gateguards",
+    setCode = "DDQ",
+    collectorNumber = "19",
+    scryfallId = "8f658073-5d90-4dca-b867-35ab827f22fd",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/8/f/8f658073-5d90-4dca-b867-35ab827f22fd.jpg?1783937853",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/TandemLookoutReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/TandemLookoutReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Tandem Lookout reprint in DDQ. Canonical def lives in AVR. */
+val TandemLookoutReprint = Printing(
+    oracleId = "1576f031-57ca-4894-b461-8ea57b6cefdc",
+    name = "Tandem Lookout",
+    setCode = "DDQ",
+    collectorNumber = "29",
+    scryfallId = "3547d3ce-0837-4fc2-9e19-904519287ad5",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/3547d3ce-0837-4fc2-9e19-904519287ad5.jpg?1783937849",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/UnbreathingHordeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/UnbreathingHordeReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Unbreathing Horde reprint in DDQ. Canonical def lives in ISD. */
+val UnbreathingHordeReprint = Printing(
+    oracleId = "e6cd9203-e4d3-4d9f-b59f-4e454fc5a477",
+    name = "Unbreathing Horde",
+    setCode = "DDQ",
+    collectorNumber = "66",
+    scryfallId = "dd119aa8-8414-4942-9a28-3e68a9a52a8e",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/dd119aa8-8414-4942-9a28-3e68a9a52a8e.jpg?1783937836",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/RelentlessSkaabs.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/RelentlessSkaabs.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Relentless Skaabs
+ * {3}{U}{U}
+ * Creature — Zombie
+ * 4/4
+ * As an additional cost to cast this spell, exile a creature card from your graveyard.
+ * Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the
+ * battlefield under its owner's control with a +1/+1 counter on it.)
+ *
+ * [StitchedDrake]'s additional cost plus [YoungWolf]'s keyword — the additional cost rides the
+ * *cast*, so the undying return (not a cast, CR 702.92a) exiles nothing, which is exactly the
+ * printed ruling.
+ */
+val RelentlessSkaabs = card("Relentless Skaabs") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie"
+    oracleText = "As an additional cost to cast this spell, exile a creature card from your graveyard.\n" +
+        "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the " +
+        "battlefield under its owner's control with a +1/+1 counter on it.)"
+    power = 4
+    toughness = 4
+
+    additionalCost(Costs.additional.ExileCards(count = 1, filter = GameObjectFilter.Creature))
+
+    keywords(Keyword.UNDYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "45"
+        artist = "Karl Kopinski"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3304cab-0dc9-47e4-ac68-00974b64f5a0.jpg?1783940838"
+        ruling("2013-04-15", "You must exile exactly one creature card from your graveyard to cast this spell; you cannot cast it without exiling a creature card, and you cannot exile additional creature cards.")
+        ruling("2013-04-15", "Players can only respond once this spell has been cast and all its costs have been paid. No one can try to otherwise remove the creature card you exiled in order to prevent you from casting this spell.")
+        ruling("2011-01-22", "When Relentless Skaabs returns to the battlefield because of its undying ability, it's not being cast. You won't exile a creature card from your graveyard.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/DearlyDeparted.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/DearlyDeparted.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dearly Departed
+ * {4}{W}{W}
+ * Creature — Spirit
+ * 5/5
+ * Flying
+ * As long as this creature is in your graveyard, each Human creature you control enters with an
+ * additional +1/+1 counter on it.
+ *
+ * [com.wingedsheep.mtg.sets.definitions.blc.cards.GrumgullyTheGenerous]'s
+ * [EntersWithDynamicCounters] with its zone moved: `activeZones = setOf(Zone.GRAVEYARD)` is the
+ * whole of "as long as this creature is in your graveyard" (CR 113.6). The scanner reads that
+ * field, so the same declaration both switches the grant **on** from the graveyard and **off** on
+ * the battlefield — a Dearly Departed you cast is a plain 5/5 flier until it dies.
+ *
+ * `otherOnly = true` is what routes the effect through the global sweep rather than the source's
+ * own entry path; it is not a narrowing here, since the Spirit is never one of the Humans it
+ * pumps, and it cannot be live for its own entry anyway (entering the battlefield is leaving the
+ * graveyard).
+ *
+ * "Each Human creature you control" resolves `youControl` against the *owner* of the graveyard,
+ * which is the only sensible reading of "you" for a card outside the battlefield (CR 108.3) — and
+ * the printed ruling that the effect is cumulative falls out of the sweep visiting every card in
+ * the graveyard: two copies hand out two counters.
+ */
+val DearlyDeparted = card("Dearly Departed") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    oracleText = "Flying\n" +
+        "As long as this creature is in your graveyard, each Human creature you control enters " +
+        "with an additional +1/+1 counter on it."
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.FLYING)
+
+    replacementEffect(
+        EntersWithDynamicCounters(
+            count = DynamicAmount.Fixed(1),
+            otherOnly = true,
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.youControl().withSubtype(Subtype.HUMAN),
+                to = Zone.BATTLEFIELD,
+            ),
+            activeZones = setOf(Zone.GRAVEYARD),
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "9"
+        artist = "Daniel Ljunggren"
+        flavorText = "\"Never forget our ancestors. They have not forgotten us.\"\n—Mikaeus, the Lunarch"
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d008061f-cda4-4bcf-b6b3-d1b4a251cc66.jpg?1783940996"
+        ruling("2011-09-22", "The effect is cumulative. Human creatures you control will enter with a +1/+1 counter for each Dearly Departed in your graveyard.")
+        ruling("2011-09-22", "In most cases, when determining whether a creature entering under your control should get a +1/+1 counter, you'll simply look at what the creature will look like on the battlefield. You'll consider any effects affecting a creature entering under your control.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/UnbreathingHorde.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/UnbreathingHorde.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PreventDamageByRemovingCounter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Unbreathing Horde
+ * {2}{B}
+ * Creature — Zombie
+ * 0/0
+ * This creature enters with a +1/+1 counter on it for each other Zombie you control and each
+ * Zombie card in your graveyard.
+ * If this creature would be dealt damage, prevent that damage and remove a +1/+1 counter from it.
+ *
+ * The entry count is one [DynamicAmount.Add] over the two zones the printed line names. The
+ * battlefield half is `excludeSelf` for "each **other** Zombie" — the Horde is on its way in, but
+ * the count is evaluated against a state that already holds it, so the exclusion is load-bearing
+ * rather than decorative.
+ *
+ * The graveyard half is deliberately *not* excluded, and that is the printed ruling: reanimate the
+ * Horde and it counts itself, because it is still in the graveyard as its own enters-with
+ * replacement is applied.
+ *
+ * The damage clause is [PreventDamageByRemovingCounter] — the printed twin of the shield counter
+ * (CR 122.1c), which is why it spends exactly one counter per damage event no matter how large the
+ * damage, and why it still prevents once the counters are gone.
+ */
+val UnbreathingHorde = card("Unbreathing Horde") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    oracleText = "This creature enters with a +1/+1 counter on it for each other Zombie you " +
+        "control and each Zombie card in your graveyard.\n" +
+        "If this creature would be dealt damage, prevent that damage and remove a +1/+1 counter from it."
+    power = 0
+    toughness = 0
+
+    replacementEffect(
+        EntersWithDynamicCounters(
+            count = DynamicAmount.Add(
+                DynamicAmount.Count(
+                    player = Player.You,
+                    zone = Zone.BATTLEFIELD,
+                    filter = GameObjectFilter.Creature
+                        .withSubtype(Subtype.ZOMBIE)
+                        .notSourceItself()
+                ),
+                DynamicAmount.Count(
+                    player = Player.You,
+                    zone = Zone.GRAVEYARD,
+                    filter = GameObjectFilter.Any.withSubtype(Subtype.ZOMBIE)
+                )
+            )
+        )
+    )
+
+    replacementEffect(PreventDamageByRemovingCounter())
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "121"
+        artist = "Dave Kendall"
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a91ea47-0c06-4333-a309-ac360c5cc9bd.jpg?1783940947"
+        ruling("2011-09-22", "Only one +1/+1 counter will be removed, no matter how much damage is prevented.")
+        ruling("2011-09-22", "If Unbreathing Horde has no +1/+1 counters on it (but its toughness is raised above 0 by another effect), any damage dealt to it will still be prevented, even though no counter will be removed.")
+        ruling("2011-09-22", "If Unbreathing Horde enters from a graveyard, it will count itself when determining how many +1/+1 counters it enters with.")
+    }
+}

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DearlyDepartedScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DearlyDepartedScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Dearly Departed — {4}{W}{W} 5/5 Spirit with flying and "As long as this
+ * creature is in your graveyard, each Human creature you control enters with an additional +1/+1
+ * counter on it."
+ *
+ * This is the first card whose replacement effect functions from the **graveyard**
+ * (`activeZones = {GRAVEYARD}`), so the tests pin both directions of that switch: live from the
+ * graveyard, inert on the battlefield.
+ */
+class DearlyDepartedScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dearly Departed") {
+
+            fun plusOneCounters(game: TestGame, name: String): Int =
+                game.findPermanent(name)?.let { id ->
+                    game.state.getEntity(id)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE)
+                } ?: 0
+
+            test("from the graveyard, a Human creature you control enters with an extra +1/+1 counter") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInGraveyard(1, "Dearly Departed")
+                    .withCardInHand(1, "Doomed Traveler")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .build()
+
+                val cast = game.castSpell(1, "Doomed Traveler")
+                withClue("the cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("the 1/1 Human Soldier entered with one +1/+1 counter") {
+                    plusOneCounters(game, "Doomed Traveler") shouldBe 1
+                }
+                withClue("and is therefore a 2/2") {
+                    val traveler = game.findPermanent("Doomed Traveler")!!
+                    game.state.projectedState.getPower(traveler) shouldBe 2
+                    game.state.projectedState.getToughness(traveler) shouldBe 2
+                }
+            }
+
+            test("on the battlefield it does nothing — the effect is scoped to the graveyard") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Dearly Departed")
+                    .withCardInHand(1, "Doomed Traveler")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .build()
+
+                game.castSpell(1, "Doomed Traveler").error shouldBe null
+                game.resolveStack()
+
+                withClue("`activeZones = {GRAVEYARD}` switches the grant off on the battlefield") {
+                    plusOneCounters(game, "Doomed Traveler") shouldBe 0
+                }
+            }
+
+            test("the effect is cumulative — two copies in the graveyard hand out two counters") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInGraveyard(1, "Dearly Departed")
+                    .withCardInGraveyard(1, "Dearly Departed")
+                    .withCardInHand(1, "Doomed Traveler")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .build()
+
+                game.castSpell(1, "Doomed Traveler").error shouldBe null
+                game.resolveStack()
+
+                withClue("the printed ruling: one counter per Dearly Departed in your graveyard") {
+                    plusOneCounters(game, "Doomed Traveler") shouldBe 2
+                }
+            }
+
+            test("a non-Human creature gets nothing") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInGraveyard(1, "Dearly Departed")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .build()
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                withClue("Bear is not Human") {
+                    plusOneCounters(game, "Grizzly Bears") shouldBe 0
+                }
+            }
+
+            test("a Human an opponent controls gets nothing — 'you' is the graveyard's owner") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInGraveyard(1, "Dearly Departed")
+                    .withCardInHand(2, "Doomed Traveler")
+                    .withLandsOnBattlefield(2, "Plains", 2)
+                    .withActivePlayer(2)
+                    .build()
+
+                game.castSpell(2, "Doomed Traveler").error shouldBe null
+                game.resolveStack()
+
+                withClue("the filter is 'each Human creature YOU control'") {
+                    plusOneCounters(game, "Doomed Traveler") shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RelentlessSkaabsScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RelentlessSkaabsScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario test for Relentless Skaabs — {3}{U}{U} 4/4 Zombie with "As an additional cost to cast
+ * this spell, exile a creature card from your graveyard" and undying.
+ *
+ * The interesting interaction is the one the printed ruling calls out: the additional cost rides the
+ * *cast*, so the undying return (CR 702.92a — not a cast) exiles nothing.
+ */
+class RelentlessSkaabsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Relentless Skaabs") {
+
+            fun plusOneCounters(game: TestGame, name: String): Int =
+                game.findPermanent(name)?.let { id ->
+                    game.state.getEntity(id)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE)
+                } ?: 0
+
+            test("casting it exiles a creature card from your graveyard") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Relentless Skaabs")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .build()
+
+                val skaabs = game.findCardsInHand(1, "Relentless Skaabs").single()
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = skaabs,
+                        targets = emptyList(),
+                        additionalCostPayment = AdditionalCostPayment(exiledCards = listOf(bears)),
+                    ),
+                )
+                withClue("the cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("the Skaabs resolved") { game.isOnBattlefield("Relentless Skaabs") shouldBe true }
+                withClue("the additional cost exiled the creature card out of the graveyard") {
+                    game.state.getGraveyard(game.player1Id).none { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                    } shouldBe true
+                    game.state.getExile(game.player1Id).any { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                    } shouldBe true
+                }
+            }
+
+            test("with no creature card in the graveyard the cost cannot be paid") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Relentless Skaabs")
+                    // A noncreature card in the graveyard is not a legal exile for this cost.
+                    .withCardInGraveyard(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .build()
+
+                val cast = game.castSpell(1, "Relentless Skaabs")
+                withClue("an unpayable additional cost makes the cast illegal") {
+                    cast.error shouldNotBe null
+                }
+                game.isOnBattlefield("Relentless Skaabs") shouldBe false
+            }
+
+            test("undying brings it back with a +1/+1 counter and exiles nothing") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Relentless Skaabs")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInHand(1, "Doom Blade")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .build()
+
+                val skaabs = game.findPermanent("Relentless Skaabs")!!
+                val kill = game.castSpell(1, "Doom Blade", targetId = skaabs)
+                withClue("the removal should succeed: ${kill.error}") { kill.error shouldBe null }
+                game.resolveStack()
+
+                withClue("undying returned it") { game.isOnBattlefield("Relentless Skaabs") shouldBe true }
+                withClue("it comes back with one +1/+1 counter (CR 702.92a)") {
+                    plusOneCounters(game, "Relentless Skaabs") shouldBe 1
+                }
+                withClue("the return is not a cast, so the additional cost is never paid") {
+                    game.state.getGraveyard(game.player1Id).any { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                    } shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SpectralGateguardsScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SpectralGateguardsScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Spectral Gateguards — {4}{W} 2/5 Spirit Soldier with soulbond (CR 702.95) and
+ * "As long as this creature is paired with another creature, both creatures have vigilance."
+ *
+ * The white sibling of Lightning Mauler's haste grant, so the interesting axis is that the payoff
+ * really is scoped to the pair: both halves get vigilance, and an unpaired Gateguards gives none.
+ */
+class SpectralGateguardsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Spectral Gateguards") {
+
+            test("pairing on its own ETB gives vigilance to both halves") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Spectral Gateguards")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("Grizzly Bears has no vigilance of its own") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.VIGILANCE) shouldBe false
+                }
+
+                val cast = game.castSpell(1, "Spectral Gateguards")
+                withClue("the cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("soulbond's ETB half asks which unpaired creature to pair with") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectCards(listOf(bears))
+
+                val guards = game.findPermanent("Spectral Gateguards")!!
+                withClue("both creatures in the pair have vigilance (CR 702.95b)") {
+                    game.state.projectedState.hasKeyword(guards, Keyword.VIGILANCE) shouldBe true
+                    game.state.projectedState.hasKeyword(bears, Keyword.VIGILANCE) shouldBe true
+                }
+            }
+
+            test("declining the pairing grants vigilance to nobody, the Gateguards included") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Spectral Gateguards")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .build()
+
+                game.castSpell(1, "Spectral Gateguards")
+                game.resolveStack()
+                game.hasPendingDecision() shouldBe true
+                game.skipSelection()
+
+                val guards = game.findPermanent("Spectral Gateguards")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("the soulbondPair scope is empty while unpaired, so the static reaches nobody") {
+                    game.state.projectedState.hasKeyword(guards, Keyword.VIGILANCE) shouldBe false
+                    game.state.projectedState.hasKeyword(bears, Keyword.VIGILANCE) shouldBe false
+                }
+            }
+
+            test("a creature entering later is pairable by soulbond's second half") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Spectral Gateguards")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .build()
+
+                val guards = game.findPermanent("Spectral Gateguards")!!
+                game.state.projectedState.hasKeyword(guards, Keyword.VIGILANCE) shouldBe false
+
+                val cast = game.castSpell(1, "Grizzly Bears")
+                withClue("the cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+                game.hasPendingDecision() shouldBe true
+                game.answerYesNo(true)
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("the pair formed and vigilance reaches both") {
+                    game.state.projectedState.hasKeyword(guards, Keyword.VIGILANCE) shouldBe true
+                    game.state.projectedState.hasKeyword(bears, Keyword.VIGILANCE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TandemLookoutScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TandemLookoutScenarioTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Tandem Lookout — {2}{U} 2/1 Human Scout with soulbond and "As long as Tandem
+ * Lookout is paired with another creature, each of those creatures has 'Whenever this creature
+ * deals damage to an opponent, draw a card.'"
+ *
+ * The point of the card is that the granted trigger is hosted on *each* half: "this creature" means
+ * whichever one dealt the damage, not the Lookout. So the interesting cases are the partner firing
+ * it, the Lookout firing it, and neither firing while unpaired.
+ */
+class TandemLookoutScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Tandem Lookout") {
+
+            test("the Lookout's own copy of the granted trigger draws when it attacks") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Tandem Lookout", summoningSickness = false)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Grizzly Bears")
+                withClue("the cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+                withClue("soulbond's 'another creature you control enters' half is a yes/no") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.answerYesNo(true)
+
+                val handBefore = game.handSize(1)
+
+                // Only the Lookout can attack — the Bears just entered.
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Tandem Lookout" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("2 unblocked combat damage got through") { game.getLifeTotal(2) shouldBe 18 }
+                withClue("the Lookout's granted trigger drew one card") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+
+            test("the partner's copy draws too — 'this creature' is whichever half dealt the damage") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Tandem Lookout")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cast = game.castSpell(1, "Tandem Lookout")
+                withClue("the cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+                game.hasPendingDecision() shouldBe true
+                game.selectCards(listOf(bears))
+
+                val handBefore = game.handSize(1)
+
+                // Only the Bears can attack — the Lookout just entered.
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("2 unblocked combat damage got through") { game.getLifeTotal(2) shouldBe 18 }
+                withClue("the partner carries its own copy of the granted trigger") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+
+            test("an unpaired Lookout draws nothing when it connects") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Tandem Lookout", summoningSickness = false)
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Tandem Lookout" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("the damage still happened") { game.getLifeTotal(2) shouldBe 18 }
+                withClue("the soulbondPair scope is empty, so nobody has the trigger") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/UnbreathingHordeScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/UnbreathingHordeScenarioTest.kt
@@ -1,0 +1,165 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Unbreathing Horde — {2}{B} 0/0 Zombie that enters with a +1/+1 counter for each
+ * other Zombie you control and each Zombie card in your graveyard, and whose damage clause is
+ * "prevent that damage and remove a +1/+1 counter from it".
+ *
+ * Two things worth pinning: the two-zone entry count (including the "**other**" exclusion), and the
+ * printed rulings on the prevention — one counter per damage event however large, and prevention
+ * even with no counter left to spend.
+ */
+class UnbreathingHordeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Unbreathing Horde") {
+
+            fun plusOneCounters(game: TestGame, name: String): Int =
+                game.findPermanent(name)?.let { id ->
+                    game.state.getEntity(id)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE)
+                } ?: 0
+
+            test("it counts other Zombies you control and Zombie cards in your graveyard") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Unbreathing Horde")
+                    .withCardOnBattlefield(1, "Diregraf Ghoul")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Diregraf Ghoul")
+                    .withCardInGraveyard(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .build()
+
+                val cast = game.castSpell(1, "Unbreathing Horde")
+                withClue("the cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("one battlefield Zombie + one graveyard Zombie card; the Bear and the Bolt don't count") {
+                    plusOneCounters(game, "Unbreathing Horde") shouldBe 2
+                }
+                withClue("a 0/0 with two counters is a 2/2") {
+                    val horde = game.findPermanent("Unbreathing Horde")!!
+                    game.state.projectedState.getPower(horde) shouldBe 2
+                    game.state.projectedState.getToughness(horde) shouldBe 2
+                }
+            }
+
+            test("'each OTHER Zombie' excludes the Horde itself") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Unbreathing Horde")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .build()
+
+                game.castSpell(1, "Unbreathing Horde").error shouldBe null
+                game.resolveStack()
+
+                withClue("no other Zombie anywhere, so it enters with nothing") {
+                    plusOneCounters(game, "Unbreathing Horde") shouldBe 0
+                }
+            }
+
+            test("damage is prevented and exactly one counter is removed, however large the damage") {
+                val game = scenario()
+                    .withPlayers()
+                    // Three graveyard Zombie cards => it enters as a 3/3.
+                    .withCardInHand(1, "Unbreathing Horde")
+                    .withCardInGraveyard(1, "Diregraf Ghoul")
+                    .withCardInGraveyard(1, "Diregraf Ghoul")
+                    .withCardInGraveyard(1, "Diregraf Ghoul")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .build()
+
+                game.castSpell(1, "Unbreathing Horde").error shouldBe null
+                game.resolveStack()
+                plusOneCounters(game, "Unbreathing Horde") shouldBe 3
+
+                val horde = game.findPermanent("Unbreathing Horde")!!
+                val bolt = game.castSpell(1, "Lightning Bolt", targetId = horde)
+                withClue("the Bolt should be castable: ${bolt.error}") { bolt.error shouldBe null }
+                game.resolveStack()
+
+                withClue("3 damage prevented, one counter spent (the printed ruling)") {
+                    plusOneCounters(game, "Unbreathing Horde") shouldBe 2
+                }
+                withClue("it survives — the damage never happened") {
+                    game.isOnBattlefield("Unbreathing Horde") shouldBe true
+                }
+            }
+
+            test("with no counters left the damage is still prevented") {
+                val game = scenario()
+                    .withPlayers()
+                    // No other Zombies, so the Horde enters with zero counters. Glorious Anthem is
+                    // already out to hold the 0/0's toughness above 0, so it survives the entry SBA
+                    // and the prevention clause is reachable with an empty counter pile.
+                    .withCardOnBattlefield(1, "Glorious Anthem")
+                    .withCardInHand(1, "Unbreathing Horde")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .build()
+
+                game.castSpell(1, "Unbreathing Horde").error shouldBe null
+                game.resolveStack()
+
+                withClue("the anthem keeps the counterless 0/0 alive") {
+                    game.isOnBattlefield("Unbreathing Horde") shouldBe true
+                }
+                plusOneCounters(game, "Unbreathing Horde") shouldBe 0
+
+                val horde = game.findPermanent("Unbreathing Horde")!!
+                game.castSpell(1, "Lightning Bolt", targetId = horde).error shouldBe null
+                game.resolveStack()
+
+                withClue("prevention does not depend on having a counter to remove") {
+                    game.isOnBattlefield("Unbreathing Horde") shouldBe true
+                    plusOneCounters(game, "Unbreathing Horde") shouldBe 0
+                }
+            }
+
+            test("combat damage is prevented too") {
+                val game = scenario()
+                    .withPlayers()
+                    // Placed directly, so the entry replacement never ran and the Horde has no
+                    // counters — Glorious Anthem is what keeps the 0/0 alive to block. That also
+                    // makes this the combat-path version of the "no counter to spend" case.
+                    .withCardOnBattlefield(2, "Glorious Anthem")
+                    .withCardOnBattlefield(2, "Unbreathing Horde")
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Hill Giant" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Unbreathing Horde" to listOf("Hill Giant"))).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("the Giant's 3 combat damage is prevented, so the 1/1 blocker lives") {
+                    game.isOnBattlefield("Unbreathing Horde") shouldBe true
+                }
+                withClue("the attack was blocked, so nothing reached the player") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -2710,6 +2710,307 @@
     ]
 }
 
+// Spectral Gateguards
+{
+    "name": "Spectral Gateguards",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Spirit Soldier",
+    "oracleText": "Soulbond (You may pair this creature with another unpaired creature when either enters. They remain paired for as long as you control both of them.)\nAs long as this creature is paired with another creature, both creatures have vigilance.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "SOULBOND"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ],
+                                    "statePredicates": [
+                                        {
+                                            "type": "StateNot",
+                                            "predicate": "IsPaired"
+                                        }
+                                    ]
+                                },
+                                "player": "You",
+                                "excludeSelf": true
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered0",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "selected1",
+                            "prompt": "You may pair this creature with an unpaired creature you control",
+                            "useTargetingUI": true
+                        },
+                        {
+                            "type": "PairWithSource",
+                            "from": "selected1"
+                        }
+                    ]
+                },
+                "interveningIf": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            {
+                                "type": "StateNot",
+                                "predicate": "IsPaired"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Soulbond (You may pair this creature with another unpaired creature when either enters. They remain paired for as long as you control both of them.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": "TriggeringEntity",
+                                "storeAs": "gathered0"
+                            },
+                            {
+                                "type": "PairWithSource",
+                                "from": "gathered0"
+                            }
+                        ]
+                    }
+                },
+                "interveningIf": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            {
+                                "type": "StateNot",
+                                "predicate": "IsPaired"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "You may pair that creature with this creature"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "SoulbondPair"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "artist": "Wayne England",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f774e0eb-5c05-4a9e-8ab7-9ee4c7741591.jpg?1783940729"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Tandem Lookout
+{
+    "name": "Tandem Lookout",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "Soulbond (You may pair this creature with another unpaired creature when either enters. They remain paired for as long as you control both of them.)\nAs long as Tandem Lookout is paired with another creature, each of those creatures has \"Whenever this creature deals damage to an opponent, draw a card.\"",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "SOULBOND"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ],
+                                    "statePredicates": [
+                                        {
+                                            "type": "StateNot",
+                                            "predicate": "IsPaired"
+                                        }
+                                    ]
+                                },
+                                "player": "You",
+                                "excludeSelf": true
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered0",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "selected1",
+                            "prompt": "You may pair this creature with an unpaired creature you control",
+                            "useTargetingUI": true
+                        },
+                        {
+                            "type": "PairWithSource",
+                            "from": "selected1"
+                        }
+                    ]
+                },
+                "interveningIf": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            {
+                                "type": "StateNot",
+                                "predicate": "IsPaired"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Soulbond (You may pair this creature with another unpaired creature when either enters. They remain paired for as long as you control both of them.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": "TriggeringEntity",
+                                "storeAs": "gathered0"
+                            },
+                            {
+                                "type": "PairWithSource",
+                                "from": "gathered0"
+                            }
+                        ]
+                    }
+                },
+                "interveningIf": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            {
+                                "type": "StateNot",
+                                "predicate": "IsPaired"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "You may pair that creature with this creature"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "DealsDamageEvent",
+                        "recipient": "RecipientOpponent"
+                    },
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "descriptionOverride": "Whenever this creature deals damage to an opponent, draw a card"
+                },
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "SoulbondPair"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "rarity": "UNCOMMON",
+        "artist": "Kev Walker",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/83564e67-2677-4955-a3b9-3b221dbb100b.jpg?1783940709",
+        "rulings": [
+            {
+                "date": "2017-03-14",
+                "text": "If Tandem Lookout or the creature it's paired with is dealt lethal damage at the same time that either deals damage to an opponent, its ability triggers. You'll draw a card even though that creature no longer has the ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Temporal Mastery
 {
     "name": "Temporal Mastery",

--- a/mtg-sets/src/test/resources/snapshots/cards/DKA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DKA.json
@@ -1482,6 +1482,56 @@
     ]
 }
 
+// Relentless Skaabs
+{
+    "name": "Relentless Skaabs",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "As an additional cost to cast this spell, exile a creature card from your graveyard.\nUndying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "UNDYING"
+    ],
+    "script": {
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomExileFrom",
+                    "zone": "Graveyard",
+                    "filter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "rarity": "UNCOMMON",
+        "artist": "Karl Kopinski",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3304cab-0dc9-47e4-ac68-00974b64f5a0.jpg?1783940838",
+        "rulings": [
+            {
+                "date": "2013-04-15",
+                "text": "You must exile exactly one creature card from your graveyard to cast this spell; you cannot cast it without exiling a creature card, and you cannot exile additional creature cards."
+            },
+            {
+                "date": "2013-04-15",
+                "text": "Players can only respond once this spell has been cast and all its costs have been paid. No one can try to otherwise remove the creature card you exiled in order to prevent you from casting this spell."
+            },
+            {
+                "date": "2011-01-22",
+                "text": "When Relentless Skaabs returns to the battlefield because of its undying ability, it's not being cast. You won't exile a creature card from your graveyard."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Russet Wolves
 {
     "name": "Russet Wolves",

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -1016,6 +1016,61 @@
     ]
 }
 
+// Dearly Departed
+{
+    "name": "Dearly Departed",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nAs long as this creature is in your graveyard, each Human creature you control enters with an additional +1/+1 counter on it.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "otherOnly": true,
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Human ctrl:you",
+                    "to": "Battlefield"
+                },
+                "activeZones": [
+                    "Graveyard"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "RARE",
+        "artist": "Daniel Ljunggren",
+        "flavorText": "\"Never forget our ancestors. They have not forgotten us.\"\n—Mikaeus, the Lunarch",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d008061f-cda4-4bcf-b6b3-d1b4a251cc66.jpg?1783940996",
+        "rulings": [
+            {
+                "date": "2011-09-22",
+                "text": "The effect is cumulative. Human creatures you control will enter with a +1/+1 counter for each Dearly Departed in your graveyard."
+            },
+            {
+                "date": "2011-09-22",
+                "text": "In most cases, when determining whether a creature entering under your control should get a +1/+1 counter, you'll simply look at what the creature will look like on the battlefield. You'll consider any effects affecting a creature entering under your control."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Delver of Secrets
 {
     "name": "Delver of Secrets",
@@ -6349,6 +6404,78 @@
         "artist": "Kev Walker",
         "flavorText": "Kidnappers caught in Havengul are given two choices: languish in prison or become rat catchers. The smart ones go to prison.",
         "imageUri": "https://cards.scryfall.io/normal/front/4/4/4490ce65-c73a-4809-abd1-ccc3175bd2a4.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Unbreathing Horde
+{
+    "name": "Unbreathing Horde",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "This creature enters with a +1/+1 counter on it for each other Zombie you control and each Zombie card in your graveyard.\nIf this creature would be dealt damage, prevent that damage and remove a +1/+1 counter from it.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": {
+                    "type": "Add",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "HasSubtype",
+                                    "subtype": "Zombie"
+                                }
+                            ],
+                            "statePredicates": [
+                                {
+                                    "type": "StateNot",
+                                    "predicate": "IsSource"
+                                }
+                            ]
+                        }
+                    },
+                    "right": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "Zombie"
+                    }
+                }
+            },
+            "PreventDamageByRemovingCounter"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "RARE",
+        "artist": "Dave Kendall",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a91ea47-0c06-4333-a309-ac360c5cc9bd.jpg?1783940947",
+        "rulings": [
+            {
+                "date": "2011-09-22",
+                "text": "Only one +1/+1 counter will be removed, no matter how much damage is prevented."
+            },
+            {
+                "date": "2011-09-22",
+                "text": "If Unbreathing Horde has no +1/+1 counters on it (but its toughness is raised above 0 by another effect), any damage dealt to it will still be prevented, even though no counter will be removed."
+            },
+            {
+                "date": "2011-09-22",
+                "text": "If Unbreathing Horde enters from a graveyard, it will count itself when determining how many +1/+1 counters it enters with."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "BLACK"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ShieldCounterHelpers.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ShieldCounterHelpers.kt
@@ -2,9 +2,15 @@ package com.wingedsheep.engine.core
 
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.PreventDamageByRemovingCounter
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
 
 /**
  * Consume one shield counter from [entityId], the single mutation behind both halves of
@@ -110,4 +116,94 @@ fun applyShieldCounterToDamage(
 ): ShieldedDamage? {
     val (newState, event) = consumeShieldCounter(state, entityId) ?: return null
     return ShieldedDamage(newState, event, damagePrevented = !cantBePrevented)
+}
+
+/**
+ * The printed sibling of [applyShieldCounterToDamage]: a
+ * [com.wingedsheep.sdk.scripting.PreventDamageByRemovingCounter] on [entityId] itself — "If this
+ * creature would be dealt damage, prevent that damage and remove a +1/+1 counter from it"
+ * (Unbreathing Horde).
+ *
+ * Same shape as the shield-counter rule and wired at the same two chokepoints, with one deliberate
+ * difference: the prevention is **not** gated on having a counter to remove. CR 122.1c's shield is
+ * *made of* its counters, so no counter means no effect; Unbreathing Horde's is a printed ability
+ * that prevents unconditionally and removes a counter if one is there. Hence this returns a
+ * [ShieldedDamage] whose `event` is nullable, where the shield version returns `null` outright.
+ *
+ * Only self-recipient patterns are honoured — the printed line says "this creature", and a
+ * card that shielded *other* permanents this way would need the scan to run over the battlefield
+ * rather than over the damaged permanent.
+ *
+ * @return `null` when [entityId] carries no such replacement effect, so callers fall through to the
+ *   normal damage-application path unchanged.
+ */
+fun applyPreventByRemovingCounterToDamage(
+    state: GameState,
+    entityId: EntityId,
+    isCombatDamage: Boolean,
+    cantBePrevented: Boolean,
+): CounterSpendingShield? {
+    val container = state.getEntity(entityId) ?: return null
+    val effects = container.get<ReplacementEffectSourceComponent>()?.replacementEffects ?: return null
+    val effect = effects.filterIsInstance<PreventDamageByRemovingCounter>().firstOrNull { candidate ->
+        val pattern = candidate.appliesTo
+        pattern is EventPattern.DamageEvent &&
+            pattern.recipient == RecipientFilter.Self &&
+            when (pattern.damageType) {
+                is DamageType.Any -> true
+                is DamageType.Combat -> isCombatDamage
+                is DamageType.NonCombat -> !isCombatDamage
+            }
+    } ?: return null
+
+    val counterType = counterTypeOf(effect.counterType) ?: return null
+    val counters = container.get<CountersComponent>()
+    val hasCounter = (counters?.getCount(counterType) ?: 0) > 0
+    if (!hasCounter) {
+        // Nothing to remove, but the damage is still prevented (the printed ruling).
+        return CounterSpendingShield(state, event = null, damagePrevented = !cantBePrevented)
+    }
+    val newState = state.updateEntity(entityId) { c ->
+        c.with(counters!!.withRemoved(counterType, 1))
+    }
+    val event = CountersRemovedEvent(
+        entityId,
+        counterType.name,
+        1,
+        container.get<CardComponent>()?.name ?: "Permanent"
+    )
+    return CounterSpendingShield(newState, event, damagePrevented = !cantBePrevented)
+}
+
+/**
+ * Outcome of a printed prevent-and-remove-a-counter ability meeting an incoming damage instance.
+ *
+ * Unlike [ShieldedDamage] the [event] is nullable: the ability fires (and prevents) even when the
+ * permanent has no counter of the named type left to remove.
+ */
+data class CounterSpendingShield(
+    val state: GameState,
+    val event: CountersRemovedEvent?,
+    val damagePrevented: Boolean,
+)
+
+/**
+ * The concrete [CounterType] a [CounterTypeFilter] names, or `null` for the filters that describe a
+ * *set* of counter types rather than one ("any counter") — those can't say which counter to remove.
+ */
+private fun counterTypeOf(filter: CounterTypeFilter): CounterType? = when (filter) {
+    is CounterTypeFilter.PlusOnePlusOne -> CounterType.PLUS_ONE_PLUS_ONE
+    is CounterTypeFilter.MinusOneMinusOne -> CounterType.MINUS_ONE_MINUS_ONE
+    is CounterTypeFilter.PlusOnePlusZero -> CounterType.PLUS_ONE_PLUS_ZERO
+    is CounterTypeFilter.PlusZeroPlusOne -> CounterType.PLUS_ZERO_PLUS_ONE
+    is CounterTypeFilter.MinusOneMinusZero -> CounterType.MINUS_ONE_MINUS_ZERO
+    is CounterTypeFilter.MinusZeroMinusOne -> CounterType.MINUS_ZERO_MINUS_ONE
+    is CounterTypeFilter.Loyalty -> CounterType.LOYALTY
+    // Fails *closed*, unlike the enters-with resolver's +1/+1 fallback: an unknown counter name
+    // here would silently spend the wrong counter, so the effect declines instead.
+    is CounterTypeFilter.Named -> CounterType.entries.firstOrNull {
+        it.name.equals(filter.name.uppercase().replace(' ', '_'), ignoreCase = true)
+    }
+    // "Any counter" cannot say which counter to remove.
+    is CounterTypeFilter.Any -> null
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/BattlefieldStaticsIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/BattlefieldStaticsIndex.kt
@@ -112,7 +112,14 @@ class BattlefieldStaticsIndex private constructor(
                 val classLevel = container.get<ClassLevelComponent>()?.currentLevel
                 for (ability in cardDef.script.effectiveStaticAbilities(classLevel)) {
                     when {
-                        ability is GrantTriggeredAbility && ability.filter.scope is Scope.Battlefield ->
+                        // Battlefield scope is the lord/sliver grant. SoulbondPair is the same
+                        // shape read through a different membership test — "each of those creatures
+                        // has '<triggered ability>'" (Tandem Lookout) — and it has to be collected
+                        // here too, or the layer system projects the pair while the trigger never
+                        // fires. `getStaticGrantedFromProviders` branches on the scope to decide
+                        // which test to apply.
+                        ability is GrantTriggeredAbility &&
+                            (ability.filter.scope is Scope.Battlefield || ability.filter.scope is Scope.SoulbondPair) ->
                             (triggerGrants
                                 ?: mutableListOf<TriggerIndex.GrantProviderEntry>().also { triggerGrants = it })
                                 .add(TriggerIndex.GrantProviderEntry(ability, sourceControllerId, permanentId))

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.event
 
+import com.wingedsheep.engine.mechanics.SoulbondPairing
 import com.wingedsheep.engine.mechanics.battle.Battles
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.handlers.ConditionEvaluator
@@ -194,6 +195,12 @@ class TriggerAbilityResolver(
             val cardDef = registry.getCard(card.cardDefinitionId) ?: continue
             for (ability in cardDef.staticAbilities) {
                 if (ability !is GrantTriggeredAbility) continue
+                // Mirrors the fast provider path: the soulbond-pair scope carries its own
+                // membership test and skips the filter/controller checks below.
+                if (ability.filter.scope is Scope.SoulbondPair) {
+                    if (SoulbondPairing.isInPairOf(state, permanentId, entityId)) result.add(ability.ability)
+                    continue
+                }
                 if (ability.filter.scope !is Scope.Battlefield) continue
 
                 // Check if the target entity matches the filter's card predicates
@@ -340,6 +347,16 @@ class TriggerAbilityResolver(
 
         return buildList {
             for (entry in grantProviders) {
+                // CR 702.95b's "both creatures" — the scope IS the membership test, so it replaces
+                // the filter/controller checks below rather than adding to them (an unpaired source
+                // reaches nobody, which is what makes "as long as this creature is paired" need no
+                // condition of its own).
+                if (entry.grant.filter.scope is Scope.SoulbondPair) {
+                    if (SoulbondPairing.isInPairOf(state, entry.sourceEntityId, entityId)) {
+                        add(entry.grant.ability)
+                    }
+                    continue
+                }
                 // "Other creatures you control have …" — the granting permanent must not grant
                 // the ability to itself. The slow path honors excludeSelf; the fast provider
                 // path previously omitted it, so the source double-triggered (e.g. Bria,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.handlers.effects
 
 import com.wingedsheep.engine.core.CountersAddedEvent
 import com.wingedsheep.engine.core.DamageDealtEvent
+import com.wingedsheep.engine.core.applyPreventByRemovingCounterToDamage
 import com.wingedsheep.engine.core.applyShieldCounterToDamage
 import com.wingedsheep.engine.core.DamagePreventedEvent
 import com.wingedsheep.engine.core.EffectResult
@@ -291,6 +292,24 @@ object DamageUtils {
                 newState = shielded.state
                 if (shielded.damagePrevented) return EffectResult.success(newState, listOf(shielded.event))
                 shieldCounterEvents = listOf(shielded.event)
+            }
+        }
+
+        // The printed sibling of the rule above: "If this creature would be dealt damage, prevent
+        // that damage and remove a +1/+1 counter from it" (Unbreathing Horde). Same one-counter-per-
+        // event scoping, same position in the CR 616.1 ordering, but it prevents even with no
+        // counter left to spend.
+        if (!isPlayer) {
+            val counterShield = applyPreventByRemovingCounterToDamage(
+                newState, targetId, isCombatDamage = isCombatDamage, cantBePrevented = cantBePrevented
+            )
+            if (counterShield != null) {
+                newState = counterShield.state
+                val counterEvents = listOfNotNull(counterShield.event)
+                if (counterShield.damagePrevented) {
+                    return EffectResult.success(newState, shieldCounterEvents + counterEvents)
+                }
+                shieldCounterEvents = shieldCounterEvents + counterEvents
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithReplacements.kt
@@ -132,7 +132,7 @@ object EntersWithReplacements {
         events.addAll(ownEvents)
 
         val (globalState, globalEvents) = applyGlobal(
-            newState, enteringEntityId, enteringControllerId
+            newState, enteringEntityId, enteringControllerId, cardRegistry
         )
         newState = globalState
         events.addAll(globalEvents)
@@ -166,6 +166,11 @@ object EntersWithReplacements {
         val replacementEffects = cardDef.script.replacementEffects + listOfNotNull(vanishingEntry)
 
         for (effect in replacementEffects) {
+            // A replacement effect that functions only from another zone (Dearly Departed's
+            // graveyard-scoped grant, CR 113.6) is not live as its own card enters the battlefield —
+            // entering *is* leaving the zone it works from. Guarded here as well as in the
+            // [applyGlobal] sweeps so no entry path can fire it against the source itself.
+            if (Zone.BATTLEFIELD !in effect.activeZones) continue
             when (effect) {
                 is EntersWithCounters -> {
                     // Skip "other only" effects when applying to self (Metallic Mimic's "each other
@@ -263,29 +268,70 @@ object EntersWithReplacements {
     }
 
     /**
-     * Scan battlefield permanents for enters-with replacement effects that apply to the
-     * entering entity, and apply them (counters added / keywords granted).
+     * Scan every source of enters-with replacement effects that apply to the entering entity and
+     * apply them (counters added / keywords granted).
+     *
+     * Two sweeps, split by [com.wingedsheep.sdk.scripting.ReplacementEffect.activeZones]:
+     *
+     * - the **battlefield**, for the ordinary `{BATTLEFIELD}` case (Gev, Scaled Scorch granting
+     *   +1/+1 counters to creatures you control that enter), and
+     * - **every player's graveyard**, for the `{GRAVEYARD}` case — a card whose printed line says
+     *   "As long as this creature is in your graveyard, …" (Dearly Departed, CR 113.6). Graveyard
+     *   cards carry no [ReplacementEffectSourceComponent] (that component is stamped only at
+     *   battlefield-entry sites), so this sweep reads the definition out of [cardRegistry] instead.
+     *   The sweep is naturally cumulative: two Dearly Departeds in one graveyard are two sources
+     *   and hand out two counters, which is the printed ruling.
+     *
+     * The `activeZones` filter runs on *both* sweeps, so declaring `{GRAVEYARD}` also switches the
+     * effect off on the battlefield.
      *
      * @param state The game state after the entering entity has been added to the battlefield.
      * @param enteringEntityId The entity that just entered the battlefield.
      * @param enteringControllerId The controller of the entering entity.
+     * @param cardRegistry Needed only for the graveyard sweep — a graveyard card's effects live on
+     *   its [CardDefinition], not on a component. Callers that have no registry (the token
+     *   executors, which cannot resolve a token's own definition either) skip that sweep; the
+     *   battlefield sweep is unaffected.
      */
     fun applyGlobal(
         state: GameState,
         enteringEntityId: EntityId,
         enteringControllerId: EntityId,
+        cardRegistry: CardRegistry? = null,
     ): Pair<GameState, List<GameEvent>> {
         var newState = state
         val events = mutableListOf<GameEvent>()
         val entityName = newState.getEntity(enteringEntityId)?.get<CardComponent>()?.name ?: ""
 
+        val sources = mutableListOf<GlobalReplacementSource>()
         for (sourceId in newState.getBattlefield()) {
             if (sourceId == enteringEntityId) continue
             val container = newState.getEntity(sourceId) ?: continue
             val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
             val sourceControllerId = container.get<ControllerComponent>()?.playerId ?: continue
+            val effects = replacementComponent.replacementEffects
+                .filter { Zone.BATTLEFIELD in it.activeZones }
+            if (effects.isEmpty()) continue
+            sources.add(GlobalReplacementSource(sourceId, sourceControllerId, effects))
+        }
+        if (cardRegistry != null) {
+            for (playerId in newState.turnOrder) {
+                for (sourceId in newState.getGraveyard(playerId)) {
+                    if (sourceId == enteringEntityId) continue
+                    val cardComponent = newState.getEntity(sourceId)?.get<CardComponent>() ?: continue
+                    val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
+                    val effects = cardDef.script.replacementEffects
+                        .filter { Zone.GRAVEYARD in it.activeZones }
+                    if (effects.isEmpty()) continue
+                    // A card outside the battlefield has no controller — "you control" on a
+                    // graveyard-scoped effect means the graveyard's owner (CR 108.3).
+                    sources.add(GlobalReplacementSource(sourceId, playerId, effects))
+                }
+            }
+        }
 
-            for (effect in replacementComponent.replacementEffects) {
+        for ((sourceId, sourceControllerId, effects) in sources) {
+            for (effect in effects) {
                 when (effect) {
                     is EntersWithCounters -> {
                         if (effect.selfOnly) continue
@@ -379,6 +425,20 @@ object EntersWithReplacements {
         }
         return newState to events
     }
+
+    /**
+     * One source of global enters-with replacement effects, already resolved to (source entity,
+     * the player its "you" resolves to, the effects live in that source's zone).
+     *
+     * The indirection is what lets the battlefield sweep and the graveyard sweep share a single
+     * application loop: the two differ only in where the effects come from (a component vs. the
+     * card definition) and in how "you" is derived (controller vs. owner).
+     */
+    private data class GlobalReplacementSource(
+        val sourceId: EntityId,
+        val sourceControllerId: EntityId,
+        val effects: List<com.wingedsheep.sdk.scripting.ReplacementEffect>,
+    )
 
     /**
      * Grant [effect]'s keywords to [enteringEntityId] as permanent floating effects. The grant

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
@@ -156,7 +156,7 @@ class CreateTokenCopyOfChosenPermanentExecutor(
             val (stateWithCounters, counterEvents) = if (cardRegistry != null) {
                 EntersWithReplacements.applyOnEntry(newState, tokenId, controllerId, cardRegistry)
             } else {
-                EntersWithReplacements.applyGlobal(newState, tokenId, controllerId)
+                EntersWithReplacements.applyGlobal(newState, tokenId, controllerId, cardRegistry)
             }
             newState = stateWithCounters
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -252,7 +252,7 @@ class CreateTokenCopyOfTargetExecutor(
                     .applyOnEntry(newState, tokenId, controllerId, cardRegistry)
             } else {
                 com.wingedsheep.engine.handlers.effects.EntersWithReplacements
-                    .applyGlobal(newState, tokenId, controllerId)
+                    .applyGlobal(newState, tokenId, controllerId, cardRegistry)
             }
             newState = afterCounters
             events.addAll(counterEvents)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
@@ -285,7 +285,7 @@ class CreateTokenExecutor(
         val counterEvents = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
         for (tokenId in createdTokens) {
             val (nextState, events) = EntersWithReplacements.applyGlobal(
-                newState, tokenId, tokenControllerId
+                newState, tokenId, tokenControllerId, cardRegistry
             )
             newState = nextState
             counterEvents.addAll(events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -905,6 +905,12 @@ internal class CombatDamageManager(
      * [applyDamageToCreature] (redirection, Anti-Venom) while `DamageUtils` puts them first — a
      * legal but different CR 616.1 ordering, recorded on [applyShieldCounterToDamage].
      *
+     * Runs both counter-spending shields in one pass — the shield-counter rule and the printed
+     * [com.wingedsheep.sdk.scripting.PreventDamageByRemovingCounter] ability (Unbreathing Horde) —
+     * because they share the batch scoping and the position in the CR 616.1 ordering. A creature
+     * carrying both spends only the shield counter: once the shield prevents the damage there is no
+     * damage left for the printed ability to replace.
+     *
      * @return the state with counters consumed, the assignments that survive (those whose target's
      *   damage was not prevented), and the [CountersRemovedEvent]s to emit.
      */
@@ -924,10 +930,26 @@ internal class CombatDamageManager(
             // Per-recipient, so it is read inside the loop: a creature marked unpreventable
             // (Whippoorwill) takes damage in full while its neighbours keep their shields.
             val cantBePrevented = DamageUtils.isDamagePreventionDisabled(state, targetId)
-            val shielded = applyShieldCounterToDamage(newState, targetId, cantBePrevented) ?: continue
-            newState = shielded.state
-            events.add(shielded.event)
-            if (shielded.damagePrevented) preventedTargets.add(targetId)
+            val shielded = applyShieldCounterToDamage(newState, targetId, cantBePrevented)
+            if (shielded != null) {
+                newState = shielded.state
+                events.add(shielded.event)
+                if (shielded.damagePrevented) {
+                    preventedTargets.add(targetId)
+                    // The damage is already gone; a printed prevent-and-remove ability on the same
+                    // creature has nothing left to replace, so it keeps its counter.
+                    continue
+                }
+            }
+            // The printed sibling (Unbreathing Horde). Batch-scoped for the same CR 510.2 reason as
+            // the shield-counter rule above: one counter per damage *event*, so a creature blocking
+            // two attackers spends one counter and prevents all of it.
+            val counterShield = applyPreventByRemovingCounterToDamage(
+                newState, targetId, isCombatDamage = true, cantBePrevented = cantBePrevented
+            ) ?: continue
+            newState = counterShield.state
+            counterShield.event?.let { events.add(it) }
+            if (counterShield.damagePrevented) preventedTargets.add(targetId)
         }
 
         if (preventedTargets.isEmpty()) return Triple(newState, assignments, events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -1149,6 +1149,7 @@ class StaticAbilityHandler(
         when (it) {
             // Damage replacement/modification:
             is PreventDamage,
+            is com.wingedsheep.sdk.scripting.PreventDamageByRemovingCounter,
             is DoubleDamage,
             is ModifyDamageAmount,
             is com.wingedsheep.sdk.scripting.CapDamage,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2956,7 +2956,7 @@ class StackResolver(
         events.addAll(ownEvents)
 
         val (globalState, globalEvents) = EntersWithReplacements.applyGlobal(
-            newState, entityId, controllerId
+            newState, entityId, controllerId, cardRegistry
         )
         newState = globalState
         events.addAll(globalEvents)


### PR DESCRIPTION
DDQ's remaining nine "missing" entries turned out to be **five real cards and four tokens** the set's own `tokenArt` already covers. All five cards are DDQ *reprints*, so each canonical lands in its earliest real printing and DDQ gets a `Printing` row.

| Card | Canonical | Vocabulary |
|---|---|---|
| Spectral Gateguards | AVR #37 | existing |
| Tandem Lookout | AVR #80 | existing |
| Relentless Skaabs | DKA #45 | existing |
| Dearly Departed | ISD #9 | `ReplacementEffect.activeZones` |
| Unbreathing Horde | ISD #121 | `PreventDamageByRemovingCounter` |

## The three that compose

- **Spectral Gateguards** — `soulbond()` + `GrantKeyword(VIGILANCE, soulbondPair())`. Lightning Mauler's shape in white; the scope is empty while unpaired, so "as long as this creature is paired" needs no condition.
- **Tandem Lookout** — `soulbond()` + `GrantTriggeredAbility` over `soulbondPair()`. `TriggerBinding.SELF` is what makes "this creature" mean the half that dealt the damage rather than the Lookout, since the engine hosts a granted trigger on the *receiving* permanent (CR 113.7). `DamageType.Any`, because the printed line says "deals damage", not combat damage.
- **Relentless Skaabs** — Stitched Drake's `ExileCards(1, Creature)` additional cost plus Young Wolf's `UNDYING`. The cost rides the *cast*, so the undying return (not a cast, CR 702.92a) exiles nothing — the printed ruling, and a test asserts it.

## Feature 1 — a replacement effect that functions from the graveyard

`ReplacementEffect.activeZones: Set<Zone>` (default `{BATTLEFIELD}`), the twin of `TriggeredAbility.activeZones` and the same shape as the interface's existing `optional` / `priorityGroup` / `restrictions` defaults.

Declaring another zone is a **move, not an addition**: `EntersWithReplacements` now runs two sweeps — the battlefield for `BATTLEFIELD` sources, every graveyard for `GRAVEYARD` ones — and filters *both* by the field. So one declaration switches the effect **on** in the graveyard and **off** on the battlefield, which is the whole of "as long as this creature is in your graveyard, …". Dearly Departed you cast is a plain 5/5 flier until it dies.

Two details the graveyard sweep forced:

- A graveyard card carries no `ReplacementEffectSourceComponent` (that component is stamped only at battlefield-entry sites), so the sweep reads the definition out of `CardRegistry` — which `applyGlobal` now takes. It stays nullable to match the token executors that already can't resolve a definition; those skip only the graveyard half.
- "You control" for a card outside the battlefield is the **owner** of the zone, not a controller (CR 108.3). And because the sweep visits every card in the graveyard, the printed "the effect is cumulative" ruling falls out for free — two copies hand out two counters, which is a test.

The self-entry path (`applyFromDefinition`) got the same guard: entering the battlefield *is* leaving the graveyard, so a `{GRAVEYARD}` effect can never be live for its own source's entry.

## Feature 2 — prevent-and-spend-a-counter

`ReplacementEffect.PreventDamageByRemovingCounter(counterType, appliesTo)` — the printed twin of the shield counter's prevention half (CR 122.1c), wired at the same two chokepoints (`DamageUtils.dealDamageToTarget` and `CombatDamageManager.applyShieldCountersToCombatDamage`) and inheriting the same scoping: exactly **one** counter per damage *event*, however large the damage and however many counters are on the permanent.

One deliberate difference from shield counters, and it is the printed ruling: **the prevention does not depend on having a counter to spend.** CR 122.1c's shield is *made of* its counters; Unbreathing Horde's is a printed ability. So the helper returns a result whose `event` is nullable where the shield version returns `null` outright.

It is a separate type rather than a flag on `PreventDamage` because the counter removal is not a parameter of the prevention — it is what the ability *is*, and it makes the effect need a state-returning application path where plain prevention is a pure arithmetic reduction. A permanent carrying both spends only the shield counter: once the shield prevents the damage, there is nothing left for the printed ability to replace.

The `CounterTypeFilter` → `CounterType` resolution here fails **closed** (an unknown name declines) rather than the enters-with resolver's fail-open +1/+1, since spending the wrong counter is worse than spending none.

## Bug found on the way: `Scope.SoulbondPair` was inert for triggered-ability grants

Tandem Lookout drew no cards. `BattlefieldStaticsIndex.build` collected trigger-grant providers only for `Scope.Battlefield`, and `TriggerAbilityResolver` bailed on `filter.scope !is Scope.Battlefield` — so the layer system projected the pair (which is why Lightning Mauler's haste and Deadeye Navigator's activated ability always worked) while the *trigger* never fired. The same fallthrough shape as the ward-grant branch sitting next to it.

Both sites now branch on the scope, using `SoulbondPairing.isInPairOf` as the membership test — which *replaces* the base-filter/controller checks rather than adding to them, since an unpaired source reaching nobody is what makes the payoff self-enforcing.

## Tests

One file per card, 21 tests total:

- `SpectralGateguardsScenarioTest` (3) — pair on own ETB, declined pairing, pair on a later entry.
- `TandemLookoutScenarioTest` (3) — the Lookout's own copy fires, the *partner's* copy fires, unpaired fires neither. The middle one is what caught the scope bug.
- `RelentlessSkaabsScenarioTest` (3) — the cost exiles, an empty graveyard makes the cast illegal, undying returns with a counter and exiles nothing.
- `DearlyDepartedScenarioTest` (5) — live from the graveyard, inert on the battlefield, cumulative with two copies, no counter for a non-Human, no counter for an opponent's Human.
- `UnbreathingHordeScenarioTest` (5) — the two-zone entry count, the "each **other**" exclusion, one counter spent against a 3-damage Bolt, prevention with zero counters, and the combat-damage path.

## Verification

`just test-rules`, `just build` (including the re-blessed AVR/DKA/ISD card snapshots), `just check`, `just check-card-printing` clean for all five, and `just assay-differential` — 46 divergences, none of them these cards.

DDQ now reads **67/71**. The four remaining are its tokens (Angel, Human, Spirit, Zombie), which by design have neither a `CardDefinition` nor a `Printing` row — the art already lives in `DuelDecksBlessedVsCursedSet.tokenArt`, as that file's KDoc explains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)