### PR TITLE
Add modal double-faced lands, and the whole ten-card Pathway cycle

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -285,6 +285,15 @@ carries the other side for the hover preview's flip toggle.
     (unlike CR 712.8e for nonmodal DFCs, where it stays the front's). The Marvel Super Heroes hero cycle —
     Jennifer Walters // The Sensational She-Hulk, Bruce Banner // The Incredible Hulk, King T'Challa, Tony Stark,
     Monica Rambeau.
+  - **Land back** — a full `CardDefinition` in `backFace`, built with
+    `CardDefinition.modalDoubleFacedLand(front, back)`. Neither face is ever *cast*: CR 712.12 makes this a
+    **play-a-land** choice — *"A player playing a modal double-faced card as a land chooses one of its faces
+    that's a land before putting it onto the battlefield. It enters the battlefield with that face up."* So the
+    card shows up as **two land plays** in hand (`PlayLandEnumerator` emits one per land face, each named for the
+    face it plays) and `PlayLand.asBackFace` says which was taken. Neither face carries a mana cost or a color
+    indicator. Once down the permanent has only the played face's characteristics (CR 712.8f) and can never turn
+    over (CR 712.9 excludes modal DFCs from transforming); off the battlefield the card is its front face again
+    (CR 712.8a). The Zendikar Rising Pathway cycle — Riverglide Pathway // Lavaglide Pathway.
 - `PREPARE` — primary characteristics are the creature face, `cardFaces[0]` is the **prepare spell** (an
   instant/sorcery) (Secrets of Strixhaven). The card is only ever cast as the creature; the prepare spell is never
   cast from hand. A creature that carries `Keyword.PREPARED` ("This creature enters prepared") becomes prepared on

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -293,7 +293,8 @@ carries the other side for the hover preview's flip toggle.
     face it plays) and `PlayLand.asBackFace` says which was taken. Neither face carries a mana cost or a color
     indicator. Once down the permanent has only the played face's characteristics (CR 712.8f) and can never turn
     over (CR 712.9 excludes modal DFCs from transforming); off the battlefield the card is its front face again
-    (CR 712.8a). The Zendikar Rising Pathway cycle — Riverglide Pathway // Lavaglide Pathway.
+    (CR 712.8a). The ten-card Pathway cycle, split across Zendikar Rising (six) and Kaldheim (four) —
+    Riverglide Pathway // Lavaglide Pathway, Hengegate Pathway // Mistgate Pathway, and the rest.
 - `PREPARE` — primary characteristics are the creature face, `cardFaces[0]` is the **prepare spell** (an
   instant/sorcery) (Secrets of Strixhaven). The card is only ever cast as the creature; the prepare spell is never
   cast from hand. A creature that carries `Keyword.PREPARED` ("This creature enters prepared") becomes prepared on

--- a/docs/engine-server-interface.md
+++ b/docs/engine-server-interface.md
@@ -166,11 +166,11 @@ Used to perform the special action of playing a land.
 | `cardId`      | `EntityId` | The land card to play.                                                                          |
 | `asBackFace`  | `Boolean`  | Play a modal double-faced card as its **back** face (CR 712.12). Defaults to `false`. See below. |
 
-A modal double-faced land (the Zendikar Rising Pathway cycle) is one card with two land faces, and
-CR 712.12 makes the face a choice taken *before* the permanent enters. The server therefore
-enumerates **one `PlayLand` per land face**, each `description` naming the face it plays, and
-`asBackFace` is what distinguishes the two otherwise-identical actions. Clients must not collapse
-them: filtering `PlayLand` actions down to the first one silently drops a face.
+A modal double-faced land (the Pathway cycle, from Zendikar Rising and Kaldheim) is one card with
+two land faces, and CR 712.12 makes the face a choice taken *before* the permanent enters. The
+server therefore enumerates **one `PlayLand` per land face**, each `description` naming the face it
+plays, and `asBackFace` is what distinguishes the two otherwise-identical actions. Clients must not
+collapse them: filtering `PlayLand` actions down to the first one silently drops a face.
 
 #### D. `PassPriority`
 

--- a/docs/engine-server-interface.md
+++ b/docs/engine-server-interface.md
@@ -161,9 +161,16 @@ Used to use an activated ability of a permanent (or card in hand/graveyard).
 
 Used to perform the special action of playing a land.
 
-| Field    | Type       | Description            |
-|----------|------------|------------------------|
-| `cardId` | `EntityId` | The land card to play. |
+| Field         | Type       | Description                                                                                     |
+|---------------|------------|-------------------------------------------------------------------------------------------------|
+| `cardId`      | `EntityId` | The land card to play.                                                                          |
+| `asBackFace`  | `Boolean`  | Play a modal double-faced card as its **back** face (CR 712.12). Defaults to `false`. See below. |
+
+A modal double-faced land (the Zendikar Rising Pathway cycle) is one card with two land faces, and
+CR 712.12 makes the face a choice taken *before* the permanent enters. The server therefore
+enumerates **one `PlayLand` per land face**, each `description` naming the face it plays, and
+`asBackFace` is what distinguishes the two otherwise-identical actions. Clients must not collapse
+them: filtering `PlayLand` actions down to the first one silently drops a face.
 
 #### D. `PassPriority`
 

