### PR TITLE
Fire "activates an ability" triggers off mana abilities

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5368,13 +5368,21 @@ Named sugar for the common type-primitive cases; reach for `youCastSpell(...)` p
   with `Effects.DealDamage(n, EffectTarget.PlayerRef(Player.TriggeringPlayer))` to punish the activator (Flamescroll
   Celebrant). Backed by `EventPattern.AbilityActivatedEvent(player)`.
 - `YouActivateAbility` — you activate an ability that isn't a mana ability (the `Player.You` form of the above).
-- `activatesAbilityOf(sourceFilter, player?)` — the source-scoped form of the above: an ability that isn't a mana
-  ability, activated from a permanent matching `sourceFilter`. Elrond, Moon-Reader's "whenever you activate an
-  ability of a creature" is `activatesAbilityOf(GameObjectFilter.Creature)`; pair it with `oncePerTurn = true` on
-  the triggered ability for the "this ability triggers only once each turn" clause. Backed by
-  `EventPattern.AbilityActivatedEvent(player, sourceFilter)`. Unlike `activatesAbilityWithoutTap` (below), which
-  keys on the literal `{T}`-in-cost wording, this keeps the "isn't a mana ability" gate — so a creature's
-  tap-for-mana never fires it while a `{T}`-costed non-mana ability does.
+- `activatesAbilityOf(sourceFilter, player?, includeManaAbilities?)` — the source-scoped form of the above: an
+  ability activated from a permanent matching `sourceFilter`. By default it keeps the "isn't a mana ability" gate;
+  set `includeManaAbilities = true` for the unqualified Oracle wording, where mana abilities count too. Elrond,
+  Moon-Reader's "whenever you activate an ability of a creature" is
+  `activatesAbilityOf(GameObjectFilter.Creature, includeManaAbilities = true)` — its ruling confirms a creature's
+  `{T}: Add {G}` triggers it, since a mana ability is still an activated ability (CR 605.3). Pair it with
+  `oncePerTurn = true` on the triggered ability for the "this ability triggers only once each turn" clause. Backed
+  by `EventPattern.AbilityActivatedEvent(player, sourceFilter, includeManaAbilities)`. Unlike
+  `activatesAbilityWithoutTap` (below), which keys on the literal `{T}`-in-cost wording, this ignores the tap cost
+  entirely. A trigger that sets `includeManaAbilities` must not itself be able to add mana, or CR 605.1b would make
+  it a mana ability (and it would resolve off the stack).
+
+  **Engine note.** The engine emits `AbilityActivatedEvent` for *every* activated mana ability, on the manual
+  activation path and on the auto-tap fast path used to pay for spells and abilities, with `isManaAbility = true`
+  and `costsTap` set from the cost. Mana-ability activations are deliberately kept out of the client game log.
 - `YouActivateExhaustAbility` — you activate an ability marked `isExhaust`. Backed by
   `EventPattern.AbilityActivatedEvent(player = Player.You, requireExhaust = true)` and the activation event's
   `isExhaust` flag. The event is emitted as soon as the exhaust ability is put on the stack, so the triggered

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1275,20 +1275,28 @@ object Triggers {
     )
 
     /**
-     * Whenever [player] activates an ability *of a permanent matching [sourceFilter]* that isn't a
-     * mana ability — Elrond, Moon-Reader's "whenever you activate an ability of a creature".
+     * Whenever [player] activates an ability *of a permanent matching [sourceFilter]* — the
+     * source-scoped sibling of [YouActivateAbility].
      *
-     * The source-scoped sibling of [YouActivateAbility]: same "isn't a mana ability" gate (CR 605 /
-     * 606), plus the activated ability's source permanent must match. Unlike
-     * [activatesAbilityWithoutTap], which keys on the literal "{T} in its activation cost" wording,
-     * this leaves the tap cost alone — a {T} ability of a creature fires it just as a costless one
-     * does.
+     * By default this keeps that trigger's "isn't a mana ability" gate (CR 605 / 606) and only adds
+     * the requirement that the activated ability's source permanent match. Set
+     * [includeManaAbilities] for the unqualified Oracle wording — Elrond, Moon-Reader's "whenever
+     * you activate an ability of a creature", whose ruling confirms a creature's "{T}: Add {G}"
+     * triggers it, since a mana ability is still an activated ability (CR 605.3).
+     *
+     * Unlike [activatesAbilityWithoutTap], which keys on the literal "{T} in its activation cost"
+     * wording, this leaves the tap cost alone — a {T} ability fires it just as a costless one does.
      */
     fun activatesAbilityOf(
         sourceFilter: GameObjectFilter,
-        player: Player = Player.You
+        player: Player = Player.You,
+        includeManaAbilities: Boolean = false
     ): TriggerSpec = TriggerSpec(
-        event = AbilityActivatedEvent(player = player, sourceFilter = sourceFilter),
+        event = AbilityActivatedEvent(
+            player = player,
+            sourceFilter = sourceFilter,
+            includeManaAbilities = includeManaAbilities
+        ),
         binding = TriggerBinding.ANY
     )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -2191,6 +2191,14 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
      * Refueler) — which counts an exhaust *mana* ability too. [excludeManaAbilities] adds back the
      * "isn't a mana ability" clause for Pit Automaton, whose Oracle text was updated to
      * "an exhaust ability that isn't a mana ability" so its copy payoff can't grab a mana ability.
