### PR TITLE
Evaluate dynamic mana amounts during auto-tap

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -82,7 +82,11 @@ data class ManaSource(
     val painAmount: Int = 0,
     /** Whether this creature can attack (no summoning sickness or has haste) */
     val canAttack: Boolean = false,
-    /** Amount of mana this source produces per tap (e.g., 3 for Elvish Aberration) */
+    /**
+     * Amount of mana this source produces per tap (e.g., 3 for Elvish Aberration). A *dynamic*
+     * amount — Elvish Archdruid's "Add {G} for each Elf you control", Gaea's Cradle, Marwyn — is
+     * evaluated against the current board, so this is what the tap would actually yield right now.
+     */
     val manaAmount: Int = 1,
     /** Extra mana produced per tap from auras like Elvish Guidance */
     val bonusManaPerTap: Int = 0,
@@ -1044,6 +1048,9 @@ class ManaSolver(
             // Collect all tap-based mana abilities to build a combined ManaSource
             val combinedColors = mutableSetOf<Color>()
             var producesColorless = false
+            // Gross mana per tap, taken from the ability that produces the most. Dynamic amounts
+            // are evaluated against the current board (see evaluateManaAmount); the floor of 1
+            // covers the intrinsic basic-land ability seeded below, which carries no amount.
             var maxManaAmount = 1
             // Extra mana produced by the SAME tap when one mana ability adds more than one mana of
             // different kinds via a CompositeEffect — Gruul Turf's "{T}: Add {R}{G}" and Mossfire
@@ -1248,11 +1255,11 @@ class ManaSolver(
                                     seenPrimary = true // the primary leaf; handled by the `when` below
                                 } else {
                                     extraBonusColor = extraBonusColor ?: leaf.color
-                                    extraBonusAmount += (leaf.amount as? DynamicAmount.Fixed)?.amount ?: 1
+                                    extraBonusAmount += evaluateManaAmount(leaf.amount, state, entityId, playerId)
                                 }
                             }
                             is AddColorlessManaEffect ->
-                                extraColorlessBonus += (leaf.amount as? DynamicAmount.Fixed)?.amount ?: 1
+                                extraColorlessBonus += evaluateManaAmount(leaf.amount, state, entityId, playerId)
                             else -> {}
                         }
                     }
