### PR TITLE
Add three red cards: Reckless Rage, Redcap Melee, Experimental Synthesizer

### DIFF
--- a/manual-scenarios/mechanics/izzet-prowess-red-cards.json
+++ b/manual-scenarios/mechanics/izzet-prowess-red-cards.json
@@ -1,0 +1,40 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Reckless Rage", "Redcap Melee", "Experimental Synthesizer"],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Centaur Courser"}
+    ],
+    "graveyard": [],
+    "library": ["Lightning Bolt", "Hill Giant", "Mountain", "Grizzly Bears", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Grizzly Bears", "Mountain"],
+    "battlefield": [
+      {"name": "Craw Wurm"},
+      {"name": "Raging Regisaur"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Hill Giant", "Mountain", "Grizzly Bears"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/RedcapMelee.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/RedcapMelee.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Redcap Melee — Throne of Eldraine #135 (canonical printing)
+ * {R} · Instant
+ *
+ * Redcap Melee deals 4 damage to target creature or planeswalker. If a nonred permanent is dealt
+ * damage this way, you sacrifice a land.
+ *
+ * Four damage for one mana, with a land sacrifice unless the thing you hit is red — which is why
+ * the drawback clause reads on the *permanent's colour*, not on the spell's. The colour test is a
+ * [Conditions.TargetMatchesFilter] over the same chosen target, so it reads **projected** state:
+ * a creature painted red by a continuous effect (Painter's Servant, Whim of Volrath) correctly
+ * spares the land, and one whose red was stripped correctly doesn't.
+ *
+ * The sacrifice is [Effects.SacrificeOwn] — the bare imperative "you sacrifice a land", where the
+ * spell's controller chooses, not a named player.
+ *
+ * Ordering matters: the two sub-effects run in one [Effects.Composite], so the colour is read
+ * after the damage, while the damaged permanent is still on the battlefield (a composite resolves
+ * sequentially with no interleaved state-based-action pass, so a lethally damaged creature has not
+ * been put into the graveyard yet and its projected colour is still readable).
+ *
+ * **Known deviation.** The printed trigger is "*is dealt* damage this way", so damage that is
+ * prevented or replaced down to nothing should leave your lands alone. This models the clause as
+ * "the target is a nonred permanent", which is the same answer in every case except an active
+ * damage-prevention shield — there the card here sacrifices a land where the printed card would
+ * not. Fixing it properly needs a "was this target dealt damage during this resolution" condition
+ * the SDK does not have yet; it is noted here rather than silently approximated away.
+ */
+val RedcapMelee = card("Redcap Melee") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Redcap Melee deals 4 damage to target creature or planeswalker. If a nonred " +
+        "permanent is dealt damage this way, you sacrifice a land."
+
+    spell {
+        val t = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+        effect = Effects.DealDamage(4, t) then ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(GameObjectFilter.Permanent.notColor(Color.RED)),
+            effect = Effects.SacrificeOwn(Filters.Land)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "135"
+        artist = "Chris Rallis"
+        flavorText = "At first, Syr Fenwick scoffed when he saw his opponents for the final match."
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6bd1dd34-d480-4dfd-9f82-73c4e24a11fc.jpg?1783932619"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/ExperimentalSynthesizer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/ExperimentalSynthesizer.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.neo.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Experimental Synthesizer — Kamigawa: Neon Dynasty #138 (canonical printing)
+ * {R} · Artifact
+ *
+ * When this artifact enters or leaves the battlefield, exile the top card of your library. Until
+ * end of turn, you may play that card.
+ * {2}{R}, Sacrifice this artifact: Create a 2/2 white Samurai creature token with vigilance.
+ * Activate only as a sorcery.
+ *
+ * A one-mana artifact that impulse-draws twice — once on the way in, once on the way out — which
+ * is what makes it a sacrifice payoff and an artifact-recursion payoff at the same time. Its own
+ * activated ability sacrifices it, so activating it collects the leave trigger too.
+ *
+ * "Enters **or** leaves" is written as two triggered abilities over [Triggers.EntersBattlefield]
+ * and [Triggers.LeavesBattlefield]. The two events can never happen at once, so one ability with a
+ * two-event pattern and two abilities are the same card in play; two abilities is the shape the
+ * corpus already uses for this wording (Cryogen Relic).
+ *
+ * Both halves are [Patterns.Exile] `.impulse(1)` — exile the top card and grant permission to play
+ * it until end of turn, at its normal cost.
+ */
+val ExperimentalSynthesizer = card("Experimental Synthesizer") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters or leaves the battlefield, exile the top card of your " +
+        "library. Until end of turn, you may play that card.\n" +
+        "{2}{R}, Sacrifice this artifact: Create a 2/2 white Samurai creature token with " +
+        "vigilance. Activate only as a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Exile.impulse(1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Patterns.Exile.impulse(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}"), Costs.SacrificeSelf)
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Samurai"),
+            keywords = setOf(Keyword.VIGILANCE),
+            name = "Samurai",
+            imageUri = "https://cards.scryfall.io/normal/front/f/6/f68e5337-6e44-4f8f-a102-2f97b433beea.jpg?1783923716"
+        )
+        timing = TimingRule.SorcerySpeed
+        description = "Create a 2/2 white Samurai creature token with vigilance."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "138"
+        artist = "Yeong-Hao Han"
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c47931c9-685d-4b83-8299-bc347224b4e8.jpg?1783923870"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/RecklessRage.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/RecklessRage.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Reckless Rage — Rivals of Ixalan #110 (canonical printing)
+ * {R} · Instant
+ *
+ * Reckless Rage deals 4 damage to target creature you don't control and 2 damage to target
+ * creature you control.
+ *
+ * Two required targets with different amounts, so the spell is uncastable unless both a creature
+ * you control and a creature you don't are available — that drawback is the whole cost of a
+ * one-mana 4-damage removal spell, and it falls out of the targeting rules for free: a required
+ * `target(...)` with no legal object makes the spell illegal to cast (CR 601.2c).
+ *
+ * "Creature you don't control" is modelled as [Targets.CreatureOpponentControls]. Every permanent
+ * on the battlefield is controlled by some player and this engine has no teams, so the two
+ * readings pick out the same set of creatures.
+ *
+ * Both damage sub-effects run in one [Effects.Composite] so they resolve together, and each is
+ * dealt by the spell itself (no `damageSource`) — matching "Reckless Rage deals".
+ */
+val RecklessRage = card("Reckless Rage") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Reckless Rage deals 4 damage to target creature you don't control and 2 damage " +
+        "to target creature you control."
+
+    spell {
+        val theirs = target("target creature you don't control", Targets.CreatureOpponentControls)
+        val yours = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.DealDamage(4, theirs) then Effects.DealDamage(2, yours)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "110"
+        artist = "Slawomir Maniak"
+        flavorText = "\"Hard to starboard! Starb— Abandon ship! Abandon ship!\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0e4b97a3-8f6f-461e-aa55-ab752752f539.jpg?1783935296"
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ExperimentalSynthesizerScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/ExperimentalSynthesizerScenarioTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Experimental Synthesizer (NEO) — "When this artifact enters **or leaves** the battlefield, exile
+ * the top card of your library. Until end of turn, you may play that card." plus
+ * "{2}{R}, Sacrifice this artifact: Create a 2/2 white Samurai creature token with vigilance."
+ *
+ * The interesting case is the two halves meeting: the activated ability sacrifices the artifact
+ * **as a cost**, which is paid before the ability is even put on the stack — so the leave trigger
+ * has to fire off a battlefield exit that happens during activation, not during resolution. That
+ * is a shape this engine has got wrong before, and it is this card's most common line, so it is
+ * pinned here rather than assumed.
+ */
+class ExperimentalSynthesizerScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("the enter trigger impulses the top card") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Experimental Synthesizer")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withCardInLibrary(1, "Hill Giant")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Experimental Synthesizer").error shouldBe null
+            game.resolveStack()
+
+            withClue("The ETB exiles the top card of the library") {
+                game.isInExile(1, "Hill Giant") shouldBe true
+            }
+        }
+
+        test("sacrificing it to its own ability fires the leave trigger and makes the Samurai") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Experimental Synthesizer")
+                .withLandsOnBattlefield(1, "Mountain", 3)
+                .withCardInLibrary(1, "Hill Giant")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val synth = game.findPermanent("Experimental Synthesizer")!!
+            val abilityId = cardRegistry.requireCard("Experimental Synthesizer")
+                .script.activatedAbilities.first().id
+
+            game.execute(ActivateAbility(game.player1Id, synth, abilityId)).error shouldBe null
+            game.resolveStack()
+
+            withClue("The sacrifice is a cost, so the artifact is gone") {
+                game.isInGraveyard(1, "Experimental Synthesizer") shouldBe true
+            }
+            withClue("The leave trigger still fires off a sacrifice paid as a cost") {
+                game.isInExile(1, "Hill Giant") shouldBe true
+            }
+            withClue("…and the ability itself resolves into a Samurai token") {
+                game.isOnBattlefield("Samurai") shouldBe true
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ELD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ELD.json
@@ -891,6 +891,74 @@
     ]
 }
 
