### PR TITLE
Keep tokens out of the set-completion denominator

### DIFF
--- a/game-server/src/main/resources/coverage/set-totals.json
+++ b/game-server/src/main/resources/coverage/set-totals.json
@@ -75973,14 +75973,6 @@
         "group": "Other Cards"
       },
       {
-        "name": "Mowu",
-        "img": "https://cards.scryfall.io/normal/front/b/1/b10441dd-9029-4f95-9566-d3771ebd36bd.jpg",
-        "products": [
-          "other"
-        ],
-        "group": "Other Cards"
-      },
-      {
         "name": "Mu Yanling",
         "img": "https://cards.scryfall.io/normal/front/a/2/a2ee3c3c-768b-434b-a121-6d897b2ae345.jpg",
         "products": [
@@ -89852,14 +89844,6 @@
         "group": "Other Cards"
       },
       {
-        "name": "Angel",
-        "img": "https://cards.scryfall.io/normal/front/8/e/8e3a583e-2310-4284-ac44-fd28c72ec11b.jpg",
-        "products": [
-          "other"
-        ],
-        "group": "Other Cards"
-      },
-      {
         "name": "Appetite for Brains",
         "img": "https://cards.scryfall.io/normal/front/e/f/ef9b4e72-2ac9-444c-81a9-756c5d3f2d65.jpg",
         "products": [
@@ -90116,14 +90100,6 @@
         "group": "Other Cards"
       },
       {
-        "name": "Human",
-        "img": "https://cards.scryfall.io/normal/front/1/5/15a620da-5056-4582-8da5-2c955c3f4c0d.jpg",
-        "products": [
-          "other"
-        ],
-        "group": "Other Cards"
-      },
-      {
         "name": "Human Frailty",
         "img": "https://cards.scryfall.io/normal/front/8/0/80b582e3-1e02-4c24-87be-05880b56df70.jpg",
         "products": [
@@ -90292,14 +90268,6 @@
         "group": "Other Cards"
       },
       {
-        "name": "Spirit",
-        "img": "https://cards.scryfall.io/normal/front/b/3/b38c8153-ded1-499f-929a-b7bc8a09cd5a.jpg",
-        "products": [
-          "other"
-        ],
-        "group": "Other Cards"
-      },
-      {
         "name": "Stitched Drake",
         "img": "https://cards.scryfall.io/normal/front/3/f/3ff74655-3156-4a02-af5a-f57c285e9d45.jpg",
         "products": [
@@ -90398,14 +90366,6 @@
       {
         "name": "Voice of the Provinces",
         "img": "https://cards.scryfall.io/normal/front/1/1/11a8437f-a783-4d76-8af1-a347d48a1bad.jpg",
-        "products": [
-          "other"
-        ],
-        "group": "Other Cards"
-      },
-      {
-        "name": "Zombie",
-        "img": "https://cards.scryfall.io/normal/front/7/c/7c60e495-8fb7-43bb-b11d-52882c0246bc.jpg",
         "products": [
           "other"
         ],

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/coverage/SetCoverageServiceTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/coverage/SetCoverageServiceTest.kt
@@ -188,6 +188,33 @@ class SetCoverageServiceTest : FunSpec({
         }
     }
 
+    test("tokens are not cards and never enter a denominator") {
+        // Most sets file their tokens under a separate `t<code>` set, which `scripts/card-status`
+        // never fetches. A few number them inside the main set — Duel Decks: Blessed vs. Cursed
+        // (#77–80) and Global Series (double-faced Mowu) — and those rows sat in the denominator
+        // forever, so DDQ read 67/71 with every card it prints authored. A token has no
+        // `CardDefinition` and no `Printing` row *by design* (its art is a `TokenPrinting` in its
+        // set's `tokenArt`), so it can never be "implemented" in the sense the count means.
+        //
+        // The invariant is deliberately narrow, because a real card may legitimately share a name
+        // with a token: a name only fails if the catalog knows it *solely* as token art. That is
+        // exactly the shape of the five rows this caught, and it stays quiet for the rest.
+        val tokenNames = MtgSetCatalog.all.flatMap { set -> set.tokenArt.map { it.name } }.toSet()
+        val realCardNames = MtgSetCatalog.all
+            .flatMap { set -> set.cards.map { it.name } + set.printings.map { it.name } }
+            .toSet()
+        val tokensOnly = tokenNames - realCardNames
+
+        val offenders = coverage.flatMap { row ->
+            val detail = service.detail(row.code) ?: return@flatMap emptyList<String>()
+            val names = detail.draft.map { it.name } + detail.extraGroups.flatMap { g -> g.cards.map { it.name } }
+            names.filter { it in tokensOnly }.map { "${row.code}/$it" }
+        }
+        withClue("token rows in the canonical totals — re-run `scripts/gen-set-totals`: $offenders") {
+            offenders shouldBe emptyList()
+        }
+    }
+
     test("detail returns null for an unknown set") {
         service.detail("ZZZ") shouldBe null
     }

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/DuelDecksBlessedVsCursedSet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/DuelDecksBlessedVsCursedSet.kt
@@ -10,8 +10,13 @@ import com.wingedsheep.sdk.model.TokenPrinting
 /**
  * Duel Decks: Blessed vs. Cursed (2016)
  *
- * mtgish-tooling seed: only the cards relocated here as their canonical earliest printing.
- * Intentionally incomplete relative to the official set.
+ * Complete: all 67 cards, every one of them a reprint whose canonical definition lives in the set
+ * that first printed it (ISD, DKA, AVR, …) with a [Printing] row here.
+ *
+ * The official product also numbers its four tokens inside the main set (#77–80) rather than in a
+ * separate `tddq` set. Those are not cards and never enter the count — see [tokenArt] below.
+ *
+ * [sealedSupported] stays false: a duel deck is two fixed 60-card decks, not a draftable product.
  *
  * Set Code: DDQ
  * Release Date: 2016-02-26
@@ -22,7 +27,6 @@ object DuelDecksBlessedVsCursedSet : MtgSet {
     override val displayName = "Duel Decks: Blessed vs. Cursed"
     override val releaseDate = "2016-02-26"
     override val sealedSupported = false
-    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)

--- a/scripts/card-status
+++ b/scripts/card-status
@@ -10,7 +10,11 @@ For each set folder under `mtg-sets/.../definitions/<code>/`:
   - loads the canonical name list from Scryfall, cached under
     `~/.cache/scryfall/<code>.json`, partitioned into draft cards (any
     printing in the set has Scryfall `booster: true`) and extras
-    (starter-deck exclusives, Special Guests, bonus sheets, etc.)
+    (starter-deck exclusives, Special Guests, bonus sheets, etc.).
+    Tokens and emblems are dropped — a handful of sets number them inside
+    the main set rather than a separate `t<code>` set, and a token has no
+    `CardDefinition` and no `Printing` row to implement (see
+    `NON_CARD_LAYOUTS`)
   - diffs the two to compute what's missing, reported per partition
 
 Cards listed in `coverage/card-exclusions.json` (ante, subgames, physical
@@ -57,7 +61,7 @@ REQUEST_DELAY_SEC = 0.15  # Scryfall asks for 50–100ms between requests; pad f
 # the script for 1h44m on one set, so every request is bounded and a timeout is retried like a 429.
 REQUEST_TIMEOUT_SEC = 30
 REFRESH_WINDOW_DAYS = 30
-CACHE_SCHEMA_VERSION = 8  # v8: `extra_products` (Scryfall promo_types per extra) recorded for every set
+CACHE_SCHEMA_VERSION = 9  # v9: token/emblem printings dropped from the canonical lists
 
 # A set is in current Standard if both:
 #   (a) its set_type is one of these (excludes commander, masters, alchemy, etc.), AND
@@ -66,6 +70,16 @@ CACHE_SCHEMA_VERSION = 8  # v8: `extra_products` (Scryfall promo_types per extra
 #       leave Standard; sets that haven't released yet pass (b) on previews.)
 STANDARD_SET_TYPES = {"core", "expansion", "draft_innovation"}
 STANDARD_LEGAL_RATIO = 0.5
+
+# Scryfall layouts that are not cards. Most sets file their tokens under a separate `t<code>` set,
+# but a few number them inside the main set — duel decks (DDQ #77–80) and Global Series (GS1's
+# double-faced Mowu) — and those rows came back from `set:<code>` and sat in the denominator
+# forever. The engine has no `CardDefinition` and no `Printing` row for a token by design: token art
+# lives in its set object's `tokenArt` as `TokenPrinting`s. So a set that has authored every card it
+# prints must be able to read 100%, and these can never be "implemented" in the sense the count
+# means. Dropped at the fetch site so every consumer of the cache — `card-status`, `gen-set-totals`
+# (the Set Completion resource) and `assay-ready.py`, which reuses `build_report` — inherits it.
+NON_CARD_LAYOUTS = {"token", "double_faced_token", "emblem"}
 
 SET_CODE_RE = re.compile(r'override\s+val\s+code\s*=\s*"([^"]+)"')
 DISPLAY_NAME_RE = re.compile(r'override\s+val\s+displayName\s*=\s*"([^"]+)"')
@@ -276,6 +290,8 @@ def fetch_from_scryfall(code: str) -> dict:
     while url:
         data = scryfall_get(url)
         for card in data.get("data", []):
+            if card.get("layout") in NON_CARD_LAYOUTS:
+                continue
             printings.setdefault(card["name"], []).append(card)
         url = data.get("next_page") if data.get("has_more") else None
 

--- a/scripts/gen-set-totals
+++ b/scripts/gen-set-totals
@@ -66,7 +66,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 OUTPUT = REPO_ROOT / "game-server/src/main/resources/coverage/set-totals.json"
 PRODUCTS_OUTPUT = REPO_ROOT / "game-server/src/main/resources/coverage/set-products.json"
 CACHE_ROOT = Path.home() / ".cache" / "scryfall"
-CACHE_SCHEMA_VERSION = 8
+CACHE_SCHEMA_VERSION = 9
 REFRESH_WINDOW_DAYS = 30
 
 # Scryfall's set pages split a set's printings into named sections — "Draft Cards" first, then the


### PR DESCRIPTION
> Stacks on #2002 — that PR is what takes DDQ to 67 authored cards, and this one is what lets it read 100%. Base retargets to `main` automatically once #2002 merges.

DDQ read **67/71** with every card it prints authored. The four "missing" entries were its tokens.

## Why they were counted

Most sets file their tokens under a separate `t<code>` set, which `scripts/card-status` never fetches. A few number them **inside the main set** — Duel Decks (DDQ #77–80) and Global Series (GS1's double-faced Mowu) — so `set:<code>` returned them and they went straight into the denominator.

A token has no `CardDefinition` and no `Printing` row **by design**: its art is a `TokenPrinting` in its set object's `tokenArt`, exactly as `DuelDecksBlessedVsCursedSet`'s own KDoc explains. So it can never be "implemented" in the sense the count means, and a set that has authored every card it prints must be able to read 100%.

## The fix

One filter at the fetch site:

```python
NON_CARD_LAYOUTS = {"token", "double_faced_token", "emblem"}
```

Dropped there rather than at each consumer, so everything reading the Scryfall cache inherits it: `card-status`, `gen-set-totals` (which bakes the Set Completion resource) and `assay-ready.py`, which reuses `build_report`. The cache schema goes **v8 → v9** in both scripts that pin it, since the payload's meaning changed.

`oracle-assay`'s `SetMembership` is deliberately untouched — it is a membership test against the Oracle corpus, which has no token entries to match, and its size is not a completion denominator.

## Blast radius: exactly five rows

Measured with one `is:token` sweep across all 163 scaffolded sets:

| Set | Rows |
|---|---|
| DDQ | Angel, Human, Spirit, Zombie |
| GS1 | Mowu (`double_faced_token`) |

`set-totals.json` is edited **surgically** rather than regenerated. A full `gen-set-totals` run from a local cache pulled in eight sets the committed resource does not have yet (a scaffolded but unreleased TRC among them) and reordered ~98k lines — none of it related to this change. The committed diff is 40 deleted lines, and nothing else.

## DDQ's `incomplete` flag

Fixing the count made DDQ 67/67, which immediately failed the existing gate:

```
complete sets still flagged `incomplete = true` — drop the override: [DDQ (67/67)]
```

So the override is gone and the set's KDoc no longer claims to be "intentionally incomplete". `sealedSupported` stays `false` — a duel deck is two fixed 60-card decks, not a draftable product.

## Regression test

New case in `SetCoverageServiceTest`: no canonical-totals row may name something the catalog knows **only** as token art.

Deliberately narrow, because a real card may legitimately share a name with a token — a name fails only when no `CardDefinition` and no `Printing` anywhere claims it. That is precisely the shape of the five rows, and it stays quiet for everything else. Verified it actually bites: with the rows restored it fails and names all five; with the fix it passes.

## Verification

`just test-server` (514 tests, green), `just build`, and `card-status` re-checked for both affected sets — DDQ **67/67**, GS1 41 → 40 with Mowu gone from its missing list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)