--- a/manual-scenarios/cards/r/riverglide-pathway.json
+++ b/manual-scenarios/cards/r/riverglide-pathway.json
@@ -1,0 +1,31 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Riverglide Pathway", "Shock", "Sleight of Hand"],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Grizzly Bears", "Hill Giant", "Mountain", "Craw Wurm"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Grizzly Bears", "Mountain"],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Hill Giant", "Mountain", "Grizzly Bears"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
@@ -795,6 +795,43 @@ data class CardDefinition(
         }
 
         /**
+         * Creates a **modal double-faced land** — a modal DFC (CR 712.3) both of whose faces are
+         * lands, the Zendikar Rising Pathway cycle (Riverglide Pathway // Lavaglide Pathway and its
+         * nine siblings).
+         *
+         * The rule that makes this its own shape is CR 712.12: *"A player playing a modal
+         * double-faced card or a copy of a modal double-faced card as a land chooses one of its
+         * faces that's a land before putting it onto the battlefield. It enters the battlefield
+         * with that face up."* So neither face is ever cast — the card is **played**, and the
+         * choice is made on the way in — which is exactly why it can't use
+         * [modalDoubleFacedPermanent]: that factory requires the back face to carry its own mana
+         * cost because it is castable (CR 712.11b), and a land has none.
+         *
+         * Once on the battlefield the permanent has only the played face's characteristics
+         * (CR 712.8f) and can never turn over — CR 712.9 excludes modal DFCs from transforming.
+         *
+         * @param frontFace The front face (must be a land with no mana cost).
+         * @param backFace The back face (must be a land with no mana cost).
+         */
+        fun modalDoubleFacedLand(
+            frontFace: CardDefinition,
+            backFace: CardDefinition
+        ): CardDefinition {
+            for (face in listOf(frontFace, backFace)) {
+                require(face.typeLine.isLand) {
+                    "Modal double-faced land face '${face.name}' must be a land (CR 712.12)"
+                }
+                require(face.manaCost.isEmpty()) {
+                    "Modal double-faced land face '${face.name}' is played, not cast — it takes no mana cost"
+                }
+                require(face.colorIndicator == null) {
+                    "Modal double-faced land face '${face.name}' takes no color indicator; a land face is colorless"
+                }
+            }
+            return frontFace.copy(backFace = backFace, layout = CardLayout.MODAL_DFC)
+        }
+
+        /**
          * Creates a planeswalker card.
          * @param name Card name
          * @param manaCost Mana cost

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BarkchannelPathway.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BarkchannelPathway.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Barkchannel Pathway // Tidechannel Pathway — Kaldheim #251 (canonical printing)
+ * Land // Land · Modal double-faced card
+ *
+ * Front — Barkchannel Pathway: "{T}: Add {G}."
+ * Back  — Tidechannel Pathway: "{T}: Add {U}."
+ *
+ * One of the ten Pathways. Per CR 712.12 the card is played as a land with one of its faces
+ * chosen on the way in, and it enters with that face up — so this is two mutually exclusive
+ * land plays off a single card, not a dual land. The choice is final: CR 712.9 excludes modal
+ * DFCs from transforming. See `RiverglidePathway` (Zendikar Rising) for the full note on how the
+ * cycle is modelled.
+ */
+private val BarkchannelPathwayFront = card("Barkchannel Pathway") {
+    typeLine = "Land"
+    colorIdentity = "G"
+    oracleText = "{T}: Add {G}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "251"
+        artist = "Daniel Ljunggren"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6de14ae-0132-4261-af00-630bf15918cd.jpg?1783928184"
+    }
+}
+
+private val TidechannelPathwayBack = card("Tidechannel Pathway") {
+    typeLine = "Land"
+    colorIdentity = "U"
+    oracleText = "{T}: Add {U}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "251"
+        artist = "Daniel Ljunggren"
+        imageUri = "https://cards.scryfall.io/normal/back/b/6/b6de14ae-0132-4261-af00-630bf15918cd.jpg?1783928184"
+    }
+}
+
+val BarkchannelPathway: CardDefinition = CardDefinition.modalDoubleFacedLand(
+    frontFace = BarkchannelPathwayFront,
+    backFace = TidechannelPathwayBack,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BlightstepPathway.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BlightstepPathway.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Blightstep Pathway // Searstep Pathway — Kaldheim #252 (canonical printing)
+ * Land // Land · Modal double-faced card
+ *
+ * Front — Blightstep Pathway: "{T}: Add {B}."
+ * Back  — Searstep Pathway: "{T}: Add {R}."
+ *
+ * One of the ten Pathways. Per CR 712.12 the card is played as a land with one of its faces
+ * chosen on the way in, and it enters with that face up — so this is two mutually exclusive
+ * land plays off a single card, not a dual land. The choice is final: CR 712.9 excludes modal
+ * DFCs from transforming. See `RiverglidePathway` (Zendikar Rising) for the full note on how the
+ * cycle is modelled.
+ */
+private val BlightstepPathwayFront = card("Blightstep Pathway") {
+    typeLine = "Land"
+    colorIdentity = "B"
+    oracleText = "{T}: Add {B}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "252"
+        artist = "Ravenna Tran"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1783928185"
+    }
+}
+
+private val SearstepPathwayBack = card("Searstep Pathway") {
+    typeLine = "Land"
+    colorIdentity = "R"
+    oracleText = "{T}: Add {R}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "252"
+        artist = "Ravenna Tran"
+        imageUri = "https://cards.scryfall.io/normal/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1783928185"
+    }
+}
+
+val BlightstepPathway: CardDefinition = CardDefinition.modalDoubleFacedLand(
+    frontFace = BlightstepPathwayFront,
+    backFace = SearstepPathwayBack,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/DarkborePathway.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/DarkborePathway.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Darkbore Pathway // Slitherbore Pathway — Kaldheim #254 (canonical printing)
+ * Land // Land · Modal double-faced card
+ *
+ * Front — Darkbore Pathway: "{T}: Add {B}."
+ * Back  — Slitherbore Pathway: "{T}: Add {G}."
+ *
+ * One of the ten Pathways. Per CR 712.12 the card is played as a land with one of its faces
+ * chosen on the way in, and it enters with that face up — so this is two mutually exclusive
+ * land plays off a single card, not a dual land. The choice is final: CR 712.9 excludes modal
+ * DFCs from transforming. See `RiverglidePathway` (Zendikar Rising) for the full note on how the
+ * cycle is modelled.
+ */
+private val DarkborePathwayFront = card("Darkbore Pathway") {
+    typeLine = "Land"
+    colorIdentity = "B"
+    oracleText = "{T}: Add {B}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "254"
+        artist = "Johannes Voss"
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1783928184"
+    }
+}
+
+private val SlitherborePathwayBack = card("Slitherbore Pathway") {
+    typeLine = "Land"
+    colorIdentity = "G"
+    oracleText = "{T}: Add {G}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "254"
+        artist = "Johannes Voss"
+        imageUri = "https://cards.scryfall.io/normal/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1783928184"
+    }
+}
+
+val DarkborePathway: CardDefinition = CardDefinition.modalDoubleFacedLand(
+    frontFace = DarkborePathwayFront,
+    backFace = SlitherborePathwayBack,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/HengegatePathway.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/HengegatePathway.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Hengegate Pathway // Mistgate Pathway — Kaldheim #260 (canonical printing)
+ * Land // Land · Modal double-faced card
+ *
+ * Front — Hengegate Pathway: "{T}: Add {W}."
+ * Back  — Mistgate Pathway: "{T}: Add {U}."
+ *
+ * One of the ten Pathways. Per CR 712.12 the card is played as a land with one of its faces
+ * chosen on the way in, and it enters with that face up — so this is two mutually exclusive
+ * land plays off a single card, not a dual land. The choice is final: CR 712.9 excludes modal
+ * DFCs from transforming. See `RiverglidePathway` (Zendikar Rising) for the full note on how the
+ * cycle is modelled.
+ */
+private val HengegatePathwayFront = card("Hengegate Pathway") {
+    typeLine = "Land"
+    colorIdentity = "W"
+    oracleText = "{T}: Add {W}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "260"
+        artist = "Yeong-Hao Han"
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7ef37cb3-d803-47d7-8a01-9c803aa2eadc.jpg?1783928182"
+    }
+}
+
+private val MistgatePathwayBack = card("Mistgate Pathway") {
+    typeLine = "Land"
+    colorIdentity = "U"
+    oracleText = "{T}: Add {U}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "260"
+        artist = "Yeong-Hao Han"
+        imageUri = "https://cards.scryfall.io/normal/back/7/e/7ef37cb3-d803-47d7-8a01-9c803aa2eadc.jpg?1783928182"
+    }
+}
+
+val HengegatePathway: CardDefinition = CardDefinition.modalDoubleFacedLand(
+    frontFace = HengegatePathwayFront,
+    backFace = MistgatePathwayBack,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/BranchloftPathway.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/BranchloftPathway.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Branchloft Pathway // Boulderloft Pathway — Zendikar Rising #258 (canonical printing)
+ * Land // Land · Modal double-faced card
+ *
+ * Front — Branchloft Pathway: "{T}: Add {G}."
+ * Back  — Boulderloft Pathway: "{T}: Add {W}."
+ *
+ * One of the ten Pathways. Per CR 712.12 the card is played as a land with one of its faces
+ * chosen on the way in, and it enters with that face up — so this is two mutually exclusive
+ * land plays off a single card, not a dual land. The choice is final: CR 712.9 excludes modal
+ * DFCs from transforming. See `RiverglidePathway` (Zendikar Rising) for the full note on how the
+ * cycle is modelled.
+ */
+private val BranchloftPathwayFront = card("Branchloft Pathway") {
+    typeLine = "Land"
+    colorIdentity = "G"
+    oracleText = "{T}: Add {G}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "258"
+        artist = "Titus Lunter"
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/0511e232-2a72-40f5-a400-4f7ebc442d17.jpg?1783929314"
+    }
+}
+
+private val BoulderloftPathwayBack = card("Boulderloft Pathway") {
+    typeLine = "Land"
+    colorIdentity = "W"
+    oracleText = "{T}: Add {W}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "258"
+        artist = "Titus Lunter"
+        imageUri = "https://cards.scryfall.io/normal/back/0/5/0511e232-2a72-40f5-a400-4f7ebc442d17.jpg?1783929314"
+    }
+}
+
+val BranchloftPathway: CardDefinition = CardDefinition.modalDoubleFacedLand(
+    frontFace = BranchloftPathwayFront,
+    backFace = BoulderloftPathwayBack,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/BrightclimbPathway.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/BrightclimbPathway.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Brightclimb Pathway // Grimclimb Pathway — Zendikar Rising #259 (canonical printing)
+ * Land // Land · Modal double-faced card
+ *
+ * Front — Brightclimb Pathway: "{T}: Add {W}."
+ * Back  — Grimclimb Pathway: "{T}: Add {B}."
+ *
+ * One of the ten Pathways. Per CR 712.12 the card is played as a land with one of its faces
+ * chosen on the way in, and it enters with that face up — so this is two mutually exclusive
+ * land plays off a single card, not a dual land. The choice is final: CR 712.9 excludes modal
+ * DFCs from transforming. See `RiverglidePathway` (Zendikar Rising) for the full note on how the
+ * cycle is modelled.
+ */
+private val BrightclimbPathwayFront = card("Brightclimb Pathway") {
+    typeLine = "Land"
+    colorIdentity = "W"
+    oracleText = "{T}: Add {W}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "259"
+        artist = "Johannes Voss"
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1783929313"
+    }
+}
+
+private val GrimclimbPathwayBack = card("Grimclimb Pathway") {
+    typeLine = "Land"
+    colorIdentity = "B"
+    oracleText = "{T}: Add {B}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "259"
+        artist = "Johannes Voss"
+        imageUri = "https://cards.scryfall.io/normal/back/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1783929313"
+    }
+}
+
+val BrightclimbPathway: CardDefinition = CardDefinition.modalDoubleFacedLand(
+    frontFace = BrightclimbPathwayFront,
+    backFace = GrimclimbPathwayBack,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/ClearwaterPathway.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/ClearwaterPathway.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Clearwater Pathway // Murkwater Pathway — Zendikar Rising #260 (canonical printing)
+ * Land // Land · Modal double-faced card
+ *
+ * Front — Clearwater Pathway: "{T}: Add {U}."
+ * Back  — Murkwater Pathway: "{T}: Add {B}."
+ *
+ * One of the ten Pathways. Per CR 712.12 the card is played as a land with one of its faces
+ * chosen on the way in, and it enters with that face up — so this is two mutually exclusive
+ * land plays off a single card, not a dual land. The choice is final: CR 712.9 excludes modal
+ * DFCs from transforming. See `RiverglidePathway` (Zendikar Rising) for the full note on how the
+ * cycle is modelled.
+ */
+private val ClearwaterPathwayFront = card("Clearwater Pathway") {
+    typeLine = "Land"
+    colorIdentity = "U"
+    oracleText = "{T}: Add {U}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "260"
+        artist = "Daarken"
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1783929316"
+    }
+}
+
+private val MurkwaterPathwayBack = card("Murkwater Pathway") {
+    typeLine = "Land"
+    colorIdentity = "B"
+    oracleText = "{T}: Add {B}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "260"
+        artist = "Daarken"
+        imageUri = "https://cards.scryfall.io/normal/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1783929316"
+    }
+}
+
+val ClearwaterPathway: CardDefinition = CardDefinition.modalDoubleFacedLand(
+    frontFace = ClearwaterPathwayFront,
+    backFace = MurkwaterPathwayBack,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/CragcrownPathway.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/CragcrownPathway.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Cragcrown Pathway // Timbercrown Pathway — Zendikar Rising #261 (canonical printing)
+ * Land // Land · Modal double-faced card
+ *
+ * Front — Cragcrown Pathway: "{T}: Add {R}."
+ * Back  — Timbercrown Pathway: "{T}: Add {G}."
+ *
+ * One of the ten Pathways. Per CR 712.12 the card is played as a land with one of its faces
+ * chosen on the way in, and it enters with that face up — so this is two mutually exclusive
+ * land plays off a single card, not a dual land. The choice is final: CR 712.9 excludes modal
+ * DFCs from transforming. See `RiverglidePathway` (Zendikar Rising) for the full note on how the
+ * cycle is modelled.
+ */
+private val CragcrownPathwayFront = card("Cragcrown Pathway") {
+    typeLine = "Land"
+    colorIdentity = "R"
+    oracleText = "{T}: Add {R}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "261"
+        artist = "Andreas Rocha"
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/da57eb54-5199-4a56-95f7-f6ac432876b1.jpg?1783929311"
+    }
+}
+
+private val TimbercrownPathwayBack = card("Timbercrown Pathway") {
+    typeLine = "Land"
+    colorIdentity = "G"
+    oracleText = "{T}: Add {G}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "261"
+        artist = "Andreas Rocha"
+        imageUri = "https://cards.scryfall.io/normal/back/d/a/da57eb54-5199-4a56-95f7-f6ac432876b1.jpg?1783929311"
+    }
+}
+
+val CragcrownPathway: CardDefinition = CardDefinition.modalDoubleFacedLand(
+    frontFace = CragcrownPathwayFront,
+    backFace = TimbercrownPathwayBack,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/NeedlevergePathway.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/NeedlevergePathway.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Needleverge Pathway // Pillarverge Pathway — Zendikar Rising #263 (canonical printing)
+ * Land // Land · Modal double-faced card
+ *
+ * Front — Needleverge Pathway: "{T}: Add {R}."
+ * Back  — Pillarverge Pathway: "{T}: Add {W}."
+ *
+ * One of the ten Pathways. Per CR 712.12 the card is played as a land with one of its faces
+ * chosen on the way in, and it enters with that face up — so this is two mutually exclusive
+ * land plays off a single card, not a dual land. The choice is final: CR 712.9 excludes modal
+ * DFCs from transforming. See `RiverglidePathway` (Zendikar Rising) for the full note on how the
+ * cycle is modelled.
+ */
+private val NeedlevergePathwayFront = card("Needleverge Pathway") {
+    typeLine = "Land"
+    colorIdentity = "R"
+    oracleText = "{T}: Add {R}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "263"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/6559047e-6ede-4815-a3a0-389062094f9d.jpg?1783929311"
+    }
+}
+
+private val PillarvergePathwayBack = card("Pillarverge Pathway") {
+    typeLine = "Land"
+    colorIdentity = "W"
+    oracleText = "{T}: Add {W}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "263"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/back/6/5/6559047e-6ede-4815-a3a0-389062094f9d.jpg?1783929311"
+    }
+}
+
+val NeedlevergePathway: CardDefinition = CardDefinition.modalDoubleFacedLand(
+    frontFace = NeedlevergePathwayFront,
+    backFace = PillarvergePathwayBack,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/RiverglidePathway.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/RiverglidePathway.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Riverglide Pathway // Lavaglide Pathway — Zendikar Rising #264 (canonical printing)
+ * Land // Land · Modal double-faced card
+ *
+ * Front — Riverglide Pathway: "{T}: Add {U}."
+ * Back  — Lavaglide Pathway:  "{T}: Add {R}."
+ *
+ * The Pathway cycle's whole trick is CR 712.12: *"A player playing a modal double-faced card as a
+ * land chooses one of its faces that's a land before putting it onto the battlefield. It enters
+ * the battlefield with that face up."* So this is not a dual land and not a land that transforms —
+ * it is one card offering **two different land plays**, and the choice is made on the way in and
+ * is permanent. Once it's on the battlefield it has only the played face's characteristics
+ * (CR 712.8f), and it can never turn over (CR 712.9 excludes modal DFCs from transforming).
+ *
+ * That is why each face is an ordinary one-colour tapland-less land with a single mana ability,
+ * and why they are joined by [CardDefinition.modalDoubleFacedLand] rather than by a dual's two
+ * mana abilities: the engine's land enumerator offers one play per land *face*, so both names
+ * appear in hand and the player picks the colour they need this turn.
+ */
+private val RiverglidePathwayFront = card("Riverglide Pathway") {
+    typeLine = "Land"
+    colorIdentity = "U"
+    oracleText = "{T}: Add {U}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "264"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1783929311"
+    }
+}
+
+private val LavaglidePathwayBack = card("Lavaglide Pathway") {
+    typeLine = "Land"
+    colorIdentity = "R"
+    oracleText = "{T}: Add {R}."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "264"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/back/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1783929311"
+    }
+}
+
+val RiverglidePathway: CardDefinition = CardDefinition.modalDoubleFacedLand(
+    frontFace = RiverglidePathwayFront,
+    backFace = LavaglidePathwayBack,
+)

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BarkchannelPathwayScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BarkchannelPathwayScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Barkchannel Pathway // Tidechannel Pathway (KHM) — one of the ten Pathways.
+ *
+ * The cycle's rules work (CR 712.12's play-a-face choice, CR 712.9's no-transform, CR 712.8a's
+ * front-face-everywhere-else) is pinned once by [RiverglidePathwayScenarioTest]. What is specific
+ * to *this* card is which two faces the single card offers and what colour each one taps for, so
+ * that is what this test covers.
+ */
+class BarkchannelPathwayScenarioTest : ScenarioTestBase() {
+
+    private fun manaAbilityIdOf(faceName: String) =
+        cardRegistry.requireCard(faceName).script.activatedAbilities.first().id
+
+    private fun newGame() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Barkchannel Pathway")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        test("one card in hand offers a land play for each face") {
+            val game = newGame()
+
+            val landPlays = game.getLegalActions(1).filter { it.actionType == "PlayLand" }
+            landPlays.map { it.description }.toSet() shouldBe
+                setOf("Play Barkchannel Pathway", "Play Tidechannel Pathway")
+        }
+
+        test("played front face up: it is Barkchannel Pathway and taps for green") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Barkchannel Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId)).error shouldBe null
+
+            val land = game.findPermanent("Barkchannel Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.FRONT
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Barkchannel Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.GREEN) shouldBe 1
+            pool?.getAmount(Color.BLUE) shouldBe 0
+        }
+
+        test("played back face up: it is Tidechannel Pathway and taps for blue") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Barkchannel Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId, asBackFace = true)).error shouldBe null
+
+            withClue("The permanent is the back face, not the printed front (CR 712.8f)") {
+                game.findPermanent("Barkchannel Pathway") shouldBe null
+            }
+            val land = game.findPermanent("Tidechannel Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.BACK
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Tidechannel Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.BLUE) shouldBe 1
+            pool?.getAmount(Color.GREEN) shouldBe 0
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BlightstepPathwayScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BlightstepPathwayScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Blightstep Pathway // Searstep Pathway (KHM) — one of the ten Pathways.
+ *
+ * The cycle's rules work (CR 712.12's play-a-face choice, CR 712.9's no-transform, CR 712.8a's
+ * front-face-everywhere-else) is pinned once by [RiverglidePathwayScenarioTest]. What is specific
+ * to *this* card is which two faces the single card offers and what colour each one taps for, so
+ * that is what this test covers.
+ */
+class BlightstepPathwayScenarioTest : ScenarioTestBase() {
+
+    private fun manaAbilityIdOf(faceName: String) =
+        cardRegistry.requireCard(faceName).script.activatedAbilities.first().id
+
+    private fun newGame() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Blightstep Pathway")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        test("one card in hand offers a land play for each face") {
+            val game = newGame()
+
+            val landPlays = game.getLegalActions(1).filter { it.actionType == "PlayLand" }
+            landPlays.map { it.description }.toSet() shouldBe
+                setOf("Play Blightstep Pathway", "Play Searstep Pathway")
+        }
+
+        test("played front face up: it is Blightstep Pathway and taps for black") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Blightstep Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId)).error shouldBe null
+
+            val land = game.findPermanent("Blightstep Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.FRONT
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Blightstep Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.BLACK) shouldBe 1
+            pool?.getAmount(Color.RED) shouldBe 0
+        }
+
+        test("played back face up: it is Searstep Pathway and taps for red") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Blightstep Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId, asBackFace = true)).error shouldBe null
+
+            withClue("The permanent is the back face, not the printed front (CR 712.8f)") {
+                game.findPermanent("Blightstep Pathway") shouldBe null
+            }
+            val land = game.findPermanent("Searstep Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.BACK
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Searstep Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.RED) shouldBe 1
+            pool?.getAmount(Color.BLACK) shouldBe 0
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BranchloftPathwayScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BranchloftPathwayScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Branchloft Pathway // Boulderloft Pathway (ZNR) — one of the ten Pathways.
+ *
+ * The cycle's rules work (CR 712.12's play-a-face choice, CR 712.9's no-transform, CR 712.8a's
+ * front-face-everywhere-else) is pinned once by [RiverglidePathwayScenarioTest]. What is specific
+ * to *this* card is which two faces the single card offers and what colour each one taps for, so
+ * that is what this test covers.
+ */
+class BranchloftPathwayScenarioTest : ScenarioTestBase() {
+
+    private fun manaAbilityIdOf(faceName: String) =
+        cardRegistry.requireCard(faceName).script.activatedAbilities.first().id
+
+    private fun newGame() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Branchloft Pathway")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        test("one card in hand offers a land play for each face") {
+            val game = newGame()
+
+            val landPlays = game.getLegalActions(1).filter { it.actionType == "PlayLand" }
+            landPlays.map { it.description }.toSet() shouldBe
+                setOf("Play Branchloft Pathway", "Play Boulderloft Pathway")
+        }
+
+        test("played front face up: it is Branchloft Pathway and taps for green") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Branchloft Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId)).error shouldBe null
+
+            val land = game.findPermanent("Branchloft Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.FRONT
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Branchloft Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.GREEN) shouldBe 1
+            pool?.getAmount(Color.WHITE) shouldBe 0
+        }
+
+        test("played back face up: it is Boulderloft Pathway and taps for white") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Branchloft Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId, asBackFace = true)).error shouldBe null
+
+            withClue("The permanent is the back face, not the printed front (CR 712.8f)") {
+                game.findPermanent("Branchloft Pathway") shouldBe null
+            }
+            val land = game.findPermanent("Boulderloft Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.BACK
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Boulderloft Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.WHITE) shouldBe 1
+            pool?.getAmount(Color.GREEN) shouldBe 0
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BrightclimbPathwayScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BrightclimbPathwayScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Brightclimb Pathway // Grimclimb Pathway (ZNR) — one of the ten Pathways.
+ *
+ * The cycle's rules work (CR 712.12's play-a-face choice, CR 712.9's no-transform, CR 712.8a's
+ * front-face-everywhere-else) is pinned once by [RiverglidePathwayScenarioTest]. What is specific
+ * to *this* card is which two faces the single card offers and what colour each one taps for, so
+ * that is what this test covers.
+ */
+class BrightclimbPathwayScenarioTest : ScenarioTestBase() {
+
+    private fun manaAbilityIdOf(faceName: String) =
+        cardRegistry.requireCard(faceName).script.activatedAbilities.first().id
+
+    private fun newGame() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Brightclimb Pathway")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        test("one card in hand offers a land play for each face") {
+            val game = newGame()
+
+            val landPlays = game.getLegalActions(1).filter { it.actionType == "PlayLand" }
+            landPlays.map { it.description }.toSet() shouldBe
+                setOf("Play Brightclimb Pathway", "Play Grimclimb Pathway")
+        }
+
+        test("played front face up: it is Brightclimb Pathway and taps for white") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Brightclimb Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId)).error shouldBe null
+
+            val land = game.findPermanent("Brightclimb Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.FRONT
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Brightclimb Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.WHITE) shouldBe 1
+            pool?.getAmount(Color.BLACK) shouldBe 0
+        }
+
+        test("played back face up: it is Grimclimb Pathway and taps for black") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Brightclimb Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId, asBackFace = true)).error shouldBe null
+
+            withClue("The permanent is the back face, not the printed front (CR 712.8f)") {
+                game.findPermanent("Brightclimb Pathway") shouldBe null
+            }
+            val land = game.findPermanent("Grimclimb Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.BACK
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Grimclimb Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.BLACK) shouldBe 1
+            pool?.getAmount(Color.WHITE) shouldBe 0
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ClearwaterPathwayScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ClearwaterPathwayScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Clearwater Pathway // Murkwater Pathway (ZNR) — one of the ten Pathways.
+ *
+ * The cycle's rules work (CR 712.12's play-a-face choice, CR 712.9's no-transform, CR 712.8a's
+ * front-face-everywhere-else) is pinned once by [RiverglidePathwayScenarioTest]. What is specific
+ * to *this* card is which two faces the single card offers and what colour each one taps for, so
+ * that is what this test covers.
+ */
+class ClearwaterPathwayScenarioTest : ScenarioTestBase() {
+
+    private fun manaAbilityIdOf(faceName: String) =
+        cardRegistry.requireCard(faceName).script.activatedAbilities.first().id
+
+    private fun newGame() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Clearwater Pathway")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        test("one card in hand offers a land play for each face") {
+            val game = newGame()
+
+            val landPlays = game.getLegalActions(1).filter { it.actionType == "PlayLand" }
+            landPlays.map { it.description }.toSet() shouldBe
+                setOf("Play Clearwater Pathway", "Play Murkwater Pathway")
+        }
+
+        test("played front face up: it is Clearwater Pathway and taps for blue") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Clearwater Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId)).error shouldBe null
+
+            val land = game.findPermanent("Clearwater Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.FRONT
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Clearwater Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.BLUE) shouldBe 1
+            pool?.getAmount(Color.BLACK) shouldBe 0
+        }
+
+        test("played back face up: it is Murkwater Pathway and taps for black") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Clearwater Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId, asBackFace = true)).error shouldBe null
+
+            withClue("The permanent is the back face, not the printed front (CR 712.8f)") {
+                game.findPermanent("Clearwater Pathway") shouldBe null
+            }
+            val land = game.findPermanent("Murkwater Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.BACK
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Murkwater Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.BLACK) shouldBe 1
+            pool?.getAmount(Color.BLUE) shouldBe 0
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CragcrownPathwayScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CragcrownPathwayScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cragcrown Pathway // Timbercrown Pathway (ZNR) — one of the ten Pathways.
+ *
+ * The cycle's rules work (CR 712.12's play-a-face choice, CR 712.9's no-transform, CR 712.8a's
+ * front-face-everywhere-else) is pinned once by [RiverglidePathwayScenarioTest]. What is specific
+ * to *this* card is which two faces the single card offers and what colour each one taps for, so
+ * that is what this test covers.
+ */
+class CragcrownPathwayScenarioTest : ScenarioTestBase() {
+
+    private fun manaAbilityIdOf(faceName: String) =
+        cardRegistry.requireCard(faceName).script.activatedAbilities.first().id
+
+    private fun newGame() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Cragcrown Pathway")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        test("one card in hand offers a land play for each face") {
+            val game = newGame()
+
+            val landPlays = game.getLegalActions(1).filter { it.actionType == "PlayLand" }
+            landPlays.map { it.description }.toSet() shouldBe
+                setOf("Play Cragcrown Pathway", "Play Timbercrown Pathway")
+        }
+
+        test("played front face up: it is Cragcrown Pathway and taps for red") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Cragcrown Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId)).error shouldBe null
+
+            val land = game.findPermanent("Cragcrown Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.FRONT
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Cragcrown Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.RED) shouldBe 1
+            pool?.getAmount(Color.GREEN) shouldBe 0
+        }
+
+        test("played back face up: it is Timbercrown Pathway and taps for green") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Cragcrown Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId, asBackFace = true)).error shouldBe null
+
+            withClue("The permanent is the back face, not the printed front (CR 712.8f)") {
+                game.findPermanent("Cragcrown Pathway") shouldBe null
+            }
+            val land = game.findPermanent("Timbercrown Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.BACK
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Timbercrown Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.GREEN) shouldBe 1
+            pool?.getAmount(Color.RED) shouldBe 0
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DarkborePathwayScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DarkborePathwayScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Darkbore Pathway // Slitherbore Pathway (KHM) — one of the ten Pathways.
+ *
+ * The cycle's rules work (CR 712.12's play-a-face choice, CR 712.9's no-transform, CR 712.8a's
+ * front-face-everywhere-else) is pinned once by [RiverglidePathwayScenarioTest]. What is specific
+ * to *this* card is which two faces the single card offers and what colour each one taps for, so
+ * that is what this test covers.
+ */
+class DarkborePathwayScenarioTest : ScenarioTestBase() {
+
+    private fun manaAbilityIdOf(faceName: String) =
+        cardRegistry.requireCard(faceName).script.activatedAbilities.first().id
+
+    private fun newGame() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Darkbore Pathway")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        test("one card in hand offers a land play for each face") {
+            val game = newGame()
+
+            val landPlays = game.getLegalActions(1).filter { it.actionType == "PlayLand" }
+            landPlays.map { it.description }.toSet() shouldBe
+                setOf("Play Darkbore Pathway", "Play Slitherbore Pathway")
+        }
+
+        test("played front face up: it is Darkbore Pathway and taps for black") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Darkbore Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId)).error shouldBe null
+
+            val land = game.findPermanent("Darkbore Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.FRONT
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Darkbore Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.BLACK) shouldBe 1
+            pool?.getAmount(Color.GREEN) shouldBe 0
+        }
+
+        test("played back face up: it is Slitherbore Pathway and taps for green") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Darkbore Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId, asBackFace = true)).error shouldBe null
+
+            withClue("The permanent is the back face, not the printed front (CR 712.8f)") {
+                game.findPermanent("Darkbore Pathway") shouldBe null
+            }
+            val land = game.findPermanent("Slitherbore Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.BACK
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Slitherbore Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.GREEN) shouldBe 1
+            pool?.getAmount(Color.BLACK) shouldBe 0
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HengegatePathwayScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HengegatePathwayScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Hengegate Pathway // Mistgate Pathway (KHM) — one of the ten Pathways.
+ *
+ * The cycle's rules work (CR 712.12's play-a-face choice, CR 712.9's no-transform, CR 712.8a's
+ * front-face-everywhere-else) is pinned once by [RiverglidePathwayScenarioTest]. What is specific
+ * to *this* card is which two faces the single card offers and what colour each one taps for, so
+ * that is what this test covers.
+ */
+class HengegatePathwayScenarioTest : ScenarioTestBase() {
+
+    private fun manaAbilityIdOf(faceName: String) =
+        cardRegistry.requireCard(faceName).script.activatedAbilities.first().id
+
+    private fun newGame() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Hengegate Pathway")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        test("one card in hand offers a land play for each face") {
+            val game = newGame()
+
+            val landPlays = game.getLegalActions(1).filter { it.actionType == "PlayLand" }
+            landPlays.map { it.description }.toSet() shouldBe
+                setOf("Play Hengegate Pathway", "Play Mistgate Pathway")
+        }
+
+        test("played front face up: it is Hengegate Pathway and taps for white") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Hengegate Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId)).error shouldBe null
+
+            val land = game.findPermanent("Hengegate Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.FRONT
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Hengegate Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.WHITE) shouldBe 1
+            pool?.getAmount(Color.BLUE) shouldBe 0
+        }
+
+        test("played back face up: it is Mistgate Pathway and taps for blue") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Hengegate Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId, asBackFace = true)).error shouldBe null
+
+            withClue("The permanent is the back face, not the printed front (CR 712.8f)") {
+                game.findPermanent("Hengegate Pathway") shouldBe null
+            }
+            val land = game.findPermanent("Mistgate Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.BACK
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Mistgate Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.BLUE) shouldBe 1
+            pool?.getAmount(Color.WHITE) shouldBe 0
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NeedlevergePathwayScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/NeedlevergePathwayScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Needleverge Pathway // Pillarverge Pathway (ZNR) — one of the ten Pathways.
+ *
+ * The cycle's rules work (CR 712.12's play-a-face choice, CR 712.9's no-transform, CR 712.8a's
+ * front-face-everywhere-else) is pinned once by [RiverglidePathwayScenarioTest]. What is specific
+ * to *this* card is which two faces the single card offers and what colour each one taps for, so
+ * that is what this test covers.
+ */
+class NeedlevergePathwayScenarioTest : ScenarioTestBase() {
+
+    private fun manaAbilityIdOf(faceName: String) =
+        cardRegistry.requireCard(faceName).script.activatedAbilities.first().id
+
+    private fun newGame() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Needleverge Pathway")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        test("one card in hand offers a land play for each face") {
+            val game = newGame()
+
+            val landPlays = game.getLegalActions(1).filter { it.actionType == "PlayLand" }
+            landPlays.map { it.description }.toSet() shouldBe
+                setOf("Play Needleverge Pathway", "Play Pillarverge Pathway")
+        }
+
+        test("played front face up: it is Needleverge Pathway and taps for red") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Needleverge Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId)).error shouldBe null
+
+            val land = game.findPermanent("Needleverge Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.FRONT
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Needleverge Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.RED) shouldBe 1
+            pool?.getAmount(Color.WHITE) shouldBe 0
+        }
+
+        test("played back face up: it is Pillarverge Pathway and taps for white") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Needleverge Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId, asBackFace = true)).error shouldBe null
+
+            withClue("The permanent is the back face, not the printed front (CR 712.8f)") {
+                game.findPermanent("Needleverge Pathway") shouldBe null
+            }
+            val land = game.findPermanent("Pillarverge Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.BACK
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Pillarverge Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.WHITE) shouldBe 1
+            pool?.getAmount(Color.RED) shouldBe 0
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RiverglidePathwayScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RiverglidePathwayScenarioTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Riverglide Pathway // Lavaglide Pathway (ZNR) — the modal double-faced **land**.
+ *
+ * CR 712.12: *"A player playing a modal double-faced card or a copy of a modal double-faced card
+ * as a land chooses one of its faces that's a land before putting it onto the battlefield. It
+ * enters the battlefield with that face up."*
+ *
+ * So one card in hand is two land plays, the choice is taken on the way in, and it is final —
+ * CR 712.9 excludes modal DFCs from transforming, so nothing turns the permanent over afterwards.
+ * Each test below pins one of those clauses.
+ */
+class RiverglidePathwayScenarioTest : ScenarioTestBase() {
+
+    private fun manaAbilityIdOf(faceName: String) =
+        cardRegistry.requireCard(faceName).script.activatedAbilities.first().id
+
+    private fun newGame() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Riverglide Pathway")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        test("one card in hand offers a land play for each face") {
+            val game = newGame()
+
+            val landPlays = game.getLegalActions(1).filter { it.actionType == "PlayLand" }
+            withClue("Both faces should be offered, each named for the face it plays") {
+                landPlays.map { it.description }.toSet() shouldBe
+                    setOf("Play Riverglide Pathway", "Play Lavaglide Pathway")
+            }
+        }
+
+        test("played front face up: it is Riverglide Pathway and taps for blue") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Riverglide Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId)).error shouldBe null
+
+            val land = game.findPermanent("Riverglide Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.FRONT
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Riverglide Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.BLUE) shouldBe 1
+            pool?.getAmount(Color.RED) shouldBe 0
+        }
+
+        test("played back face up: it is Lavaglide Pathway and taps for red") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Riverglide Pathway").single()
+
+            game.execute(PlayLand(game.player1Id, cardId, asBackFace = true)).error shouldBe null
+
+            withClue("The permanent is the back face, not the printed front (CR 712.8f)") {
+                game.findPermanent("Riverglide Pathway") shouldBe null
+            }
+            val land = game.findPermanent("Lavaglide Pathway")
+            land.shouldNotBeNull()
+            game.state.getEntity(land)?.get<DoubleFacedComponent>()?.currentFace shouldBe
+                DoubleFacedComponent.Face.BACK
+
+            game.execute(
+                ActivateAbility(game.player1Id, land, manaAbilityIdOf("Lavaglide Pathway"))
+            ).error shouldBe null
+            val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+            pool?.getAmount(Color.RED) shouldBe 1
+            pool?.getAmount(Color.BLUE) shouldBe 0
+        }
+
+        test("either face spends the same single land drop") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Riverglide Pathway")
+                .withCardInHand(1, "Island")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val pathway = game.findCardsInHand(1, "Riverglide Pathway").single()
+            game.execute(PlayLand(game.player1Id, pathway, asBackFace = true)).error shouldBe null
+
+            val island = game.findCardsInHand(1, "Island").single()
+            withClue("The back-face play is still a land play — the drop is gone") {
+                game.execute(PlayLand(game.player1Id, island)).error shouldNotBe null
+            }
+            game.getLegalActions(1).none { it.actionType == "PlayLand" } shouldBe true
+        }
+
+        test("the played face is final — a modal DFC never transforms (CR 712.9)") {
+            val game = newGame()
+            val cardId = game.findCardsInHand(1, "Riverglide Pathway").single()
+            game.execute(PlayLand(game.player1Id, cardId, asBackFace = true))
+
+            val land = game.findPermanent("Lavaglide Pathway")!!
+            withClue("Nothing on either face can turn it back over") {
+                cardRegistry.requireCard("Lavaglide Pathway").script.activatedAbilities
+                    .none { it.effect.description.contains("ransform") } shouldBe true
+                game.state.getEntity(land)?.get<CardComponent>()?.name shouldBe "Lavaglide Pathway"
+            }
+        }
+
+        test("off the battlefield it is the front face again (CR 712.8a)") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Riverglide Pathway")
+                .withCardInHand(1, "Stone Rain")
+                .withLandsOnBattlefield(1, "Mountain", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val cardId = game.findCardsInHand(1, "Riverglide Pathway").single()
+            game.execute(PlayLand(game.player1Id, cardId, asBackFace = true)).error shouldBe null
+            val land = game.findPermanent("Lavaglide Pathway")
+            land.shouldNotBeNull()
+
+            // Player 1 blows up their own Pathway — a sorcery in their own main phase, so no
+            // priority juggling is needed to observe what hits the graveyard.
+            game.castSpell(1, "Stone Rain", land).error shouldBe null
+            game.resolveStack()
+
+            withClue("A modal DFC in a zone other than battlefield/stack has only its front face's characteristics") {
+                game.isInGraveyard(1, "Riverglide Pathway") shouldBe true
+                game.isInGraveyard(1, "Lavaglide Pathway") shouldBe false
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/KHM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KHM.json
@@ -44,6 +44,189 @@
     ]
 }
 
