### PR TITLE
Add City in a Bottle to Arabian Nights

### DIFF
--- a/backlog/sets/arabian-nights/TODO.md
+++ b/backlog/sets/arabian-nights/TODO.md
@@ -110,7 +110,6 @@ Remaining:
 - **Replacement / redirection**: Ali from Cairo (life can't drop below 1),
   Eye for an Eye (redirect damage to its source's controller).
 - **Opponent-chosen target**: Cuombajj Witches (1 dmg you choose + 1 dmg an opponent chooses).
-- **Set-membership effects**: City in a Bottle (destroy/lock out "Arabian Nights" cards).
 - **Untap-cost lock**: Magnetic Mountain (blue creatures don't untap unless {4} each).
 - **Cumulative counters dealing damage**: Cyclone.
 - **Card-from-outside-the-game**: Ring of Ma'rûf (wish-style).

--- a/backlog/sets/arabian-nights/cards.md
+++ b/backlog/sets/arabian-nights/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 78 cards
 **Release Date:** December 17, 1993
-**Implemented:** 75 / 78
+**Implemented:** 76 / 78
 | Color | Count |
 |-------|-------|
 | White | 11 |
@@ -74,7 +74,7 @@
 - [x] Aladdin's Ring
 - [x] Bottle of Suleiman
 - [x] Brass Man
-- [ ] City in a Bottle
+- [x] City in a Bottle
 - [x] Dancing Scimitar
 - [x] Ebony Horse
 - [x] Flying Carpet

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6757,12 +6757,18 @@ staticAbility {
   `defaultBlockEvasionRules` a declared block goes through. A creature that couldn't have blocked a
   flier by declaring can't be handed one here either. If either direction is illegal the effect does
   nothing at all — not a partial swap.
-- `PlayersCantPlayLands(affected = Player.Each, condition = null)` — the land-play sibling of
-  `PlayersCantCastSpells` (Worms of the Earth). Playing a land is a *special action*, not casting a
-  spell, so a card stopping one says nothing about the other. Enforced in **both** `PlayLandHandler`
-  (rejecting the action) and `EnumerationContext.canPlayLand` (never advertising it) via
-  `LandDropUtils.playerCantPlayLands`, which also unwraps a `ConditionalStaticAbility` so an
-  "as long as …" gate is honored rather than locking forever.
+- `PlayersCantPlayLands(affected = Player.Each, condition = null, landFilter = GameObjectFilter.Any)`
+  — the land-play sibling of `PlayersCantCastSpells` (Worms of the Earth). Playing a land is a
+  *special action*, not casting a spell, so a card stopping one says nothing about the other.
+  Enforced in **both** `PlayLandHandler` (rejecting the action) and `EnumerationContext` (never
+  advertising it) via `LandDropUtils.playerCantPlayLands`, which also unwraps a
+  `ConditionalStaticAbility` so an "as long as …" gate is honored rather than locking forever.
+  Scoped along the same three axes as `PlayersCantCastSpells`: **who** (`affected`), **which**
+  (`landFilter`, matched against the land card being played, so card predicates read the same from
+  hand, graveyard or exile — City in a Bottle narrows it to `originallyPrintedInSet("ARN")`) and
+  **when** (`condition`). A *filtered* lock never suppresses the land drop wholesale: the blanket
+  `canPlayLand` probe deliberately ignores it and `EnumerationContext.cantPlayLand(cardId)` removes
+  only the named cards, so the unaffected lands in a hand stay playable.
 - `LandsCantEnterTheBattlefield` — the other half of the same lock, and genuinely separate: this one
   catches a land arriving by an *effect* (a fetch, a reanimation, a blink), which the play-side
   restriction never sees. A card printing only one of the two leaves the other route open, which is
@@ -9227,9 +9233,17 @@ answer it and would silently return `false`.
   signature promises. Self-exclusion is a property of the *count*, not a predicate on the filter,
   which is why it is a separate entry and not a `GameObjectFilter` modifier.
 - `ControlCreature` — you control any creature.
-- `NoCreaturesOnBattlefield` — there are no creatures anywhere on the battlefield (global, either player;
-  `Exists(Player.Each, …, negate = true)`). Used by Drop of Honey's "when there are no creatures on the
-  battlefield, sacrifice this enchantment" state trigger.
+- `AnyPlayerControls(filter, negate = false, excludeSelf = false)` — at least one permanent matching
+  `filter` is on the battlefield **under anyone's control**; the controller-blind sibling of
+  `YouControl` / `OpponentControls` (`Exists(Player.Each, Zone.BATTLEFIELD, …)`). This is what "are
+  on the battlefield" means on a card that never says whose. `excludeSelf` supplies the printed
+  "other" — City in a Bottle's "whenever one or more **other** nontoken permanents with a name
+  originally printed in the Arabian Nights expansion are on the battlefield", where without it the
+  artifact's own ARN-printed name would hold its condition true forever. `negate` gives the two
+  named shorthands below.
+- `NoCreaturesOnBattlefield` — there are no creatures anywhere on the battlefield (either player;
+  `AnyPlayerControls(Creature, negate = true)`). Used by Drop of Honey's "when there are no creatures
+  on the battlefield, sacrifice this enchantment" state trigger.
 - `NoLandsOnBattlefield` — the land sibling of `NoCreaturesOnBattlefield`, same global shape. Used by
   Mana Vortex's "when there are no lands on the battlefield, sacrifice this enchantment" state trigger.
 - `EntityNumericProperty.ValueChosenAsEntered` (via `DynamicAmount.EntityProperty(EntityReference.Source, …)`)

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/coverage/SetCoverageServiceTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/coverage/SetCoverageServiceTest.kt
@@ -7,7 +7,6 @@ import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
-import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.comparables.shouldBeLessThanOrEqualTo
 import io.kotest.matchers.doubles.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.doubles.shouldBeLessThanOrEqual
@@ -152,14 +151,15 @@ class SetCoverageServiceTest : FunSpec({
             detail.total shouldBe detail.draft.count { it.notPlanned == null }
         }
 
-        test("only excuse cards that are actually still missing — Arabian Nights keeps its real gaps") {
-            // ARN's holes are two policy exclusions (Jeweled Bird = ante, Shahrazad = subgame) and
-            // the cards we could still build — City in a Bottle, now that Ring of Ma'rûf is done.
-            // Excluding the first pair must not paper over the second, so the set stays short of 100%.
+        test("an excused set still names what it isn't counting — Arabian Nights and its two exclusions") {
+            // ARN's only remaining holes are two policy exclusions (Jeweled Bird = ante, Shahrazad
+            // = subgame); every card we intend to build is built, City in a Bottle included. The
+            // exclusions drop out of the denominator but stay named in the detail view, so a set
+            // that reads 100% can always say which cards it excused to get there.
             val arn = coverage.find { it.code == "ARN" }.shouldNotBeNull()
             arn.notPlanned shouldBe 2
-            arn.total - arn.implemented shouldBeGreaterThanOrEqualTo 1
-            arn.percent shouldBeLessThan 100.0
+            arn.implemented shouldBe arn.total
+            arn.percent shouldBe 100.0
             val detail = service.detail("ARN").shouldNotBeNull()
             detail.draft.filter { it.notPlanned != null }.map { it.name } shouldBe
                 listOf("Jeweled Bird", "Shahrazad")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -252,21 +252,41 @@ object Conditions {
         Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Creature)
 
     /**
-     * If there are no creatures anywhere on the battlefield (either player). Global scope —
-     * `Player.Each` checks every player's battlefield, negated. Used by Drop of Honey's
-     * "when there are no creatures on the battlefield, sacrifice this enchantment".
+     * If at least one permanent matching [filter] is on the battlefield, **under anyone's
+     * control** — the controller-blind sibling of [YouControl] / [OpponentControls].
+     *
+     * `Player.Each` is the global scope: every player's battlefield is searched and the
+     * condition holds as soon as one match is found anywhere. That is what "are on the
+     * battlefield" means on a card that never says whose — Drop of Honey's "when there are no
+     * creatures on the battlefield" (`negate = true`) and City in a Bottle's "whenever one or
+     * more *other* nontoken permanents … are on the battlefield" (`excludeSelf = true`).
+     *
+     * Set [excludeSelf] for the "other" wording — the source permanent is left out of the
+     * search, so a card whose own filter would match itself doesn't hold its own condition
+     * true forever. Set [negate] for "there are no …".
+     */
+    fun AnyPlayerControls(
+        filter: GameObjectFilter,
+        negate: Boolean = false,
+        excludeSelf: Boolean = false
+    ): ConditionInterface =
+        Exists(Player.Each, Zone.BATTLEFIELD, filter, negate = negate, excludeSelf = excludeSelf)
+
+    /**
+     * If there are no creatures anywhere on the battlefield (either player). Used by Drop of
+     * Honey's "when there are no creatures on the battlefield, sacrifice this enchantment".
      */
     val NoCreaturesOnBattlefield: ConditionInterface =
-        Exists(Player.Each, Zone.BATTLEFIELD, GameObjectFilter.Creature, negate = true)
+        AnyPlayerControls(GameObjectFilter.Creature, negate = true)
 
     /**
      * If there are no lands anywhere on the battlefield (either player). The land sibling of
-     * [NoCreaturesOnBattlefield], same global `Player.Each` + negate shape. Used by Mana Vortex's
-     * "when there are no lands on the battlefield, sacrifice this enchantment" — the clause that
-     * ends the card once it has eaten every land in play.
+     * [NoCreaturesOnBattlefield]. Used by Mana Vortex's "when there are no lands on the
+     * battlefield, sacrifice this enchantment" — the clause that ends the card once it has
+     * eaten every land in play.
      */
     val NoLandsOnBattlefield: ConditionInterface =
-        Exists(Player.Each, Zone.BATTLEFIELD, GameObjectFilter.Land, negate = true)
+        AnyPlayerControls(GameObjectFilter.Land, negate = true)
 
     /**
      * If you control at least one permanent matching [filter].

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -779,6 +779,17 @@ data class MayCastWithoutPayingManaCost(
  * (never advertising it), because a legal-action list that offers a land drop the handler will
  * refuse is worse than either alone.
  *
+ * Scoped along the same axes as [PlayersCantCastSpells]:
+ *
+ *  - **who** — [affected], relative to this permanent's controller.
+ *  - **which** — [landFilter], matched against the land card being played (card predicates work
+ *    in any zone, so it reads the same from hand, graveyard or exile). Defaults to every land;
+ *    City in a Bottle narrows it to `originallyPrintedInSet("ARN")`.
+ *  - **when** — [condition], evaluated in the controller's context; `null` = always.
+ *
+ * A filtered lock (`landFilter != Any`) never suppresses the land drop wholesale — it is applied
+ * per candidate card during enumeration, so the unaffected lands in a hand stay playable.
+ *
  * This stops the *play*. A land put onto the battlefield by an effect is a different event and
  * needs [LandsCantEnterTheBattlefield]; Worms of the Earth prints both lines for exactly that
  * reason.
@@ -804,16 +815,25 @@ data object LandsCantEnterTheBattlefield : StaticAbility {
 @Serializable
 data class PlayersCantPlayLands(
     val affected: Player = Player.Each,
-    val condition: Condition? = null
+    val condition: Condition? = null,
+    val landFilter: GameObjectFilter = GameObjectFilter.Any
 ) : StaticAbility {
     override val description: String = buildString {
+        val lands = if (landFilter == GameObjectFilter.Any) "lands" else "${landFilter.description} lands"
         when (affected) {
-            is Player.You -> append("You can't play lands")
-            is Player.EachOpponent -> append("Your opponents can't play lands")
-            is Player.Each -> append("Players can't play lands")
-            else -> append("${affected.description.replaceFirstChar { it.uppercase() }} can't play lands")
+            is Player.You -> append("You can't play $lands")
+            is Player.EachOpponent -> append("Your opponents can't play $lands")
+            is Player.Each -> append("Players can't play $lands")
+            else -> append("${affected.description.replaceFirstChar { it.uppercase() }} can't play $lands")
         }
         condition?.let { append(" ${it.description}") }
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = landFilter.applyTextReplacement(replacer)
+        val newCondition = condition?.applyTextReplacement(replacer)
+        return if (newFilter === landFilter && newCondition === condition) this
+        else copy(landFilter = newFilter, condition = newCondition)
     }
 }
 

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/ArabianNightsSet.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/ArabianNightsSet.kt
@@ -12,9 +12,12 @@ import com.wingedsheep.sdk.model.TokenPrinting
  *
  * The first Magic: The Gathering expansion. 78 cards, no block. Many of its
  * mechanics (banding, landwalk variants, coin flips, control-changing effects,
- * subgames, ante) predate or stress the modern rules, so a handful of cards
- * require engine work and are tracked separately in
- * `backlog/sets/arabian-nights/cards.md`.
+ * subgames, ante) predate or stress the modern rules.
+ *
+ * Complete: every card we intend to build is built. The two that remain are policy
+ * exclusions listed in `coverage/card-exclusions.json` — Jeweled Bird needs the ante
+ * zone the engine doesn't have, and Shahrazad needs a full Magic subgame — so the set
+ * is draftable and no longer carries `incomplete`.
  *
  * Set Code: ARN
  * Release Date: December 17, 1993
@@ -26,11 +29,14 @@ object ArabianNightsSet : MtgSet {
     override val displayName = "Arabian Nights"
     override val releaseDate = "1993-12-17"
     override val basicLandsFallback = PortalSet
-    override val incomplete = true
     override val sealedSupported = true
 
     override val cards: List<CardDefinition> by lazy {
-        CardDiscovery.findIn(CARDS_PACKAGE)
+        // Self-stamp [code] onto every card, honouring the MtgSet contract that `cards` is already
+        // set-stamped. This makes `CardDefinition.setCode` a reliable "originally printed in ARN"
+        // signal for every consumer (engine tests included), not only the game-server load path —
+        // which is what City in a Bottle's OriginallyPrintedInSet("ARN") predicate reads.
+        CardDiscovery.findIn(CARDS_PACKAGE).map { if (it.setCode == null) it.copy(setCode = code) else it }
     }
 
     /**

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/CityInABottle.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/CityInABottle.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.arn.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PlayersCantCastSpells
+import com.wingedsheep.sdk.scripting.PlayersCantPlayLands
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * City in a Bottle
+ * {2}
+ * Artifact
+ * Whenever one or more other nontoken permanents with a name originally printed in the Arabian
+ * Nights expansion are on the battlefield, their controllers sacrifice them.
+ * Players can't cast spells or play lands with a name originally printed in the Arabian Nights
+ * expansion.
+ *
+ * Composition — three existing primitives over one set-membership filter:
+ *  - `originallyPrintedInSet("ARN")` ([com.wingedsheep.sdk.scripting.predicates.CardPredicate.OriginallyPrintedInSet])
+ *    is the whole card's vocabulary. It reads `CardComponent.originalSetCode`, the *canonical*
+ *    set of the definition rather than the printing a player owns, so a reprint of an Arabian
+ *    Nights card still matches — the 2014-02-01 ruling's "even if the physical card representing
+ *    that permanent is a reprint with a different expansion symbol". Tokens have no original set,
+ *    so they never match, which is also the 2004-10-04 ruling.
+ *  - The first line is a `stateTriggeredAbility` (CR 603.8), not an enters/leaves trigger: it is
+ *    checked each time a player would receive priority, which is exactly what the ruling
+ *    describes. `excludeSelf = true` supplies the printed "other" — City in a Bottle's own name
+ *    was originally printed in ARN, so without it the card would hold its own condition true
+ *    forever and sacrifice itself on sight. The effect is `SacrificeAll(excludeTriggering = true)`,
+ *    which sacrifices each matching permanent under its own controller (CR 701.17) — "their
+ *    controllers sacrifice them" — and leaves this artifact alone.
+ *  - The second line is the pair of lock statics scoped by the same filter:
+ *    [PlayersCantCastSpells] (read at cast-legality time, so it covers every casting zone) and
+ *    [PlayersCantPlayLands] (playing a land is a special action, never a cast, so it needs its own
+ *    line — the same split Worms of the Earth prints). Both are `Player.Each`: the printed text
+ *    says "Players", including this card's own controller.
+ *
+ * Note the two lines are deliberately not redundant. The lock stops new Arabian Nights cards
+ * arriving by cast or land drop; the state trigger catches the ones already on the battlefield
+ * and the ones that arrive by any other route (a search effect, a reanimation, a copy).
+ */
+val CityInABottle = card("City in a Bottle") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever one or more other nontoken permanents with a name originally printed " +
+        "in the Arabian Nights expansion are on the battlefield, their controllers sacrifice them.\n" +
+        "Players can't cast spells or play lands with a name originally printed in the Arabian " +
+        "Nights expansion."
+
+    stateTriggeredAbility {
+        condition = Conditions.AnyPlayerControls(
+            GameObjectFilter.Permanent.nontoken().originallyPrintedInSet("ARN"),
+            excludeSelf = true
+        )
+        effect = Effects.SacrificeAll(
+            filter = GameObjectFilter.Permanent.nontoken().originallyPrintedInSet("ARN"),
+            excludeTriggering = true
+        )
+        description = "Whenever one or more other nontoken permanents with a name originally " +
+            "printed in the Arabian Nights expansion are on the battlefield, their controllers " +
+            "sacrifice them"
+    }
+
+    staticAbility {
+        ability = PlayersCantCastSpells(
+            affected = Player.Each,
+            spellFilter = GameObjectFilter.Any.originallyPrintedInSet("ARN")
+        )
+    }
+
+    staticAbility {
+        ability = PlayersCantPlayLands(
+            affected = Player.Each,
+            landFilter = GameObjectFilter.Any.originallyPrintedInSet("ARN")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "60"
+        artist = "Drew Tucker"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/9598b346-a47d-4c4c-9571-156824e86b9c.jpg?1783948377"
+        ruling(
+            "2014-02-01",
+            "Any time a player receives priority to cast spells or activate abilities, check to " +
+                "see whether any permanents on the battlefield were originally printed in the " +
+                "Arabian Nights expansion (even if the physical card representing that permanent " +
+                "is a reprint with a different expansion symbol). If there are any such " +
+                "permanents, the ability will trigger and those permanents will be sacrificed."
+        )
+        ruling("2004-10-04", "Token creatures and counters created by Arabian Nights cards are not removed.")
+    }
+}

--- a/mtg-sets/1993-1999/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CityInABottleScenarioTest.kt
+++ b/mtg-sets/1993-1999/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CityInABottleScenarioTest.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for City in a Bottle (ARN #60).
+ *
+ * {2} Artifact
+ * "Whenever one or more other nontoken permanents with a name originally printed in the Arabian
+ *  Nights expansion are on the battlefield, their controllers sacrifice them.
+ *  Players can't cast spells or play lands with a name originally printed in the Arabian Nights
+ *  expansion."
+ *
+ * Three separately-enforced things, so three tests:
+ *  - the state trigger (CR 603.8) sweeping the battlefield — and the printed "other", which is
+ *    load-bearing here because City in a Bottle's own name was originally printed in ARN;
+ *  - the cast lock, read at cast-legality time;
+ *  - the land-play lock, which is a *different* enforcement path (playing a land is a special
+ *    action, never a cast) and which must stay per-card: the unaffected lands in hand are still
+ *    playable.
+ *
+ * ARN printed only one basic land, Mountain, so every test below draws its mana from Forests and
+ * Islands to keep the basics out of the set-membership filter.
+ */
+class CityInABottleScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("City in a Bottle") {
+
+            test("sacrifices every other ARN nontoken permanent, sparing itself and non-ARN cards") {
+                val game = scenario()
+                    .withPlayers("Bottler", "Victim")
+                    .withCardOnBattlefield(1, "City in a Bottle")
+                    .withCardOnBattlefield(1, "Kird Ape", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Erhnam Djinn", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // The state trigger is polled at a priority pass, goes on the stack, and resolves.
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("Kird Ape (ARN) is sacrificed by its controller") {
+                    game.isOnBattlefield("Kird Ape") shouldBe false
+                    game.isInGraveyard(1, "Kird Ape") shouldBe true
+                }
+                withClue("Erhnam Djinn (ARN) is sacrificed by *its* controller, P2") {
+                    game.isOnBattlefield("Erhnam Djinn") shouldBe false
+                    game.isInGraveyard(2, "Erhnam Djinn") shouldBe true
+                }
+                withClue("Grizzly Bears (non-ARN) survives") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                withClue("City in a Bottle spares itself — the oracle text says *other*") {
+                    game.isOnBattlefield("City in a Bottle") shouldBe true
+                }
+            }
+
+            test("an ARN spell can't be cast, while a non-ARN spell of the same colour still can") {
+                val game = scenario()
+                    .withPlayers("Bottler", "Caster")
+                    .withCardOnBattlefield(1, "City in a Bottle")
+                    .withCardInHand(2, "Erhnam Djinn")
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 4)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castable = game.getLegalActions(2)
+                    .filter { it.actionType == "CastSpell" }
+                    .map { it.description }
+                withClue("Erhnam Djinn is never offered: $castable") {
+                    castable.none { it.contains("Erhnam Djinn") } shouldBe true
+                }
+                withClue("Grizzly Bears is still offered: $castable") {
+                    castable.any { it.contains("Grizzly Bears") } shouldBe true
+                }
+
+                withClue("and the handler rejects the cast even when the action is submitted directly") {
+                    game.castSpell(2, "Erhnam Djinn").error shouldNotBe null
+                }
+
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+                withClue("the non-ARN spell resolves normally") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("an ARN land can't be played, while a non-ARN land in the same hand still can") {
+                val game = scenario()
+                    .withPlayers("Bottler", "Lander")
+                    .withCardOnBattlefield(1, "City in a Bottle")
+                    .withCardInHand(2, "Desert")
+                    .withCardInHand(2, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val landDrops = game.getLegalActions(2)
+                    .filter { it.actionType == "PlayLand" }
+                    .map { it.description }
+                withClue("Desert (ARN) is not offered as a land drop: $landDrops") {
+                    landDrops.none { it.contains("Desert") } shouldBe true
+                }
+                withClue("Forest is still offered — a filtered lock must not eat the land drop: $landDrops") {
+                    landDrops.any { it.contains("Forest") } shouldBe true
+                }
+
+                val desert = game.findCardsInHand(2, "Desert").single()
+                withClue("and the handler rejects the play even when submitted directly") {
+                    game.execute(PlayLand(game.player2Id, desert)).error shouldNotBe null
+                }
+                withClue("Desert stays in hand") {
+                    game.findCardsInHand(2, "Desert").size shouldBe 1
+                }
+
+                val forest = game.findCardsInHand(2, "Forest").single()
+                withClue("the unaffected land still drops") {
+                    game.execute(PlayLand(game.player2Id, forest)).error shouldBe null
+                    game.isOnBattlefield("Forest") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -40,6 +40,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "1",
         "rarity": "UNCOMMON",
@@ -101,6 +102,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "34",
         "rarity": "RARE",
@@ -201,6 +203,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "56",
         "rarity": "RARE",
@@ -252,6 +255,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "57",
         "rarity": "RARE",
@@ -301,6 +305,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "35",
         "rarity": "UNCOMMON",
@@ -328,6 +333,7 @@
             "LifeLossFloor"
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "36",
         "rarity": "RARE",
@@ -382,6 +388,7 @@
             }
         }
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "2",
         "artist": "Brian Snõddy",
@@ -454,6 +461,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "70",
         "rarity": "UNCOMMON",
@@ -476,6 +484,7 @@
     "keywords": [
         "FLYING"
     ],
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "37",
         "artist": "Kaja Foglio",
@@ -537,6 +546,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "58",
         "rarity": "RARE",
@@ -585,6 +595,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "59",
         "rarity": "UNCOMMON",
@@ -628,6 +639,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "3",
         "artist": "Sandra Everingham",
@@ -637,6 +649,114 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// City in a Bottle
+{
+    "name": "City in a Bottle",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever one or more other nontoken permanents with a name originally printed in the Arabian Nights expansion are on the battlefield, their controllers sacrifice them.\nPlayers can't cast spells or play lands with a name originally printed in the Arabian Nights expansion.",
+    "script": {
+        "stateTriggeredAbilities": [
+            {
+                "id": "ability_1",
+                "condition": {
+                    "type": "Exists",
+                    "player": "Each",
+                    "zone": "Battlefield",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsPermanent",
+                            "IsNontoken",
+                            {
+                                "type": "OriginallyPrintedInSet",
+                                "setCode": "ARN"
+                            }
+                        ]
+                    },
+                    "excludeSelf": true
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsPermanent",
+                                        "IsNontoken",
+                                        {
+                                            "type": "OriginallyPrintedInSet",
+                                            "setCode": "ARN"
+                                        }
+                                    ]
+                                },
+                                "excludeSelf": true,
+                                "excludeTriggering": true
+                            },
+                            "storeAs": "sacrificeAll_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "sacrificeAll_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Sacrifice"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever one or more other nontoken permanents with a name originally printed in the Arabian Nights expansion are on the battlefield, their controllers sacrifice them"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "PlayersCantCastSpells",
+                "affected": "Each",
+                "spellFilter": {
+                    "cardPredicates": [
+                        {
+                            "type": "OriginallyPrintedInSet",
+                            "setCode": "ARN"
+                        }
+                    ]
+                }
+            },
+            {
+                "type": "PlayersCantPlayLands",
+                "landFilter": {
+                    "cardPredicates": [
+                        {
+                            "type": "OriginallyPrintedInSet",
+                            "setCode": "ARN"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "setCode": "ARN",
+    "metadata": {
+        "collectorNumber": "60",
+        "rarity": "RARE",
+        "artist": "Drew Tucker",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/9598b346-a47d-4c4c-9571-156824e86b9c.jpg?1783948377",
+        "rulings": [
+            {
+                "date": "2014-02-01",
+                "text": "Any time a player receives priority to cast spells or activate abilities, check to see whether any permanents on the battlefield were originally printed in the Arabian Nights expansion (even if the physical card representing that permanent is a reprint with a different expansion symbol). If there are any such permanents, the ability will trigger and those permanents will be sacrificed."
+            },
+            {
+                "date": "2004-10-04",
+                "text": "Token creatures and counters created by Arabian Nights cards are not removed."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // City of Brass
@@ -670,6 +790,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "71",
         "rarity": "UNCOMMON",
@@ -735,6 +856,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "23",
         "artist": "Kaja Foglio",
@@ -861,6 +983,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "45",
         "rarity": "UNCOMMON",
@@ -885,6 +1008,7 @@
     "keywords": [
         "FLYING"
     ],
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "61",
         "rarity": "RARE",
@@ -934,6 +1058,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "12",
         "artist": "Drew Tucker",
@@ -997,6 +1122,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "72",
         "artist": "Jesper Myrfors",
@@ -1033,6 +1159,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "38",
         "artist": "Christopher Rush",
@@ -1069,6 +1196,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "46",
         "rarity": "UNCOMMON",
@@ -1114,6 +1242,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "73",
         "rarity": "RARE",
@@ -1203,6 +1332,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "47",
         "rarity": "RARE",
@@ -1271,6 +1401,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "62",
         "rarity": "RARE",
@@ -1304,6 +1435,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "24",
         "rarity": "RARE",
@@ -1358,6 +1490,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "74",
         "rarity": "RARE",
@@ -1427,6 +1560,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "25",
         "artist": "Dameon Willich",
@@ -1484,6 +1618,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "48",
         "rarity": "RARE",
@@ -1516,6 +1651,7 @@
             "preventDamage": false
         }
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "4",
         "rarity": "UNCOMMON",
@@ -1547,6 +1683,7 @@
             }
         }
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "13",
         "artist": "Anson Maddocks",
@@ -1601,6 +1738,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "63",
         "rarity": "UNCOMMON",
@@ -1622,6 +1760,7 @@
     "keywords": [
         "FLYING"
     ],
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "14",
         "artist": "Christopher Rush",
@@ -1659,6 +1798,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "49",
         "artist": "Jesper Myrfors",
@@ -1700,6 +1840,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "15",
         "artist": "Kaja Foglio",
@@ -1796,6 +1937,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "26",
         "rarity": "RARE",
@@ -1843,6 +1985,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "27",
         "artist": "Dan Frazier",
@@ -1887,6 +2030,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "39",
         "artist": "Drew Tucker",
@@ -1964,6 +2108,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "50",
         "rarity": "RARE",
@@ -2043,6 +2188,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "16",
         "rarity": "RARE",
@@ -2089,6 +2235,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "75",
         "rarity": "RARE",
@@ -2133,6 +2280,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "64",
         "rarity": "RARE",
@@ -2194,6 +2342,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "65",
         "rarity": "RARE",
@@ -2269,6 +2418,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "5",
         "rarity": "RARE",
@@ -2316,6 +2466,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "28",
         "rarity": "RARE",
@@ -2357,6 +2508,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "29",
         "rarity": "RARE",
@@ -2410,6 +2562,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "30",
         "rarity": "UNCOMMON",
@@ -2485,6 +2638,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "6",
         "rarity": "RARE",
@@ -2529,6 +2683,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "40",
         "artist": "Ken Meyer, Jr.",
@@ -2612,6 +2767,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "76",
         "rarity": "UNCOMMON",
@@ -2718,6 +2874,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "41",
         "rarity": "UNCOMMON",
@@ -2782,6 +2939,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "17",
         "rarity": "UNCOMMON",
@@ -2826,6 +2984,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "51",
         "artist": "Christopher Rush",
@@ -2880,6 +3039,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "42",
         "rarity": "RARE",
@@ -2904,6 +3064,7 @@
     "keywords": [
         "TRAMPLE"
     ],
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "7",
         "artist": "Dameon Willich",
@@ -2969,6 +3130,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "52",
         "artist": "Christopher Rush",
@@ -3027,6 +3189,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "78",
         "rarity": "UNCOMMON",
@@ -3085,6 +3248,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "18",
         "rarity": "RARE",
@@ -3136,6 +3300,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "31",
         "artist": "Douglas Shuler",
@@ -3175,6 +3340,7 @@
             }
         }
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "8",
         "artist": "Mark Poole",
@@ -3264,6 +3430,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "67",
         "rarity": "RARE",
@@ -3291,6 +3458,7 @@
             }
         }
     ],
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "9",
         "rarity": "RARE",
@@ -3367,6 +3535,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "68",
         "rarity": "RARE",
@@ -3422,6 +3591,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "43",
         "artist": "Christopher Rush",
@@ -3500,6 +3670,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "69",
         "rarity": "UNCOMMON",
@@ -3533,6 +3704,7 @@
             }
         }
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "53",
         "artist": "Brian Snõddy",
@@ -3616,6 +3788,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "19",
         "rarity": "RARE",
@@ -3660,6 +3833,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "20",
         "rarity": "RARE",
@@ -3745,6 +3919,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "21",
         "rarity": "UNCOMMON",
@@ -3795,6 +3970,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "54",
         "rarity": "RARE",
@@ -3850,6 +4026,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "32",
         "rarity": "UNCOMMON",
@@ -3874,6 +4051,7 @@
     "keywords": [
         "FIRST_STRIKE"
     ],
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "33",
         "artist": "Ken Meyer, Jr.",
@@ -3922,6 +4100,7 @@
             }
         }
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "22",
         "artist": "Douglas Shuler",
@@ -3946,6 +4125,7 @@
         "TRAMPLE",
         "BANDING"
     ],
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "11",
         "artist": "Kristen Bishop",
@@ -3999,6 +4179,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "55",
         "artist": "Susan Van Camp",
@@ -4045,6 +4226,7 @@
             }
         ]
     },
+    "setCode": "ARN",
     "metadata": {
         "collectorNumber": "44",
         "rarity": "RARE",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -102,6 +102,16 @@ class PlayLandHandler(
             return "You can only play land cards as lands"
         }
 
+        // Filtered "players can't play <these> lands" lock (City in a Bottle). The blanket probe
+        // above deliberately ignores filtered locks, so the named card is asked about here — the
+        // mirror of PlayLandEnumerator's per-candidate check.
+        if (LandDropUtils.playerCantPlayLands(
+                state, action.playerId, cardRegistry, conditionEvaluator, landCardId = action.cardId
+            )
+        ) {
+            return "You can't play ${cardComponent.name}"
+        }
+
         // Check card is in hand, on top of library with PlayFromTopOfLibrary, in exile with MayPlayPermission,
         // or in graveyard with MayPlayPermanentsFromGraveyard permission (Muldrotha)
         val handZone = ZoneKey(action.playerId, Zone.HAND)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
@@ -101,6 +101,20 @@ class EnumerationContext(
                 .playerCantPlayLands(state, playerId, cardRegistry)
     }
 
+    /**
+     * Whether a *filtered* [com.wingedsheep.sdk.scripting.PlayersCantPlayLands] lock forbids this
+     * player from playing the specific land [cardId] (City in a Bottle's "players can't … play
+     * lands with a name originally printed in the Arabian Nights expansion").
+     *
+     * The per-card sibling of [canPlayLand]'s blanket probe, mirroring how [cantCastSpell] sits
+     * beside [cantCastSpells]: the blanket flag suppresses the land drop wholesale, this one only
+     * removes the lands the lock actually names. Consulted by every PlayLand enumeration branch,
+     * and mirrored in `PlayLandHandler` so the offered list and the handler agree.
+     */
+    fun cantPlayLand(cardId: EntityId): Boolean =
+        com.wingedsheep.engine.legalactions.utils.LandDropUtils
+            .playerCantPlayLands(state, playerId, cardRegistry, landCardId = cardId)
+
     // Cast restrictions — blanket, spell-independent locks (a Silence-style CantCastSpellsComponent
     // or a RestrictSpellsCastPerTurn per-turn limit). Cached once per enumeration pass.
     val cantCastSpells: Boolean by lazy {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PlayLandEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PlayLandEnumerator.kt
@@ -22,7 +22,7 @@ class PlayLandEnumerator : ActionEnumerator {
             val hand = state.getHand(playerId)
             for (cardId in hand) {
                 val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: continue
-                if (cardComponent.typeLine.isLand) {
+                if (cardComponent.typeLine.isLand && !context.cantPlayLand(cardId)) {
                     result.add(LegalAction(
                         actionType = "PlayLand",
                         description = "Play ${cardComponent.name}",
@@ -37,7 +37,7 @@ class PlayLandEnumerator : ActionEnumerator {
             val graveyardCards = state.getZone(ZoneKey(playerId, Zone.GRAVEYARD))
             for (cardId in graveyardCards) {
                 val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: continue
-                if (cardComponent.typeLine.isLand) {
+                if (cardComponent.typeLine.isLand && !context.cantPlayLand(cardId)) {
                     result.add(LegalAction(
                         actionType = "PlayLand",
                         description = "Play ${cardComponent.name}",
@@ -60,6 +60,7 @@ class PlayLandEnumerator : ActionEnumerator {
                 if (cardId !in discardedThisTurn) continue
                 val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: continue
                 if (!cardComponent.typeLine.isLand) continue
+                if (context.cantPlayLand(cardId)) continue
                 val cardDef = context.cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
                 if (com.wingedsheep.engine.mechanics.MayhemGrants.effectiveMayhem(state, cardId, cardDef) == null) continue
                 result.add(LegalAction(
@@ -79,6 +80,7 @@ class PlayLandEnumerator : ActionEnumerator {
                 if (!seenLinkedLands.add(exiledId)) continue
                 val cardComponent = state.getEntity(exiledId)?.get<CardComponent>() ?: continue
                 if (!cardComponent.typeLine.isLand) continue
+                if (context.cantPlayLand(exiledId)) continue
                 if (granter.ability.ownedByYou && cardComponent.ownerId != playerId) continue
                 val inExile = state.turnOrder.any { pid -> exiledId in state.getZone(ZoneKey(pid, Zone.EXILE)) }
                 if (!inExile) continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/LandDropUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/LandDropUtils.kt
@@ -2,11 +2,14 @@ package com.wingedsheep.engine.legalactions.utils
 
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantAdditionalLandDrop
 import com.wingedsheep.sdk.scripting.PlayersCantPlayLands
 import com.wingedsheep.sdk.scripting.references.Player
@@ -33,17 +36,25 @@ object LandDropUtils {
      * enchantment. A [ConditionalStaticAbility] wrapper is unwrapped and evaluated against its own
      * source, the same way the land-drop bonus above is, so an "as long as …" gate is honored
      * instead of silently locking forever.
+     *
+     * [landCardId] scopes the question to one candidate card, which is what a *filtered* lock
+     * needs (City in a Bottle stops only the lands originally printed in ARN). Pass `null` — the
+     * default — to ask the blanket question "is this player locked out of land drops entirely?";
+     * a filtered lock deliberately answers `false` there, so the unaffected lands in the hand stay
+     * playable and only the per-card call below rejects the matching ones.
      */
     fun playerCantPlayLands(
         state: GameState,
         playerId: EntityId,
         cardRegistry: CardRegistry,
         conditionEvaluator: ConditionEvaluator = ConditionEvaluator(),
+        landCardId: EntityId? = null,
     ): Boolean {
+        val projected = state.projectedState
         for (entityId in state.getBattlefield()) {
             val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            val sourceController = state.projectedState.getController(entityId) ?: continue
+            val sourceController = projected.getController(entityId) ?: continue
             for (ability in cardDef.script.staticAbilities) {
                 val lock = when (ability) {
                     is PlayersCantPlayLands -> ability
@@ -61,16 +72,26 @@ object LandDropUtils {
                     is Player.EachOpponent -> state.getOpponents(sourceController)
                     else -> continue
                 }
-                if (playerId in affected) {
-                    val context = EffectContext(sourceId = entityId, controllerId = sourceController)
-                    if (lock.condition == null || conditionEvaluator.evaluate(state, lock.condition!!, context)) {
-                        return true
-                    }
+                if (playerId !in affected) continue
+                // A filtered lock only bites on a named candidate; the blanket probe skips it.
+                if (lock.landFilter != GameObjectFilter.Any) {
+                    if (landCardId == null) continue
+                    if (!predicateEvaluator.matches(
+                            state, projected, landCardId, lock.landFilter,
+                            PredicateContext(controllerId = playerId)
+                        )
+                    ) continue
+                }
+                val context = EffectContext(sourceId = entityId, controllerId = sourceController)
+                if (lock.condition == null || conditionEvaluator.evaluate(state, lock.condition!!, context)) {
+                    return true
                 }
             }
         }
         return false
     }
+
+    private val predicateEvaluator = PredicateEvaluator()
 
     fun getAdditionalLandDrops(
         state: GameState,


### PR DESCRIPTION
**City in a Bottle** — ARN #60, `{2}` Artifact.

> Whenever one or more other nontoken permanents with a name originally printed in the Arabian Nights expansion are on the battlefield, their controllers sacrifice them.
> Players can't cast spells or play lands with a name originally printed in the Arabian Nights expansion.

The set-membership predicate (`CardPredicate.OriginallyPrintedInSet`, via `GameObjectFilter.originallyPrintedInSet`) already existed for Golgothian Sylex, and the whole card is written on top of it. Three pieces were missing around it.

### `Conditions.AnyPlayerControls(filter, negate, excludeSelf)`

The controller-blind sibling of `YouControl` / `OpponentControls` (`Exists(Player.Each, Zone.BATTLEFIELD, …)`) — which is what "are on the battlefield" means on a card that never says whose. `NoCreaturesOnBattlefield` and `NoLandsOnBattlefield` are re-expressed on top of it rather than repeating the shape a third time.

`excludeSelf` supplies the printed **"other"**, and it is load-bearing here: City in a Bottle's own name was originally printed in ARN, so without it the artifact holds its own state trigger true forever and sacrifices itself on sight.

The first line is a `stateTriggeredAbility` (CR 603.8), not an enters/leaves trigger — checked each time a player would receive priority, which is exactly what the 2014-02-01 ruling describes. The effect is `Effects.SacrificeAll(excludeTriggering = true)`: each matching permanent is sacrificed by its own controller (CR 701.17, "their controllers sacrifice them") and this artifact is left alone.

### `PlayersCantPlayLands` gains a `landFilter` axis

Mirroring the `spellFilter` `PlayersCantCastSpells` already has, so the lock line splits into the two statics it actually is — playing a land is a special action, never a cast, the same split Worms of the Earth prints.

The interesting half is that a **filtered** lock must not eat the land drop wholesale. `LandDropUtils.playerCantPlayLands` grew an optional `landCardId`: the blanket probe behind `EnumerationContext.canPlayLand` deliberately ignores filtered locks, and a new per-card `EnumerationContext.cantPlayLand(cardId)` removes only the lands the lock names. Checked in every `PlayLandEnumerator` branch (hand, graveyard, Mayhem, linked exile) *and* in `PlayLandHandler`, the way the blanket lock already was — a legal-action list that offers a land drop the handler will refuse is worse than either check alone.

### `ArabianNightsSet` self-stamps its set code

The same line Antiquities carries for Golgothian Sylex, and the reason it carries it: without the stamp `CardComponent.originalSetCode` is null off the game-server load path, and the predicate silently matches nothing in every engine test. This is why the ARN snapshot golden moves for all 75 existing cards (`+"setCode": "ARN"` rows only — re-blessed, and no other set's golden moved).

### ARN is now complete

City in a Bottle was the set's last buildable card. What remains is the two policy exclusions already in `coverage/card-exclusions.json` — Jeweled Bird (ante) and Shahrazad (subgame) — so `incomplete = true` is dropped, which is what `SetCoverageServiceTest`'s "a set that reaches 100% is no longer flagged incomplete" guard demands. The sibling ARN test in that file asserted the set stays *short* of 100% while City in a Bottle was missing; it is reframed to assert the complementary property it can still prove — that an excused set still names the cards it isn't counting.

### Verification

- `just test-class CityInABottleScenarioTest` — 3 tests, green: the state trigger sweeping both players' ARN permanents while sparing itself and non-ARN cards; the cast lock (absent from legal actions *and* rejected by the handler); the land lock (Desert suppressed, Forest in the same hand still playable).
- `just test-rules` — `:rules-engine:test` + every era's scenario suite, green.
- `:mtg-sets:test` (FacadeBoundaryTest + snapshots) and `:game-server:test`, green.
- `just build`, green.
- `just rebless-cards` — only `ARN.json` moved.
- `just check-card-printing "City in a Bottle"` — canonical in ARN, its earliest real printing. VMA (2014) isn't scaffolded, so no `Printing` row is owed.
- `just assay-differential --set ARN` — 23/23 confirmed, 0 divergent.
- Backlog ticked; `just fix-backlog` resynced ARN to 76/78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)