+     *
+     * [includeManaAbilities] drops the default "isn't a mana ability" gate entirely: the trigger
+     * fires for *every* activated ability, mana or not. This is the unqualified Oracle wording —
+     * Elrond, Moon-Reader's "whenever you activate an ability of a creature", whose ruling states
+     * that a creature's "{T}: Add {G}" does cause it to trigger. Note this is the opposite axis to
+     * [excludeManaAbilities], which subtracts mana abilities from the *exhaust* semantic; this one
+     * adds them to the default semantic. A trigger that sets it must not itself be able to produce
+     * mana, or CR 605.1b would make it a mana ability.
      */
     @SerialName("AbilityActivatedEvent")
     @Serializable
@@ -2201,27 +2209,33 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
         val requireNoTapInCost: Boolean = false,
         val requireExhaust: Boolean = false,
         val excludeManaAbilities: Boolean = false,
+        val includeManaAbilities: Boolean = false,
     ) : EventPattern {
         override val description: String = buildString {
+            // The clause that narrows *which* abilities count, appended after "...ability".
+            // Empty for the unqualified [includeManaAbilities] wording, where the source filter
+            // alone does the narrowing ("you activate a creature's ability" — Elrond).
+            val qualifier = when {
+                targetMatch != null -> "targets a " + targetMatch.description
+                requireExhaust && excludeManaAbilities ->
+                    "is an exhaust ability that isn't a mana ability"
+                requireExhaust -> "is an exhaust ability"
+                requireNoTapInCost -> "doesn't have {T} in its activation cost"
+                includeManaAbilities -> ""
+                else -> "isn't a mana ability"
+            }
             append(player.description)
             append(" activates ")
             if (sourceFilter != null) {
                 append("a ")
                 append(sourceFilter.description)
-                append("'s ability that ")
+                append("'s ability")
             } else {
-                append("an ability that ")
+                append("an ability")
             }
-            when {
-                targetMatch != null -> {
-                    append("targets a ")
-                    append(targetMatch.description)
-                }
-                requireExhaust && excludeManaAbilities ->
-                    append("is an exhaust ability that isn't a mana ability")
-                requireExhaust -> append("is an exhaust ability")
-                requireNoTapInCost -> append("doesn't have {T} in its activation cost")
-                else -> append("isn't a mana ability")
+            if (qualifier.isNotEmpty()) {
+                append(" that ")
+                append(qualifier)
             }
         }
 

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ElrondMoonReader.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ElrondMoonReader.kt
@@ -23,13 +23,15 @@ import com.wingedsheep.sdk.scripting.targets.TargetPermanent
  * {5}{U}{U}: Exile up to two other target nonland permanents you control. Return those cards to
  * the battlefield under their owner's control at the beginning of the next end step.
  *
- * The trigger is [Triggers.activatesAbilityOf] — the source-scoped form of the existing "whenever
- * you activate an ability that isn't a mana ability" event, so a creature's mana ability doesn't
- * fire it, but a {T} ability does. `oncePerTurn` carries the "only once each turn" clause; a
- * per-permanent restriction would be wrong here since the clause bounds the *ability*, not the
- * creatures it watches. The filter is unrestricted by controller — the oracle says "a creature",
- * not "a creature you control" — so an ability of a creature you don't control but may activate
- * still triggers it.
+ * The trigger is [Triggers.activatesAbilityOf] with `includeManaAbilities = true`: the Oracle text
+ * puts no "that isn't a mana ability" clause on it, and a mana ability is still an activated
+ * ability (CR 605.3), so a creature's "{T}: Add {G}" fires it — the card's own ruling says so
+ * explicitly. Elrond's trigger is not itself a mana ability (CR 605.1b needs one that could add
+ * mana; drawing a card can't), so it uses the stack normally. `oncePerTurn` carries the "only once
+ * each turn" clause; a per-permanent restriction would be wrong here since the clause bounds the
+ * *ability*, not the creatures it watches. The filter is unrestricted by controller — the oracle
+ * says "a creature", not "a creature you control" — so an ability of a creature you don't control
+ * but may activate still triggers it.
  *
  * The activated ability is the blink pattern from Hide on the Ceiling: one target requirement of
  * `count = 2, optional = true` for "up to two", then [ForEachTargetEffect] running
@@ -49,7 +51,7 @@ val ElrondMoonReader = card("Elrond, Moon-Reader") {
     toughness = 3
 
     triggeredAbility {
-        trigger = Triggers.activatesAbilityOf(GameObjectFilter.Creature)
+        trigger = Triggers.activatesAbilityOf(GameObjectFilter.Creature, includeManaAbilities = true)
         oncePerTurn = true
         effect = DrawCardsEffect(1)
     }

--- a/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ElrondMoonReaderScenarioTest.kt
+++ b/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ElrondMoonReaderScenarioTest.kt
@@ -19,10 +19,13 @@ import io.kotest.matchers.shouldBe
  * each turn." + "{5}{U}{U}: Exile up to two other target nonland permanents you control. Return
  * those cards to the battlefield under their owner's control at the beginning of the next end step."
  *
- * The trigger is the new source-filtered form of the "you activate an ability" event
- * ([com.wingedsheep.sdk.dsl.Triggers.activatesAbilityOf]), so the interesting cases are the two
- * ways it must *not* fire: a creature's mana ability (excluded by the shared "isn't a mana ability"
- * gate) and a noncreature permanent's ability (excluded by the source filter).
+ * The trigger is the source-filtered form of the "you activate an ability" event
+ * ([com.wingedsheep.sdk.dsl.Triggers.activatesAbilityOf]) with `includeManaAbilities = true`. The
+ * Oracle text carries no "that isn't a mana ability" clause and a mana ability is still an
+ * activated ability (CR 605.3), so a creature's "{T}: Add {G}" fires it — the card's own ruling
+ * says so. That holds whether the player taps the mana creature by hand or the engine auto-taps it
+ * to pay for a spell; both are covered below. The one way it must *not* fire is a noncreature
+ * permanent's ability, excluded by the source filter.
  */
 class ElrondMoonReaderScenarioTest : ScenarioTestBase() {
 
@@ -70,7 +73,7 @@ class ElrondMoonReaderScenarioTest : ScenarioTestBase() {
                 }
             }
 
-            test("a creature's mana ability does not trigger it") {
+            test("tapping a creature for mana triggers it") {
                 val game = scenario()
                     .withPlayers("Player", "Opponent")
                     .withCardOnBattlefield(1, "Elrond, Moon-Reader", summoningSickness = false)
@@ -89,8 +92,73 @@ class ElrondMoonReaderScenarioTest : ScenarioTestBase() {
                 ).error shouldBe null
                 game.resolveStack()
 
-                withClue("mana abilities don't use the stack and never fire this trigger") {
+                withClue("a mana ability is still an activated ability (CR 605.3), so it triggers") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+
+            test("auto-tapping a creature for mana while casting a spell triggers it") {
+                // The engine's auto-tap fast path is a UI shortcut for the player activating the
+                // source's mana ability, not a different game action — so it must fire the trigger
+                // exactly as the manual tap above does. The drawn card lands on top of the spell
+                // per CR 603.3: the trigger waits for priority, which comes after the cast.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Elrond, Moon-Reader", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Llanowar Elves", summoningSickness = false)
+                    .withCardInHand(1, "Llanowar Elves")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                // The battlefield Elves is the only mana source, so paying {G} must tap it.
+                game.castSpell(1, "Llanowar Elves").error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the cast spent the card and the trigger drew one, netting zero") {
                     game.handSize(1) shouldBe handBefore
+                }
+                withClue("the drawn card is the one that was on top of the library") {
+                    game.isInHand(1, "Forest") shouldBe true
+                }
+            }
+
+            test("auto-tapping a creature to pay another permanent's ability cost triggers it") {
+                // The enchantment's own activation is out of scope (source filter is "a creature"),
+                // so the only thing that can draw here is the Elves being tapped for the generic
+                // {1} — which isolates the auto-tap path used to pay an *ability's* mana cost.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Elrond, Moon-Reader", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Llanowar Elves", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Along the Crooked Way")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val enchantment = game.findPermanent("Along the Crooked Way")!!
+                val grantMenace = AlongTheCrookedWay.activatedAbilities.single().id
+                val handBefore = game.handSize(1)
+
+                // {1}{B}: the lone Swamp covers {B}, so the {1} must come from the Elves.
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = enchantment,
+                        abilityId = grantMenace
+                    )
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("tapping the Elves to help pay the cost activated its mana ability") {
+                    game.handSize(1) shouldBe handBefore + 1
                 }
             }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -4007,7 +4007,8 @@
                 "id": "ability_1",
                 "trigger": {
                     "type": "AbilityActivatedEvent",
-                    "sourceFilter": "creature"
+                    "sourceFilter": "creature",
+                    "includeManaAbilities": true
                 },
                 "binding": "ANY",
                 "effect": {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -310,12 +310,13 @@ class TriggerMatcher(
                     // (Haunting Wind / Powerleech / Artifact Possession). Match any activated
                     // ability whose cost lacks {T} — mana abilities without {T} count too.
                     if (event.costsTap) return false
-                } else {
+                } else if (!trigger.includeManaAbilities) {
                     // Default "activates an ability that isn't a mana ability" (Flamescroll
-                    // Celebrant): the engine emits AbilityActivatedEvent for non-mana abilities
-                    // (which use the stack) and, for the {T}-cost template above, for non-{T} mana
-                    // abilities — so explicitly reject the mana-ability ones here. Loyalty
-                    // abilities qualify (they aren't mana abilities).
+                    // Celebrant): the engine emits AbilityActivatedEvent for every activated
+                    // ability, mana or not, so explicitly reject the mana-ability ones here.
+                    // Loyalty abilities qualify (they aren't mana abilities). The
+                    // includeManaAbilities branch is the unqualified wording (Elrond,
+                    // Moon-Reader) and skips this gate, accepting mana abilities too.
                     if (event.isManaAbility) return false
                 }
                 // SELF/ATTACHED binding: the ability's source must be this permanent (Artifact

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -108,6 +108,8 @@ class ActivateAbilityHandler(
     private val triggerDetector: TriggerDetector,
     private val triggerProcessor: TriggerProcessor,
     private val castPermissionUtils: CastPermissionUtils,
+    private val manaAbilitySideEffectExecutor:
+        com.wingedsheep.engine.mechanics.mana.ManaAbilitySideEffectExecutor,
 ) : ActionHandler<ActivateAbility> {
     override val actionType: KClass<ActivateAbility> = ActivateAbility::class
 
@@ -1611,6 +1613,31 @@ class ActivateAbilityHandler(
 
         // Mana abilities don't use the stack
         if (ability.isManaAbility) {
+            // A mana ability is still an *activated* ability (CR 605.3), so activating one is an
+            // activation event like any other — Elrond, Moon-Reader's "whenever you activate an
+            // ability of a creature" fires off a creature's "{T}: Add {G}" per its ruling. Mana
+            // abilities resolve off the stack, so StackResolver never emits AbilityActivatedEvent
+            // for them; emit it here for every mana ability, {T}-costed or not. Consumers pick
+            // their own semantic off the flags: the default "isn't a mana ability" wording rejects
+            // `isManaAbility`, the Antiquities "without {T} in its activation cost" template
+            // (Haunting Wind / Powerleech / Artifact Possession) rejects `costsTap`, and the
+            // unqualified wording accepts both.
+            //
+            // Emitted here rather than after resolution because the branch below has two pause
+            // exits — an any-color effect (Birds of Paradise) and an any-color tap bonus (Fertile
+            // Ground) — and the ability is already activated by this point: its costs are paid.
+            // Adding it to [events] now carries it out through those exits too.
+            val manaAbilityActivatedEvent = AbilityActivatedEvent(
+                sourceId = action.sourceId,
+                sourceName = cardComponent.name,
+                controllerId = action.playerId,
+                abilityEntityId = null,
+                costsTap = hasTapCost(effectiveCost),
+                isManaAbility = true,
+                isExhaust = ability.isExhaust
+            )
+            events.add(manaAbilityActivatedEvent)
+
             // Check for an attached aura that overrides the produced mana color
             // (e.g., Shimmerwilds Growth: "Enchanted land is the chosen color").
             val overrideColor = findEnchantedLandManaColorOverride(currentState, action.sourceId)
@@ -1680,7 +1707,9 @@ class ActivateAbilityHandler(
                 // must survive that pause. Queue it as a PendingTriggersContinuation beneath the
                 // in-flight decision so it's put on the stack once the ability finishes resolving
                 // (mirrors PassPriorityHandler / SubmitDecisionHandler mid-resolution handling).
-                val deferred = triggerDetector.detectTriggers(effectResult.state, costPaymentEvents)
+                val deferred = triggerDetector.detectTriggers(
+                    effectResult.state, costPaymentEvents + manaAbilityActivatedEvent
+                )
                 if (deferred.isNotEmpty()) {
                     val pending = com.wingedsheep.engine.core.PendingTriggersContinuation(
                         decisionId = "mana-ability-cost-triggers-${java.util.UUID.randomUUID()}",
@@ -1831,37 +1860,21 @@ class ActivateAbilityHandler(
             )
             if (bonusResult.isPaused) return bonusResult
 
-            // A mana ability whose cost lacks {T} (e.g. Ashnod's Altar's "Sacrifice a creature: Add
-            // {C}{C}") still satisfies the Antiquities "activates an ability without {T} in its
-            // activation cost" template (Haunting Wind / Powerleech / Artifact Possession). Mana
-            // abilities resolve off the stack, so StackResolver never emits AbilityActivatedEvent
-            // for them — emit it here. The common tap-for-mana case (cost has {T}) is skipped, so
-            // there's no behavior change or client-log noise for ordinary mana sources.
-            val manaAbilityActivatedEvents: List<GameEvent> =
-                if (!hasTapCost(effectiveCost)) {
-                    listOf(
-                        AbilityActivatedEvent(
-                            sourceId = action.sourceId,
-                            sourceName = cardComponent.name,
-                            controllerId = action.playerId,
-                            abilityEntityId = null,
-                            costsTap = false,
-                            isManaAbility = true
-                        )
-                    )
-                } else emptyList()
-
             // Detect and queue any triggered abilities from the activation — the cost-side events
             // (a sacrificed source's dies trigger, the {T} TappedEvent for an artifact-tap trigger),
-            // the non-{T} mana-ability activation event above, and the mana ability's OWN effect
+            // the mana-ability activation event from the top of this branch, and the mana ability's OWN effect
             // resolution events (e.g. a `ReflexiveTriggerEffect`'s `ReflexiveAbilityTriggeredEvent` —
             // Rubble Rouser's "Add {R}. When you do, deal 1 damage to each opponent": the reflexive
             // half is NOT itself a mana ability (CR 605.1a requires it produce mana), so it must go
             // on the stack normally even though the ability that caused it resolved off it). Such
             // triggered abilities still use the stack even though the mana ability itself resolves
             // off it.
-            val activationTriggerEvents = activationCostEvents + manaAbilityActivatedEvents + effectResult.events
-            val resultEvents = bonusResult.events + manaAbilityActivatedEvents
+            // `activationCostEvents` was snapshotted before `manaAbilityActivatedEvent` was added,
+            // so naming it here adds it exactly once. `bonusResult.events` already carries it —
+            // it flowed in through `events` — so `resultEvents` must not append it again.
+            val activationTriggerEvents =
+                activationCostEvents + manaAbilityActivatedEvent + effectResult.events
+            val resultEvents = bonusResult.events
             val costTriggers = triggerDetector.detectTriggers(bonusResult.newState, activationTriggerEvents)
             if (costTriggers.isNotEmpty()) {
                 val triggerResult = triggerProcessor.processTriggers(bonusResult.newState, costTriggers)
@@ -1877,8 +1890,7 @@ class ActivateAbilityHandler(
                     resultEvents + triggerResult.events
                 )
             }
-            return if (manaAbilityActivatedEvents.isEmpty()) bonusResult
-            else ExecutionResult.success(bonusResult.newState, resultEvents)
+            return bonusResult
         }
 
         // Non-mana abilities go on the stack
@@ -2394,6 +2406,16 @@ class ActivateAbilityHandler(
             val (tappedState, tapEvent) = tap(currentState, source.entityId)
             currentState = tappedState
             tapEvent?.let(events::add)
+            // Auto-tapping a source to pay an ability's mana cost activates that source's mana
+            // ability just as a manual tap would (CR 605.3) — emit the same activation event the
+            // shared cast/cycling/plot auto-tap path emits, so "whenever you activate an ability"
+            // triggers (Elrond, Moon-Reader) don't silently miss the fast path.
+            manaAbilitySideEffectExecutor.activationEvent(
+                currentState,
+                source.entityId,
+                solution.manaProduced[source.entityId]?.color,
+                playerId
+            )?.let(events::add)
         }
 
         // Add produced mana to floating pool so costHandler.payAbilityCost can consume it.
@@ -2925,7 +2947,8 @@ class ActivateAbilityHandler(
                 services.conditionEvaluator,
                 services.triggerDetector,
                 services.triggerProcessor,
-                services.castPermissionUtils
+                services.castPermissionUtils,
+                services.manaAbilitySideEffectExecutor
             )
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaAbilitySideEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaAbilitySideEffectExecutor.kt
@@ -74,19 +74,22 @@ class ManaAbilitySideEffectExecutor(
             event?.let(events::add)
 
             val production = solution.manaProduced[source.entityId]
+            // Resolved once and shared: both the activation event and the side effects want the
+            // same ability, and this loop runs for every auto-tapped source of every payment.
+            val ability = matchingManaAbility(currentState, source.entityId, production?.color)
+
             // Auto-tapping a source *is* the player activating its mana ability — the fast path is
             // a UI shortcut, not a different game action (CR 605.3). Emit the activation event the
             // manual path emits so "whenever you activate an ability" triggers see it (Elrond,
             // Moon-Reader off an auto-tapped Llanowar Elves). Emitted after the TappedEvent: the
             // tap is the cost, and the ability is activated once its costs are paid.
-            activationEvent(currentState, source.entityId, production?.color, controllerId)
-                ?.let(events::add)
+            activationEvent(currentState, source.entityId, controllerId, ability)?.let(events::add)
 
             val (after, sideEvents) = runSideEffects(
                 state = currentState,
                 sourceId = source.entityId,
-                producedColor = production?.color,
                 controllerId = controllerId,
+                matchingAbility = ability,
             )
             currentState = after
             events.addAll(sideEvents)
@@ -108,9 +111,17 @@ class ManaAbilitySideEffectExecutor(
         sourceId: EntityId,
         producedColor: Color?,
         controllerId: EntityId,
+    ): AbilityActivatedEvent? = activationEvent(
+        state, sourceId, controllerId, matchingManaAbility(state, sourceId, producedColor)
+    )
+
+    private fun activationEvent(
+        state: GameState,
+        sourceId: EntityId,
+        controllerId: EntityId,
+        matchingAbility: ActivatedAbility?,
     ): AbilityActivatedEvent? {
         val card = state.getEntity(sourceId)?.get<CardComponent>() ?: return null
-        val matchingAbility = matchingManaAbility(state, sourceId, producedColor)
         return AbilityActivatedEvent(
             sourceId = sourceId,
             sourceName = card.name,
@@ -140,9 +151,17 @@ class ManaAbilitySideEffectExecutor(
         sourceId: EntityId,
         producedColor: Color?,
         controllerId: EntityId,
+    ): Pair<GameState, List<GameEvent>> = runSideEffects(
+        state, sourceId, controllerId, matchingManaAbility(state, sourceId, producedColor)
+    )
+
+    private fun runSideEffects(
+        state: GameState,
+        sourceId: EntityId,
+        controllerId: EntityId,
+        matchingAbility: ActivatedAbility?,
     ): Pair<GameState, List<GameEvent>> {
-        val matchingAbility = matchingManaAbility(state, sourceId, producedColor)
-            ?: return state to emptyList()
+        if (matchingAbility == null) return state to emptyList()
 
         var currentState = state
         val events = mutableListOf<GameEvent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaAbilitySideEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaAbilitySideEffectExecutor.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.mechanics.mana
 
+import com.wingedsheep.engine.core.AbilityActivatedEvent
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.LifeChangeReason
@@ -73,6 +74,14 @@ class ManaAbilitySideEffectExecutor(
             event?.let(events::add)
 
             val production = solution.manaProduced[source.entityId]
+            // Auto-tapping a source *is* the player activating its mana ability — the fast path is
+            // a UI shortcut, not a different game action (CR 605.3). Emit the activation event the
+            // manual path emits so "whenever you activate an ability" triggers see it (Elrond,
+            // Moon-Reader off an auto-tapped Llanowar Elves). Emitted after the TappedEvent: the
+            // tap is the cost, and the ability is activated once its costs are paid.
+            activationEvent(currentState, source.entityId, production?.color, controllerId)
+                ?.let(events::add)
+
             val (after, sideEvents) = runSideEffects(
                 state = currentState,
                 sourceId = source.entityId,
@@ -85,19 +94,54 @@ class ManaAbilitySideEffectExecutor(
         return currentState to events
     }
 
+    /**
+     * The [AbilityActivatedEvent] for an auto-tapped mana source, or null if [sourceId] isn't a
+     * card (nothing to name in the event).
+     *
+     * `costsTap` is true by construction — this path only ever reaches sources it taps — so the
+     * Antiquities "without {T} in its activation cost" template correctly ignores these. `isExhaust`
+     * is read off the matching printed ability where one is found; an intrinsic land mana ability
+     * has no [ActivatedAbility] entry to consult and is never exhaust anyway.
+     */
+    fun activationEvent(
+        state: GameState,
+        sourceId: EntityId,
+        producedColor: Color?,
+        controllerId: EntityId,
+    ): AbilityActivatedEvent? {
+        val card = state.getEntity(sourceId)?.get<CardComponent>() ?: return null
+        val matchingAbility = matchingManaAbility(state, sourceId, producedColor)
+        return AbilityActivatedEvent(
+            sourceId = sourceId,
+            sourceName = card.name,
+            controllerId = controllerId,
+            abilityEntityId = null,
+            costsTap = true,
+            isManaAbility = true,
+            isExhaust = matchingAbility?.isExhaust == true
+        )
+    }
+
+    /** The printed mana ability of [sourceId] that produced [producedColor], if there is one. */
+    private fun matchingManaAbility(
+        state: GameState,
+        sourceId: EntityId,
+        producedColor: Color?,
+    ): ActivatedAbility? {
+        val card = state.getEntity(sourceId)?.get<CardComponent>() ?: return null
+        val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: return null
+        return cardDef.script.activatedAbilities
+            .filter { it.isManaAbility }
+            .firstOrNull { abilityProducesColor(it, producedColor) }
+    }
+
     fun runSideEffects(
         state: GameState,
         sourceId: EntityId,
         producedColor: Color?,
         controllerId: EntityId,
     ): Pair<GameState, List<GameEvent>> {
-        val card = state.getEntity(sourceId)?.get<CardComponent>()
-            ?: return state to emptyList()
-        val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: return state to emptyList()
-
-        val matchingAbility = cardDef.script.activatedAbilities
-            .filter { it.isManaAbility }
-            .firstOrNull { abilityProducesColor(it, producedColor) }
+        val matchingAbility = matchingManaAbility(state, sourceId, producedColor)
             ?: return state to emptyList()
 
         var currentState = state

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
@@ -1066,7 +1066,11 @@ object ClientEventTransformer {
                 isYours = event.controllerId == viewingPlayerId
             )
 
-            is AbilityActivatedEvent -> ClientEvent.AbilityActivated(
+            // Mana abilities never used the stack and so never showed up in the game log; the
+            // engine now emits AbilityActivatedEvent for them too (so "whenever you activate an
+            // ability" triggers can see them — Elrond, Moon-Reader), but they stay out of the log.
+            // A line whose description is empty says nothing the ManaAddedEvent doesn't already.
+            is AbilityActivatedEvent -> if (event.isManaAbility) null else ClientEvent.AbilityActivated(
                 sourceId = event.sourceId,
                 sourceName = event.sourceName,
                 abilityDescription = "", // Description not available

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ManaAbilityActivationTriggerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ManaAbilityActivationTriggerScenarioTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine-level coverage for "whenever you activate an ability" firing off *mana* abilities.
+ *
+ * A mana ability is still an activated ability (CR 605.3) — it just resolves without using the
+ * stack (CR 605.3b). So a trigger whose Oracle text carries no "that isn't a mana ability" clause
+ * must see one. `EventPattern.AbilityActivatedEvent.includeManaAbilities` is that wording; the
+ * default keeps the exclusion (Flamescroll Celebrant).
+ *
+ * These tests pin the *engine* rule rather than any one card, across both ways a mana ability gets
+ * activated: the player tapping the source by hand, and the engine auto-tapping it to pay a cost.
+ * The auto-tap fast path bypasses the activated-ability flow entirely — it taps sources straight
+ * from the mana solver — so it is the half most likely to silently regress.
+ */
+class ManaAbilityActivationTriggerScenarioTest : FunSpec({
+
+    // "Whenever a player activates a land's ability, you gain 1 life" — no mana-ability clause,
+    // so a land's {T}: Add {R} counts. Scoped to lands so nothing else in the scenario fires it.
+    val manaWatcher = card("Mana Watcher") {
+        manaCost = "{2}"
+        typeLine = "Enchantment"
+        oracleText = "Whenever a player activates a land's ability, you gain 1 life."
+        triggeredAbility {
+            trigger = Triggers.activatesAbilityOf(
+                GameObjectFilter.Land,
+                player = Player.Each,
+                includeManaAbilities = true
+            )
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    // The same watcher without the flag: the default "that isn't a mana ability" wording, which
+    // must stay blind to the very same activation.
+    val nonManaWatcher = card("Non-Mana Watcher") {
+        manaCost = "{2}"
+        typeLine = "Enchantment"
+        oracleText = "Whenever a player activates a land's ability that isn't a mana ability, " +
+            "you gain 1 life."
+        triggeredAbility {
+            trigger = Triggers.activatesAbilityOf(GameObjectFilter.Land, player = Player.Each)
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    // A {1} sink with no tap cost, so paying it forces the engine to auto-tap a land.
+    val manaSink = card("Mana Sink") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        oracleText = "{1}: Draw a card."
+        activatedAbility {
+            cost = Costs.Mana("{1}")
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    // A land whose mana ability is reachable by name from the registry.
+    val tapLand = card("Quiet Waste") {
+        typeLine = "Land"
+        oracleText = "{T}: Add {C}."
+        activatedAbility {
+            cost = AbilityCost.Tap
+            effect = AddColorlessManaEffect(1)
+            manaAbility = true
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        listOf(manaWatcher, nonManaWatcher, manaSink, tapLand).forEach { driver.registerCard(it) }
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 30) {
+            bothPass(); guard++
+        }
+    }
+
+    test("tapping a land for mana by hand fires an includeManaAbilities trigger") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        driver.putPermanentOnBattlefield(me, "Mana Watcher")
+        val land = driver.putLandOnBattlefield(me, "Quiet Waste")
+
+        val lifeBefore = driver.getLifeTotal(me)
+        val abilityId = driver.cardRegistry.requireCard("Quiet Waste").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = land, abilityId = abilityId))
+        driver.resolveStack()
+
+        driver.getLifeTotal(me) shouldBe lifeBefore + 1
+    }
+
+    test("the default wording stays blind to that same mana ability") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        driver.putPermanentOnBattlefield(me, "Non-Mana Watcher")
+        val land = driver.putLandOnBattlefield(me, "Quiet Waste")
+
+        val lifeBefore = driver.getLifeTotal(me)
+        val abilityId = driver.cardRegistry.requireCard("Quiet Waste").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = land, abilityId = abilityId))
+        driver.resolveStack()
+
+        driver.getLifeTotal(me) shouldBe lifeBefore
+    }
+
+    test("auto-tapping a land to pay an ability cost fires it too") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        driver.putPermanentOnBattlefield(me, "Mana Watcher")
+        val sink = driver.putPermanentOnBattlefield(me, "Mana Sink")
+        driver.putLandOnBattlefield(me, "Quiet Waste")
+
+        val lifeBefore = driver.getLifeTotal(me)
+        // No floating mana: the {1} can only come from the engine tapping the land itself.
+        val abilityId = driver.cardRegistry.requireCard("Mana Sink").activatedAbilities[0].id
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = sink, abilityId = abilityId))
+        driver.resolveStack()
+
+        driver.getLifeTotal(me) shouldBe lifeBefore + 1
+    }
+})


### PR DESCRIPTION
# Fire "activates an ability" triggers off mana abilities

Elrond, Moon-Reader reads "Whenever you activate an ability of a creature, draw a card."
There is no *"that isn't a mana ability"* clause on it, and a mana ability is still an
activated ability — CR 605.3 says activating one "follows the rules for activating any
other activated ability", it just resolves without using the stack (CR 605.3b). So
tapping a Llanowar Elves for `{G}` has to trigger it. The card's own Scryfall ruling says
so in as many words:

> An activated ability of a creature that's also a mana ability (such as "{T}: Add {G}")
> can cause Elrond's first ability to trigger.

We had the opposite behaviour codified in three places: the trigger spec, the card's
KDoc, and a scenario test asserting the mana ability does *not* fire it. Fixing it took
two independent changes, because two separate things stopped the event from ever reaching
the matcher.

## The trigger vocabulary

`EventPattern.AbilityActivatedEvent` gains `includeManaAbilities`, which drops the default
"isn't a mana ability" gate. It is deliberately a separate field from the existing
`excludeManaAbilities` rather than a reuse of it: that one *subtracts* mana abilities from
the exhaust semantic (Pit Automaton), this one *adds* them to the default semantic. Same
axis, opposite polarity — folding them into one flag makes both unreadable at the call
site. `Triggers.activatesAbilityOf` takes it through, and the pattern's rendered
`description` now omits the qualifying clause entirely when nothing narrows the trigger
beyond its source, so Elrond reads as "you activate a creature's ability" rather than
gaining a contradictory tail. Every existing combination renders byte-identically.

A trigger that sets the flag must not itself be able to produce mana, or CR 605.1b would
make it a mana ability and it would resolve off the stack. Elrond draws a card, so it uses
the stack normally — and per CR 603.3 it waits for priority, which means the draw goes on
the stack *above* the spell whose cost the mana paid for.

No new effect, executor, or SDK type: this is a flag on an existing event pattern and a
parameter on an existing trigger factory.

## Gap 1 — the manual activation path

`ActivateAbilityHandler` emitted `AbilityActivatedEvent` for a mana ability only when its
cost lacked `{T}` — the carve-out that serves the Antiquities "activates an ability without
{T} in its activation cost" template (Haunting Wind, Powerleech, Artifact Possession).
Tapping Llanowar Elves emitted nothing at all, so there was no event for any matcher to
accept or reject.

It now emits for every mana ability, with `costsTap` set from the cost, so consumers pick
their semantic off the flags rather than off which events happen to exist: the default
wording rejects `isManaAbility`, the Antiquities wording rejects `costsTap`, and the
unqualified wording accepts both.

The emission also **moved to the top of the mana branch**. That branch has two pause exits
— an any-color mana effect (Birds of Paradise pausing for a color decision) and an
any-color tap bonus (Fertile Ground) — and the ability is already activated by the time we
reach it, its costs paid. Building the event up front and adding it to the carried event
list gets it out through those exits; the pause path's deferred-trigger detection names it
too.

## Gap 2 — the auto-tap fast path

When the engine auto-taps sources to pay a cost, the mana solver taps them directly and
credits the mana, bypassing the activated-ability flow entirely. No activation event was
emitted anywhere. That path is a UI shortcut for the player activating the source's mana
ability, not a different game action, so it now emits the same event — otherwise Elrond
would miss every mana dork tapped to pay for a spell, which in real games is most of them.

`ManaAbilitySideEffectExecutor.tapSourcesWithSideEffects` is the shared choke point for ten
call sites (cast, cycle, plot, foretell, suspend, typecycle, morph, room unlock, cost
payment, mana payment window), so one emission covers all of them.
`ActivateAbilityHandler.autoTapForManaCost` taps inline rather than through that executor
and needed the same treatment; the executor is now a constructor dependency, wired through
the single `create(services)` factory.

## Knock-on effects, both intended

**`YouActivateExhaustAbility` now works as documented.** It is described as counting an
exhaust *mana* ability too, but never could, because a `{T}`-costed one emitted no event.
This is a live behaviour change for Aetherdrift cards beyond Elrond, and the most likely
thing to surprise a reviewer.

**Mana-ability activations stay out of the client game log.** `ClientEvent` drops them.
They have never appeared there, and the mapping has no ability description to render, so
un-gating emission would otherwise have put an empty-description line in the log on every
land tap. `ManaAddedEvent` already reports what the tap produced.

## Deliberately not fixed here

`LandTappedForManaEvent` still doesn't fire on auto-pay, so "whenever a player taps a land
for mana" (Mana Flare, Overabundance) continues to under-fire there. I had expected this to
come for free at the same emission site and it does not: the solver already pre-accounts
for mana-adding tap statics via `bonusManaSpentByColor` / `remainingBonusMana`, so firing
those triggers on auto-pay would double-add the mana. It needs that accounting reworked
first and belongs in its own change. `AbilityActivatedEvent` has no such conflict — nothing
consumes it to produce mana.

## Verification

`just test-rules` and `just test` on this box both surface killed test JVMs
(`finished with non-zero exit value 13`) and coroutine spec timeouts whenever several test
JVMs run concurrently, so the modules were also gated **serially**, and every result below
was confirmed fresh by reading the JUnit XML timestamps rather than trusting
`BUILD SUCCESSFUL`:

**14,470 tests, 0 failures, 0 errors** across every module, each run against source at or
newer than the last edit it depends on.

A fresh PR-readiness pass also ran the focused gates on the final branch:
`just test-class ManaAbilityActivationTriggerScenarioTest` (3/3 green) and
`just test-class ElrondMoonReaderScenarioTest` (6/6 green).

Three failures during the parallel runs were investigated rather than retried away:

- `CardDefinitionSnapshotTest` (HOB golden) — **real, and mine.** Re-blessed; the diff is
  exactly `includeManaAbilities: true` on Elrond and nothing else in the corpus moved,
  which also confirms no other card's trigger spec or rendered description shifted.
- `ARealmRebornTest` and `AbhorrentOculusScenarioTest` — 120-second coroutine spec
  timeouts. Both are contention, not a slowdown from the extra event: run serially those
  same tests take **20.2s** and **16.8s**, and their modules complete 1,595 and 1,921 tests
  in about a minute each, which leaves no room for a spec anywhere near 120s.
- `FreeForAllLobbyTest` — websocket `eventually(10s)` timeout at load average 9.5; 14/14
  green on an idle box.

Both halves are mutation-checked. Disabling only the auto-tap emission turns
`auto-tapping a creature for mana while casting a spell` red with the manual-path tests
still green; disabling only `autoTapForManaCost`'s emission turns
`auto-tapping a land to pay an ability cost fires it too` red with the other two engine
cases still green. So each tier is independently load-bearing and each test exercises the
code it names.

**What this does not cover.** No TypeScript changed, so nothing here is evidence about the
web client beyond the fact that `AbilityActivatedEvent` for a mana ability simply stops
arriving; no client code branches on it today (the type is declared but has no consumer).
No E2E run. And no self-play pass — the auto-tap emission touches the mana-payment hot
path used by every game, and while the unit and scenario suites are green, a
`gym`-driven self-play sweep would exercise it far harder than they do.