+// Barkchannel Pathway
+{
+    "name": "Barkchannel Pathway",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {G}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Tidechannel Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {U}.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "BLUE"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "251",
+            "rarity": "RARE",
+            "artist": "Daniel Ljunggren",
+            "imageUri": "https://cards.scryfall.io/normal/back/b/6/b6de14ae-0132-4261-af00-630bf15918cd.jpg?1783928184"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "251",
+        "rarity": "RARE",
+        "artist": "Daniel Ljunggren",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6de14ae-0132-4261-af00-630bf15918cd.jpg?1783928184"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ],
+    "layout": "MODAL_DFC"
+}
+
+// Blightstep Pathway
+{
+    "name": "Blightstep Pathway",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {B}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Searstep Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {R}.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "RED"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "252",
+            "rarity": "RARE",
+            "artist": "Ravenna Tran",
+            "imageUri": "https://cards.scryfall.io/normal/back/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1783928185"
+        },
+        "colorIdentityOverride": [
+            "RED"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "252",
+        "rarity": "RARE",
+        "artist": "Ravenna Tran",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0ce39a19-f51d-4a35-ae80-5b82eb15fcff.jpg?1783928185"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "MODAL_DFC"
+}
+
+// Darkbore Pathway
+{
+    "name": "Darkbore Pathway",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {B}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Slitherbore Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {G}.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "GREEN"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "254",
+            "rarity": "RARE",
+            "artist": "Johannes Voss",
+            "imageUri": "https://cards.scryfall.io/normal/back/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1783928184"
+        },
+        "colorIdentityOverride": [
+            "GREEN"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "254",
+        "rarity": "RARE",
+        "artist": "Johannes Voss",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/87a4e5fe-161f-42da-9ca2-67c8e8970e94.jpg?1783928184"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "MODAL_DFC"
+}
+
 // Demon Bolt
 {
     "name": "Demon Bolt",
@@ -306,6 +489,67 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Hengegate Pathway
+{
+    "name": "Hengegate Pathway",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {W}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Mistgate Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {U}.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "BLUE"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "260",
+            "rarity": "RARE",
+            "artist": "Yeong-Hao Han",
+            "imageUri": "https://cards.scryfall.io/normal/back/7/e/7ef37cb3-d803-47d7-8a01-9c803aa2eadc.jpg?1783928182"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "260",
+        "rarity": "RARE",
+        "artist": "Yeong-Hao Han",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7ef37cb3-d803-47d7-8a01-9c803aa2eadc.jpg?1783928182"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ],
+    "layout": "MODAL_DFC"
 }
 
 // Highland Forest

--- a/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
@@ -694,6 +694,67 @@
     ]
 }
 