@@ -1261,13 +1268,13 @@ class ManaSolver(
                     is AddManaEffect -> {
                         combinedColors.add(effect.color)
                         effectColors.add(effect.color)
-                        val manaAmount = (effect.amount as? DynamicAmount.Fixed)?.amount ?: 1
+                        val manaAmount = evaluateManaAmount(effect.amount, state, entityId, playerId)
                         maxManaAmount = maxOf(maxManaAmount, manaAmount)
                         effect.restriction
                     }
                     is AddColorlessManaEffect -> {
                         producesColorless = true
-                        val manaAmount = (effect.amount as? DynamicAmount.Fixed)?.amount ?: 1
+                        val manaAmount = evaluateManaAmount(effect.amount, state, entityId, playerId)
                         maxManaAmount = maxOf(maxManaAmount, manaAmount)
                         effect.restriction
                     }
@@ -1307,7 +1314,7 @@ class ManaSolver(
                     is AddDynamicManaEffect -> {
                         combinedColors.addAll(effect.allowedColors)
                         effectColors.addAll(effect.allowedColors)
-                        val manaAmount = (effect.amountSource as? DynamicAmount.Fixed)?.amount ?: 1
+                        val manaAmount = evaluateManaAmount(effect.amountSource, state, entityId, playerId)
                         maxManaAmount = maxOf(maxManaAmount, manaAmount)
                         effect.restriction
                     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -1092,6 +1092,9 @@ class ManaSolver(
             // across the abilities producing each — see ManaSource.colorPainCost.
             val perColorPainCost = mutableMapOf<Color, Int>()
             var cheapestColorlessPain = Int.MAX_VALUE
+            // Set when a mana ability was skipped purely because its dynamic amount is zero right
+            // now. It gates the land fallback below: such a land is not a colorless source.
+            var hadDryManaAbility = false
             // Track which colors are produceable WITHOUT sacrificing the source. A color is
             // sacrifice-free if any accepted ability producing it has no SacrificeSelf cost.
             // Colors in `combinedColors` but not here can only be made by sacrificing — the
@@ -1214,6 +1217,21 @@ class ManaSolver(
                     continue // Can't use this ability due to summoning sickness
                 }
 
+                val manaEffect = manaProducingEffect(ability.effect, state, entityId, playerId)
+
+                // A dynamic amount that evaluates to zero right now — Gaea's Cradle with no
+                // creatures, Marwyn the Nurturer at 0 power, Quintorius Kand with nothing exiled —
+                // adds no mana at all, even though the ability stays activatable. Skip the ability
+                // whole rather than just zeroing its amount: it must not contribute its colors,
+                // claim a tap's worth of mana, or drag its pain/sacrifice shape into the combined
+                // source. A permanent whose every mana ability is dry is not a mana source at all:
+                // a non-land drops out below on its own, and the land fallback is gated on the flag
+                // set here so it can't quietly re-offer the land as a colorless one.
+                if (addsNoManaRightNow(ability.effect, manaEffect, state, entityId, playerId)) {
+                    hadDryManaAbility = true
+                    continue
+                }
+
                 // Pain modeled as a self-damage side effect in the ability's effect chain
                 // (Battlefield Forge: "{T}: Add {R} or {W}. This land deals 1 damage to you.")
                 // counts the same as a PayLife cost atom.
@@ -1232,7 +1250,6 @@ class ManaSolver(
                 // separately via colorActivationManaCost / colorlessActivationManaCost,
                 // tapping additional sources to cover them.
                 val effectColors = mutableSetOf<Color>()
-                val manaEffect = manaProducingEffect(ability.effect, state, entityId, playerId)
                 // A single tap that adds several mana of different kinds (Gruul Turf: {R}{G}). The
                 // primary leaf below feeds producesColors/maxManaAmount as usual; the *additional*
                 // fixed-color/colorless leaves have no home in the choice-based producesColors set,
@@ -1470,6 +1487,14 @@ class ManaSolver(
             // (e.g., fetch lands like Windswept Heath)
             if (!card.typeLine.isLand) return@mapNotNull null
             if (allAbilities.isNotEmpty() && manaAbilities.isEmpty()) return@mapNotNull null
+            // A land whose mana ability is dry right now (Gaea's Cradle with no creatures) must not
+            // fall through to the colorless default — that would invent a {C} the land cannot
+            // produce, which is the same phantom mana this fix exists to remove. Lands whose
+            // abilities the loop rejected for *other* reasons (an unsatisfied activation
+            // restriction, a cost shape auto-tap doesn't model, a summoning-sick creature-land)
+            // still reach the fallback exactly as before; whether they should is a separate
+            // question from this one, and not one to settle silently here.
+            if (hadDryManaAbility) return@mapNotNull null
 
             ManaSource(
                 entityId = entityId,
@@ -1637,6 +1662,57 @@ class ManaSolver(
             // time from the source's CastChoicesComponent, so we don't pre-filter it.
             else -> null
         }
+    }
+
+    /**
+     * The mana [effect] would add right now, or null when it is not an amount-bearing mana effect
+     * (a non-mana leaf of a composite, or a shape with no amount to read such as "add one mana of
+     * each color among …"). Null means "don't judge this one", never "zero".
+     */
+    private fun manaAmountOf(
+        effect: Effect,
+        state: GameState,
+        sourceId: EntityId,
+        playerId: EntityId,
+    ): Int? = when (effect) {
+        is AddManaEffect -> evaluateManaAmount(effect.amount, state, sourceId, playerId)
+        is AddColorlessManaEffect -> evaluateManaAmount(effect.amount, state, sourceId, playerId)
+        is AddManaOfChoiceEffect -> evaluateManaAmount(effect.amount, state, sourceId, playerId)
+        is AddAnyColorManaSpendOnChosenTypeEffect ->
+            evaluateManaAmount(effect.amount, state, sourceId, playerId)
+        is AddDynamicManaEffect -> evaluateManaAmount(effect.amountSource, state, sourceId, playerId)
+        else -> null
+    }
+
+    /**
+     * True when activating this mana ability would add no mana whatsoever at this moment.
+     *
+     * Only a dynamic amount can be dry — every printed fixed amount is at least one — so this is
+     * cheap for the common case: [evaluateManaAmount] returns a [DynamicAmount.Fixed] without
+     * touching game state.
+     *
+     * [manaEffect] is the primary leaf [manaProducingEffect] picked out of [effect]. When that leaf
+     * is dry the whole ability still isn't, necessarily: one tap can add several mana of different
+     * kinds through a [CompositeEffect] (Gruul Turf's "{T}: Add {R}{G}"), so a sibling leaf that
+     * still adds something keeps the ability alive. An effect with no readable amount answers
+     * false — unknown shapes are assumed to produce, which is the conservative direction here.
+     */
+    private fun addsNoManaRightNow(
+        effect: Effect,
+        manaEffect: Effect,
+        state: GameState,
+        sourceId: EntityId,
+        playerId: EntityId,
+    ): Boolean {
+        val primaryAmount = manaAmountOf(manaEffect, state, sourceId, playerId) ?: return false
+        if (primaryAmount > 0) return false
+        if (effect is CompositeEffect) {
+            for (leaf in effect.effects) {
+                if (leaf === manaEffect) continue
+                if ((manaAmountOf(leaf, state, sourceId, playerId) ?: 0) > 0) return false
+            }
+        }
+        return true
     }
 
     private fun evaluateManaAmount(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/mana/DynamicManaAmountAutoTapTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/mana/DynamicManaAmountAutoTapTest.kt
@@ -20,6 +20,8 @@ import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
@@ -78,7 +80,25 @@ class DynamicManaAmountAutoTapTest : FunSpec({
         toughness = 3
     }
 
-    val allTestCards = TestCards.all + listOf(archdruid, warrior, bear)
+    // Gaea's Cradle, whose count can legitimately be zero — the other end of the same amount.
+    val cradle = card("Test Legendary Cradle") {
+        manaCost = ""
+        colorIdentity = "G"
+        typeLine = "Legendary Land"
+        oracleText = "{T}: Add {G} for each creature you control."
+
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.AddMana(
+                Color.GREEN,
+                DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature)
+            )
+            manaAbility = true
+            timing = TimingRule.ManaAbility
+        }
+    }
+
+    val allTestCards = TestCards.all + listOf(archdruid, warrior, bear, cradle)
 
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
@@ -145,5 +165,39 @@ class DynamicManaAmountAutoTapTest : FunSpec({
         driver.state.getEntity(druidId)?.has<TappedComponent>() shouldBe true
         // Exactly {G}{G}{G} was produced and exactly {2}{G} spent — nothing left floating.
         (driver.state.getEntity(playerId)?.get<ManaPoolComponent>()?.green ?: 0) shouldBe 0
+    }
+
+    test("a land whose dynamic ability is dry right now is not offered as a mana source") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val playerId = driver.activePlayer!!
+        driver.putLandOnBattlefield(playerId, "Test Legendary Cradle")
+
+        val solver = ManaSolver(createRegistry())
+
+        // "Add {G} for each creature you control" with no creatures adds nothing. The land must not
+        // claim a green it can't make, and must not fall back to the colorless land default either.
+        solver.findAvailableManaSources(driver.state, playerId)
+            .map { it.name } shouldNotContain "Test Legendary Cradle"
+        solver.getAvailableManaCount(driver.state, playerId) shouldBe 0
+        solver.solve(driver.state, playerId, ManaCost.parse("{G}")).shouldBeNull()
+        solver.solve(driver.state, playerId, ManaCost.parse("{1}")).shouldBeNull()
+    }
+
+    test("the same land is a full source again as soon as the count is nonzero") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val playerId = driver.activePlayer!!
+        driver.putLandOnBattlefield(playerId, "Test Legendary Cradle")
+        repeat(2) { driver.putCreatureOnBattlefield(playerId, "Test Elf Warrior") }
+
+        val source = ManaSolver(createRegistry())
+            .findAvailableManaSources(driver.state, playerId)
+            .single { it.name == "Test Legendary Cradle" }
+
+        source.producesColors shouldContain Color.GREEN
+        source.manaAmount shouldBe 2
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/mana/DynamicManaAmountAutoTapTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/mana/DynamicManaAmountAutoTapTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.mechanics.mana
+
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression: the auto-tapper (ManaSolver) must count what a *dynamic* mana ability actually
+ * produces — Elvish Archdruid: "{T}: Add {G} for each Elf you control".
+ *
+ * The amount on `AddManaEffect` / `AddColorlessManaEffect` / `AddDynamicManaEffect` is a
+ * [DynamicAmount], and the solver only read it when it was a [DynamicAmount.Fixed], falling back to
+ * "one mana per tap" for everything else. So an Archdruid with three Elves out was reported as a
+ * single green source: spells it could pay for on its own were never highlighted as castable, and
+ * auto-pay refused to cast them. The same undercount hit Gaea's Cradle, Tolarian Academy, Marwyn,
+ * and Viridian Joiner. The fix evaluates the amount against current state (stable during a
+ * payment), as the choice-based effects already did.
+ */
+class DynamicManaAmountAutoTapTest : FunSpec({
+
+    /** The shared board: the driver, the Elf player, and the Archdruid's entity. */
+    data class Board(val driver: GameTestDriver, val playerId: EntityId, val druidId: EntityId)
+
+    // Faithful copy of Elvish Archdruid's mana ability (the lord half is irrelevant here).
+    val archdruid = card("Test Elf Archdruid") {
+        typeLine = "Creature — Elf Druid"
+        manaCost = "{1}{G}{G}"
+        colorIdentity = "G"
+        power = 2
+        toughness = 2
+        oracleText = "{T}: Add {G} for each Elf you control."
+
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.AddMana(
+                Color.GREEN,
+                DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature.withSubtype(Subtype.ELF))
+            )
+            manaAbility = true
+            timing = TimingRule.ManaAbility
+        }
+    }
+
+    // A vanilla Elf, purely to raise the Elf count the ability reads.
+    val warrior = card("Test Elf Warrior") {
+        typeLine = "Creature — Elf Warrior"
+        manaCost = "{G}"
+        colorIdentity = "G"
+        power = 1
+        toughness = 1
+    }
+
+    // A plain {2}{G} body — not an Elf, so casting it can't change the Elf count mid-payment.
+    val bear = card("Test Payoff Bear") {
+        typeLine = "Creature — Bear"
+        manaCost = "{2}{G}"
+        colorIdentity = "G"
+        power = 3
+        toughness = 3
+    }
+
+    val allTestCards = TestCards.all + listOf(archdruid, warrior, bear)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(allTestCards)
+        return driver
+    }
+
+    fun createRegistry(): CardRegistry {
+        val registry = CardRegistry()
+        registry.register(allTestCards)
+        return registry
+    }
+
+    /** Archdruid plus two other Elves, all able to tap: one tap makes {G}{G}{G}. */
+    fun boardWithThreeElves(): Board {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val playerId = driver.activePlayer!!
+        val druidId = driver.putCreatureOnBattlefield(playerId, "Test Elf Archdruid")
+        driver.removeSummoningSickness(druidId)
+        repeat(2) {
+            driver.removeSummoningSickness(driver.putCreatureOnBattlefield(playerId, "Test Elf Warrior"))
+        }
+        return Board(driver, playerId, druidId)
+    }
+
+    test("mana source reports the dynamic amount its ability produces") {
+        val (driver, playerId) = boardWithThreeElves()
+
+        val source = ManaSolver(createRegistry())
+            .findAvailableManaSources(driver.state, playerId)
+            .single { it.name == "Test Elf Archdruid" }
+
+        source.producesColors shouldContain Color.GREEN
+        source.manaAmount shouldBe 3
+    }
+
+    test("available mana count includes every mana a dynamic ability makes") {
+        val (driver, playerId) = boardWithThreeElves()
+
+        ManaSolver(createRegistry()).getAvailableManaCount(driver.state, playerId) shouldBe 3
+    }
+
+    test("a cost payable off one dynamic tap is solved by tapping that source alone") {
+        val (driver, playerId) = boardWithThreeElves()
+
+        val solution = ManaSolver(createRegistry())
+            .solve(driver.state, playerId, ManaCost.parse("{2}{G}"))
+
+        solution.shouldNotBeNull()
+        solution.sources.map { it.name } shouldBe listOf("Test Elf Archdruid")
+    }
+
+    test("auto-pay floats every mana the tap makes, so the spell it planned for actually resolves") {
+        val (driver, playerId, druidId) = boardWithThreeElves()
+        val bearId = driver.putCardInHand(playerId, "Test Payoff Bear")
+
+        // No lands on the battlefield: the {2}{G} can only come from one Archdruid tap.
+        driver.castSpell(playerId, bearId)
+        driver.bothPass()
+
+        driver.state.getBattlefield(playerId) shouldContain bearId
+        driver.state.getEntity(druidId)?.has<TappedComponent>() shouldBe true
+        // Exactly {G}{G}{G} was produced and exactly {2}{G} spent — nothing left floating.
+        (driver.state.getEntity(playerId)?.get<ManaPoolComponent>()?.green ?: 0) shouldBe 0
+    }
+})


### PR DESCRIPTION
# Evaluate dynamic mana amounts during auto-tap

Mana sources whose output depends on the current game state were previously treated as producing one mana by the auto-tap solver. That made sources such as Elvish Archdruid, Gaea's Cradle, Tolarian Academy, Marwyn the Nurturer, and Viridian Joiner disagree with manual activation: payable spells could be hidden, and automatic payment could credit the wrong amount.

Evaluate existing `DynamicAmount` values against the current state when building `ManaSource` entries and when collecting additional leaves from composite mana effects. The solver now reports and spends the amount the ability would actually produce.

An ability whose dynamic amount currently evaluates to zero is omitted as a source. In particular, a land such as Gaea's Cradle with no creatures no longer falls through to the generic colorless-land fallback and offers phantom mana. Composite abilities remain available when another mana-producing leaf still has a positive amount.

This uses the existing dynamic-amount evaluator and introduces no new SDK vocabulary.

## Verification

- `just test-class DynamicManaAmountAutoTapTest` — passed all six regression tests, covering source discovery, available-mana counting, solving, end-to-end auto-payment, zero-output exclusion, and restoration after the count becomes positive.
- `just test-rules` — all observed engine and scenario tasks passed except `:mtg-sets:2008-2016:tests:test`, where the unrelated `AbattoirGhoulScenarioTest` exceeded its 120-second timeout. That test and its combat/life-gain behavior are outside this branch's diff.

The targeted gate directly covers this change but does not independently prove every other rules-engine or card scenario. The broader gate attempted that coverage but did not complete green because of the unrelated timeout above. This branch contains no server or web-client changes, and these commands do not cover those layers.
