### PR TITLE
Add Cryptic Serpent to Amonkhet (clean redo of #2013)

### DIFF
--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CrypticSerpent.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CrypticSerpent.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Cryptic Serpent — {5}{U}{U}
+ * Creature — Serpent
+ * 6/5
+ *
+ * This spell costs {1} less to cast for each instant and sorcery card in your graveyard.
+ *
+ * [CostReductionSource.CardsInGraveyardMatchingFilter] totals *cards*, which is what the printed
+ * line asks for — five instants give {5} off. (Its distinct-types sibling `CardTypesInYourGraveyard`
+ * would give {2} for any mix of instants and sorceries, which is a different card.) Only the generic
+ * portion shrinks: the {U}{U} pips are never reduced, and the generic component floors at 0.
+ *
+ * AKH #48, Lius Lasahido.
+ */
+val CrypticSerpent = card("Cryptic Serpent") {
+    manaCost = "{5}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Serpent"
+    power = 6
+    toughness = 5
+    oracleText = "This spell costs {1} less to cast for each instant and sorcery card in your graveyard."
+
+    // {1} less for each instant and sorcery card in your graveyard
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.CardsInGraveyardMatchingFilter(
+                    filter = GameObjectFilter.InstantOrSorcery
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "48"
+        artist = "Lius Lasahido"
+        flavorText = "It slithers through the senses, constricting consciousness and poisoning perceptions."
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/43d11a24-8abf-46ff-8cc6-57b8ac3013f6.jpg?1783936524"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CrypticSerpentReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CrypticSerpentReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cryptic Serpent reprint in J22. Canonical CardDefinition lives in Amonkhet (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.akh.cards.CrypticSerpent`.
+ */
+val CrypticSerpentReprint = Printing(
+    oracleId = "0f26c04a-9bf7-4cbd-a95f-73ee4a3b1af1",
+    name = "Cryptic Serpent",
+    setCode = "J22",
+    collectorNumber = "285",
+    scryfallId = "cfc3e4cd-022d-48e4-abc9-b8ddfb0c8c5c",
+    artist = "Lius Lasahido",
+    imageUri = "https://cards.scryfall.io/normal/front/c/f/cfc3e4cd-022d-48e4-abc9-b8ddfb0c8c5c.jpg?1783919065",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CrypticSerpentReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CrypticSerpentReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cryptic Serpent reprint in JMP. Canonical CardDefinition lives in Amonkhet (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.akh.cards.CrypticSerpent`.
+ */
+val CrypticSerpentReprint = Printing(
+    oracleId = "0f26c04a-9bf7-4cbd-a95f-73ee4a3b1af1",
+    name = "Cryptic Serpent",
+    setCode = "JMP",
+    collectorNumber = "146",
+    scryfallId = "6a636f74-3bac-4b88-a24f-32a66a94e340",
+    artist = "Lius Lasahido",
+    imageUri = "https://cards.scryfall.io/normal/front/6/a/6a636f74-3bac-4b88-a24f-32a66a94e340.jpg?1783930457",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CrypticSerpentScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CrypticSerpentScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Cryptic Serpent's self-cost reduction.
+ *
+ * Oracle: "This spell costs {1} less to cast for each instant and sorcery card in your graveyard."
+ *
+ * Base cost is {5}{U}{U} — 5 generic plus two blue pips. Only the generic portion is reduced, once
+ * per *card* (not once per card type), and only for cards in the caster's own graveyard.
+ */
+class CrypticSerpentScenarioTest : ScenarioTestBase() {
+
+    private fun genericCostFor(game: TestGame): Int =
+        CostCalculator(cardRegistry).calculateEffectiveCost(
+            game.state,
+            cardRegistry.requireCard("Cryptic Serpent"),
+            game.player1Id,
+        ).genericAmount
+
+    init {
+        context("Cryptic Serpent — cost reduction") {
+
+            test("empty graveyard → full 5 generic") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cryptic Serpent")
+                    .build()
+
+                withClue("with no instants or sorceries the generic component stays at 5") {
+                    genericCostFor(game) shouldBe 5
+                }
+            }
+
+            test("one instant and one sorcery → generic reduced by 2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cryptic Serpent")
+                    .withCardInGraveyard(1, "Shock")        // instant
+                    .withCardInGraveyard(1, "Divination")   // sorcery
+                    .build()
+
+                withClue("two matching cards reduce generic from 5 to 3") {
+                    genericCostFor(game) shouldBe 3
+                }
+            }
+
+            test("counts cards, not card types — three instants reduce by 3") {
+                val builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cryptic Serpent")
+                repeat(3) { builder.withCardInGraveyard(1, "Shock") }
+                val game = builder.build()
+
+                withClue("three instant cards give {3} off, not {1} for the 'instant' type") {
+                    genericCostFor(game) shouldBe 2
+                }
+            }
+
+            test("non-instant/sorcery cards in the graveyard do not reduce cost") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cryptic Serpent")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .build()
+
+                withClue("creature cards provide no discount") {
+                    genericCostFor(game) shouldBe 5
+                }
+            }
+
+            test("opponent's instants and sorceries do not reduce cost") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cryptic Serpent")
+                    .withCardInGraveyard(2, "Shock")
+                    .withCardInGraveyard(2, "Divination")
+                    .build()
+
+                withClue("only your own graveyard counts") {
+                    genericCostFor(game) shouldBe 5
+                }
+            }
+
+            test("reduction floors at 0 generic — an overshooting discount never eats the pips") {
+                val builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cryptic Serpent")
+                repeat(8) { builder.withCardInGraveyard(1, "Shock") }
+                val game = builder.build()
+
+                withClue("generic cost floors at 0 even when the discount overshoots") {
+                    genericCostFor(game) shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/AKH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AKH.json
@@ -131,6 +131,43 @@
     ]
 }
 
+// Cryptic Serpent
+{
+    "name": "Cryptic Serpent",
+    "manaCost": "{5}{U}{U}",
+    "typeLine": "Creature — Serpent",
+    "oracleText": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "CardsInGraveyardMatchingFilter",
+                        "filter": "instant|sorcery"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "rarity": "UNCOMMON",
+        "artist": "Lius Lasahido",
+        "flavorText": "It slithers through the senses, constricting consciousness and poisoning perceptions.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/43d11a24-8abf-46ff-8cc6-57b8ac3013f6.jpg?1783936524"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Doomed Dissenter
 {
     "name": "Doomed Dissenter",


### PR DESCRIPTION
Replaces #2013 and #2012. Both were branched off a stale base, so their "re-bless"
commits deleted other people's work and CI failed; this branch is cut from current
`main` and carries only the one genuinely-new card.

## What was wrong with the two open PRs

**#2012 "Add sneaky snacker"** — Sneaky Snacker already ships on `main` (merged as #1950).
Because the branch predates that merge, git renders it as a *modification*, and the
modification is a regression on two counts:

- it swaps `Effects.PutOntoBattlefieldFromGraveyard(Self, tapped = true)` for a raw
  `MoveToZoneEffect(...)`, against the facades-not-raw-constructors rule;
- it widens `triggerZones` from `{GRAVEYARD}` to `{BATTLEFIELD, GRAVEYARD}`. The ability
  only functions in the graveyard (CR 113.6m) — a Snacker already on the battlefield must
  not see your third draw.

Nothing in it is worth salvaging, so this PR does not carry it. #2012 can be closed.

**#2013 "Add cryptic serpent"** — stacked on #2012, so it inherited all of the above, plus
its stale-base re-bless deleted 11 scenario test files (the Pathway cycle, Experimental
Synthesizer, Riverglide) and rewrote 10 snapshot goldens, wiping ~1,000 lines of merged
work. The card definition itself was fine; it is carried over here.

## What this PR contains

- `CrypticSerpent` in **AKH**, its earliest real printing (2017-04-28, #48, uncommon).
  Fields verified field-for-field against Scryfall.
- `Printing` rows in **JMP** (#146) and **J22** (#285) — the other two scaffolded sets that
  print it. GN2, AKR and CMM are not scaffolded, so they get nothing.
- `CrypticSerpentScenarioTest` — six cases: empty graveyard, one instant + one sorcery,
  cards-not-types (three instants → {3} off), non-matching cards, the opponent's graveyard,
  and the floor at 0 generic.
- `AKH.json` snapshot re-blessed. **37 insertions, 1 deletion — nothing else moves.**

The reduction uses `CostReductionSource.CardsInGraveyardMatchingFilter` over
`GameObjectFilter.InstantOrSorcery`. That is the card-counting source, matching the printed
line's "{1} less for each instant and sorcery *card*"; the distinct-types sibling
`CardTypesInYourGraveyard` would cap the discount at {2}, which is a different card.

## Verification

- `just test-class CrypticSerpentScenarioTest` — 6/6 pass
- `just check-card-printing "Cryptic Serpent"` — canonical in earliest real printing, all
  scaffolded reprints have rows
- `:mtg-sets:test` (the `content` CI group, the one red on both PRs) — green
- `just rebless-cards` — only AKH.json moves

🤖 Generated with [Claude Code](https://claude.com/claude-code)