+// Riverglide Pathway
+{
+    "name": "Riverglide Pathway",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {U}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Lavaglide Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {R}.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "RED"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "264",
+            "rarity": "RARE",
+            "artist": "Kieran Yanner",
+            "imageUri": "https://cards.scryfall.io/normal/back/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1783929311"
+        },
+        "colorIdentityOverride": [
+            "RED"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "264",
+        "rarity": "RARE",
+        "artist": "Kieran Yanner",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/2668ac91-6cda-4f81-a08d-4fc5f9cb35b2.jpg?1783929311"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "MODAL_DFC"
+}
+
 // Spitfire Lagac
 {
     "name": "Spitfire Lagac",

--- a/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
@@ -1,3 +1,125 @@
+// Branchloft Pathway
+{
+    "name": "Branchloft Pathway",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {G}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Boulderloft Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {W}.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "WHITE"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "258",
+            "rarity": "RARE",
+            "artist": "Titus Lunter",
+            "imageUri": "https://cards.scryfall.io/normal/back/0/5/0511e232-2a72-40f5-a400-4f7ebc442d17.jpg?1783929314"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "258",
+        "rarity": "RARE",
+        "artist": "Titus Lunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/0511e232-2a72-40f5-a400-4f7ebc442d17.jpg?1783929314"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ],
+    "layout": "MODAL_DFC"
+}
+
+// Brightclimb Pathway
+{
+    "name": "Brightclimb Pathway",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {W}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Grimclimb Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {B}.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "BLACK"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "259",
+            "rarity": "RARE",
+            "artist": "Johannes Voss",
+            "imageUri": "https://cards.scryfall.io/normal/back/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1783929313"
+        },
+        "colorIdentityOverride": [
+            "BLACK"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "259",
+        "rarity": "RARE",
+        "artist": "Johannes Voss",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d24c3d51-795d-4c01-a34a-3280fccd2d78.jpg?1783929313"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ],
+    "layout": "MODAL_DFC"
+}
+
 // Broken Wings
 {
     "name": "Broken Wings",
@@ -194,6 +316,67 @@
     ]
 }
 