+// Redcap Melee
+{
+    "name": "Redcap Melee",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Redcap Melee deals 4 damage to target creature or planeswalker. If a nonred permanent is dealt damage this way, you sacrifice a land.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or planeswalker"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "filter": {
+                                "cardPredicates": [
+                                    "IsPermanent",
+                                    {
+                                        "type": "NotColor",
+                                        "color": "RED"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "Sacrifice",
+                        "filter": "land"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target creature or planeswalker"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Rallis",
+        "flavorText": "At first, Syr Fenwick scoffed when he saw his opponents for the final match.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6bd1dd34-d480-4dfd-9f82-73c4e24a11fc.jpg?1783932619"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Run Away Together
 {
     "name": "Run Away Together",

--- a/mtg-sets/src/test/resources/snapshots/cards/NEO.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/NEO.json
@@ -52,6 +52,132 @@
     "colorIdentityOverride": []
 }
 
+// Experimental Synthesizer
+{
+    "name": "Experimental Synthesizer",
+    "manaCost": "{R}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters or leaves the battlefield, exile the top card of your library. Until end of turn, you may play that card.\n{2}{R}, Sacrifice this artifact: Create a 2/2 white Samurai creature token with vigilance. Activate only as a sorcery.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "impulseExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "impulseExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "impulseExiled"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "impulseExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "impulseExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "impulseExiled"
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Samurai"
+                    ],
+                    "keywords": [
+                        "VIGILANCE"
+                    ],
+                    "name": "Samurai",
+                    "imageUri": "https://cards.scryfall.io/normal/front/f/6/f68e5337-6e44-4f8f-a102-2f97b433beea.jpg?1783923716"
+                },
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Create a 2/2 white Samurai creature token with vigilance."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "artist": "Yeong-Hao Han",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c47931c9-685d-4b83-8299-bc347224b4e8.jpg?1783923870"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Secluded Courtyard
 {
     "name": "Secluded Courtyard",

--- a/mtg-sets/src/test/resources/snapshots/cards/RIX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RIX.json
@@ -610,6 +610,69 @@
     ]
 }
 
+// Reckless Rage
+{
+    "name": "Reckless Rage",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Reckless Rage deals 4 damage to target creature you don't control and 2 damage to target creature you control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you don't control"
+                    }
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                },
+                "id": "target creature you don't control"
+            },
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target creature you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "rarity": "UNCOMMON",
+        "artist": "Slawomir Maniak",
+        "flavorText": "\"Hard to starboard! Starb— Abandon ship! Abandon ship!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0e4b97a3-8f6f-461e-aa55-ab752752f539.jpg?1783935296"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Seafloor Oracle
 {
     "name": "Seafloor Oracle",


### PR DESCRIPTION
# Add three red cards: Reckless Rage, Redcap Melee, Experimental Synthesizer

Three cards from the Izzet Prowess shell, each built entirely from existing
`Effects.*` / `Patterns.*` — no new SDK vocabulary, so they share one branch and one
PR per `CONTRIBUTING.md`. Each is canonical in its own earliest real printing
(`just check-card-printing` clean on all three).

## The cards

**Reckless Rage** — RIX #110, `{R}` Instant.
"Reckless Rage deals 4 damage to target creature you don't control and 2 damage to
target creature you control." Two required targets with different amounts, composed
as `DealDamage(4, theirs) then DealDamage(2, yours)`. The card's real drawback — it
is uncastable unless you have a creature to hurt — falls out of the targeting rules
for free: a required `target(...)` with no legal object makes the spell illegal to
cast (CR 601.2c), so there is nothing to model. "Creature you don't control" is
`Targets.CreatureOpponentControls`; every permanent is controlled by some player and
this engine has no teams, so the two readings pick out the same creatures.

**Redcap Melee** — ELD #135, `{R}` Instant.
"Redcap Melee deals 4 damage to target creature or planeswalker. If a nonred
permanent is dealt damage this way, you sacrifice a land." The colour test is a
`Conditions.TargetMatchesFilter` over the same chosen target, so it reads **projected**
state: a creature painted red by a continuous effect correctly spares the land, and one
whose red was stripped correctly doesn't. The sacrifice is `Effects.SacrificeOwn` — the
bare imperative "you sacrifice a land", not a named player. Ordering matters and is
load-bearing: both sub-effects sit in one `Effects.Composite`, which resolves
sequentially with no interleaved state-based-action pass, so a lethally damaged
creature has not been put into the graveyard yet and its projected colour is still
readable when the condition runs.

**Experimental Synthesizer** — NEO #138, `{R}` Artifact.
"When this artifact enters or leaves the battlefield, exile the top card of your
library. Until end of turn, you may play that card." plus
"`{2}{R}`, Sacrifice this artifact: Create a 2/2 white Samurai creature token with
vigilance. Activate only as a sorcery." Both trigger halves are
`Patterns.Exile.impulse(1)`. "Enters **or** leaves" is written as two triggered
abilities: the two events can never happen at once, so one ability with a two-event
pattern and two abilities are the same card in play, and two abilities is the shape
the corpus already uses for this wording (Cryogen Relic). The card's own activated
ability sacrifices it, so activating it collects the leave trigger too — which is the
whole design.

## Deliberately not modelled

Redcap Melee's printed trigger is "*is dealt* damage this way", so damage that is
prevented or replaced down to nothing should leave your lands alone. This models the
clause as "the target is a nonred permanent", which gives the same answer in every
case except an active damage-prevention shield — there this card sacrifices a land
where the printed card would not. Fixing it properly needs a "was this target dealt
damage during this resolution" condition the SDK does not have; adding one would have
ejected the card from the batch. The deviation is written into the card's KDoc rather
than left silent.

## Verification

- `./scripts/gradle-locked :mtg-sets:test` — green after re-blessing. The only
  failures on the first run were the three expected `CardDefinitionSnapshotTest`
  mismatches (RIX/ELD/NEO); `just rebless-cards` moved **only** the three new cards in
  the goldens (pure additions, no existing card's tree changed), which is the check
  that no shared SDK behaviour shifted.
- `./scripts/gradle-locked :mtg-sets:2017-2022:compileKotlin` — green.
- `just check-card-printing` — clean for all three; each canonical is in its earliest
  real printing.
- `just assay-differential --set RIX / ELD / NEO` — RIX 0 divergences, ELD's single
  divergence is the pre-existing Keeper of Fables row (untouched by this branch), and
  NEO's row is **Experimental Synthesizer matching Assay's independent reading
  exactly**, differing only in ability ids, the token's name/art, and the ability
  description — all known folds. That is the one check here that isn't me re-reading
  my own work.

- `just test-class ExperimentalSynthesizerScenarioTest` — 2/2. Reckless Rage and Redcap
  Melee add no engine behaviour and are covered by the snapshot and lint nets, per
  `add-card` step 5. Experimental Synthesizer got a test anyway, for one reason: its
  most common line sacrifices it to its own ability, paying the sacrifice as a **cost**,
  so the "or leaves the battlefield" trigger has to fire off a battlefield exit during
  *activation* rather than during resolution — a shape this engine has got wrong before.
  It behaves correctly; the test is there so it stays that way.

**What this does not cover:** nothing here touches the web client, the server, or the
AI, so no TypeScript or server gate was run and none would say anything about this
diff.

## Try it

```bash
curl -X POST http://localhost:8080/api/dev/scenarios \
  -H 'Content-Type: application/json' -d @manual-scenarios/mechanics/izzet-prowess-red-cards.json
```

All three cards in hand with six Mountains — enough for every cast plus the Synthesizer's
`{2}{R}` sacrifice activation. The opponent's board makes each branch reachable in one turn:
Craw Wurm is a nonred 6/4 that *survives* Redcap Melee (so the land sacrifice is visible with
the creature still standing), and Raging Regisaur is red (so aiming Redcap Melee there
sacrifices nothing).
