### PR TITLE
Add 90 Assay-ready cards to Guilds of Ravnica

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/WeeDragonauts.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gpt/cards/WeeDragonauts.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.gpt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wee Dragonauts
+ * {1}{U}{R}
+ * Creature — Faerie Wizard
+ * 1/3
+ * Flying
+ * Whenever you cast an instant or sorcery spell, this creature gets +2/+0 until end of turn.
+ */
+val WeeDragonauts = card("Wee Dragonauts") {
+    manaCost = "{1}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Creature — Faerie Wizard"
+    oracleText = "Flying\n" +
+        "Whenever you cast an instant or sorcery spell, this creature gets +2/+0 until end of turn."
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "137"
+        artist = "Greg Staples"
+        flavorText = "\"The blazekite is a simple concept, really—just a vehicular application of dragscoop ionics and electropropulsion magnetronics.\"\n—Juzba, Izzet tinker"
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/14fd3734-8c28-4bd0-b202-eee1ab98c328.jpg?1783943466"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/RighteousBlow.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/RighteousBlow.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Righteous Blow
+ * {W}
+ * Instant
+ * Righteous Blow deals 2 damage to target attacking or blocking creature.
+ */
+val RighteousBlow = card("Righteous Blow") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Righteous Blow deals 2 damage to target attacking or blocking creature."
+
+    spell {
+        val creature = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Creature.attackingOrBlocking()))
+        )
+        effect = Effects.DealDamage(2, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "34"
+        artist = "Clint Cearley"
+        flavorText = "\"Monsters will no longer find safety under the mists of Morkrut!\"\n—Bruna, Light of Alabaster"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b640fdc-7a19-475e-858f-e159f61e154e.jpg?1783940729"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/ChromaticLanternReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/ChromaticLanternReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chromatic Lantern reprint in C16. Canonical CardDefinition lives in its earliest set.
+ */
+val ChromaticLanternReprint = Printing(
+    oracleId = "539f5396-d99a-417d-a84c-dff7930b5900",
+    name = "Chromatic Lantern",
+    setCode = "C16",
+    collectorNumber = "247",
+    scryfallId = "7ff8e733-877b-46e2-ac80-c51cafe18d3d",
+    artist = "Jung Park",
+    imageUri = "https://cards.scryfall.io/normal/front/7/f/7ff8e733-877b-46e2-ac80-c51cafe18d3d.jpg",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/HitchclawRecluse.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/HitchclawRecluse.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hitchclaw Recluse
+ * {2}{G}
+ * Creature — Spider
+ * 1/4
+ * Reach
+ */
+val HitchclawRecluse = card("Hitchclaw Recluse") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider"
+    oracleText = "Reach"
+    power = 1
+    toughness = 4
+
+    keywords(Keyword.REACH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "181"
+        artist = "Jeff Simpson"
+        flavorText = "Not all spiders need webs to catch their prey."
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bf335eac-e57b-44ec-afe2-8aed567469e7.jpg?1783938322"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/ChromaticLantern.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/ChromaticLantern.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Chromatic Lantern
+ * {3}
+ * Artifact
+ * Lands you control have "{T}: Add one mana of any color."
+ * {T}: Add one mana of any color.
+ */
+val ChromaticLantern = card("Chromatic Lantern") {
+    manaCost = "{3}"
+    typeLine = "Artifact"
+    oracleText = "Lands you control have \"{T}: Add one mana of any color.\"\n" +
+        "{T}: Add one mana of any color."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Tap,
+                effect = Effects.AddAnyColorMana(1),
+                isManaAbility = true,
+                timing = TimingRule.ManaAbility
+            ),
+            filter = GroupFilter(GameObjectFilter.Land.youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "226"
+        artist = "Jung Park"
+        flavorText = "Dimir mages put the lanterns to good use, creating shapeshifters and sleeper agents from mana foreign to them."
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/57f4e0f0-13d1-43ed-8d95-13cff94a26e7.jpg?1783940325"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/GenerousStrayReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/GenerousStrayReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Generous Stray reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val GenerousStrayReprint = Printing(
+    oracleId = "5722a13f-7d70-438c-94ba-97a3f53fbc5c",
+    name = "Generous Stray",
+    setCode = "ANB",
+    collectorNumber = "95",
+    scryfallId = "728b74b7-9d2d-4d91-a036-e9a3dc49bc7f",
+    artist = "Milivoj Ćeran",
+    imageUri = "https://cards.scryfall.io/normal/front/7/2/728b74b7-9d2d-4d91-a036-e9a3dc49bc7f.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/InescapableBlazeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/InescapableBlazeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inescapable Blaze reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val InescapableBlazeReprint = Printing(
+    oracleId = "5fcc057e-e6c2-4e37-a786-9a5ef94926e1",
+    name = "Inescapable Blaze",
+    setCode = "ANB",
+    collectorNumber = "76",
+    scryfallId = "a5e77225-3b31-49ba-909c-b0c2b3aaeb9b",
+    artist = "Steve Argyle",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a5e77225-3b31-49ba-909c-b0c2b3aaeb9b.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/GuildsOfRavnicaSet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/GuildsOfRavnicaSet.kt
@@ -21,6 +21,10 @@ object GuildsOfRavnicaSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/ArboretumElemental.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/ArboretumElemental.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arboretum Elemental
+ * {7}{G}{G}
+ * Creature — Elemental
+ * 7/5
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * Hexproof (This creature can't be the target of spells or abilities your opponents control.)
+ */
+val ArboretumElemental = card("Arboretum Elemental") {
+    manaCost = "{7}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Hexproof (This creature can't be the target of spells or abilities your opponents control.)"
+    power = 7
+    toughness = 5
+
+    keywords(Keyword.CONVOKE, Keyword.HEXPROOF)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "122"
+        artist = "James Paick"
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6f4400bf-134b-4011-985d-eed4e5ba1de8.jpg?1783934157"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/ArtfulTakedown.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/ArtfulTakedown.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Artful Takedown
+ * {2}{U}{B}
+ * Instant
+ * Choose one or both —
+ * • Tap target creature.
+ * • Target creature gets -2/-4 until end of turn.
+ */
+val ArtfulTakedown = card("Artful Takedown") {
+    manaCost = "{2}{U}{B}"
+    colorIdentity = "BU"
+    typeLine = "Instant"
+    oracleText = "Choose one or both —\n" +
+        "• Tap target creature.\n" +
+        "• Target creature gets -2/-4 until end of turn."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Tap target creature") {
+                val creature = target("target", Targets.Creature)
+                effect = Effects.Tap(creature)
+            }
+            mode("Target creature gets -2/-4 until end of turn") {
+                val creature = target("target", Targets.Creature)
+                effect = Effects.ModifyStats(-2, -4, creature)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "151"
+        artist = "Mike Bierek"
+        flavorText = "Dimir assassinations are choreographed like dance routines. Each challenge is anticipated and countered with graceful ease."
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c9e8f24-af62-4d13-bfed-a8b3294b64c3.jpg?1783934144"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/BarrierOfBones.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/BarrierOfBones.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barrier of Bones
+ * {B}
+ * Creature — Skeleton Wall
+ * 0/3
+ * Defender
+ * When this creature enters, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)
+ */
+val BarrierOfBones = card("Barrier of Bones") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Skeleton Wall"
+    oracleText = "Defender\n" +
+        "When this creature enters, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)"
+    power = 0
+    toughness = 3
+
+    keywords(Keyword.DEFENDER)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.surveil(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "61"
+        artist = "Vincent Proce"
+        flavorText = "The Dimir rarely make statements, but when they do, the message is clear."
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/28129aaf-aaff-47f4-8dd2-8c576c55052c.jpg?1783934180"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/BartizanBats.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/BartizanBats.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bartizan Bats
+ * {3}{B}
+ * Creature — Bat
+ * 3/1
+ * Flying (This creature can't be blocked except by creatures with flying or reach.)
+ */
+val BartizanBats = card("Bartizan Bats") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Bat"
+    oracleText = "Flying (This creature can't be blocked except by creatures with flying or reach.)"
+    power = 3
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "62"
+        artist = "Nils Hamm"
+        flavorText = "\"Bats are welcome to eat thousands of my pets. I have multitudes more that will ultimately eat the bats.\"\n—Izoni"
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/210da4ad-d8c5-436b-b1a4-5233e8074a1b.jpg?1783934180"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/BeastWhisperer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/BeastWhisperer.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Beast Whisperer
+ * {2}{G}{G}
+ * Creature — Elf Druid
+ * 2/3
+ * Whenever you cast a creature spell, draw a card.
+ */
+val BeastWhisperer = card("Beast Whisperer") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid"
+    oracleText = "Whenever you cast a creature spell, draw a card."
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(GameObjectFilter.Creature)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "123"
+        artist = "Matt Stewart"
+        flavorText = "\"The tiniest mouse speaks louder to me than all the festival crowds on Tin Street.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9da6f595-41b2-4e52-b15a-6ad18e4232c7.jpg?1783934153"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/BorosGuildgateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/BorosGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Boros Guildgate reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val BorosGuildgateReprint = Printing(
+    oracleId = "73c423b7-cab8-4e69-8070-9edbf96a6c2c",
+    name = "Boros Guildgate",
+    setCode = "GRN",
+    collectorNumber = "243",
+    scryfallId = "c52ceefc-90d0-49d1-ae54-9a4eab819849",
+    artist = "Titus Lunter",
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c52ceefc-90d0-49d1-ae54-9a4eab819849.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/BorosLocket.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/BorosLocket.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Boros Locket
+ * {3}
+ * Artifact
+ * {T}: Add {R} or {W}.
+ * {R/W}{R/W}{R/W}{R/W}, {T}, Sacrifice this artifact: Draw two cards.
+ */
+val BorosLocket = card("Boros Locket") {
+    manaCost = "{3}"
+    colorIdentity = "RW"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {R} or {W}.\n" +
+        "{R/W}{R/W}{R/W}{R/W}, {T}, Sacrifice this artifact: Draw two cards."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R/W}{R/W}{R/W}{R/W}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "231"
+        artist = "Aaron Miller"
+        flavorText = "\"We pass these along to our fellow soldiers to recognize deeds of valor. It won't stay with you for long.\"\n—Alovnek, Boros guildmage"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e972d97-0df2-44e4-8ff2-cc8707316dc1.jpg?1783934109"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/CandlelightVigil.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/CandlelightVigil.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Candlelight Vigil
+ * {3}{W}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +3/+2 and has vigilance.
+ */
+val CandlelightVigil = card("Candlelight Vigil") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +3/+2 and has vigilance."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(3, 2)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "3"
+        artist = "Alexander Forssberg"
+        flavorText = "Selesnya guildmages do not sleep so the rest of the Conclave can."
+        imageUri = "https://cards.scryfall.io/normal/front/e/9/e920a75f-7dec-4815-a358-e174401da83b.jpg?1783934204"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/ChromaticLanternReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/ChromaticLanternReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chromatic Lantern reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val ChromaticLanternReprint = Printing(
+    oracleId = "539f5396-d99a-417d-a84c-dff7930b5900",
+    name = "Chromatic Lantern",
+    setCode = "GRN",
+    collectorNumber = "233",
+    scryfallId = "ea123356-3055-4e42-b816-ac3c4e9087d1",
+    artist = "Jung Park",
+    imageUri = "https://cards.scryfall.io/normal/front/e/a/ea123356-3055-4e42-b816-ac3c4e9087d1.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/CitywatchSphinx.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/CitywatchSphinx.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Citywatch Sphinx
+ * {5}{U}
+ * Creature — Sphinx
+ * 5/4
+ * Flying
+ * When this creature dies, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)
+ */
+val CitywatchSphinx = card("Citywatch Sphinx") {
+    manaCost = "{5}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sphinx"
+    oracleText = "Flying\n" +
+        "When this creature dies, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)"
+    power = 5
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Patterns.Library.surveil(2)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "33"
+        artist = "Magali Villeneuve"
+        flavorText = "All those who trade in questions must answer to the Dimir."
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b809f89-13c7-4236-86a5-60745defb271.jpg?1783934191"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/CommandTheStorm.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/CommandTheStorm.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Command the Storm
+ * {4}{R}
+ * Instant
+ * Command the Storm deals 5 damage to target creature.
+ */
+val CommandTheStorm = card("Command the Storm") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Command the Storm deals 5 damage to target creature."
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.DealDamage(5, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "94"
+        artist = "Jason Rainville"
+        flavorText = "In the wake of Niv-Mizzet's disappearance, Ral found himself leading the guild. He had dreamed of this day, but couldn't help feeling like a pawn in someone else's game."
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c4144e98-957e-43ac-b107-8ccf450748df.jpg?1783934166"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/CrushContraband.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/CrushContraband.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crush Contraband
+ * {3}{W}
+ * Instant
+ * Choose one or both —
+ * • Exile target artifact.
+ * • Exile target enchantment.
+ */
+val CrushContraband = card("Crush Contraband") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Choose one or both —\n" +
+        "• Exile target artifact.\n" +
+        "• Exile target enchantment."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Exile target artifact") {
+                val artifact = target("target", Targets.Artifact)
+                effect = Effects.Exile(artifact)
+            }
+            mode("Exile target enchantment") {
+                val enchantment = target("target", Targets.Enchantment)
+                effect = Effects.Exile(enchantment)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "7"
+        artist = "Jason A. Engle"
+        flavorText = "The Izzet mage knew she would neither get her thermoinverter back nor have the satisfaction of exploding it herself."
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13e162b3-2e5a-4235-a2a7-1c8e3e9f2c19.jpg?1783934202"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/CrushingCanopyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/CrushingCanopyReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crushing Canopy reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val CrushingCanopyReprint = Printing(
+    oracleId = "618cd1bc-4422-441b-906f-1a209277be93",
+    name = "Crushing Canopy",
+    setCode = "GRN",
+    collectorNumber = "126",
+    scryfallId = "c0c4f213-0ea4-44c0-8429-172a317b77f5",
+    artist = "Simon Dominic",
+    imageUri = "https://cards.scryfall.io/normal/front/c/0/c0c4f213-0ea4-44c0-8429-172a317b77f5.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DawnOfHope.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DawnOfHope.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Dawn of Hope
+ * {1}{W}
+ * Enchantment
+ * Whenever you gain life, you may pay {2}. If you do, draw a card.
+ * {3}{W}: Create a 1/1 white Soldier creature token with lifelink.
+ */
+val DawnOfHope = card("Dawn of Hope") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you gain life, you may pay {2}. If you do, draw a card.\n" +
+        "{3}{W}: Create a 1/1 white Soldier creature token with lifelink."
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = MayPayManaEffect(ManaCost.parse("{2}"), Effects.DrawCards(1))
+    }
+    activatedAbility {
+        cost = Costs.Mana("{3}{W}")
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Soldier"),
+            keywords = setOf(Keyword.LIFELINK)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "8"
+        artist = "Sung Choi"
+        flavorText = "\"To wage war, secure peace within yourself.\"\n—Emmara"
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cf2a9e82-8670-4b7f-b5f0-8e10f8aeff1c.jpg?1783934203"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DeadWeightReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DeadWeightReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dead Weight reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val DeadWeightReprint = Printing(
+    oracleId = "b1804304-fac1-4b19-a48d-6ade9407972a",
+    name = "Dead Weight",
+    setCode = "GRN",
+    collectorNumber = "67",
+    scryfallId = "a1a81554-50d4-4fe0-bf0d-5304f215d19e",
+    artist = "Lake Hurwitz",
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a1a81554-50d4-4fe0-bf0d-5304f215d19e.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DeafeningClarion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DeafeningClarion.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Deafening Clarion
+ * {1}{R}{W}
+ * Sorcery
+ * Choose one or both —
+ * • Deafening Clarion deals 3 damage to each creature.
+ * • Creatures you control gain lifelink until end of turn.
+ */
+val DeafeningClarion = card("Deafening Clarion") {
+    manaCost = "{1}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Sorcery"
+    oracleText = "Choose one or both —\n" +
+        "• Deafening Clarion deals 3 damage to each creature.\n" +
+        "• Creatures you control gain lifelink until end of turn."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Deafening Clarion deals 3 damage to each creature") {
+                effect = Patterns.Group.dealDamageToAll(3, GroupFilter.AllCreatures)
+            }
+            mode("Creatures you control gain lifelink until end of turn") {
+                effect = Patterns.Group.grantKeywordToAll(
+                    Keyword.LIFELINK,
+                    GroupFilter.AllCreaturesYouControl
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "165"
+        artist = "Adam Paquette"
+        flavorText = "\"Commander, what's the signal to attack?\"\n\"You'll know.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1e115a81-001d-4e17-98af-6a63f2b0967f.jpg?1783934138"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DevkarinDissident.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DevkarinDissident.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Devkarin Dissident
+ * {1}{G}
+ * Creature — Elf Warrior
+ * 2/2
+ * {4}{G}: This creature gets +2/+2 until end of turn.
+ */
+val DevkarinDissident = card("Devkarin Dissident") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    oracleText = "{4}{G}: This creature gets +2/+2 until end of turn."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{G}")
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "127"
+        artist = "Mark Zug"
+        flavorText = "\"This is Mileva, in the Tenth. We've got an elf in the plaza with a chip on her shoulder. Actually, it's more of a morningstar.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/490cd287-5f09-442f-9150-4a6ac2cf3e2e.jpg?1783934153"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DimirGuildgateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DimirGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dimir Guildgate reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val DimirGuildgateReprint = Printing(
+    oracleId = "52d14717-0cbc-4d7e-b546-54ea91580338",
+    name = "Dimir Guildgate",
+    setCode = "GRN",
+    collectorNumber = "245",
+    scryfallId = "b7129bdf-de02-4ed2-b5de-f774b8a7d302",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/b/7/b7129bdf-de02-4ed2-b5de-f774b8a7d302.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DimirInformant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DimirInformant.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dimir Informant
+ * {2}{U}
+ * Creature — Human Rogue
+ * 1/4
+ * When this creature enters, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)
+ */
+val DimirInformant = card("Dimir Informant") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Rogue"
+    oracleText = "When this creature enters, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)"
+    power = 1
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.surveil(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Lucas Graciano"
+        flavorText = "The letters arrive, all sealed and read."
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/0230afeb-5ce8-436e-9afc-73cdd7baf424.jpg?1783934190"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DimirLocket.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DimirLocket.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Dimir Locket
+ * {3}
+ * Artifact
+ * {T}: Add {U} or {B}.
+ * {U/B}{U/B}{U/B}{U/B}, {T}, Sacrifice this artifact: Draw two cards.
+ */
+val DimirLocket = card("Dimir Locket") {
+    manaCost = "{3}"
+    colorIdentity = "BU"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {U} or {B}.\n" +
+        "{U/B}{U/B}{U/B}{U/B}, {T}, Sacrifice this artifact: Draw two cards."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U/B}{U/B}{U/B}{U/B}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "234"
+        artist = "Zezhou Chen"
+        flavorText = "\"Wear this, and take your place among the shadows—wise, lethal, and unseen.\"\n—Ivrelya, Dimir spymaster"
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/dfb6810b-9bc9-43c5-8cd9-817b12ee3110.jpg?1783934108"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DoomWhisperer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DoomWhisperer.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Doom Whisperer
+ * {3}{B}{B}
+ * Creature — Nightmare Demon
+ * 6/6
+ * Flying, trample
+ * Pay 2 life: Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)
+ */
+val DoomWhisperer = card("Doom Whisperer") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Nightmare Demon"
+    oracleText = "Flying, trample\n" +
+        "Pay 2 life: Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)"
+    power = 6
+    toughness = 6
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE)
+    activatedAbility {
+        cost = Costs.PayLife(2)
+        effect = Patterns.Library.surveil(2)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "69"
+        artist = "Vincent Proce"
+        flavorText = "The sound of every twisted secret tempts you to hear another."
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0a11ee0d-ff8d-4648-8b4e-29440c135c30.jpg?1783934176"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/ElectrostaticField.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/ElectrostaticField.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Electrostatic Field
+ * {1}{R}
+ * Creature — Wall
+ * 0/4
+ * Defender
+ * Whenever you cast an instant or sorcery spell, this creature deals 1 damage to each opponent.
+ */
+val ElectrostaticField = card("Electrostatic Field") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Wall"
+    oracleText = "Defender\n" +
+        "Whenever you cast an instant or sorcery spell, this creature deals 1 damage to each opponent."
+    power = 0
+    toughness = 4
+
+    keywords(Keyword.DEFENDER)
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "97"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"It's both an ingress-denial mechanism and an attractive hallway light!\"\n—Daxiver, Izzet electromancer"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/7096c9a6-2e73-41f8-b20a-b29a9f0b760c.jpg?1783934165"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/ErstwhileTrooper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/ErstwhileTrooper.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Erstwhile Trooper
+ * {1}{B}{G}
+ * Creature — Zombie Soldier
+ * 2/2
+ * Discard a creature card: This creature gets +2/+2 and gains trample until end of turn. Activate only once each turn.
+ */
+val ErstwhileTrooper = card("Erstwhile Trooper") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Zombie Soldier"
+    oracleText = "Discard a creature card: This creature gets +2/+2 and gains trample until end of turn. Activate only once each turn."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Discard(GameObjectFilter.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self)
+        )
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "169"
+        artist = "Jason A. Engle"
+        flavorText = "\"The Erstwhile—rotten of body and outmoded in dress, but unfailing in loyalty.\"\n—Vraska"
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/351ee4ba-882d-48c1-837d-e9eccc5bc50d.jpg?1783934137"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/FireUrchin.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/FireUrchin.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fire Urchin
+ * {1}{R}
+ * Creature — Elemental
+ * 1/3
+ * Trample
+ * Whenever you cast an instant or sorcery spell, this creature gets +1/+0 until end of turn.
+ */
+val FireUrchin = card("Fire Urchin") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    oracleText = "Trample\n" +
+        "Whenever you cast an instant or sorcery spell, this creature gets +1/+0 until end of turn."
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.TRAMPLE)
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "101"
+        artist = "Deruchenko Alexander"
+        flavorText = "Rain runoff in the Smelting District is known to spontaneously burst into flame."
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3a843ff-6bd0-42d5-9348-44b774d438b1.jpg?1783934164"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/FiremindsResearch.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/FiremindsResearch.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Firemind's Research
+ * {U}{R}
+ * Enchantment
+ * Whenever you cast an instant or sorcery spell, put a charge counter on this enchantment.
+ * {1}{U}, Remove two charge counters from this enchantment: Draw a card.
+ * {1}{R}, Remove five charge counters from this enchantment: It deals 5 damage to any target.
+ */
+val FiremindsResearch = card("Firemind's Research") {
+    manaCost = "{U}{R}"
+    colorIdentity = "RU"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you cast an instant or sorcery spell, put a charge counter on this enchantment.\n" +
+        "{1}{U}, Remove two charge counters from this enchantment: Draw a card.\n" +
+        "{1}{R}, Remove five charge counters from this enchantment: It deals 5 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.AddCounters(Counters.CHARGE, 1, EffectTarget.Self)
+    }
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{U}"),
+            Costs.RemoveCounterFromSelf(Counters.CHARGE, 2)
+        )
+        effect = Effects.DrawCards(1)
+    }
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{R}"),
+            Costs.RemoveCounterFromSelf(Counters.CHARGE, 5)
+        )
+        val any = target("target", Targets.Any)
+        effect = Effects.DealDamage(5, any)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "171"
+        artist = "Grzegorz Rutkowski"
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4bc926b2-1e54-4c62-8b6c-fce4ef013abc.jpg?1783934133"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/FlightOfEquenauts.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/FlightOfEquenauts.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flight of Equenauts
+ * {7}{W}
+ * Creature — Human Knight
+ * 4/5
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * Flying
+ */
+val FlightOfEquenauts = card("Flight of Equenauts") {
+    manaCost = "{7}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Flying"
+    power = 4
+    toughness = 5
+
+    keywords(Keyword.CONVOKE, Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "11"
+        artist = "Zezhou Chen"
+        flavorText = "\"Yes, there's competition between our equenauts and the Boros skyjeks. At least they think it's a competition.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/accfc430-114e-4ce0-93ea-e8900955a71e.jpg?1783934201"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/GatewayPlaza.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/GatewayPlaza.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+
+/**
+ * Gateway Plaza
+ * Land — Gate
+ * This land enters tapped.
+ * When this land enters, sacrifice it unless you pay {1}.
+ * {T}: Add one mana of any color.
+ */
+val GatewayPlaza = card("Gateway Plaza") {
+    manaCost = ""
+    typeLine = "Land — Gate"
+    oracleText = "This land enters tapped.\n" +
+        "When this land enters, sacrifice it unless you pay {1}.\n" +
+        "{T}: Add one mana of any color."
+
+    replacementEffect(EntersTapped())
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = PayOrSufferEffect(cost = Costs.pay.Mana("{1}"), suffer = SacrificeSelfEffect)
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "247"
+        artist = "Jedd Chevrier"
+        flavorText = "The Chamber of the Guildpact stands as a reminder that even the bitterest struggles can end in cooperation."
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d3d5162-126d-4430-9884-8e79afa974c2.jpg?1783934103"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/GenerousStray.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/GenerousStray.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Generous Stray
+ * {2}{G}
+ * Creature — Cat
+ * 1/2
+ * When this creature enters, draw a card.
+ */
+val GenerousStray = card("Generous Stray") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat"
+    oracleText = "When this creature enters, draw a card."
+    power = 1
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "129"
+        artist = "Milivoj Ćeran"
+        flavorText = "Cats place their gifts with care, so that a bare foot will step on them in the middle of the night."
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/3289db66-231f-4370-aca6-644d75bee293.jpg?1783934152"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/GolgariFindbroker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/GolgariFindbroker.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Golgari Findbroker
+ * {B}{B}{G}{G}
+ * Creature — Elf Shaman
+ * 3/4
+ * When this creature enters, return target permanent card from your graveyard to your hand.
+ */
+val GolgariFindbroker = card("Golgari Findbroker") {
+    manaCost = "{B}{B}{G}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Elf Shaman"
+    oracleText = "When this creature enters, return target permanent card from your graveyard to your hand."
+    power = 3
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val card = target("target", TargetObject(filter = TargetFilter.PermanentInYourGraveyard))
+        effect = Effects.ReturnToHand(card)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "175"
+        artist = "Bram Sels"
+        flavorText = "\"We gather the past from surface dwellers and sell it right back to them.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e12bd0e5-db96-4340-9b04-6855fd0fd8b9.jpg?1783934133"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/GolgariGuildgateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/GolgariGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Golgari Guildgate reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val GolgariGuildgateReprint = Printing(
+    oracleId = "fa2da325-6859-45bb-b185-35526b01bcc1",
+    name = "Golgari Guildgate",
+    setCode = "GRN",
+    collectorNumber = "248",
+    scryfallId = "86706d8e-de08-4778-94ba-ae75ed522472",
+    artist = "Eytan Zana",
+    imageUri = "https://cards.scryfall.io/normal/front/8/6/86706d8e-de08-4778-94ba-ae75ed522472.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/GolgariLocket.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/GolgariLocket.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Golgari Locket
+ * {3}
+ * Artifact
+ * {T}: Add {B} or {G}.
+ * {B/G}{B/G}{B/G}{B/G}, {T}, Sacrifice this artifact: Draw two cards.
+ */
+val GolgariLocket = card("Golgari Locket") {
+    manaCost = "{3}"
+    colorIdentity = "BG"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {B} or {G}.\n" +
+        "{B/G}{B/G}{B/G}{B/G}, {T}, Sacrifice this artifact: Draw two cards."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B/G}{B/G}{B/G}{B/G}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "237"
+        artist = "Milivoj Ćeran"
+        flavorText = "\"Wear it at all times. It will guide our reanimators to your corpse.\"\n—Mazirek, kraul death priest"
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1c2e7843-9a87-46cb-be06-6db58649db85.jpg?1783934106"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/GrapplingSundew.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/GrapplingSundew.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Grappling Sundew
+ * {1}{G}
+ * Creature — Plant
+ * 0/4
+ * Defender, reach
+ * {4}{G}: This creature gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy this creature.)
+ */
+val GrapplingSundew = card("Grappling Sundew") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant"
+    oracleText = "Defender, reach\n" +
+        "{4}{G}: This creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy this creature.)"
+    power = 0
+    toughness = 4
+
+    keywords(Keyword.DEFENDER, Keyword.REACH)
+    activatedAbility {
+        cost = Costs.Mana("{4}{G}")
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "131"
+        artist = "Sung Choi"
+        flavorText = "Some rooftop gardens attract bees; others capture dragons."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f74d8d76-8091-424d-ad11-e8a1faae584d.jpg?1783934152"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/GuildsOfRavnicaBasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/GuildsOfRavnicaBasicLands.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Guilds of Ravnica Basic Lands
+ *
+ * One art per basic land type, cards 260-264, all by Richard Wright.
+ */
+
+val GuildsOfRavnicaPlains260 = basicLand("Plains") {
+    collectorNumber = "260"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/b/9/b983acda-68b6-468b-b0c1-aad8b53db49c.jpg?1783934098"
+}
+
+val GuildsOfRavnicaIsland261 = basicLand("Island") {
+    collectorNumber = "261"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/2/9/29bfbf3e-3a6c-40d4-8e1b-255f429de6cc.jpg?1783934098"
+}
+
+val GuildsOfRavnicaSwamp262 = basicLand("Swamp") {
+    collectorNumber = "262"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/b/d/bdd5a7f0-5ad3-44e8-a103-07739fd53630.jpg?1783934097"
+}
+
+val GuildsOfRavnicaMountain263 = basicLand("Mountain") {
+    collectorNumber = "263"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/7/f/7f918a49-a046-4115-80b8-13490ed5cd0a.jpg?1783934096"
+}
+
+val GuildsOfRavnicaForest264 = basicLand("Forest") {
+    collectorNumber = "264"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/d/8/d85892ae-dacd-4a55-a557-9db3c16017c7.jpg?1783934097"
+}
+
+/**
+ * All Guilds of Ravnica basic land variants.
+ */
+val GuildsOfRavnicaBasicLands = listOf(
+    GuildsOfRavnicaPlains260,
+    GuildsOfRavnicaIsland261,
+    GuildsOfRavnicaSwamp262,
+    GuildsOfRavnicaMountain263,
+    GuildsOfRavnicaForest264
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/HiredPoisoner.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/HiredPoisoner.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hired Poisoner
+ * {B}
+ * Creature — Human Assassin
+ * 1/1
+ * Deathtouch
+ */
+val HiredPoisoner = card("Hired Poisoner") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Assassin"
+    oracleText = "Deathtouch"
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "72"
+        artist = "Joe Slucher"
+        flavorText = "\"They don't even feel the cut. I'm ordering a drink in a nearby tavern before anyone notices something's wrong.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bf97e572-90d6-46fc-81c3-956a7ef88983.jpg?1783934175"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/HitchclawRecluseReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/HitchclawRecluseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hitchclaw Recluse reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val HitchclawRecluseReprint = Printing(
+    oracleId = "241ec1fc-cc50-468e-8ee3-f95a82a3e07b",
+    name = "Hitchclaw Recluse",
+    setCode = "GRN",
+    collectorNumber = "133",
+    scryfallId = "fe349432-8726-49cf-ad07-6f8add8f78c8",
+    artist = "Mike Bierek",
+    imageUri = "https://cards.scryfall.io/normal/front/f/e/fe349432-8726-49cf-ad07-6f8add8f78c8.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/HuntedWitness.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/HuntedWitness.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hunted Witness
+ * {W}
+ * Creature — Human
+ * 1/1
+ * When this creature dies, create a 1/1 white Soldier creature token with lifelink.
+ */
+val HuntedWitness = card("Hunted Witness") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human"
+    oracleText = "When this creature dies, create a 1/1 white Soldier creature token with lifelink."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Soldier"),
+            keywords = setOf(Keyword.LIFELINK)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "15"
+        artist = "David Palumbo"
+        flavorText = "He ferried weapons, spells, exotic animals—but his most dangerous cargo was the truth."
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8c31b8e5-2349-4119-9dc2-3e41c5364a78.jpg?1783934200"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/ImperviousGreatwurm.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/ImperviousGreatwurm.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Impervious Greatwurm
+ * {7}{G}{G}{G}
+ * Creature — Wurm
+ * 16/16
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * Indestructible
+ */
+val ImperviousGreatwurm = card("Impervious Greatwurm") {
+    manaCost = "{7}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Indestructible"
+    power = 16
+    toughness = 16
+
+    keywords(Keyword.CONVOKE, Keyword.INDESTRUCTIBLE)
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "273"
+        artist = "Simon Dominic"
+        flavorText = "The ultimate answer to intrigue and subtlety."
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f5e6dc5f-fd83-4166-a5da-cd953722642a.jpg?1783934092"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/InescapableBlaze.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/InescapableBlaze.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inescapable Blaze
+ * {4}{R}{R}
+ * Instant
+ * This spell can't be countered.
+ * Inescapable Blaze deals 6 damage to any target.
+ */
+val InescapableBlaze = card("Inescapable Blaze") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "This spell can't be countered.\n" +
+        "Inescapable Blaze deals 6 damage to any target."
+
+    cantBeCountered = true
+    spell {
+        val any = target("target", Targets.Any)
+        effect = Effects.DealDamage(6, any)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "107"
+        artist = "Steve Argyle"
+        flavorText = "\"The Izzet are blamed for every little disaster, which is unfair because we only cause most of them.\"\n—Mizzix of the Izmagnus"
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/46651efd-0906-4350-a1b8-52e3f8aff45d.jpg?1783934160"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/IronshellBeetleReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/IronshellBeetleReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ironshell Beetle reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val IronshellBeetleReprint = Printing(
+    oracleId = "693ca077-2b91-4de1-8136-8fe45f8ea5a7",
+    name = "Ironshell Beetle",
+    setCode = "GRN",
+    collectorNumber = "134",
+    scryfallId = "57f8b6b0-f858-41d5-9839-fd1247b9477f",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/5/7/57f8b6b0-f858-41d5-9839-fd1247b9477f.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/IzzetGuildgateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/IzzetGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Izzet Guildgate reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val IzzetGuildgateReprint = Printing(
+    oracleId = "bf75a3d1-f184-4b48-a913-21caee1db084",
+    name = "Izzet Guildgate",
+    setCode = "GRN",
+    collectorNumber = "251",
+    scryfallId = "2055a83a-99c8-4808-90b9-1c2fdcda79b4",
+    artist = "Kirsten Zirngibl",
+    imageUri = "https://cards.scryfall.io/normal/front/2/0/2055a83a-99c8-4808-90b9-1c2fdcda79b4.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/IzzetLocket.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/IzzetLocket.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Izzet Locket
+ * {3}
+ * Artifact
+ * {T}: Add {U} or {R}.
+ * {U/R}{U/R}{U/R}{U/R}, {T}, Sacrifice this artifact: Draw two cards.
+ */
+val IzzetLocket = card("Izzet Locket") {
+    manaCost = "{3}"
+    colorIdentity = "RU"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {U} or {R}.\n" +
+        "{U/R}{U/R}{U/R}{U/R}, {T}, Sacrifice this artifact: Draw two cards."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U/R}{U/R}{U/R}{U/R}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "238"
+        artist = "Dmitry Burmak"
+        flavorText = "\"Remember to discharge your locket every seven hours. Unless you prefer the spontaneous aether overload, of course.\"\n—Daxiver, Izzet electromancer"
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/348f3bec-ad16-4bc7-8da9-3956c9900f95.jpg?1783934106"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/KnightOfAutumn.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/KnightOfAutumn.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.withId
+
+/**
+ * Knight of Autumn
+ * {1}{G}{W}
+ * Creature — Dryad Knight
+ * 2/1
+ * When this creature enters, choose one —
+ * • Put two +1/+1 counters on this creature.
+ * • Destroy target artifact or enchantment.
+ * • You gain 4 life.
+ */
+val KnightOfAutumn = card("Knight of Autumn") {
+    manaCost = "{1}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Dryad Knight"
+    oracleText = "When this creature enters, choose one —\n" +
+        "• Put two +1/+1 counters on this creature.\n" +
+        "• Destroy target artifact or enchantment.\n" +
+        "• You gain 4 life."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect(
+            modes = listOf(
+                Mode.noTarget(
+                    Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+                ),
+                Mode.withTarget(
+                    Effects.Destroy(EffectTarget.BoundVariable("target")),
+                    Targets.ArtifactOrEnchantment.withId("target")
+                ),
+                Mode.noTarget(Effects.GainLife(4))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "183"
+        artist = "Ryan Pancoast"
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/3028075c-5fc5-4942-a984-1ffcf7a8933d.jpg?1783934130"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/KraulRaider.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/KraulRaider.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kraul Raider
+ * {2}{B}
+ * Creature — Insect Warrior
+ * 2/3
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ */
+val KraulRaider = card("Kraul Raider") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect Warrior"
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)"
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.MENACE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "270"
+        artist = "Ben Wootten"
+        flavorText = "The kraul once skulked in the outskirts of Golgari society, but with Vraska's rise, they became valued forces of the Swarm."
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/133d9d56-d906-4252-9954-e34cc8564ced.jpg?1783934094"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/KraulSwarm.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/KraulSwarm.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kraul Swarm
+ * {4}{B}
+ * Creature — Insect Warrior
+ * 4/1
+ * Flying
+ * {2}{B}, Discard a creature card: Return this card from your graveyard to your hand.
+ */
+val KraulSwarm = card("Kraul Swarm") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect Warrior"
+    oracleText = "Flying\n" +
+        "{2}{B}, Discard a creature card: Return this card from your graveyard to your hand."
+    power = 4
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}"), Costs.Discard(GameObjectFilter.Creature))
+        effect = Effects.ReturnToHandFromGraveyard(EffectTarget.Self)
+        activateFromZone = Zone.GRAVEYARD
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "73"
+        artist = "Jehan Choo"
+        flavorText = "The hive has a long memory. It knows how every member ever died, and to whom it owes the grudge."
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/490dc165-b10d-4384-8c13-d7969844b2bb.jpg?1783934174"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/LedevGuardian.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/LedevGuardian.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ledev Guardian
+ * {3}{W}
+ * Creature — Human Knight
+ * 2/4
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ */
+val LedevGuardian = card("Ledev Guardian") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)"
+    power = 2
+    toughness = 4
+
+    keywords(Keyword.CONVOKE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Kimonas Theodossiou"
+        flavorText = "\"I've raised her since she was a pup, and she's raised me since I was a recruit.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cbeb4ae3-2a7a-44e1-923b-20c772fd1b8b.jpg?1783934198"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/LoxodonRestorer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/LoxodonRestorer.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Loxodon Restorer
+ * {4}{W}{W}
+ * Creature — Elephant Cleric
+ * 3/4
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * When this creature enters, you gain 4 life.
+ */
+val LoxodonRestorer = card("Loxodon Restorer") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elephant Cleric"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "When this creature enters, you gain 4 life."
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.CONVOKE)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(4)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1ead2166-a7ca-49cb-bf93-2f59c37b4cb9.jpg?1783934196"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/Molderhulk.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/Molderhulk.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Molderhulk
+ * {7}{B}{G}
+ * Creature — Fungus Zombie
+ * 6/6
+ * Undergrowth — This spell costs {1} less to cast for each creature card in your graveyard.
+ * When this creature enters, return target land card from your graveyard to the battlefield.
+ */
+val Molderhulk = card("Molderhulk") {
+    manaCost = "{7}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Fungus Zombie"
+    oracleText = "Undergrowth — This spell costs {1} less to cast for each creature card in your graveyard.\n" +
+        "When this creature enters, return target land card from your graveyard to the battlefield."
+    power = 6
+    toughness = 6
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.CardsInGraveyardMatchingFilter(GameObjectFilter.Creature)
+            )
+        )
+    }
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val land = target(
+            "target",
+            TargetObject(
+                filter = TargetFilter(GameObjectFilter.Land.ownedByYou(), zone = Zone.GRAVEYARD)
+            )
+        )
+        effect = Effects.PutOntoBattlefieldFromGraveyard(land)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "190"
+        artist = "Titus Lunter"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba88e031-b194-4621-9e97-2f33ee46f6d0.jpg?1783934125"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/MuseDrake.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/MuseDrake.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Muse Drake
+ * {3}{U}
+ * Creature — Drake
+ * 1/3
+ * Flying
+ * When this creature enters, draw a card.
+ */
+val MuseDrake = card("Muse Drake") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    oracleText = "Flying\n" +
+        "When this creature enters, draw a card."
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "46"
+        artist = "Titus Lunter"
+        flavorText = "A composer wrote a symphony based on the drakes screeching outside her window. Reviews were mixed—except among the drakes."
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5df7a96-6548-41c0-85a6-e0c4566e0fe6.jpg?1783934187"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/NightveilPredator.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/NightveilPredator.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nightveil Predator
+ * {U}{U}{B}{B}
+ * Creature — Vampire
+ * 3/3
+ * Flying, deathtouch
+ * Hexproof (This creature can't be the target of spells or abilities your opponents control.)
+ */
+val NightveilPredator = card("Nightveil Predator") {
+    manaCost = "{U}{U}{B}{B}"
+    colorIdentity = "BU"
+    typeLine = "Creature — Vampire"
+    oracleText = "Flying, deathtouch\n" +
+        "Hexproof (This creature can't be the target of spells or abilities your opponents control.)"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH, Keyword.HEXPROOF)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "191"
+        artist = "Darek Zabrocki"
+        flavorText = "\"Three daggers left in an angel's back, three enforcers with memory loss, three keys stolen from my own belt—and you talk of peace?\"\n—Tajic, to Aurelia"
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/193289c9-837d-4d18-9ef1-720e8e335e62.jpg?1783934125"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/NightveilSprite.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/NightveilSprite.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nightveil Sprite
+ * {1}{U}
+ * Creature — Faerie Rogue
+ * 1/2
+ * Flying
+ * Whenever this creature attacks, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)
+ */
+val NightveilSprite = card("Nightveil Sprite") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Rogue"
+    oracleText = "Flying\n" +
+        "Whenever this creature attacks, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)"
+    power = 1
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Patterns.Library.surveil(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "48"
+        artist = "Uriah Voth"
+        flavorText = "\"We're on the fortieth floor, with one window, no balcony. No one could possibly get in.\"\n—Minosz, Orzhov chief of security"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/534d1166-4e01-4ec8-b4d9-e76861ec51b9.jpg?1783934187"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/PacksFavor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/PacksFavor.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pack's Favor
+ * {2}{G}
+ * Instant
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * Target creature gets +3/+3 until end of turn.
+ */
+val PacksFavor = card("Pack's Favor") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Target creature gets +3/+3 until end of turn."
+
+    keywords(Keyword.CONVOKE)
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(3, 3, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "139"
+        artist = "Lius Lasahido"
+        flavorText = "Selesnya grows its ranks in more ways than one."
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f88c3aa-63e1-4617-bf1f-48f44988e7d6.jpg?1783934147"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/PasswallAdept.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/PasswallAdept.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Passwall Adept
+ * {1}{U}
+ * Creature — Human Wizard
+ * 1/3
+ * {2}{U}: Target creature can't be blocked this turn.
+ */
+val PasswallAdept = card("Passwall Adept") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "{2}{U}: Target creature can't be blocked this turn."
+    power = 1
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{U}")
+        val creature = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "John Thacker"
+        flavorText = "\"My doors are called trespassing, my signatures, forgeries. They don't respect my talents, and I don't respect their labels.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a8ed28c3-8c66-4883-8774-67ac5ab9e81c.jpg?1783934185"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/PauseForReflection.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/PauseForReflection.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pause for Reflection
+ * {2}{G}
+ * Instant
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * Prevent all combat damage that would be dealt this turn.
+ */
+val PauseForReflection = card("Pause for Reflection") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Prevent all combat damage that would be dealt this turn."
+
+    keywords(Keyword.CONVOKE)
+    spell {
+        effect = Effects.PreventAllCombatDamage()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "140"
+        artist = "Alayna Danner"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3cfcf84c-a30c-4c4f-9f8c-ee807661e499.jpg?1783934148"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/PitilessGorgon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/PitilessGorgon.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pitiless Gorgon
+ * {1}{B/G}{B/G}
+ * Creature — Gorgon
+ * 2/2
+ * Deathtouch
+ */
+val PitilessGorgon = card("Pitiless Gorgon") {
+    manaCost = "{1}{B/G}{B/G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Gorgon"
+    oracleText = "Deathtouch"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "218"
+        artist = "Alex Konstad"
+        flavorText = "\"The reign of the Swarm begins. Let us rise now and dress ourselves in vengeance.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1a925a0-9d26-441b-8b4a-0614a0485fe6.jpg?1783934114"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/PortcullisVine.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/PortcullisVine.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Portcullis Vine
+ * {G}
+ * Creature — Plant Wall
+ * 0/3
+ * Defender (This creature can't attack.)
+ * {2}, {T}, Sacrifice a creature with defender: Draw a card.
+ */
+val PortcullisVine = card("Portcullis Vine") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Wall"
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "{2}, {T}, Sacrifice a creature with defender: Draw a card."
+    power = 0
+    toughness = 3
+
+    keywords(Keyword.DEFENDER)
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Tap,
+            Costs.Sacrifice(GameObjectFilter.Creature.withKeyword(Keyword.DEFENDER))
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "James Paick"
+        flavorText = "Nature's way of saying \"take the long way home.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5b6dab62-b747-4d76-9fa8-4914582fc212.jpg?1783934148"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/PrecisionBolt.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/PrecisionBolt.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Precision Bolt
+ * {2}{R}
+ * Sorcery
+ * Precision Bolt deals 3 damage to any target.
+ */
+val PrecisionBolt = card("Precision Bolt") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Precision Bolt deals 3 damage to any target."
+
+    spell {
+        val any = target("target", Targets.Any)
+        effect = Effects.DealDamage(3, any)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "267"
+        artist = "Grzegorz Rutkowski"
+        flavorText = "Ral had wielded lightning all his life but had never harnessed the power of an entire guild."
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a59b4e5b-e9e0-4507-b9e7-8fba7e3a54f9.jpg?1783934094"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/RampagingMonument.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/RampagingMonument.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rampaging Monument
+ * {4}
+ * Artifact Creature — Cleric
+ * 0/0
+ * Trample
+ * This creature enters with three +1/+1 counters on it.
+ * Whenever you cast a multicolored spell, put a +1/+1 counter on this creature.
+ */
+val RampagingMonument = card("Rampaging Monument") {
+    manaCost = "{4}"
+    typeLine = "Artifact Creature — Cleric"
+    oracleText = "Trample\n" +
+        "This creature enters with three +1/+1 counters on it.\n" +
+        "Whenever you cast a multicolored spell, put a +1/+1 counter on this creature."
+    power = 0
+    toughness = 0
+
+    keywords(Keyword.TRAMPLE)
+    replacementEffect(EntersWithCounters(count = 3, selfOnly = true))
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(GameObjectFilter.Multicolored)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "239"
+        artist = "Tyler Walpole"
+        flavorText = "\"Be advised: suspect is nine stories tall, marble hair, answers to Saint Gusztav.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5fbe445-a788-4624-8ecf-8bc06c3ca8f8.jpg?1783934106"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/RhizomeLurcher.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/RhizomeLurcher.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+
+/**
+ * Rhizome Lurcher
+ * {2}{B}{G}
+ * Creature — Fungus Zombie
+ * 2/2
+ * Undergrowth — This creature enters with a number of +1/+1 counters on it equal to the number of creature cards in your graveyard.
+ */
+val RhizomeLurcher = card("Rhizome Lurcher") {
+    manaCost = "{2}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Fungus Zombie"
+    oracleText = "Undergrowth — This creature enters with a number of +1/+1 counters on it equal to the number of creature cards in your graveyard."
+    power = 2
+    toughness = 2
+
+    replacementEffect(
+        EntersWithDynamicCounters(count = DynamicAmounts.creatureCardsInYourGraveyard())
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "196"
+        artist = "Mathias Kollros"
+        flavorText = "\"The dead gain new purpose here. What is strange in the eyes of other guilds is harmonious in ours.\"\n—Devesh, Golgari shaman"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db9ce92b-79cc-4e26-b511-30ae8ea6a2a1.jpg?1783934125"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/RighteousBlowReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/RighteousBlowReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Righteous Blow reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val RighteousBlowReprint = Printing(
+    oracleId = "bc2bf46f-2c9b-4f85-b8d6-d13a3b64436d",
+    name = "Righteous Blow",
+    setCode = "GRN",
+    collectorNumber = "23",
+    scryfallId = "b4501520-acf4-438f-9e96-4a649875ffdd",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b4501520-acf4-438f-9e96-4a649875ffdd.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/RitualOfSoot.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/RitualOfSoot.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Ritual of Soot
+ * {2}{B}{B}
+ * Sorcery
+ * Destroy all creatures with mana value 3 or less.
+ */
+val RitualOfSoot = card("Ritual of Soot") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all creatures with mana value 3 or less."
+
+    spell {
+        effect = Effects.DestroyAll(GameObjectFilter.Creature.manaValueAtMost(3))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "84"
+        artist = "Dimitar Marinski"
+        flavorText = "Only the patrol's armor was found, so tainted with the acrid smell of sudden death that it could never be worn again."
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/269af993-4894-4bf1-b55a-af4d736cb3cc.jpg?1783934172"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/RocCharger.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/RocCharger.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Roc Charger
+ * {2}{W}
+ * Creature — Bird
+ * 1/3
+ * Flying
+ * Whenever this creature attacks, target attacking creature without flying gains flying until end of turn.
+ */
+val RocCharger = card("Roc Charger") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird"
+    oracleText = "Flying\n" +
+        "Whenever this creature attacks, target attacking creature without flying gains flying until end of turn."
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val flyer = target(
+            "target",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.withoutKeyword(Keyword.FLYING).attacking()
+                )
+            )
+        )
+        effect = Effects.GrantKeyword(Keyword.FLYING, flyer)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "24"
+        artist = "Titus Lunter"
+        flavorText = "Rocs' innate fearlessness makes them ideal mounts for emergency response."
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/4932c635-b729-4348-92de-2c1b207ea460.jpg?1783934195"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/RosemaneCentaur.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/RosemaneCentaur.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rosemane Centaur
+ * {3}{G}{W}
+ * Creature — Centaur Soldier
+ * 4/4
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * Vigilance
+ */
+val RosemaneCentaur = card("Rosemane Centaur") {
+    manaCost = "{3}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Centaur Soldier"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "Vigilance"
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.CONVOKE, Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "197"
+        artist = "Nils Hamm"
+        flavorText = "\"I long for peaceful times, when I may tend to my garden instead of our borders.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/cee30585-f7b1-4ca4-8171-dc5a837f2b93.jpg?1783934126"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/RubblebeltBoar.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/RubblebeltBoar.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rubblebelt Boar
+ * {3}{R}
+ * Creature — Boar
+ * 3/3
+ * When this creature enters, target creature gets +2/+0 until end of turn.
+ */
+val RubblebeltBoar = card("Rubblebelt Boar") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Boar"
+    oracleText = "When this creature enters, target creature gets +2/+0 until end of turn."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(2, 0, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "114"
+        artist = "Tomasz Jedruszek"
+        flavorText = "Some Gruul druids believe that boars are spawn of the great Ilharg, the mighty Raze-Boar who will one day rise and level the city."
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/196bf114-e135-43f3-83d5-cb08ca766881.jpg?1783934159"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SelesnyaGuildgateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SelesnyaGuildgateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Selesnya Guildgate reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val SelesnyaGuildgateReprint = Printing(
+    oracleId = "75b235d3-595a-4859-be45-9559d8445db5",
+    name = "Selesnya Guildgate",
+    setCode = "GRN",
+    collectorNumber = "255",
+    scryfallId = "6d5ee7a5-937a-4c2b-af8c-6e5734677c53",
+    artist = "Dimitar Marinski",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6d5ee7a5-937a-4c2b-af8c-6e5734677c53.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SelesnyaLocket.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SelesnyaLocket.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Selesnya Locket
+ * {3}
+ * Artifact
+ * {T}: Add {G} or {W}.
+ * {G/W}{G/W}{G/W}{G/W}, {T}, Sacrifice this artifact: Draw two cards.
+ */
+val SelesnyaLocket = card("Selesnya Locket") {
+    manaCost = "{3}"
+    colorIdentity = "GW"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {G} or {W}.\n" +
+        "{G/W}{G/W}{G/W}{G/W}, {T}, Sacrifice this artifact: Draw two cards."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G/W}{G/W}{G/W}{G/W}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "240"
+        artist = "Winona Nelson"
+        flavorText = "\"Think of the locket as a seed you bear, spreading life from Vitu-Ghazi across all of Ravnica.\"\n—Heruj, Selesnya hierophant"
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea0c04b9-c7fc-4204-9af2-5d1987bdd97e.jpg?1783934106"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SiegeWurmReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SiegeWurmReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Siege Wurm reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val SiegeWurmReprint = Printing(
+    oracleId = "8a802eae-abfb-47fd-8458-1689055531ef",
+    name = "Siege Wurm",
+    setCode = "GRN",
+    collectorNumber = "144",
+    scryfallId = "2d1dfd96-8e17-4ba8-b786-a5cc0ae2ff2d",
+    artist = "Filip Burburan",
+    imageUri = "https://cards.scryfall.io/normal/front/2/d/2d1dfd96-8e17-4ba8-b786-a5cc0ae2ff2d.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SilentDart.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SilentDart.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silent Dart
+ * {1}
+ * Artifact
+ * {4}, {T}, Sacrifice this artifact: It deals 3 damage to target creature.
+ */
+val SilentDart = card("Silent Dart") {
+    manaCost = "{1}"
+    typeLine = "Artifact"
+    oracleText = "{4}, {T}, Sacrifice this artifact: It deals 3 damage to target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap, Costs.SacrificeSelf)
+        val creature = target("target", Targets.Creature)
+        effect = Effects.DealDamage(3, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "241"
+        artist = "Yeong-Hao Han"
+        flavorText = "\"These terms are acceptable to House Dimir. Shall we shake on it?\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3af00fdd-6869-4080-8a75-66c8fceeb7de.jpg?1783934106"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SkyknightLegionnaireReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SkyknightLegionnaireReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skyknight Legionnaire reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val SkyknightLegionnaireReprint = Printing(
+    oracleId = "61178a6c-70b7-447d-87ee-a8d9369c3d15",
+    name = "Skyknight Legionnaire",
+    setCode = "GRN",
+    collectorNumber = "198",
+    scryfallId = "3c27f2ce-702a-4ec2-a470-982171a9ec73",
+    artist = "Chase Stone",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3c27f2ce-702a-4ec2-a470-982171a9ec73.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SkylineScout.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SkylineScout.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Skyline Scout
+ * {1}{W}
+ * Creature — Human Scout
+ * 2/1
+ * Whenever this creature attacks, you may pay {1}{W}. If you do, it gains flying until end of turn.
+ */
+val SkylineScout = card("Skyline Scout") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Scout"
+    oracleText = "Whenever this creature attacks, you may pay {1}{W}. If you do, it gains flying until end of turn."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = MayPayManaEffect(
+            ManaCost.parse("{1}{W}"),
+            Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "Paul Scott Canavan"
+        flavorText = "\"Sometimes an angel passes by and gives me a little nod, like, 'You're a daring one!' That always makes my day.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b052b641-fce9-45c1-a15b-1e22f1a64e4d.jpg?1783934195"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SmeltWardMinotaur.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SmeltWardMinotaur.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Smelt-Ward Minotaur
+ * {2}{R}
+ * Creature — Minotaur Warrior
+ * 2/3
+ * Whenever you cast an instant or sorcery spell, target creature an opponent controls can't block this turn.
+ */
+val SmeltWardMinotaur = card("Smelt-Ward Minotaur") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Warrior"
+    oracleText = "Whenever you cast an instant or sorcery spell, target creature an opponent controls can't block this turn."
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        val creature = target("target", Targets.CreatureOpponentControls)
+        effect = Effects.CantBlock(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "116"
+        artist = "Wisnu Tan"
+        flavorText = "\"Don't arrest him—enlist him!\"\n—Commander Yaszen"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f851d74e-90ad-417f-8372-8437d2d68b0d.jpg?1783934157"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SpinalCentipede.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SpinalCentipede.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spinal Centipede
+ * {2}{B}
+ * Creature — Insect
+ * 3/2
+ * When this creature dies, put a +1/+1 counter on target creature you control.
+ */
+val SpinalCentipede = card("Spinal Centipede") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect"
+    oracleText = "When this creature dies, put a +1/+1 counter on target creature you control."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val creature = target("target", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86"
+        artist = "Zezhou Chen"
+        flavorText = "The Golgari adorn themselves with the exoskeletons of iridescent insects. It's only fair the insects do likewise."
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/74d579fb-615a-43a6-a1c1-c535087abf2a.jpg?1783934169"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SumalaWoodshaper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SumalaWoodshaper.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sumala Woodshaper
+ * {2}{G}{W}
+ * Creature — Elf Druid
+ * 2/1
+ * When this creature enters, look at the top four cards of your library. You may reveal a creature or enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
+ */
+val SumalaWoodshaper = card("Sumala Woodshaper") {
+    manaCost = "{2}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Elf Druid"
+    oracleText = "When this creature enters, look at the top four cards of your library. You may reveal a creature or enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.lookAtTopRevealMatchingToHand(
+            count = DynamicAmount.Fixed(4),
+            filter = GameObjectFilter.CreatureOrEnchantment,
+            prompt = "You may reveal a creature or enchantment card from among them and " +
+                "put it into your hand"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "200"
+        artist = "Sara Winters"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8c4e427e-c061-43c5-9e8e-34bf5b447ab1.jpg?1783934124"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SureStrikeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SureStrikeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sure Strike reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val SureStrikeReprint = Printing(
+    oracleId = "fb694e7e-f66e-4958-b6ed-aa74bc9ac43e",
+    name = "Sure Strike",
+    setCode = "GRN",
+    collectorNumber = "118",
+    scryfallId = "8d01f1ce-9931-4712-a907-72c2c6d5ee76",
+    artist = "Steve Argyle",
+    imageUri = "https://cards.scryfall.io/normal/front/8/d/8d01f1ce-9931-4712-a907-72c2c6d5ee76.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SwarmGuildmage.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SwarmGuildmage.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Swarm Guildmage
+ * {B}{G}
+ * Creature — Elf Shaman
+ * 2/2
+ * {4}{B}, {T}: Creatures you control get +1/+0 and gain menace until end of turn. (They can't be blocked except by two or more creatures.)
+ * {1}{G}, {T}: You gain 2 life.
+ */
+val SwarmGuildmage = card("Swarm Guildmage") {
+    manaCost = "{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Elf Shaman"
+    oracleText = "{4}{B}, {T}: Creatures you control get +1/+0 and gain menace until end of turn. (They can't be blocked except by two or more creatures.)\n" +
+        "{1}{G}, {T}: You gain 2 life."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{B}"), Costs.Tap)
+        effect = Patterns.Group.pumpAndGrantToAll(
+            power = 1,
+            toughness = 0,
+            keyword = Keyword.MENACE,
+            filter = GroupFilter.AllCreaturesYouControl
+        )
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{G}"), Costs.Tap)
+        effect = Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "201"
+        artist = "Simon Dominic"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/7599adc7-72b2-4079-ac0a-1a821f9de925.jpg?1783934123"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SwornCompanions.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/SwornCompanions.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sworn Companions
+ * {2}{W}
+ * Sorcery
+ * Create two 1/1 white Soldier creature tokens with lifelink.
+ */
+val SwornCompanions = card("Sworn Companions") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Create two 1/1 white Soldier creature tokens with lifelink."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Soldier"),
+            keywords = setOf(Keyword.LIFELINK),
+            count = 2
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "27"
+        artist = "Jason Rainville"
+        flavorText = "\"The trouble with youths these days is that, in outright defiance of their elders, they refuse to be bought.\"\n—Karlov of the Ghost Council"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2ccfa5c1-69f9-4351-aba3-883fe92c9b98.jpg?1783934194"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/TakeHeart.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/TakeHeart.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Take Heart
+ * {W}
+ * Instant
+ * Target creature gets +2/+2 until end of turn. You gain 1 life for each attacking creature you control.
+ */
+val TakeHeart = card("Take Heart") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+2 until end of turn. You gain 1 life for each attacking creature you control."
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2, creature),
+            Effects.GainLife(DynamicAmounts.attackingCreaturesYouControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "28"
+        artist = "Lucas Graciano"
+        flavorText = "In the quiet before a battle, Boros soldiers whisper prayers that steady their nerves and focus their minds."
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b26f10d5-b826-45b0-abed-80d86e1335c9.jpg?1783934194"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/TenthDistrictGuard.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/TenthDistrictGuard.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tenth District Guard
+ * {1}{W}
+ * Creature — Human Soldier
+ * 2/2
+ * When this creature enters, target creature gets +0/+1 until end of turn.
+ */
+val TenthDistrictGuard = card("Tenth District Guard") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "When this creature enters, target creature gets +0/+1 until end of turn."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(0, 1, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Craig J Spearing"
+        flavorText = "\"The Tenth has always been my home. This city is constantly embroiled in one crisis or another, but I'm determined to protect my piece.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/829f959e-91cd-42ea-8644-ce828a304d01.jpg?1783934193"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/VedalkenMesmerist.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/VedalkenMesmerist.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vedalken Mesmerist
+ * {1}{U}
+ * Creature — Vedalken Wizard
+ * 2/1
+ * Whenever this creature attacks, target creature an opponent controls gets -2/-0 until end of turn.
+ */
+val VedalkenMesmerist = card("Vedalken Mesmerist") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Vedalken Wizard"
+    oracleText = "Whenever this creature attacks, target creature an opponent controls gets -2/-0 until end of turn."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val creature = target("target", Targets.CreatureOpponentControls)
+        effect = Effects.ModifyStats(-2, 0, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "57"
+        artist = "Zezhou Chen"
+        flavorText = "\"There's no need to sound the alarm. You are minding your post admirably. I am authorized. All is well.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5b5e0a12-2589-473b-90e4-1ee5acc055a2.jpg?1783934181"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/VeiledShade.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/VeiledShade.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Veiled Shade
+ * {2}{B}
+ * Creature — Shade
+ * 2/2
+ * {1}{B}: This creature gets +1/+1 until end of turn.
+ */
+val VeiledShade = card("Veiled Shade") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Shade"
+    oracleText = "{1}{B}: This creature gets +1/+1 until end of turn."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{B}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "88"
+        artist = "Anna Steinbauer"
+        flavorText = "\"I sang songs of sorrow for my lost love. Imagine my horror when, one night, they were answered.\"\n—Milana, Orzhov prelate"
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/35cb18ae-0229-40a1-8838-ffb678ab2ed9.jpg?1783934169"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/VernadiShieldmate.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/VernadiShieldmate.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vernadi Shieldmate
+ * {1}{G/W}
+ * Creature — Human Soldier
+ * 2/2
+ * Vigilance
+ */
+val VernadiShieldmate = card("Vernadi Shieldmate") {
+    manaCost = "{1}{G/W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "Vigilance"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "219"
+        artist = "Matt Stewart"
+        flavorText = "\"Selesnya's soil is sacred, and you're about to meet it with your face.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/efddad21-553e-4947-80d2-833b42c45f77.jpg?1783934114"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WallOfMistReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WallOfMistReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Mist reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val WallOfMistReprint = Printing(
+    oracleId = "b2ca8824-6bd8-4aa3-b156-618118eb98a4",
+    name = "Wall of Mist",
+    setCode = "GRN",
+    collectorNumber = "58",
+    scryfallId = "62a37646-8f7c-40fc-851d-e3fdd205b012",
+    artist = "Tianhua X",
+    imageUri = "https://cards.scryfall.io/normal/front/6/2/62a37646-8f7c-40fc-851d-e3fdd205b012.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WaryOkapi.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WaryOkapi.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wary Okapi
+ * {2}{G}
+ * Creature — Antelope
+ * 3/2
+ * Vigilance
+ */
+val WaryOkapi = card("Wary Okapi") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Antelope"
+    oracleText = "Vigilance"
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "149"
+        artist = "Jason Felix"
+        flavorText = "\"Be like the grazers of the Saruli. Keep your herd close, and stay alert for encroaching danger.\"\n—Lalia, Selesnya dryad"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/54f26697-0d4b-4af4-a644-3d0ae13f1d2e.jpg?1783934144"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WatcherInTheMist.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WatcherInTheMist.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Watcher in the Mist
+ * {3}{U}{U}
+ * Creature — Spirit
+ * 3/4
+ * Flying
+ * When this creature enters, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)
+ */
+val WatcherInTheMist = card("Watcher in the Mist") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    oracleText = "Flying\n" +
+        "When this creature enters, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)"
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.surveil(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "Ryan Yee"
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb971f49-8898-444a-a17c-caeb1696c62a.jpg?1783934181"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WeeDragonautsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WeeDragonautsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wee Dragonauts reprint in GRN. Canonical CardDefinition lives in its earliest set.
+ */
+val WeeDragonautsReprint = Printing(
+    oracleId = "e9e56b1d-5ad2-4807-8c4c-1a1a6a25ecbf",
+    name = "Wee Dragonauts",
+    setCode = "GRN",
+    collectorNumber = "214",
+    scryfallId = "37ee17a1-76ce-4ae8-9109-ba32457cbeec",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/3/7/37ee17a1-76ce-4ae8-9109-ba32457cbeec.jpg",
+    releaseDate = "2018-10-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WhisperAgent.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WhisperAgent.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Whisper Agent
+ * {1}{U/B}{U/B}
+ * Creature — Human Rogue
+ * 3/2
+ * Flash
+ * When this creature enters, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)
+ */
+val WhisperAgent = card("Whisper Agent") {
+    manaCost = "{1}{U/B}{U/B}"
+    colorIdentity = "BU"
+    typeLine = "Creature — Human Rogue"
+    oracleText = "Flash\n" +
+        "When this creature enters, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)"
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.FLASH)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.surveil(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "220"
+        artist = "Deruchenko Alexander"
+        flavorText = "He has a job to finish, and it's you."
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6d318e7-f49e-49f8-98b6-d62c34aa4af2.jpg?1783934113"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WorldsoulColossus.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WorldsoulColossus.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Worldsoul Colossus
+ * {X}{G}{W}
+ * Creature — Elemental
+ * 0/0
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * This creature enters with X +1/+1 counters on it.
+ */
+val WorldsoulColossus = card("Worldsoul Colossus") {
+    manaCost = "{X}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Elemental"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\n" +
+        "This creature enters with X +1/+1 counters on it."
+    power = 0
+    toughness = 0
+
+    keywords(Keyword.CONVOKE)
+    replacementEffect(EntersWithDynamicCounters(count = DynamicAmount.XValue))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "215"
+        artist = "James Paick"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5186304-b0fb-44a6-ba61-0265b7f42da4.jpg?1783934117"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DawnOfHopeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DawnOfHopeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dawn of Hope reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val DawnOfHopeReprint = Printing(
+    oracleId = "d7a38484-2acc-49a6-b32d-d54dddb14d31",
+    name = "Dawn of Hope",
+    setCode = "J22",
+    collectorNumber = "169",
+    scryfallId = "6f66cf2f-191d-4cbf-a340-a516973a7751",
+    artist = "Sung Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/6/f/6f66cf2f-191d-4cbf-a340-a516973a7751.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KraulSwarmReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KraulSwarmReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kraul Swarm reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val KraulSwarmReprint = Printing(
+    oracleId = "ac97d8fc-15fa-4a60-96d3-4c09deafa83a",
+    name = "Kraul Swarm",
+    setCode = "J22",
+    collectorNumber = "432",
+    scryfallId = "d5758460-d1bc-49ba-80de-c0849958f705",
+    artist = "Jehan Choo",
+    imageUri = "https://cards.scryfall.io/normal/front/d/5/d5758460-d1bc-49ba-80de-c0849958f705.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/TakeHeartReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/TakeHeartReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Take Heart reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val TakeHeartReprint = Printing(
+    oracleId = "2c5e30c3-0b9f-4d3e-af44-be7fcd34df25",
+    name = "Take Heart",
+    setCode = "JMP",
+    collectorNumber = "134",
+    scryfallId = "457eb507-bbbf-4064-bdb0-cfeefe2195df",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/4/5/457eb507-bbbf-4064-bdb0-cfeefe2195df.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/BeastWhispererReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/BeastWhispererReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Beast Whisperer reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val BeastWhispererReprint = Printing(
+    oracleId = "5da7eea8-bb9e-47ce-a554-8a1ee058bd7a",
+    name = "Beast Whisperer",
+    setCode = "KHC",
+    collectorNumber = "54",
+    scryfallId = "b7e90355-80ca-49db-914c-62b3a7bd4726",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/b/7/b7e90355-80ca-49db-914c-62b3a7bd4726.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/GolgariFindbrokerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/GolgariFindbrokerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Golgari Findbroker reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val GolgariFindbrokerReprint = Printing(
+    oracleId = "e5456b35-d7a9-4717-90df-c6c46f1ec437",
+    name = "Golgari Findbroker",
+    setCode = "KHC",
+    collectorNumber = "86",
+    scryfallId = "26413356-327c-494b-a895-0a0ddd466242",
+    artist = "Bram Sels",
+    imageUri = "https://cards.scryfall.io/normal/front/2/6/26413356-327c-494b-a895-0a0ddd466242.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/WallOfMist.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/WallOfMist.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Mist
+ * {1}{U}
+ * Creature — Wall
+ * 0/5
+ * Defender
+ */
+val WallOfMist = card("Wall of Mist") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Wall"
+    oracleText = "Defender"
+    power = 0
+    toughness = 5
+
+    keywords(Keyword.DEFENDER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "83"
+        artist = "Dimitar Marinski"
+        flavorText = "The seafloor is flecked with the bones of fools who dared to sail into the mist."
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4fb995c8-1bc2-4ff4-b8e9-f9b6bc0de0fe.jpg?1783934577"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/BartizanBatsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/BartizanBatsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bartizan Bats reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val BartizanBatsReprint = Printing(
+    oracleId = "6987d5d4-0ef6-4326-a590-678ac160fe56",
+    name = "Bartizan Bats",
+    setCode = "M20",
+    collectorNumber = "319",
+    scryfallId = "445e41d8-317d-46ce-b858-54df716e0214",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/4/4/445e41d8-317d-46ce-b858-54df716e0214.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/PortcullisVineReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/PortcullisVineReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Portcullis Vine reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val PortcullisVineReprint = Printing(
+    oracleId = "a217f386-11b5-48f0-b173-3b0700ba295f",
+    name = "Portcullis Vine",
+    setCode = "M21",
+    collectorNumber = "195",
+    scryfallId = "d1abd95a-4ecc-479c-b200-5aaf7c993ef8",
+    artist = "James Paick",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d1abd95a-4ecc-479c-b200-5aaf7c993ef8.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/SilentDartReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/SilentDartReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silent Dart reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val SilentDartReprint = Printing(
+    oracleId = "912bc348-9ba3-4001-90a8-104d2bb17527",
+    name = "Silent Dart",
+    setCode = "M21",
+    collectorNumber = "237",
+    scryfallId = "4e12530d-5509-46f1-8273-dce2c1f60965",
+    artist = "Yeong-Hao Han",
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4e12530d-5509-46f1-8273-dce2c1f60965.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GatewayPlazaReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/GatewayPlazaReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gateway Plaza reprint in RNA. Canonical CardDefinition lives in its earliest set.
+ */
+val GatewayPlazaReprint = Printing(
+    oracleId = "a6543f71-0326-4e1f-b58f-9ce325d5d036",
+    name = "Gateway Plaza",
+    setCode = "RNA",
+    collectorNumber = "247",
+    scryfallId = "3433a2c2-d252-4cd8-97e8-389875b2cda0",
+    artist = "Jedd Chevrier",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/3433a2c2-d252-4cd8-97e8-389875b2cda0.jpg",
+    releaseDate = "2019-01-25",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/CrushContrabandReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/CrushContrabandReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crush Contraband reprint in VOC. Canonical CardDefinition lives in its earliest set.
+ */
+val CrushContrabandReprint = Printing(
+    oracleId = "ecbc234d-e1d3-4bcc-81d4-fffc2c7ea16a",
+    name = "Crush Contraband",
+    setCode = "VOC",
+    collectorNumber = "81",
+    scryfallId = "db041d7f-253f-4643-b635-24d0e79695af",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/d/b/db041d7f-253f-4643-b635-24d0e79695af.jpg",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/GatewayPlazaReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/GatewayPlazaReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gateway Plaza reprint in WAR. Canonical CardDefinition lives in its earliest set.
+ */
+val GatewayPlazaReprint = Printing(
+    oracleId = "a6543f71-0326-4e1f-b58f-9ce325d5d036",
+    name = "Gateway Plaza",
+    setCode = "WAR",
+    collectorNumber = "246",
+    scryfallId = "81d69cf2-8643-4926-857e-febbd54d870f",
+    artist = "Sung Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/81d69cf2-8643-4926-857e-febbd54d870f.jpg",
+    releaseDate = "2019-05-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MolderhulkScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/MolderhulkScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario coverage for Molderhulk (GRN #190).
+ *
+ * {7}{B}{G} Creature — Fungus Zombie 6/6
+ * "Undergrowth — This spell costs {1} less to cast for each creature card in your graveyard.
+ *  When this creature enters, return target land card from your graveyard to the battlefield."
+ *
+ * Undergrowth as a cost reduction rather than a counter count: it reduces only the *generic*
+ * portion, so {B}{G} is still owed no matter how full the graveyard is. The two halves read
+ * different piles — the discount counts creature cards, the trigger returns a land card.
+ */
+class MolderhulkScenarioTest : ScenarioTestBase() {
+
+    private val costCalculator by lazy { CostCalculator(cardRegistry) }
+
+    init {
+        context("Molderhulk") {
+
+            fun board(creatureCardsInGraveyard: Int, landsInGraveyard: Int = 1) = run {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Molderhulk")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                repeat(creatureCardsInGraveyard) {
+                    builder = builder.withCardInGraveyard(1, "Centaur Courser")
+                }
+                repeat(landsInGraveyard) { builder = builder.withCardInGraveyard(1, "Mountain") }
+                builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+            }
+
+            test("each creature card in your graveyard shaves {1} off the generic cost") {
+                val game = board(creatureCardsInGraveyard = 4)
+
+                withClue("{7} generic minus four creature cards") {
+                    costCalculator.calculateEffectiveCost(
+                        game.state,
+                        cardRegistry.requireCard("Molderhulk"),
+                        game.player1Id
+                    ).genericAmount shouldBe 3
+                }
+            }
+
+            test("the discount never eats the coloured pips") {
+                val game = board(creatureCardsInGraveyard = 12)
+
+                val cost = costCalculator.calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Molderhulk"),
+                    game.player1Id
+                )
+                withClue("twelve creature cards floor the generic at zero") {
+                    cost.genericAmount shouldBe 0
+                }
+                withClue("{B}{G} is still owed") {
+                    cost.colorCount[Color.BLACK] shouldBe 1
+                    cost.colorCount[Color.GREEN] shouldBe 1
+                }
+            }
+
+            test("it returns a land card from your graveyard to the battlefield on entry") {
+                val game = board(creatureCardsInGraveyard = 3)
+                val land = game.findCardsInGraveyard(1, "Mountain").single()
+
+                game.castSpell(1, "Molderhulk").error shouldBe null
+                game.resolveStack()
+                game.selectTargets(listOf(land))
+                game.resolveStack()
+
+                withClue("the Mountain leaves the graveyard for the battlefield") {
+                    game.findCardsInGraveyard(1, "Mountain").size shouldBe 0
+                    game.findPermanent("Mountain") shouldBe land
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RhizomeLurcherScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RhizomeLurcherScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario coverage for Rhizome Lurcher (GRN #196).
+ *
+ * {2}{B}{G} Creature — Fungus Zombie 2/2
+ * "Undergrowth — This creature enters with a number of +1/+1 counters on it equal to the number
+ *  of creature cards in your graveyard."
+ *
+ * Undergrowth's first appearance in the corpus. The count is read as the permanent *enters*
+ * (a replacement effect, CR 614.1c), so it is fixed at entry rather than re-read afterwards, and
+ * only creature cards in *your* graveyard count — an opponent's graveyard and your non-creature
+ * cards are both invisible to it.
+ */
+class RhizomeLurcherScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Rhizome Lurcher") {
+
+            fun board(
+                yourCreatureCards: Int,
+                yourNoncreatureCards: Int = 0,
+                opponentCreatureCards: Int = 0,
+            ) = run {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Rhizome Lurcher")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                repeat(yourCreatureCards) { builder = builder.withCardInGraveyard(1, "Centaur Courser") }
+                repeat(yourNoncreatureCards) { builder = builder.withCardInGraveyard(1, "Shock") }
+                repeat(opponentCreatureCards) { builder = builder.withCardInGraveyard(2, "Centaur Courser") }
+                builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+            }
+
+            test("enters with one +1/+1 counter per creature card in your graveyard") {
+                val game = board(yourCreatureCards = 3)
+
+                game.castSpell(1, "Rhizome Lurcher").error shouldBe null
+                game.resolveStack()
+
+                val lurcher = game.findPermanent("Rhizome Lurcher")!!
+                val projected = projector.project(game.state)
+                withClue("2/2 base plus three counters") {
+                    projected.getPower(lurcher) shouldBe 5
+                    projected.getToughness(lurcher) shouldBe 5
+                }
+            }
+
+            test("only creature cards in YOUR graveyard count") {
+                val game = board(
+                    yourCreatureCards = 1,
+                    yourNoncreatureCards = 4,
+                    opponentCreatureCards = 4,
+                )
+
+                game.castSpell(1, "Rhizome Lurcher").error shouldBe null
+                game.resolveStack()
+
+                val lurcher = game.findPermanent("Rhizome Lurcher")!!
+                withClue("one counter — the instants and the opponent's creatures are invisible") {
+                    projector.project(game.state).getPower(lurcher) shouldBe 3
+                }
+            }
+
+            test("an empty graveyard leaves it a plain 2/2") {
+                val game = board(yourCreatureCards = 0)
+
+                game.castSpell(1, "Rhizome Lurcher").error shouldBe null
+                game.resolveStack()
+
+                val lurcher = game.findPermanent("Rhizome Lurcher")!!
+                val projected = projector.project(game.state)
+                projected.getPower(lurcher) shouldBe 2
+                projected.getToughness(lurcher) shouldBe 2
+            }
+        }
+    }
+}

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/ChromaticLanternReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/ChromaticLanternReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chromatic Lantern reprint in MSC. Canonical CardDefinition lives in its earliest set.
+ */
+val ChromaticLanternReprint = Printing(
+    oracleId = "539f5396-d99a-417d-a84c-dff7930b5900",
+    name = "Chromatic Lantern",
+    setCode = "MSC",
+    collectorNumber = "195",
+    scryfallId = "693da13a-49af-4f7e-b247-36b454fb31a0",
+    artist = "Rytis Sabaliauskas",
+    imageUri = "https://cards.scryfall.io/normal/front/6/9/693da13a-49af-4f7e-b247-36b454fb31a0.jpg",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -2282,6 +2282,58 @@
     ]
 }
 
+// Righteous Blow
+{
+    "name": "Righteous Blow",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Righteous Blow deals 2 damage to target attacking or blocking creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "artist": "Clint Cearley",
+        "flavorText": "\"Monsters will no longer find safety under the mists of Morkrut!\"\n—Bruna, Light of Alabaster",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b640fdc-7a19-475e-858f-e159f61e154e.jpg?1783940729"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Scrapskin Drake
 {
     "name": "Scrapskin Drake",

--- a/mtg-sets/src/test/resources/snapshots/cards/GPT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GPT.json
@@ -984,6 +984,65 @@
     ]
 }
 
+// Wee Dragonauts
+{
+    "name": "Wee Dragonauts",
+    "manaCost": "{1}{U}{R}",
+    "typeLine": "Creature — Faerie Wizard",
+    "oracleText": "Flying\nWhenever you cast an instant or sorcery spell, this creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "artist": "Greg Staples",
+        "flavorText": "\"The blazekite is a simple concept, really—just a vehicular application of dragscoop ionics and electropropulsion magnetronics.\"\n—Juzba, Izzet tinker",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/14fd3734-8c28-4bd0-b202-eee1ab98c328.jpg?1783943466"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // Wild Cantor
 {
     "name": "Wild Cantor",

--- a/mtg-sets/src/test/resources/snapshots/cards/GRN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GRN.json
@@ -50,6 +50,104 @@
     ]
 }
 
+// Arboretum Elemental
+{
+    "name": "Arboretum Elemental",
+    "manaCost": "{7}{G}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 5
+    },
+    "keywords": [
+        "CONVOKE",
+        "HEXPROOF"
+    ],
+    "metadata": {
+        "collectorNumber": "122",
+        "rarity": "UNCOMMON",
+        "artist": "James Paick",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6f4400bf-134b-4011-985d-eed4e5ba1de8.jpg?1783934157"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Artful Takedown
+{
+    "name": "Artful Takedown",
+    "manaCost": "{2}{U}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one or both —\n• Tap target creature.\n• Target creature gets -2/-4 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Tap target creature"
+                },
+                {
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": -4
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target creature gets -2/-4 until end of turn"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "artist": "Mike Bierek",
+        "flavorText": "Dimir assassinations are choreographed like dance routines. Each challenge is anticipated and countered with graceful ease.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c9e8f24-af62-4d13-bfed-a8b3294b64c3.jpg?1783934144"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
 // Assassin's Trophy
 {
     "name": "Assassin's Trophy",
@@ -154,6 +252,180 @@
     ]
 }
 
+// Barrier of Bones
+{
+    "name": "Barrier of Bones",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Skeleton Wall",
+    "oracleText": "Defender\nWhen this creature enters, surveil 1. (Look at the top card of your library. You may put that card into your graveyard.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Surveil",
+                    "count": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "artist": "Vincent Proce",
+        "flavorText": "The Dimir rarely make statements, but when they do, the message is clear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/28129aaf-aaff-47f4-8dd2-8c576c55052c.jpg?1783934180"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Bartizan Bats
+{
+    "name": "Bartizan Bats",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Bat",
+    "oracleText": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "62",
+        "artist": "Nils Hamm",
+        "flavorText": "\"Bats are welcome to eat thousands of my pets. I have multitudes more that will ultimately eat the bats.\"\n—Izoni",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/210da4ad-d8c5-436b-b1a4-5233e8074a1b.jpg?1783934180"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Beast Whisperer
+{
+    "name": "Beast Whisperer",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "Whenever you cast a creature spell, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "rarity": "RARE",
+        "artist": "Matt Stewart",
+        "flavorText": "\"The tiniest mouse speaks louder to me than all the festival crowds on Tin Street.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9da6f595-41b2-4e52-b15a-6ad18e4232c7.jpg?1783934153"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Boros Locket
+{
+    "name": "Boros Locket",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {R} or {W}.\n{R/W}{R/W}{R/W}{R/W}, {T}, Sacrifice this artifact: Draw two cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R/W}{R/W}{R/W}{R/W}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "artist": "Aaron Miller",
+        "flavorText": "\"We pass these along to our fellow soldiers to recognize deeds of valor. It won't stay with you for long.\"\n—Alovnek, Boros guildmage",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e972d97-0df2-44e4-8ff2-cc8707316dc1.jpg?1783934109"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Burglar Rat
 {
     "name": "Burglar Rat",
@@ -224,6 +496,42 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Candlelight Vigil
+{
+    "name": "Candlelight Vigil",
+    "manaCost": "{3}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +3/+2 and has vigilance.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "artist": "Alexander Forssberg",
+        "flavorText": "Selesnya guildmages do not sleep so the rest of the Conclave can.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/9/e920a75f-7dec-4815-a358-e174401da83b.jpg?1783934204"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -303,6 +611,481 @@
     ]
 }
 
+// Citywatch Sphinx
+{
+    "name": "Citywatch Sphinx",
+    "manaCost": "{5}{U}",
+    "typeLine": "Creature — Sphinx",
+    "oracleText": "Flying\nWhen this creature dies, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Surveil",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "rarity": "UNCOMMON",
+        "artist": "Magali Villeneuve",
+        "flavorText": "All those who trade in questions must answer to the Dimir.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b809f89-13c7-4236-86a5-60745defb271.jpg?1783934191"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Command the Storm
+{
+    "name": "Command the Storm",
+    "manaCost": "{4}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Command the Storm deals 5 damage to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "artist": "Jason Rainville",
+        "flavorText": "In the wake of Niv-Mizzet's disappearance, Ral found himself leading the guild. He had dreamed of this day, but couldn't help feeling like a pawn in someone else's game.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c4144e98-957e-43ac-b107-8ccf450748df.jpg?1783934166"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Crush Contraband
+{
+    "name": "Crush Contraband",
+    "manaCost": "{3}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one or both —\n• Exile target artifact.\n• Exile target enchantment.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Exile"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Exile target artifact"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Exile"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Exile target enchantment"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "rarity": "UNCOMMON",
+        "artist": "Jason A. Engle",
+        "flavorText": "The Izzet mage knew she would neither get her thermoinverter back nor have the satisfaction of exploding it herself.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13e162b3-2e5a-4235-a2a7-1c8e3e9f2c19.jpg?1783934202"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Dawn of Hope
+{
+    "name": "Dawn of Hope",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you gain life, you may pay {2}. If you do, draw a card.\n{3}{W}: Create a 1/1 white Soldier creature token with lifelink.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{2}"
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Soldier"
+                    ],
+                    "keywords": [
+                        "LIFELINK"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "rarity": "RARE",
+        "artist": "Sung Choi",
+        "flavorText": "\"To wage war, secure peace within yourself.\"\n—Emmara",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/f/cf2a9e82-8670-4b7f-b5f0-8e10f8aeff1c.jpg?1783934203"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Deafening Clarion
+{
+    "name": "Deafening Clarion",
+    "manaCost": "{1}{R}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one or both —\n• Deafening Clarion deals 3 damage to each creature.\n• Creatures you control gain lifelink until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        },
+                        "body": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Deafening Clarion deals 3 damage to each creature"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "GrantKeyword",
+                            "keyword": "LIFELINK",
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Creatures you control gain lifelink until end of turn"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "RARE",
+        "artist": "Adam Paquette",
+        "flavorText": "\"Commander, what's the signal to attack?\"\n\"You'll know.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e115a81-001d-4e17-98af-6a63f2b0967f.jpg?1783934138"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Devkarin Dissident
+{
+    "name": "Devkarin Dissident",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "{4}{G}: This creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "artist": "Mark Zug",
+        "flavorText": "\"This is Mileva, in the Tenth. We've got an elf in the plaza with a chip on her shoulder. Actually, it's more of a morningstar.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/490cd287-5f09-442f-9150-4a6ac2cf3e2e.jpg?1783934153"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Dimir Informant
+{
+    "name": "Dimir Informant",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "When this creature enters, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Surveil",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Lucas Graciano",
+        "flavorText": "The letters arrive, all sealed and read.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/0230afeb-5ce8-436e-9afc-73cdd7baf424.jpg?1783934190"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Dimir Locket
+{
+    "name": "Dimir Locket",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {U} or {B}.\n{U/B}{U/B}{U/B}{U/B}, {T}, Sacrifice this artifact: Draw two cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U/B}{U/B}{U/B}{U/B}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "234",
+        "artist": "Zezhou Chen",
+        "flavorText": "\"Wear this, and take your place among the shadows—wise, lethal, and unseen.\"\n—Ivrelya, Dimir spymaster",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/dfb6810b-9bc9-43c5-8cd9-817b12ee3110.jpg?1783934108"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
+// Doom Whisperer
+{
+    "name": "Doom Whisperer",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Nightmare Demon",
+    "oracleText": "Flying, trample\nPay 2 life: Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomPayLife",
+                        "amount": 2
+                    }
+                },
+                "effect": {
+                    "type": "Surveil",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "rarity": "MYTHIC",
+        "artist": "Vincent Proce",
+        "flavorText": "The sound of every twisted secret tempts you to hear another.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0a11ee0d-ff8d-4648-8b4e-29440c135c30.jpg?1783934176"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Douser of Lights
 {
     "name": "Douser of Lights",
@@ -323,6 +1106,125 @@
     ]
 }
 
+// Electrostatic Field
+{
+    "name": "Electrostatic Field",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender\nWhenever you cast an instant or sorcery spell, this creature deals 1 damage to each opponent.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"It's both an ingress-denial mechanism and an attractive hallway light!\"\n—Daxiver, Izzet electromancer",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/7096c9a6-2e73-41f8-b20a-b29a9f0b760c.jpg?1783934165"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Erstwhile Trooper
+{
+    "name": "Erstwhile Trooper",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Creature — Zombie Soldier",
+    "oracleText": "Discard a creature card: This creature gets +2/+2 and gains trample until end of turn. Activate only once each turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomDiscard",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "TRAMPLE",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "OncePerTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "169",
+        "artist": "Jason A. Engle",
+        "flavorText": "\"The Erstwhile—rotten of body and outmoded in dress, but unfailing in loyalty.\"\n—Vraska",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/351ee4ba-882d-48c1-837d-e9eccc5bc50d.jpg?1783934137"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Fearless Halberdier
 {
     "name": "Fearless Halberdier",
@@ -340,6 +1242,464 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Fire Urchin
+{
+    "name": "Fire Urchin",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Trample\nWhenever you cast an instant or sorcery spell, this creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "Rain runoff in the Smelting District is known to spontaneously burst into flame.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3a843ff-6bd0-42d5-9348-44b774d438b1.jpg?1783934164"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Firemind's Research
+{
+    "name": "Firemind's Research",
+    "manaCost": "{U}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you cast an instant or sorcery spell, put a charge counter on this enchantment.\n{1}{U}, Remove two charge counters from this enchantment: Draw a card.\n{1}{R}, Remove five charge counters from this enchantment: It deals 5 damage to any target.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "charge",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                },
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "RARE",
+        "artist": "Grzegorz Rutkowski",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4bc926b2-1e54-4c62-8b6c-fce4ef013abc.jpg?1783934133"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
+}
+
+// Flight of Equenauts
+{
+    "name": "Flight of Equenauts",
+    "manaCost": "{7}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nFlying",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "CONVOKE",
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "11",
+        "rarity": "UNCOMMON",
+        "artist": "Zezhou Chen",
+        "flavorText": "\"Yes, there's competition between our equenauts and the Boros skyjeks. At least they think it's a competition.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/accfc430-114e-4ce0-93ea-e8900955a71e.jpg?1783934201"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Gateway Plaza
+{
+    "name": "Gateway Plaza",
+    "manaCost": "",
+    "typeLine": "Land — Gate",
+    "oracleText": "This land enters tapped.\nWhen this land enters, sacrifice it unless you pay {1}.\n{T}: Add one mana of any color.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{1}"
+                        }
+                    },
+                    "suffer": "SacrificeSelf"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "artist": "Jedd Chevrier",
+        "flavorText": "The Chamber of the Guildpact stands as a reminder that even the bitterest struggles can end in cooperation.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d3d5162-126d-4430-9884-8e79afa974c2.jpg?1783934103"
+    }
+}
+
+// Generous Stray
+{
+    "name": "Generous Stray",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "When this creature enters, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "artist": "Milivoj Ćeran",
+        "flavorText": "Cats place their gifts with care, so that a bare foot will step on them in the middle of the night.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/3289db66-231f-4370-aca6-644d75bee293.jpg?1783934152"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Golgari Findbroker
+{
+    "name": "Golgari Findbroker",
+    "manaCost": "{B}{B}{G}{G}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "When this creature enters, return target permanent card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "175",
+        "rarity": "UNCOMMON",
+        "artist": "Bram Sels",
+        "flavorText": "\"We gather the past from surface dwellers and sell it right back to them.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e12bd0e5-db96-4340-9b04-6855fd0fd8b9.jpg?1783934133"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Golgari Locket
+{
+    "name": "Golgari Locket",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {B} or {G}.\n{B/G}{B/G}{B/G}{B/G}, {T}, Sacrifice this artifact: Draw two cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B/G}{B/G}{B/G}{B/G}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "artist": "Milivoj Ćeran",
+        "flavorText": "\"Wear it at all times. It will guide our reanimators to your corpse.\"\n—Mazirek, kraul death priest",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1c2e7843-9a87-46cb-be06-6db58649db85.jpg?1783934106"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Grappling Sundew
+{
+    "name": "Grappling Sundew",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Plant",
+    "oracleText": "Defender, reach\n{4}{G}: This creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy this creature.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER",
+        "REACH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "rarity": "UNCOMMON",
+        "artist": "Sung Choi",
+        "flavorText": "Some rooftop gardens attract bees; others capture dragons.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f74d8d76-8091-424d-ad11-e8a1faae584d.jpg?1783934152"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -365,6 +1725,141 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Hired Poisoner
+{
+    "name": "Hired Poisoner",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Human Assassin",
+    "oracleText": "Deathtouch",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "72",
+        "artist": "Joe Slucher",
+        "flavorText": "\"They don't even feel the cut. I'm ordering a drink in a nearby tavern before anyone notices something's wrong.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bf97e572-90d6-46fc-81c3-956a7ef88983.jpg?1783934175"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Hunted Witness
+{
+    "name": "Hunted Witness",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human",
+    "oracleText": "When this creature dies, create a 1/1 white Soldier creature token with lifelink.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Soldier"
+                    ],
+                    "keywords": [
+                        "LIFELINK"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "artist": "David Palumbo",
+        "flavorText": "He ferried weapons, spells, exotic animals—but his most dangerous cargo was the truth.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8c31b8e5-2349-4119-9dc2-3e41c5364a78.jpg?1783934200"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Impervious Greatwurm
+{
+    "name": "Impervious Greatwurm",
+    "manaCost": "{7}{G}{G}{G}",
+    "typeLine": "Creature — Wurm",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nIndestructible",
+    "creatureStats": {
+        "power": 16,
+        "toughness": 16
+    },
+    "keywords": [
+        "CONVOKE",
+        "INDESTRUCTIBLE"
+    ],
+    "metadata": {
+        "collectorNumber": "273",
+        "rarity": "MYTHIC",
+        "artist": "Simon Dominic",
+        "flavorText": "The ultimate answer to intrigue and subtlety.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5e6dc5f-fd83-4166-a5da-cd953722642a.jpg?1783934092"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Inescapable Blaze
+{
+    "name": "Inescapable Blaze",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Instant",
+    "oracleText": "This spell can't be countered.\nInescapable Blaze deals 6 damage to any target.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 6
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Argyle",
+        "flavorText": "\"The Izzet are blamed for every little disaster, which is unfair because we only cause most of them.\"\n—Mizzix of the Izmagnus",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/46651efd-0906-4350-a1b8-52e3f8aff45d.jpg?1783934160"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -414,6 +1909,294 @@
         "artist": "Even Amundsen",
         "flavorText": "There are two lives: the life you live before you see a unicorn, and the life you live after.",
         "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce8b745e-1e62-4c54-9e73-e2d0a40568a0.jpg?1783934199"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Izzet Locket
+{
+    "name": "Izzet Locket",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {U} or {R}.\n{U/R}{U/R}{U/R}{U/R}, {T}, Sacrifice this artifact: Draw two cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U/R}{U/R}{U/R}{U/R}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "artist": "Dmitry Burmak",
+        "flavorText": "\"Remember to discharge your locket every seven hours. Unless you prefer the spontaneous aether overload, of course.\"\n—Daxiver, Izzet electromancer",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/4/348f3bec-ad16-4bc7-8da9-3956c9900f95.jpg?1783934106"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
+}
+
+// Knight of Autumn
+{
+    "name": "Knight of Autumn",
+    "manaCost": "{1}{G}{W}",
+    "typeLine": "Creature — Dryad Knight",
+    "oracleText": "When this creature enters, choose one —\n• Put two +1/+1 counters on this creature.\n• Destroy target artifact or enchantment.\n• You gain 4 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 2,
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "artifact|enchantment"
+                                    },
+                                    "id": "target"
+                                }
+                            ]
+                        },
+                        {
+                            "effect": {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "rarity": "RARE",
+        "artist": "Ryan Pancoast",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/3028075c-5fc5-4942-a984-1ffcf7a8933d.jpg?1783934130"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Kraul Raider
+{
+    "name": "Kraul Raider",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Insect Warrior",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "metadata": {
+        "collectorNumber": "270",
+        "artist": "Ben Wootten",
+        "flavorText": "The kraul once skulked in the outskirts of Golgari society, but with Vraska's rise, they became valued forces of the Swarm.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/133d9d56-d906-4252-9954-e34cc8564ced.jpg?1783934094"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Kraul Swarm
+{
+    "name": "Kraul Swarm",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Insect Warrior",
+    "oracleText": "Flying\n{2}{B}, Discard a creature card: Return this card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomDiscard",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand",
+                    "fromZone": "Graveyard"
+                },
+                "activateFromZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "rarity": "UNCOMMON",
+        "artist": "Jehan Choo",
+        "flavorText": "The hive has a long memory. It knows how every member ever died, and to whom it owes the grudge.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/490dc165-b10d-4384-8c13-d7969844b2bb.jpg?1783934174"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Ledev Guardian
+{
+    "name": "Ledev Guardian",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "CONVOKE"
+    ],
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Kimonas Theodossiou",
+        "flavorText": "\"I've raised her since she was a pup, and she's raised me since I was a recruit.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cbeb4ae3-2a7a-44e1-923b-20c772fd1b8b.jpg?1783934198"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Loxodon Restorer
+{
+    "name": "Loxodon Restorer",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Creature — Elephant Cleric",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nWhen this creature enters, you gain 4 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "Svetlin Velinov",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1ead2166-a7ca-49cb-bf93-2f59c37b4cb9.jpg?1783934196"
     },
     "colorIdentityOverride": [
         "WHITE"
@@ -516,6 +2299,1137 @@
     ]
 }
 
+// Molderhulk
+{
+    "name": "Molderhulk",
+    "manaCost": "{7}{B}{G}",
+    "typeLine": "Creature — Fungus Zombie",
+    "oracleText": "Undergrowth — This spell costs {1} less to cast for each creature card in your graveyard.\nWhen this creature enters, return target land card from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "land own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "CardsInGraveyardMatchingFilter",
+                        "filter": "creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "190",
+        "rarity": "UNCOMMON",
+        "artist": "Titus Lunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba88e031-b194-4621-9e97-2f33ee46f6d0.jpg?1783934125"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Muse Drake
+{
+    "name": "Muse Drake",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying\nWhen this creature enters, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "artist": "Titus Lunter",
+        "flavorText": "A composer wrote a symphony based on the drakes screeching outside her window. Reviews were mixed—except among the drakes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5df7a96-6548-41c0-85a6-e0c4566e0fe6.jpg?1783934187"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Nightveil Predator
+{
+    "name": "Nightveil Predator",
+    "manaCost": "{U}{U}{B}{B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Flying, deathtouch\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "DEATHTOUCH",
+        "HEXPROOF"
+    ],
+    "metadata": {
+        "collectorNumber": "191",
+        "rarity": "UNCOMMON",
+        "artist": "Darek Zabrocki",
+        "flavorText": "\"Three daggers left in an angel's back, three enforcers with memory loss, three keys stolen from my own belt—and you talk of peace?\"\n—Tajic, to Aurelia",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/193289c9-837d-4d18-9ef1-720e8e335e62.jpg?1783934125"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
+// Nightveil Sprite
+{
+    "name": "Nightveil Sprite",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Faerie Rogue",
+    "oracleText": "Flying\nWhenever this creature attacks, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Surveil",
+                    "count": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "rarity": "UNCOMMON",
+        "artist": "Uriah Voth",
+        "flavorText": "\"We're on the fortieth floor, with one window, no balcony. No one could possibly get in.\"\n—Minosz, Orzhov chief of security",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/534d1166-4e01-4ec8-b4d9-e76861ec51b9.jpg?1783934187"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Pack's Favor
+{
+    "name": "Pack's Favor",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nTarget creature gets +3/+3 until end of turn.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "artist": "Lius Lasahido",
+        "flavorText": "Selesnya grows its ranks in more ways than one.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f88c3aa-63e1-4617-bf1f-48f44988e7d6.jpg?1783934147"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Passwall Adept
+{
+    "name": "Passwall Adept",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{2}{U}: Target creature can't be blocked this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "John Thacker",
+        "flavorText": "\"My doors are called trespassing, my signatures, forgeries. They don't respect my talents, and I don't respect their labels.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a8ed28c3-8c66-4883-8774-67ac5ab9e81c.jpg?1783934185"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Pause for Reflection
+{
+    "name": "Pause for Reflection",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nPrevent all combat damage that would be dealt this turn.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "PreventDamageShield",
+            "scope": "CombatOnly"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "artist": "Alayna Danner",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3cfcf84c-a30c-4c4f-9f8c-ee807661e499.jpg?1783934148"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Pitiless Gorgon
+{
+    "name": "Pitiless Gorgon",
+    "manaCost": "{1}{B/G}{B/G}",
+    "typeLine": "Creature — Gorgon",
+    "oracleText": "Deathtouch",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "218",
+        "artist": "Alex Konstad",
+        "flavorText": "\"The reign of the Swarm begins. Let us rise now and dress ourselves in vengeance.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c1a925a0-9d26-441b-8b4a-0614a0485fe6.jpg?1783934114"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Portcullis Vine
+{
+    "name": "Portcullis Vine",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Plant Wall",
+    "oracleText": "Defender (This creature can't attack.)\n{2}, {T}, Sacrifice a creature with defender: Draw a card.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature kw:defender"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "artist": "James Paick",
+        "flavorText": "Nature's way of saying \"take the long way home.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5b6dab62-b747-4d76-9fa8-4914582fc212.jpg?1783934148"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Precision Bolt
+{
+    "name": "Precision Bolt",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Precision Bolt deals 3 damage to any target.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "267",
+        "artist": "Grzegorz Rutkowski",
+        "flavorText": "Ral had wielded lightning all his life but had never harnessed the power of an entire guild.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a59b4e5b-e9e0-4507-b9e7-8fba7e3a54f9.jpg?1783934094"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Rampaging Monument
+{
+    "name": "Rampaging Monument",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Cleric",
+    "oracleText": "Trample\nThis creature enters with three +1/+1 counters on it.\nWhenever you cast a multicolored spell, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsMulticolored"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 3,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "239",
+        "rarity": "UNCOMMON",
+        "artist": "Tyler Walpole",
+        "flavorText": "\"Be advised: suspect is nine stories tall, marble hair, answers to Saint Gusztav.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5fbe445-a788-4624-8ecf-8bc06c3ca8f8.jpg?1783934106"
+    }
+}
+
+// Rhizome Lurcher
+{
+    "name": "Rhizome Lurcher",
+    "manaCost": "{2}{B}{G}",
+    "typeLine": "Creature — Fungus Zombie",
+    "oracleText": "Undergrowth — This creature enters with a number of +1/+1 counters on it equal to the number of creature cards in your graveyard.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Graveyard",
+                    "filter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "196",
+        "artist": "Mathias Kollros",
+        "flavorText": "\"The dead gain new purpose here. What is strange in the eyes of other guilds is harmonious in ours.\"\n—Devesh, Golgari shaman",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db9ce92b-79cc-4e26-b511-30ae8ea6a2a1.jpg?1783934125"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Ritual of Soot
+{
+    "name": "Ritual of Soot",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy all creatures with mana value 3 or less.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "creature mv<=3"
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "rarity": "RARE",
+        "artist": "Dimitar Marinski",
+        "flavorText": "Only the patrol's armor was found, so tainted with the acrid smell of sudden death that it could never be worn again.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/269af993-4894-4bf1-b55a-af4d736cb3cc.jpg?1783934172"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Roc Charger
+{
+    "name": "Roc Charger",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying\nWhenever this creature attacks, target attacking creature without flying gains flying until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "NotKeyword",
+                                    "keyword": "FLYING"
+                                }
+                            ],
+                            "statePredicates": [
+                                "IsAttacking"
+                            ]
+                        }
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "UNCOMMON",
+        "artist": "Titus Lunter",
+        "flavorText": "Rocs' innate fearlessness makes them ideal mounts for emergency response.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/4932c635-b729-4348-92de-2c1b207ea460.jpg?1783934195"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Rosemane Centaur
+{
+    "name": "Rosemane Centaur",
+    "manaCost": "{3}{G}{W}",
+    "typeLine": "Creature — Centaur Soldier",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nVigilance",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "CONVOKE",
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "197",
+        "artist": "Nils Hamm",
+        "flavorText": "\"I long for peaceful times, when I may tend to my garden instead of our borders.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/cee30585-f7b1-4ca4-8171-dc5a837f2b93.jpg?1783934126"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Rubblebelt Boar
+{
+    "name": "Rubblebelt Boar",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Boar",
+    "oracleText": "When this creature enters, target creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "Some Gruul druids believe that boars are spawn of the great Ilharg, the mighty Raze-Boar who will one day rise and level the city.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/196bf114-e135-43f3-83d5-cb08ca766881.jpg?1783934159"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Selesnya Locket
+{
+    "name": "Selesnya Locket",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {G} or {W}.\n{G/W}{G/W}{G/W}{G/W}, {T}, Sacrifice this artifact: Draw two cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G/W}{G/W}{G/W}{G/W}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "240",
+        "artist": "Winona Nelson",
+        "flavorText": "\"Think of the locket as a seed you bear, spreading life from Vitu-Ghazi across all of Ravnica.\"\n—Heruj, Selesnya hierophant",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/ea0c04b9-c7fc-4204-9af2-5d1987bdd97e.jpg?1783934106"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Silent Dart
+{
+    "name": "Silent Dart",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{4}, {T}, Sacrifice this artifact: It deals 3 damage to target creature.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "rarity": "UNCOMMON",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "\"These terms are acceptable to House Dimir. Shall we shake on it?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3af00fdd-6869-4080-8a75-66c8fceeb7de.jpg?1783934106"
+    }
+}
+
+// Skyline Scout
+{
+    "name": "Skyline Scout",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "Whenever this creature attacks, you may pay {1}{W}. If you do, it gains flying until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}{W}"
+                        }
+                    },
+                    "then": {
+                        "type": "GrantKeyword",
+                        "keyword": "FLYING",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "artist": "Paul Scott Canavan",
+        "flavorText": "\"Sometimes an angel passes by and gives me a little nod, like, 'You're a daring one!' That always makes my day.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b052b641-fce9-45c1-a15b-1e22f1a64e4d.jpg?1783934195"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Smelt-Ward Minotaur
+{
+    "name": "Smelt-Ward Minotaur",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Minotaur Warrior",
+    "oracleText": "Whenever you cast an instant or sorcery spell, target creature an opponent controls can't block this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CantBlockTargetCreatures",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "116",
+        "rarity": "UNCOMMON",
+        "artist": "Wisnu Tan",
+        "flavorText": "\"Don't arrest him—enlist him!\"\n—Commander Yaszen",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f851d74e-90ad-417f-8372-8437d2d68b0d.jpg?1783934157"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Spinal Centipede
+{
+    "name": "Spinal Centipede",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "When this creature dies, put a +1/+1 counter on target creature you control.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "artist": "Zezhou Chen",
+        "flavorText": "The Golgari adorn themselves with the exoskeletons of iridescent insects. It's only fair the insects do likewise.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/74d579fb-615a-43a6-a1c1-c535087abf2a.jpg?1783934169"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Sumala Woodshaper
+{
+    "name": "Sumala Woodshaper",
+    "manaCost": "{2}{G}{W}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "When this creature enters, look at the top four cards of your library. You may reveal a creature or enchantment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "creature|enchantment",
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "prompt": "You may reveal a creature or enchantment card from among them and put it into your hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "200",
+        "artist": "Sara Winters",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8c4e427e-c061-43c5-9e8e-34bf5b447ab1.jpg?1783934124"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Swarm Guildmage
+{
+    "name": "Swarm Guildmage",
+    "manaCost": "{B}{G}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "{4}{B}, {T}: Creatures you control get +1/+0 and gain menace until end of turn. (They can't be blocked except by two or more creatures.)\n{1}{G}, {T}: You gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "MENACE",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "201",
+        "rarity": "UNCOMMON",
+        "artist": "Simon Dominic",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/7599adc7-72b2-4079-ac0a-1a821f9de925.jpg?1783934123"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Swiftblade Vindicator
 {
     "name": "Swiftblade Vindicator",
@@ -541,6 +3455,153 @@
     "colorIdentityOverride": [
         "WHITE",
         "RED"
+    ]
+}
+
+// Sworn Companions
+{
+    "name": "Sworn Companions",
+    "manaCost": "{2}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create two 1/1 white Soldier creature tokens with lifelink.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "WHITE"
+            ],
+            "creatureTypes": [
+                "Soldier"
+            ],
+            "keywords": [
+                "LIFELINK"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "27",
+        "artist": "Jason Rainville",
+        "flavorText": "\"The trouble with youths these days is that, in outright defiance of their elders, they refuse to be bought.\"\n—Karlov of the Ghost Council",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2ccfa5c1-69f9-4351-aba3-883fe92c9b98.jpg?1783934194"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Take Heart
+{
+    "name": "Take Heart",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 until end of turn. You gain 1 life for each attacking creature you control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature attacking"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "artist": "Lucas Graciano",
+        "flavorText": "In the quiet before a battle, Boros soldiers whisper prayers that steady their nerves and focus their minds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b26f10d5-b826-45b0-abed-80d86e1335c9.jpg?1783934194"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Tenth District Guard
+{
+    "name": "Tenth District Guard",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "When this creature enters, target creature gets +0/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "artist": "Craig J Spearing",
+        "flavorText": "\"The Tenth has always been my home. This city is constantly embroiled in one crisis or another, but I'm determined to protect my piece.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/829f959e-91cd-42ea-8644-ce828a304d01.jpg?1783934193"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -632,6 +3693,231 @@
     ]
 }
 
+// Vedalken Mesmerist
+{
+    "name": "Vedalken Mesmerist",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Vedalken Wizard",
+    "oracleText": "Whenever this creature attacks, target creature an opponent controls gets -2/-0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "artist": "Zezhou Chen",
+        "flavorText": "\"There's no need to sound the alarm. You are minding your post admirably. I am authorized. All is well.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5b5e0a12-2589-473b-90e4-1ee5acc055a2.jpg?1783934181"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Veiled Shade
+{
+    "name": "Veiled Shade",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Shade",
+    "oracleText": "{1}{B}: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "artist": "Anna Steinbauer",
+        "flavorText": "\"I sang songs of sorrow for my lost love. Imagine my horror when, one night, they were answered.\"\n—Milana, Orzhov prelate",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/35cb18ae-0229-40a1-8838-ffb678ab2ed9.jpg?1783934169"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Vernadi Shieldmate
+{
+    "name": "Vernadi Shieldmate",
+    "manaCost": "{1}{G/W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Vigilance",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "219",
+        "artist": "Matt Stewart",
+        "flavorText": "\"Selesnya's soil is sacred, and you're about to meet it with your face.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/efddad21-553e-4947-80d2-833b42c45f77.jpg?1783934114"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Wary Okapi
+{
+    "name": "Wary Okapi",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Antelope",
+    "oracleText": "Vigilance",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "149",
+        "artist": "Jason Felix",
+        "flavorText": "\"Be like the grazers of the Saruli. Keep your herd close, and stay alert for encroaching danger.\"\n—Lalia, Selesnya dryad",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/54f26697-0d4b-4af4-a644-3d0ae13f1d2e.jpg?1783934144"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Watcher in the Mist
+{
+    "name": "Watcher in the Mist",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nWhen this creature enters, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Surveil",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "artist": "Ryan Yee",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb971f49-8898-444a-a17c-caeb1696c62a.jpg?1783934181"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Whisper Agent
+{
+    "name": "Whisper Agent",
+    "manaCost": "{1}{U/B}{U/B}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "Flash\nWhen this creature enters, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Surveil",
+                    "count": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "He has a job to finish, and it's you.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6d318e7-f49e-49f8-98b6-d62c34aa4af2.jpg?1783934113"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
 // Wild Ceratok
 {
     "name": "Wild Ceratok",
@@ -669,5 +3955,38 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Worldsoul Colossus
+{
+    "name": "Worldsoul Colossus",
+    "manaCost": "{X}{G}{W}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nThis creature enters with X +1/+1 counters on it.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": "XValue"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "UNCOMMON",
+        "artist": "James Paick",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5186304-b0fb-44a6-ba61-0265b7f42da4.jpg?1783934117"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/M19.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M19.json
@@ -2103,3 +2103,27 @@
         "RED"
     ]
 }
+
+// Wall of Mist
+{
+    "name": "Wall of Mist",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 5
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "metadata": {
+        "collectorNumber": "83",
+        "artist": "Dimitar Marinski",
+        "flavorText": "The seafloor is flecked with the bones of fools who dared to sail into the mist.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4fb995c8-1bc2-4ff4-b8e9-f9b6bc0de0fe.jpg?1783934577"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ORI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ORI.json
@@ -750,6 +750,30 @@
     ]
 }
 
+// Hitchclaw Recluse
+{
+    "name": "Hitchclaw Recluse",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Reach",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "181",
+        "artist": "Jeff Simpson",
+        "flavorText": "Not all spiders need webs to catch their prey.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bf335eac-e57b-44ec-afe2-8aed567469e7.jpg?1783938322"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Joraga Invocation
 {
     "name": "Joraga Invocation",

--- a/mtg-sets/src/test/resources/snapshots/cards/RTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RTR.json
@@ -151,6 +151,47 @@
     ]
 }
 
+// Chromatic Lantern
+{
+    "name": "Chromatic Lantern",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Lands you control have \"{T}: Add one mana of any color.\"\n{T}: Add one mana of any color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": "AddManaOfChoice",
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                "filter": {
+                    "baseFilter": "land ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "rarity": "RARE",
+        "artist": "Jung Park",
+        "flavorText": "Dimir mages put the lanterns to good use, creating shapeshifters and sleeper agents from mana foreign to them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/57f4e0f0-13d1-43ed-8d95-13cff94a26e7.jpg?1783940325"
+    }
+}
+
 // Cobblebrute
 {
     "name": "Cobblebrute",


### PR DESCRIPTION
GRN's ⚡ Assay-ready count goes **90 → 0**. Every card was authored to `assay compile`'s JSON rather than to the oracle text.

## The four-way split

| Bucket | Count | Work |
|---|---:|---|
| `original` | 69 | canonical authored in GRN |
| `elsewhere` | 5 | canonical authored in its earliest real printing, `Printing` row here |
| `row-only` | 11 | `Printing` row in GRN only |
| `basic` | 5 | `basicLand(...)` file + the `basicLands` override |
| **reprint tail** | **15** | rows the new canonicals owe in 11 other sets |

The `elsewhere` five: Chromatic Lantern → RTR, Hitchclaw Recluse → ORI, Righteous Blow → AVR, Wall of Mist → M19, Wee Dragonauts → GPT.

The tail lands in ANB (2), C16 (1), J22 (2), JMP (1), KHC (2), M20 (1), M21 (2), MSC (1), RNA (1), VOC (1), WAR (1).

## Capability pre-flight

No new SDK vocabulary, and no engine work:

- **Convoke** (9 cards) is engine-live — `CastSpellEnumerator` and `AlternativePaymentHandler` both read `Keyword.CONVOKE`; 52 corpus cards already carry it.
- **Surveil** (7 cards) is engine-live — `SurveiledEvent`, `TriggerMatcher`, `Patterns.Library.surveil`; 133 corpus users.
- **Undergrowth** is an ability word with no keyword behind it. It is spelled out of live primitives: `CostModification.ReduceGenericBy(CostReductionSource.CardsInGraveyardMatchingFilter(Creature))` on Molderhulk, `EntersWithDynamicCounters(DynamicAmounts.creatureCardsInYourGraveyard())` on Rhizome Lurcher.

Undergrowth is **first-in-corpus** (the two prior `Undergrowth*` hits are card names, not the mechanic), so both cards get a scenario test — `MolderhulkScenarioTest` and `RhizomeLurcherScenarioTest`, one card per file.

## Differential

Taken with a freshly-built binary in this checkout, before and after:

| | compared | confirmed | divergent |
|---|---:|---:|---:|
| before | 4275 | 4226 | 49 |
| after | 4348 | 4299 | 49 |

73 newly-compared cards, **zero new divergences**. The 49 are all pre-existing on `main`.

### The one divergence the sweep did surface, and fixed

**Golgari Findbroker** was first written with `Effects.ReturnToHandFromGraveyard`, which stamps `fromZone: Graveyard` on the move; Assay reads the sentence without it. Assay is right here, and it is consistent — Raise Dead, Disentomb, Grim Discovery and Gravedigger all compile to a bare `MoveToZone → Hand` with the graveyard expressed only in the *target filter*. For a **targeted** return, target legality is re-checked on resolution, so the guard is redundant. The guard earns its place on a **self**-return from an ability activated in the graveyard, where nothing re-checks `activateFromZone` — which is exactly Kraul Swarm in this batch, and Assay emits `fromZone` there too. Findbroker now uses plain `Effects.ReturnToHand`.

Worth noting because `Effects.ReturnToHandFromGraveyard`'s KDoc reads as though *every* card whose printed line names the graveyard should use it. It should say "every card that returns **itself**"; the targeted case is the counterexample.

### One tooling note

`scripts/generate-reprints.py --set <CODE>` generates rows for **every** card in that set with a fresh printing cache, not only the ones the sweep authored. Running it across the 11 tail sets produced 96 rows where 15 belong to this sweep; the other 81 were pre-existing gaps unrelated to GRN and were dropped from this PR to keep the review surface honest. They are real missing rows and are still there for whoever wants them.

## Verification

- `just build` — green (compile + `:mtg-sets:test`, including the reblessed snapshots)
- `just rebless-cards` — only AVR / GPT / GRN / M19 / ORI / RTR moved, all this batch's cards
- `just assay-differential` — exit 0, table above
- `just check-card-printing` — `ok` for all 17 cards that own or owe cross-set rows
- `just assay-ready GRN` on the branch — **0 Assay-ready, empty tail**
- `:mtg-sets:2017-2022:tests:test --rerun-tasks` — green, including the two new scenario tests

GRN keeps `incomplete = true`: 158 cards remain, all of them declined by the grammar (142 `LINE_DECLINED`, 10 `MULTI_FACE`, 6 `LINES_DO_NOT_FOLD`). That tail is grammar work, not authoring work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)