+// Clearwater Pathway
+{
+    "name": "Clearwater Pathway",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {U}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Murkwater Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {B}.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "BLACK"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "260",
+            "rarity": "RARE",
+            "artist": "Daarken",
+            "imageUri": "https://cards.scryfall.io/normal/back/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1783929316"
+        },
+        "colorIdentityOverride": [
+            "BLACK"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "260",
+        "rarity": "RARE",
+        "artist": "Daarken",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b4b99ebb-0d54-4fe5-a495-979aaa564aa8.jpg?1783929316"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "MODAL_DFC"
+}
+
 // Cliffhaven Sell-Sword
 {
     "name": "Cliffhaven Sell-Sword",
@@ -212,6 +395,67 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// Cragcrown Pathway
+{
+    "name": "Cragcrown Pathway",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {R}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Timbercrown Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {G}.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "GREEN"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "261",
+            "rarity": "RARE",
+            "artist": "Andreas Rocha",
+            "imageUri": "https://cards.scryfall.io/normal/back/d/a/da57eb54-5199-4a56-95f7-f6ac432876b1.jpg?1783929311"
+        },
+        "colorIdentityOverride": [
+            "GREEN"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "261",
+        "rarity": "RARE",
+        "artist": "Andreas Rocha",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/da57eb54-5199-4a56-95f7-f6ac432876b1.jpg?1783929311"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "MODAL_DFC"
 }
 
 // Crawling Barrens
@@ -574,6 +818,67 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Needleverge Pathway
+{
+    "name": "Needleverge Pathway",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {R}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Pillarverge Pathway",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {W}.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "WHITE"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "263",
+            "rarity": "RARE",
+            "artist": "Piotr Dura",
+            "imageUri": "https://cards.scryfall.io/normal/back/6/5/6559047e-6ede-4815-a3a0-389062094f9d.jpg?1783929311"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "263",
+        "rarity": "RARE",
+        "artist": "Piotr Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/6559047e-6ede-4815-a3a0-389062094f9d.jpg?1783929311"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "MODAL_DFC"
 }
 
 // Nullpriest of Oblivion

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
@@ -509,12 +509,20 @@ data class TypecycleCard(
 
 /**
  * Player plays a land.
+ *
+ * @property asBackFace Play a modal double-faced card as its **back** face (CR 712.12 — *"A player
+ *   playing a modal double-faced card as a land chooses one of its faces that's a land before
+ *   putting it onto the battlefield. It enters the battlefield with that face up."*). The Zendikar
+ *   Rising Pathway cycle is the whole user: Riverglide Pathway // Lavaglide Pathway is one card
+ *   offering two land plays, and this flag is which one was taken. Defaults to false — the printed
+ *   front face — so every single-faced land play is unchanged.
  */
 @Serializable
 @SerialName("PlayLand")
 data class PlayLand(
     override val playerId: EntityId,
-    val cardId: EntityId
+    val cardId: EntityId,
+    val asBackFace: Boolean = false
 ) : GameAction
 
 // =============================================================================

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.event.TriggerDetector
 import com.wingedsheep.engine.event.TriggerProcessor
 import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.handlers.actions.ActionHandler
+import com.wingedsheep.engine.handlers.effects.permanent.types.setDfcFace
 import com.wingedsheep.engine.handlers.effects.permanent.types.stampDoubleFacedFrontFace
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
@@ -98,7 +99,16 @@ class PlayLandHandler(
         val cardComponent = container.get<CardComponent>()
             ?: return "Not a card: ${action.cardId}"
 
-        if (!cardComponent.typeLine.isLand) {
+        // CR 712.11c's play-a-land analogue: only the face being played is evaluated. A modal DFC
+        // played as its back face is legal on the strength of *that* face's type line, and the
+        // printed front's (which is what `cardComponent` carries off the battlefield, CR 712.8a)
+        // is not consulted at all.
+        val playedFace = if (action.asBackFace) {
+            com.wingedsheep.engine.mechanics.ModalDfcCasts
+                .landFace(cardRegistry.getCard(cardComponent.cardDefinitionId))
+                ?: return "${cardComponent.name} has no land back face to play"
+        } else null
+        if (playedFace == null && !cardComponent.typeLine.isLand) {
             return "You can only play land cards as lands"
         }
 
@@ -138,7 +148,7 @@ class PlayLandHandler(
         val container = state.getEntity(action.cardId)
             ?: return ExecutionResult.error(state, "Card not found")
 
-        val cardComponent = container.get<CardComponent>()
+        val printedCardComponent = container.get<CardComponent>()
             ?: return ExecutionResult.error(state, "Not a card")
 
         var newState = state
@@ -206,6 +216,23 @@ class PlayLandHandler(
         newState = newState.updateEntity(action.cardId) { c ->
             c.with(ControllerComponent(action.playerId))
         }
+
+        // CR 712.12 — a modal double-faced card played as a land chooses a land face *before*
+        // putting it onto the battlefield, and it enters with that face up. So the face swap
+        // happens here, ahead of everything that reads the permanent's characteristics: the
+        // ETB-by-type record below, the static/replacement registration, the enters-tapped and
+        // as-enters replacements, and the entry event's name. Choosing a face is not a transform
+        // (CR 712.9 excludes modal DFCs from transforming), so this fires no transform trigger and
+        // no "can't transform" effect can stop it — which is why it uses [setDfcFace] directly
+        // rather than the flip helper.
+        if (action.asBackFace) {
+            newState = stampDoubleFacedFrontFace(newState, cardRegistry, action.cardId)
+            newState = setDfcFace(
+                newState, cardRegistry, action.cardId,
+                com.wingedsheep.engine.state.components.identity.DoubleFacedComponent.Face.BACK
+            ) ?: return ExecutionResult.error(state, "Card has no back face to play")
+        }
+
         newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
             .place(newState, action.playerId, action.cardId)
 
@@ -308,6 +335,11 @@ class PlayLandHandler(
             newState = newState.removeMayPlayPermissionsForCard(action.cardId)
         }
 
+        // CR 712.8f — a modal double-faced permanent has only the characteristics of the face
+        // that's up. Everything below (the entry event's name, enters-tapped, the as-enters
+        // replacements) has to read the face actually played, not the printed front.
+        val cardComponent = newState.getEntity(action.cardId)?.get<CardComponent>()
+            ?: printedCardComponent
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
 
         // OnEnterRunEffect — generic "as ~ enters, run [effect]" replacement.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
@@ -124,30 +124,79 @@ internal fun flipDfcInPlace(
     }
     val nextCardDef = cardRegistry.getCard(nextDefinitionId) ?: return null
 
-    // CR 712.8e: a nonmodal DFC keeps its *front* face's mana value while the back is up.
-    // `currentCard` is the front face on the way in, so its mana value is that number; flipping to
-    // the front instead clears the override, since the front's own cost is the answer again.
-    val swappedCard = buildCardComponentForDfcFace(
-        currentCard,
-        nextCardDef,
-        manaValueOverride = if (intoBackFace) {
-            dfcBackFaceManaValue(cardRegistry.getCard(dfc.frontCardDefinitionId), currentCard.manaValue)
-        } else null,
-    )
     // A DFC on the battlefield always has a controller; fall back to owner, and treat a truly
     // owner-less object as un-flippable (null → the caller's no-op contract) rather than fabricate an id.
     val controllerId = container.get<ControllerComponent>()?.playerId ?: currentCard.ownerId ?: return null
 
+    // CR 712.8e: a nonmodal DFC keeps its *front* face's mana value while the back is up.
+    // `currentCard` is the front face on the way in, so its mana value is that number; flipping to
+    // the front instead clears the override, since the front's own cost is the answer again.
+    val newState = setDfcFace(
+        state, cardRegistry, entityId, nextFace,
+        manaValueOverride = if (intoBackFace) {
+            dfcBackFaceManaValue(cardRegistry.getCard(dfc.frontCardDefinitionId), currentCard.manaValue)
+        } else null,
+    ) ?: return null
+
+    return newState to TransformedEvent(
+        entityId = entityId,
+        intoBackFace = intoBackFace,
+        newFaceName = nextCardDef.name,
+        controllerId = controllerId
+    )
+}
+
+/**
+ * Put the double-faced permanent [entityId] onto [nextFace] **in place**: swap its
+ * [CardComponent] to that face's definition, record the face on its [DoubleFacedComponent], and
+ * re-register the face's static / replacement effects so layer projection picks them up on the
+ * next projection. Returns null when [entityId] is not a face-tracked card or the face's
+ * definition is not in the registry.
+ *
+ * Deliberately says nothing about *why* the face changed: it emits no event, checks no
+ * "can't transform" restriction, and does not care whether the target face is the current one.
+ * The two callers want different things around it —
+ *
+ *  - [flipDfcInPlace] adds the CR 701.27b restriction check and the [TransformedEvent] that
+ *    "whenever this transforms" triggers key on;
+ *  - the play-land path (CR 712.12 — *"A player playing a modal double-faced card as a land
+ *    chooses one of its faces that's a land before putting it onto the battlefield. It enters the
+ *    battlefield with that face up."*) wants neither. Choosing a face on the way in is not a
+ *    transform (CR 712.9 excludes modal DFCs from transforming at all), so it must not fire
+ *    transform triggers and must not be stoppable by a "can't transform" effect.
+ *
+ * @param manaValueOverride Pins the resulting [CardComponent]'s mana value, for the CR 712.8e case
+ *   where a nonmodal DFC's back face keeps the *front* face's mana value. Null leaves the face's
+ *   own cost to answer, which is what CR 712.8f says for a modal DFC.
+ */
+internal fun setDfcFace(
+    state: GameState,
+    cardRegistry: CardRegistry,
+    entityId: EntityId,
+    nextFace: DoubleFacedComponent.Face,
+    manaValueOverride: Int? = null,
+): GameState? {
+    val container = state.getEntity(entityId) ?: return null
+    val dfc = container.get<DoubleFacedComponent>() ?: return null
+    val currentCard = container.get<CardComponent>() ?: return null
+
+    val nextDefinitionId = when (nextFace) {
+        DoubleFacedComponent.Face.FRONT -> dfc.frontCardDefinitionId
+        DoubleFacedComponent.Face.BACK -> dfc.backCardDefinitionId
+    }
+    val nextCardDef = cardRegistry.getCard(nextDefinitionId) ?: return null
+
+    val swappedCard = buildCardComponentForDfcFace(currentCard, nextCardDef, manaValueOverride)
+
     // Rule 712.8a: save the front face card so ZoneTransitionService can restore it
     // without a registry lookup when the DFC leaves the battlefield on its back face.
-    val updatedDfc = if (intoBackFace) {
-        dfc.copy(currentFace = nextFace, frontFaceCard = currentCard)
-    } else {
-        dfc.copy(currentFace = nextFace, frontFaceCard = null)
+    val updatedDfc = when (nextFace) {
+        DoubleFacedComponent.Face.BACK -> dfc.copy(currentFace = nextFace, frontFaceCard = currentCard)
+        DoubleFacedComponent.Face.FRONT -> dfc.copy(currentFace = nextFace, frontFaceCard = null)
     }
 
     val staticAbilityHandler = StaticAbilityHandler(cardRegistry)
-    val newState = state.updateEntity(entityId) { c ->
+    return state.updateEntity(entityId) { c ->
         var updated = c
             .with(swappedCard)
             .with(updatedDfc)
@@ -162,13 +211,6 @@ internal fun flipDfcInPlace(
         updated = withDfcFaceSelfRedirects(updated, nextCardDef)
         updated
     }
-
-    return newState to TransformedEvent(
-        entityId = entityId,
-        intoBackFace = intoBackFace,
-        newFaceName = nextCardDef.name,
-        controllerId = controllerId
-    )
 }
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PlayLandEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PlayLandEnumerator.kt
@@ -4,9 +4,11 @@ import com.wingedsheep.engine.core.PlayLand
 import com.wingedsheep.engine.legalactions.ActionEnumerator
 import com.wingedsheep.engine.legalactions.EnumerationContext
 import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.mechanics.ModalDfcCasts
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
 
 class PlayLandEnumerator : ActionEnumerator {
     override fun enumerate(context: EnumerationContext): List<LegalAction> {
@@ -22,13 +24,7 @@ class PlayLandEnumerator : ActionEnumerator {
             val hand = state.getHand(playerId)
             for (cardId in hand) {
                 val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: continue
-                if (cardComponent.typeLine.isLand) {
-                    result.add(LegalAction(
-                        actionType = "PlayLand",
-                        description = "Play ${cardComponent.name}",
-                        action = PlayLand(playerId, cardId)
-                    ))
-                }
+                result.addAll(landPlays(context, cardId, cardComponent))
             }
         }
 
@@ -37,14 +33,7 @@ class PlayLandEnumerator : ActionEnumerator {
             val graveyardCards = state.getZone(ZoneKey(playerId, Zone.GRAVEYARD))
             for (cardId in graveyardCards) {
                 val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: continue
-                if (cardComponent.typeLine.isLand) {
-                    result.add(LegalAction(
-                        actionType = "PlayLand",
-                        description = "Play ${cardComponent.name}",
-                        action = PlayLand(playerId, cardId),
-                        sourceZone = "GRAVEYARD"
-                    ))
-                }
+                result.addAll(landPlays(context, cardId, cardComponent, sourceZone = "GRAVEYARD"))
             }
         }
 
@@ -82,15 +71,53 @@ class PlayLandEnumerator : ActionEnumerator {
                 if (granter.ability.ownedByYou && cardComponent.ownerId != playerId) continue
                 val inExile = state.turnOrder.any { pid -> exiledId in state.getZone(ZoneKey(pid, Zone.EXILE)) }
                 if (!inExile) continue
-                result.add(LegalAction(
-                    actionType = "PlayLand",
-                    description = "Play ${cardComponent.name}",
-                    action = PlayLand(playerId, exiledId),
-                    sourceZone = "EXILE"
-                ))
+                result.addAll(landPlays(context, exiledId, cardComponent, sourceZone = "EXILE"))
             }
         }
 
+        return result
+    }
+
+    /**
+     * Every land play [cardId] offers from [sourceZone] — one per land *face*, not one per card.
+     *
+     * A single-faced land is one action, as before. A modal double-faced card is up to two, because
+     * CR 712.12 makes the face a choice taken on the way in: *"A player playing a modal double-faced
+     * card as a land chooses one of its faces that's a land before putting it onto the battlefield.
+     * It enters the battlefield with that face up."* Riverglide Pathway // Lavaglide Pathway is the
+     * cycle this exists for — one card in hand, two entries in the drag-to-play menu, each naming
+     * the face it plays so the choice is legible rather than a mode prompt after the fact.
+     *
+     * The front offer is gated on [cardComponent]'s own type line, which off the battlefield is the
+     * front face's (CR 712.8a) — so a modal DFC whose *front* is a spell and whose back is a land
+     * correctly offers only the back.
+     */
+    private fun landPlays(
+        context: EnumerationContext,
+        cardId: EntityId,
+        cardComponent: CardComponent,
+        sourceZone: String? = null,
+    ): List<LegalAction> {
+        val result = mutableListOf<LegalAction>()
+        if (cardComponent.typeLine.isLand) {
+            result.add(LegalAction(
+                actionType = "PlayLand",
+                description = "Play ${cardComponent.name}",
+                action = PlayLand(context.playerId, cardId),
+                sourceZone = sourceZone
+            ))
+        }
+        val backLand = ModalDfcCasts.landFace(
+            context.cardRegistry.getCard(cardComponent.cardDefinitionId)
+        )
+        if (backLand != null) {
+            result.add(LegalAction(
+                actionType = "PlayLand",
+                description = "Play ${backLand.name}",
+                action = PlayLand(context.playerId, cardId, asBackFace = true),
+                sourceZone = sourceZone
+            ))
+        }
         return result
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PlayLandEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PlayLandEnumerator.kt
@@ -98,6 +98,13 @@ class PlayLandEnumerator : ActionEnumerator {
         cardComponent: CardComponent,
         sourceZone: String? = null,
     ): List<LegalAction> {
+        // Hot path: legal-action enumeration runs on every priority pass and every AI/MCTS node,
+        // and the hand loop now reaches this for *every* card rather than only for lands. A card
+        // that is neither a land nor double-faced can offer no land play, and answering that from
+        // two booleans already on the CardComponent keeps the registry lookup below off the common
+        // path entirely.
+        if (!cardComponent.typeLine.isLand && !cardComponent.isDoubleFaced) return emptyList()
+
         val result = mutableListOf<LegalAction>()
         if (cardComponent.typeLine.isLand) {
             result.add(LegalAction(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/ModalDfcCasts.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/ModalDfcCasts.kt
@@ -38,6 +38,28 @@ object ModalDfcCasts {
      */
     fun castFace(cardDef: CardDefinition?): CardDefinition? {
         if (cardDef?.layout != CardLayout.MODAL_DFC) return null
-        return cardDef.backFace?.takeIf { it.isPermanent }
+        // A land face is a permanent face but is never *cast* — it is played (CR 305.1), which is
+        // [landFace]'s business. Excluding it here keeps a spell-front // land-back modal DFC
+        // (Emeria's Call // Emeria, Shattered Skyclave) from being offered as an illegal cast.
+        return cardDef.backFace?.takeIf { it.isPermanent && !it.typeLine.isLand }
+    }
+
+    /**
+     * The back face a modal-DFC **land play** would put onto the battlefield, or null when
+     * [cardDef] is not a modal DFC with a land back face.
+     *
+     * CR 712.12: *"A player playing a modal double-faced card or a copy of a modal double-faced
+     * card as a land chooses one of its faces that's a land before putting it onto the battlefield.
+     * It enters the battlefield with that face up."* The front face's own land-ness is the ordinary
+     * play-a-land question and needs nothing from here; this answers only "is there a *second*
+     * land play hiding on the back of this card", which is what the Zendikar Rising Pathway cycle
+     * (Riverglide Pathway // Lavaglide Pathway) needs from the land enumerator.
+     *
+     * The land-play mirror of [castFace], and disjoint from it by construction: a back face is
+     * either castable or playable-as-a-land, never both.
+     */
+    fun landFace(cardDef: CardDefinition?): CardDefinition? {
+        if (cardDef?.layout != CardLayout.MODAL_DFC) return null
+        return cardDef.backFace?.takeIf { it.typeLine.isLand }
     }
 }

--- a/web-client/src/components/game/board/shared.test.ts
+++ b/web-client/src/components/game/board/shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { attachmentStackLayout, shouldShowCastModal } from './shared'
+import { attachmentStackLayout, hasMultipleCastingOptions, shouldShowCastModal } from './shared'
 import type { LegalActionInfo } from '../../../types'
 import { entityId } from '../../../types'
 
@@ -68,6 +68,15 @@ function playLand(): LegalActionInfo {
   }
 }
 
+/** The back-face half of a modal double-faced land (CR 712.12). */
+function playLandBackFace(): LegalActionInfo {
+  return {
+    actionType: 'PlayLand',
+    description: 'Play Lavaglide Pathway',
+    action: { type: 'PlayLand', playerId: PLAYER, cardId: CARD, asBackFace: true },
+  }
+}
+
 describe('shouldShowCastModal', () => {
   it('does not open the menu when there are no legal actions', () => {
     expect(shouldShowCastModal([])).toBe(false)
@@ -118,6 +127,22 @@ describe('shouldShowCastModal', () => {
 
   it('does not open the menu for a plain land with only a play-land action', () => {
     expect(shouldShowCastModal([playLand()])).toBe(false)
+  })
+
+  it('opens the menu for a modal double-faced land — two land faces are two choices', () => {
+    expect(shouldShowCastModal([playLand(), playLandBackFace()])).toBe(true)
+  })
+})
+
+describe('hasMultipleCastingOptions', () => {
+  it('counts a modal double-faced land\'s two land faces as two ways to play it', () => {
+    // Both actions are PlayLand, so a boolean "has a play-land action" would count them as one
+    // — and this helper's whole job is answering how many ways the card can be played (CR 712.12).
+    expect(hasMultipleCastingOptions([playLand(), playLandBackFace()])).toBe(true)
+  })
+
+  it('an ordinary land is still a single way to play it', () => {
+    expect(hasMultipleCastingOptions([playLand()])).toBe(false)
   })
 
   it('opens the menu for multiple casting variants (morph + normal cast)', () => {

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -414,7 +414,9 @@ export function hasMultipleCastingOptions(cardLegalActions: LegalActionInfo[]): 
   const hasCycling = cardLegalActions.some((a) => a.action.type === 'CycleCard')
   const hasPlot = cardLegalActions.some((a) => a.action.type === 'PlotCard')
   const hasSuspend = cardLegalActions.some((a) => a.action.type === 'SuspendCardFromHand')
-  const hasPlayLand = cardLegalActions.some((a) => a.action.type === 'PlayLand')
+  // Counted rather than flagged: a modal double-faced land offers one PlayLand per land face
+  // (CR 712.12), and two faces are two options even though there is no cast among them.
+  const playLandCount = cardLegalActions.filter((a) => a.action.type === 'PlayLand').length
 
   let options = 0
   if (hasNormalCast) options++
@@ -427,7 +429,7 @@ export function hasMultipleCastingOptions(cardLegalActions: LegalActionInfo[]): 
   if (hasCycling) options++
   if (hasPlot) options++
   if (hasSuspend) options++
-  if (hasPlayLand) options++
+  options += playLandCount
 
   return options > 1
 }

--- a/web-client/src/types/actions.ts
+++ b/web-client/src/types/actions.ts
@@ -301,6 +301,12 @@ export interface PlayLandAction {
   readonly type: 'PlayLand'
   readonly playerId: EntityId
   readonly cardId: EntityId
+  /**
+   * Play a modal double-faced card as its back face (CR 712.12 — the Zendikar Rising Pathway
+   * cycle). The server sends one PlayLand action per land face; this is the flag that tells them
+   * apart. Absent for every ordinary land.
+   */
+  readonly asBackFace?: boolean
 }
 
 // =============================================================================

--- a/web-client/src/utils/actionOptions.test.ts
+++ b/web-client/src/utils/actionOptions.test.ts
@@ -152,6 +152,42 @@ describe('playCostRange', () => {
   })
 })
 
+describe('buildActionOptions — modal double-faced lands', () => {
+  const pathwayCard = card('', { name: 'Riverglide Pathway', cardTypes: ['LAND'] } as Partial<ClientCard>)
+
+  it('lists one entry per land face, labelled by the face rather than by the card', () => {
+    // CR 712.12: the server sends one PlayLand per land face, each described by the face it plays.
+    // `cardInfo.name` is the front face's name for both, so the descriptions are the only thing
+    // telling them apart — a `find` here would silently drop the back face.
+    const options = buildActionOptions(pathwayCard, [
+      action({
+        action: { type: 'PlayLand' },
+        actionType: 'PlayLand',
+        description: 'Play Riverglide Pathway',
+      }),
+      action({
+        action: { type: 'PlayLand', asBackFace: true },
+        actionType: 'PlayLand',
+        description: 'Play Lavaglide Pathway',
+      }),
+    ])
+    expect(options.map((o) => o.label)).toEqual([
+      'Play Riverglide Pathway',
+      'Play Lavaglide Pathway',
+    ])
+    expect(options.map((o) => o.key)).toEqual(['playLand', 'playLand-1'])
+    expect(options.every((o) => o.actionType === 'playLand')).toBe(true)
+  })
+
+  it('an ordinary land still reads "Play <card name>"', () => {
+    const options = buildActionOptions(
+      card('', { name: 'Island', cardTypes: ['LAND'] } as Partial<ClientCard>),
+      [action({ action: { type: 'PlayLand' }, actionType: 'PlayLand', description: 'Play Island' })],
+    )
+    expect(options.map((o) => o.label)).toEqual(['Play Island'])
+  })
+})
+
 describe('playLadderOptions', () => {
   it('lists cycling alongside the cast, even though cycling stays out of the range', () => {
     const options = buildActionOptions(card('{5}{W}'), [

--- a/web-client/src/utils/actionOptions.ts
+++ b/web-client/src/utils/actionOptions.ts
@@ -219,7 +219,9 @@ export function buildActionOptions(
   const typecycleAction = legalActions.find((a) => a.action.type === 'TypecycleCard')
   const plotAction = legalActions.find((a) => a.action.type === 'PlotCard')
   const suspendAction = legalActions.find((a) => a.action.type === 'SuspendCardFromHand')
-  const playLandAction = legalActions.find((a) => a.action.type === 'PlayLand')
+  // A modal double-faced land (the Zendikar Rising Pathway cycle) sends *two* PlayLand actions
+  // for one card — one per land face, CR 712.12 — so this is a filter, not a find.
+  const playLandActions = legalActions.filter((a) => a.action.type === 'PlayLand')
 
   // 1. Modal spell modes — show one button per mode instead of a single "Cast" button
   const modeActions = legalActions.filter((a) => a.actionType === 'CastSpellMode')
@@ -355,14 +357,19 @@ export function buildActionOptions(
   }
 
   // 2. Play land (for land cards)
-  if (playLandAction) {
-    options.push({
-      key: 'playLand',
-      label: `Play ${cardInfo.name}`,
-      manaCost: null,
-      isAvailable: playLandAction.isAffordable !== false,
-      action: playLandAction,
-      actionType: 'playLand',
+  if (playLandActions.length > 0) {
+    playLandActions.forEach((playLandAction, index) => {
+      options.push({
+        // One entry per land face. The server's description already names the face being
+        // played ("Play Lavaglide Pathway"), which is the only thing telling the two apart —
+        // `cardInfo.name` is the front face's name for both.
+        key: index === 0 ? 'playLand' : `playLand-${index}`,
+        label: playLandActions.length > 1 ? playLandAction.description : `Play ${cardInfo.name}`,
+        manaCost: null,
+        isAvailable: playLandAction.isAffordable !== false,
+        action: playLandAction,
+        actionType: 'playLand',
+      })
     })
   } else if (cycleAction && cardInfo.cardTypes.includes('LAND')) {
     // Land with cycling but no PlayLand action (already played a land this turn)


### PR DESCRIPTION
# Add modal double-faced lands, and the whole ten-card Pathway cycle

CR 712.12, verified against `MagicCompRules_20260808.txt`:

> A player playing a modal double-faced card or a copy of a modal double-faced card as
> a land chooses one of its faces that's a land before putting it onto the battlefield.
> It enters the battlefield with that face up.

Nothing in the engine modelled that. `PlayLandEnumerator` had no notion of faces at
all, and the only MDFC-land path that existed was the *opposite* shape — a land front
with a castable spell back (the FIN Towns adventure), handled over in
`CastSpellEnumerator`. A Pathway could only ever have been its front face, so the whole
ten-card cycle was unimplementable.

## Engine

- **`PlayLand.asBackFace`** — the face choice, taken at play time. Defaulted `false`,
  so every existing land play and every serialized action is unchanged. There is no
  mode prompt after the fact; the choice *is* which action you take.
- **`ModalDfcCasts.landFace`** — the land-play mirror of `castFace`, in the object that
  is already the single source of truth for "which face of this modal DFC, and may I".
  The two are now disjoint by construction: `castFace` excludes a land back face, which
  also stops a future spell-front // land-back card (Emeria's Call // Emeria, Shattered
  Skyclave) from being offered as an illegal cast. That was a latent bug — a land is a
  permanent, so the old `isPermanent` filter would have surfaced "Cast Emeria,
  Shattered Skyclave".
- **`PlayLandEnumerator`** now emits one action per land *face*, each described by the
  face it plays, from hand, from a Muldrotha-style graveyard permission, and from a
  linked exile. The front offer still keys on the card's own type line, which off the
  battlefield is the front face's (CR 712.8a) — so a spell-front card correctly offers
  only its back.
- **`PlayLandHandler`** validates against the face being played (CR 712.11c's
  play-a-land analogue: only the face being played is evaluated) and swaps to it
  *before* the permanent enters — ahead of the ETB-by-type record, the
  static/replacement registration, the enters-tapped and as-enters replacements, and
  the entry event's name, all of which must read the played face (CR 712.8f). The
  existing code already anticipated this seam in a comment; this fills it in.
- **`setDfcFace`, extracted from `flipDfcInPlace`.** Choosing a face on the way in is
  *not* a transform — CR 712.9 excludes modal DFCs from transforming at all — so it
  must fire no transform trigger and must not be stoppable by a "can't transform"
  effect (Bound by Moonsilver). The extracted half does the state work; the flip
  wrapper adds back the CR 701.27b restriction check and the `TransformedEvent`. Both
  callers then share the `CardComponent` swap, the CR 712.8a front-face save, the
  static/replacement re-registration and the self-redirect rebuild, rather than the
  play path growing a second copy of them.

## SDK

`CardDefinition.modalDoubleFacedLand(front, back)` — a sibling of
`modalDoubleFacedPermanent` for exactly the case its "the back face must carry its own
mana cost, because it is castable (CR 712.11b)" requirement excludes. Both faces must
be lands with no mana cost and no colour indicator.

## Client

Two `PlayLand` actions for one card broke two client assumptions that were a `find`
and a boolean where they needed to be a `filter` and a count:

- `buildActionOptions` took `legalActions.find(type === 'PlayLand')` and would have
  silently dropped the back face, dumping the player onto whichever face the server
  happened to list first.
- `hasMultipleCastingOptions` counted "has a play-land action" as one option, so two
  land faces read as one way to play the card.

Both now count faces. The menu labels each entry with the server's description
("Play Lavaglide Pathway") rather than `cardInfo.name`, which is the *front* face's
name for both entries and so can't tell them apart. The hand card's flip preview and
the battlefield art needed nothing: `ClientStateTransformer.dfcBackFace` already falls
back to `cardDef.backFace` off the battlefield, and `buildCardComponentForDfcFace`
already prefers the played face's own image.

## The cards

All ten Pathways. The cycle is **not** a Zendikar Rising cycle, which is what an earlier
draft of this branch assumed: ZNR printed six and Kaldheim printed the other four, and
between them they cover all ten colour pairs exactly once.

| Set | # | Card | Front // Back |
|-----|---|------|---------------|
| ZNR | 258 | Branchloft Pathway // Boulderloft Pathway | `{G}` // `{W}` |
| ZNR | 259 | Brightclimb Pathway // Grimclimb Pathway | `{W}` // `{B}` |
| ZNR | 260 | Clearwater Pathway // Murkwater Pathway | `{U}` // `{B}` |
| ZNR | 261 | Cragcrown Pathway // Timbercrown Pathway | `{R}` // `{G}` |
| ZNR | 263 | Needleverge Pathway // Pillarverge Pathway | `{R}` // `{W}` |
| ZNR | 264 | Riverglide Pathway // Lavaglide Pathway | `{U}` // `{R}` |
| KHM | 251 | Barkchannel Pathway // Tidechannel Pathway | `{G}` // `{U}` |
| KHM | 252 | Blightstep Pathway // Searstep Pathway | `{B}` // `{R}` |
| KHM | 254 | Darkbore Pathway // Slitherbore Pathway | `{B}` // `{G}` |
| KHM | 260 | Hengegate Pathway // Mistgate Pathway | `{W}` // `{U}` |

None is a dual land and none is a land that transforms: each is one card offering two
different land plays, chosen on the way in and final. The nine added after the engine
work needed no new vocabulary — every one is
`CardDefinition.modalDoubleFacedLand(front, back)` over two single-mana-ability land
faces, which is the point of the SDK facade above.

Each card gets its own scenario test, per the repo's one-card-one-test-file rule. Those
nine are deliberately narrower than `RiverglidePathwayScenarioTest`: that one pins the
cycle's rules work once (CR 712.12, 712.9, 712.8a, the shared land drop), so the
per-card tests assert only what is card-specific — that the single card offers both
named land plays, and that each face taps for the colour it prints.

## Verification

- `./scripts/gradle-locked :rules-engine:test` — **0 failures**, re-run after the
  enumerator hot-path fix below. This is the gate that matters for the
  `flipDfcInPlace` extraction: the whole transform / daybound / disturb / DFC suite
  still passes against the refactored helper.
- `./scripts/gradle-locked :mtg-sets:test` — green after re-blessing, re-run with all
  ten cards in the corpus. Covers the golden snapshots, `FacadeBoundaryTest` and the set
  catalog. Only additions in `ZNR.json` and `KHM.json`; no existing card moved.
- `just test-class "*PathwayScenarioTest"` — **33/33 across all ten cards.** Riverglide's
  six pin the cycle's rules work: both faces offered and named; each face's identity and
  mana ability once played (asserted on the mana pool); either face spending the same
  single land drop; the face being final; and CR 712.8a putting **Riverglide** Pathway
  into the graveyard when the *Lavaglide* permanent dies — the test that proves the
  front-face save survives `ZoneTransitionService`. The other nine cards contribute three
  each: both named land plays offered, and each face taps for the colour it prints.
- `:oracle-assay`, `:game-server`, `:ai` all compile against the changed
  `PlayLand` shape.
- `just check-card-printing` on all ten — clean. ZNR is the earliest real printing for
  six, KHM for four; PZNR/PKHM/PRM/SLU/PLST are unimplemented sets, so no reprint rows
  are owed.
- `just assay-differential --set ZNR` — 9/9 confirmed, 0 divergences. Run when the branch
  held one Pathway; not re-run since, and not run for KHM.
- **Web client:** `npx tsc --noEmit` clean, and `vitest` on the two touched suites at
  45 tests (up from 42). Both client changes were mutation-checked — reverting the
  option list to `find` reddens the two-face label test, and reverting the counter to a
  boolean reddens the `hasMultipleCastingOptions` test — so neither is an untested
  edit.

**What this does not cover:**

- **No E2E run.** The drag-to-play menu path is exercised only by the unit tests above,
  so "two entries appear and each plays the right face" is verified at the option-list
  level, not in a real browser. If you want a Playwright pass before merge, say so and
  I'll add one.
- **The era scenario suite did not complete.** `just test-scenarios 2017-2022` ran 762
  tests with **zero test failures** — the 33 Pathway tests among them — and then the
  Gradle build itself died writing HTML report entries into
  `/workspace/.gradle/9.6.1/fileHashes/fileHashes.bin` (`EOFException`, "Could not add
  entry … to cache fileHashes.bin"). That is shared-cache corruption in this sandbox, not
  anything in the diff, and the house rule here is to report it rather than `clean`
  shared state. So the era-wide green is **claimed only up to those 762 passing tests**,
  not as a completed gate. `:mtg-sets:test` and the targeted `*PathwayScenarioTest` run
  both completed cleanly on their own.
- **No TypeScript re-run for the nine new cards** — they touch no client code, and the
  `tsc`/`vitest` results above are from the engine/client half of the branch.

## One thing caught on review

The first cut of the enumerator dropped the outer `typeLine.isLand` guard, so the
per-face helper ran for every card in hand and did a card-registry lookup before
concluding "not a land, no faces". Legal-action enumeration runs on every priority pass
and every AI/MCTS node, so that is a lookup per hand card per node. Fixed in `3c48304`
with an early-out on two booleans already on the `CardComponent`; the registry is now
consulted only for cards that could actually have a second face.

## Known limits, stated rather than hidden

- **The AI rollout policy is face-blind.** `PlayoutPolicy` takes
  `candidates.firstOrNull { it.actionType == "PlayLand" }`, so a rollout always picks a
  Pathway's front face. Real MCTS search sees both actions and can pick either; this
  only biases rollouts. Left alone rather than reaching into `:ai` from a rules PR.
- **The Mayhem graveyard loop** in `PlayLandEnumerator` still offers only the front
  face. It is gated on the card carrying Mayhem, which no Pathway does, so it is
  unreachable for this cycle — extending it would have been untestable speculation.
- **The dev scenario covers one card, not ten.** `manual-scenarios/` gets the Riverglide
  scenario only. The client path is name-agnostic — it keys on the server's action
  descriptions — so nine more near-identical JSON files would exercise nothing new.

## Try it

```bash
curl -X POST http://localhost:8080/api/dev/scenarios \
  -H 'Content-Type: application/json' -d @manual-scenarios/cards/r/riverglide-pathway.json
```

Deliberately no other lands: the hand holds one `{R}` spell and one `{U}` spell and you get
one land drop, so the face choice *is* the turn. Dragging the Pathway out should open the play
menu with two entries — this is the client half of the change, and the part no unit test
drives (see I2 in the review).
