### PR TITLE
Add 84 Assay-ready cards to Battle for Zendikar

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/Plummet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/Plummet.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet
+ * {1}{G}
+ * Instant
+ * Destroy target creature with flying.
+ */
+val Plummet = card("Plummet") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature with flying."
+
+    spell {
+        val flier = target("target creature with flying", Targets.CreatureWithKeyword(Keyword.FLYING))
+        effect = Effects.Destroy(flier)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "65"
+        artist = "Pete Venters"
+        flavorText = "\"You are the grandest of all,\" said the archdruid to the trees. They became so proud of bark " +
+            "and branch that they suffered no creature to fly overhead or perch upon a bough."
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a67bb585-cc4f-4cbc-9a5a-d31df98c07ae.jpg?1783941902"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/BoneSplintersReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/BoneSplintersReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bone Splinters reprint in AVR. Canonical CardDefinition lives in its earliest set.
+ */
+val BoneSplintersReprint = Printing(
+    oracleId = "0c936582-d4c0-4da8-bc7e-49da5a433939",
+    name = "Bone Splinters",
+    setCode = "AVR",
+    collectorNumber = "88",
+    scryfallId = "387eda28-f35b-48b0-ba59-773d82902327",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/3/8/387eda28-f35b-48b0-ba59-773d82902327.jpg",
+    releaseDate = "2012-05-04",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/BattleForZendikarSet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/BattleForZendikarSet.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.bfz
 
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
@@ -18,11 +17,15 @@ object BattleForZendikarSet : MtgSet {
     override val displayName = "Battle for Zendikar"
     override val releaseDate = "2015-10-02"
     override val block = "Battle for Zendikar"
-    override val basicLandsFallback = PortalSet
     override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    /** Battle for Zendikar's own basics: one representative full-art printing per type. */
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/AllyEncampment.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/AllyEncampment.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Ally Encampment
+ * Land
+ * {T}: Add {C}.
+ * {T}: Add one mana of any color. Spend this mana only to cast an Ally spell.
+ * {1}, {T}, Sacrifice this land: Return target Ally you control to its owner's hand.
+ */
+val AllyEncampment = card("Ally Encampment") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{T}: Add one mana of any color. Spend this mana only to cast an Ally spell.\n" +
+        "{1}, {T}, Sacrifice this land: Return target Ally you control to its owner's hand."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChoice(
+            restriction = ManaRestriction.SubtypeSpellsOnly(setOf("Ally")),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.SacrificeSelf)
+        val ally = target(
+            "target Ally you control",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Permanent.withSubtype("Ally").youControl())),
+        )
+        effect = Effects.ReturnToHand(ally)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "228"
+        artist = "Jonas De Ro"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bcb7124c-ba69-4da8-ad81-58f00fd0181d.jpg?1783938175"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/AltarSReapReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/AltarSReapReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Altar's Reap reprint in BFZ. Canonical CardDefinition lives in its earliest set.
+ */
+val AltarSReapReprint = Printing(
+    oracleId = "6a125750-2b8c-4f9d-8173-ac8d14c91ddb",
+    name = "Altar's Reap",
+    setCode = "BFZ",
+    collectorNumber = "103",
+    scryfallId = "d4ca3f24-eb14-46fe-9a7a-3752f706d067",
+    artist = "Tyler Jacobson",
+    imageUri = "https://cards.scryfall.io/normal/front/d/4/d4ca3f24-eb14-46fe-9a7a-3752f706d067.jpg",
+    releaseDate = "2015-10-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/AngelOfRenewal.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/AngelOfRenewal.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angel of Renewal
+ * {5}{W}
+ * Creature — Angel Ally
+ * 4/4
+ * Flying
+ * When this creature enters, you gain 1 life for each creature you control.
+ */
+val AngelOfRenewal = card("Angel of Renewal") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel Ally"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When this creature enters, you gain 1 life for each creature you control."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(DynamicAmounts.creaturesYouControl())
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "18"
+        artist = "Todd Lockwood"
+        flavorText = "\"No more fear. No more failure. No more death. No more!\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f882ac2-3cbc-4548-8c83-d2a7443991df.jpg?1783938222"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/AngelicGift.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/AngelicGift.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Angelic Gift
+ * {1}{W}
+ * Enchantment — Aura
+ * Enchant creature
+ * When this Aura enters, draw a card.
+ * Enchanted creature has flying.
+ */
+val AngelicGift = card("Angelic Gift") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, draw a card.\n" +
+        "Enchanted creature has flying."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Josu Hernaiz"
+        flavorText = "\"Zendikar will triumph this day, and our armies will fly with angels.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/4941246b-7d6a-4b2d-8144-f36ac890a389.jpg?1783938222"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BattleForZendikarBasicLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BattleForZendikarBasicLands.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Battle for Zendikar Basic Lands
+ *
+ * Battle for Zendikar printed five full-art variants of each basic land type (cards 250–274),
+ * each also available in a non-full-art version. Our Scryfall cache retains one canonical
+ * variant per type, so we register that representative printing for each: Plains 250,
+ * Island 255, Swamp 260, Mountain 265, Forest 270.
+ */
+
+val BfzPlains250 = basicLand("Plains") {
+    collectorNumber = "250"
+    artist = "Noah Bradley"
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/58a735c9-08a1-4950-bf8c-ed1cfba76765.jpg?1783938172"
+}
+
+val BfzIsland255 = basicLand("Island") {
+    collectorNumber = "255"
+    artist = "Noah Bradley"
+    imageUri = "https://cards.scryfall.io/normal/front/8/4/8490261d-4246-4232-b7fc-23204c14a7b5.jpg?1783938169"
+}
+
+val BfzSwamp260 = basicLand("Swamp") {
+    collectorNumber = "260"
+    artist = "Noah Bradley"
+    imageUri = "https://cards.scryfall.io/normal/front/1/3/132155ae-f7a4-4957-91cb-e51ff52716f9.jpg?1783938168"
+}
+
+val BfzMountain265 = basicLand("Mountain") {
+    collectorNumber = "265"
+    artist = "Noah Bradley"
+    imageUri = "https://cards.scryfall.io/normal/front/0/c/0c9cbae1-6b04-4408-82fe-3fcf61dffbe2.jpg?1783938165"
+}
+
+val BfzForest270 = basicLand("Forest") {
+    collectorNumber = "270"
+    artist = "Noah Bradley"
+    imageUri = "https://cards.scryfall.io/normal/front/6/4/642102a2-abde-4e76-a6d6-08f7befe1196.jpg?1783938163"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BeastcallerSavant.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BeastcallerSavant.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Beastcaller Savant
+ * {1}{G}
+ * Creature — Elf Shaman Ally
+ * 1/1
+ * Haste
+ * {T}: Add one mana of any color. Spend this mana only to cast a creature spell.
+ */
+val BeastcallerSavant = card("Beastcaller Savant") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Shaman Ally"
+    power = 1
+    toughness = 1
+    oracleText = "Haste\n" +
+        "{T}: Add one mana of any color. Spend this mana only to cast a creature spell."
+
+    keywords(Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChoice(restriction = ManaRestriction.CreatureSpellsOnly)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "170"
+        artist = "Anthony Palumbo"
+        flavorText = "\"They come because I call. They stay because I listen.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cca9f5da-986c-43ab-a2ec-efb8b098c17c.jpg?1783938191"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BelligerentWhiptail.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BelligerentWhiptail.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Belligerent Whiptail
+ * {3}{R}
+ * Creature — Wurm
+ * 4/2
+ * Landfall — Whenever a land you control enters, this creature gains first strike until end of turn.
+ *
+ * Landfall is a plain [Triggers.LandYouControlEnters] — ANY binding, because the printed line never says "another".
+ */
+val BelligerentWhiptail = card("Belligerent Whiptail") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Wurm"
+    power = 4
+    toughness = 2
+    oracleText = "Landfall — Whenever a land you control enters, this creature gains first strike until end of " +
+        "turn."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "141"
+        artist = "Jakub Kasper"
+        flavorText = "\"Whiptails can sense a traveler's footsteps from a great distance. Measuring that distance " +
+            "has been . . . difficult.\"\n" +
+            "—Jalun, Affa sentry"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a5b5b7d2-acb8-4aca-b9e7-67e59aeb384b.jpg?1783938195"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BlightedCataract.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BlightedCataract.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Blighted Cataract
+ * Land
+ * {T}: Add {C}.
+ * {5}{U}, {T}, Sacrifice this land: Draw two cards.
+ */
+val BlightedCataract = card("Blighted Cataract") {
+    manaCost = ""
+    colorIdentity = "U"
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{5}{U}, {T}, Sacrifice this land: Draw two cards."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}{U}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "229"
+        artist = "Vincent Proce"
+        flavorText = "Once, water ran here. Now only dust and ash fall from the clifftops."
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/8908b6b0-a488-426c-954d-458456be0651.jpg?1783938175"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BlightedGorge.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BlightedGorge.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Blighted Gorge
+ * Land
+ * {T}: Add {C}.
+ * {4}{R}, {T}, Sacrifice this land: It deals 2 damage to any target.
+ */
+val BlightedGorge = card("Blighted Gorge") {
+    manaCost = ""
+    colorIdentity = "R"
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{4}{R}, {T}, Sacrifice this land: It deals 2 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{R}"), Costs.Tap, Costs.SacrificeSelf)
+        val victim = target("any target", Targets.Any)
+        effect = Effects.DealDamage(2, victim)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "231"
+        artist = "Jung Park"
+        flavorText = "The land is dying, but it will not go peacefully."
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88cbfe5d-79b7-45db-b3cd-4ae7a9964a37.jpg?1783938175"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BlightedSteppe.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BlightedSteppe.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Blighted Steppe
+ * Land
+ * {T}: Add {C}.
+ * {3}{W}, {T}, Sacrifice this land: You gain 2 life for each creature you control.
+ */
+val BlightedSteppe = card("Blighted Steppe") {
+    manaCost = ""
+    colorIdentity = "W"
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{3}{W}, {T}, Sacrifice this land: You gain 2 life for each creature you control."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{W}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.GainLife(
+            DynamicAmount.Multiply(DynamicAmounts.creaturesYouControl(), 2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "232"
+        artist = "Yeong-Hao Han"
+        flavorText = "\"When a limb is gangrenous, you cut it off. This is no different.\"\n" +
+            "—Greenweaver Mina"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f43df8ee-d3e4-419e-aed0-1059d95f9cab.jpg?1783938175"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BloodbondVampire.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BloodbondVampire.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Bloodbond Vampire
+ * {2}{B}{B}
+ * Creature — Vampire Shaman Ally
+ * 3/3
+ * Whenever you gain life, put a +1/+1 counter on this creature.
+ */
+val BloodbondVampire = card("Bloodbond Vampire") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Shaman Ally"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever you gain life, put a +1/+1 counter on this creature."
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "104"
+        artist = "Anna Steinbauer"
+        flavorText = "\"Let the vampires join us. In this war, we no longer have the luxury of choosing our " +
+            "comrades.\"\n" +
+            "—General Tazri, allied commander"
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/ca31ce70-24c5-4fb2-8d88-c9ffa8474c8f.jpg?1783938203"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BoneSplintersReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BoneSplintersReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bone Splinters reprint in BFZ. Canonical CardDefinition lives in its earliest set.
+ */
+val BoneSplintersReprint = Printing(
+    oracleId = "0c936582-d4c0-4da8-bc7e-49da5a433939",
+    name = "Bone Splinters",
+    setCode = "BFZ",
+    collectorNumber = "105",
+    scryfallId = "74780faa-1c64-4d73-8d09-53b47ba02d7a",
+    artist = "Deruchenko Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/7/4/74780faa-1c64-4d73-8d09-53b47ba02d7a.jpg",
+    releaseDate = "2015-10-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ChasmGuide.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ChasmGuide.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Chasm Guide
+ * {3}{R}
+ * Creature — Goblin Scout Ally
+ * 3/2
+ * Rally — Whenever this creature or another Ally you control enters, creatures you control gain haste until end of turn.
+ *
+ * Rally is an ability word, not a keyword: the trigger is an ANY-bound enters trigger over
+ * Allies you control, so the creature's own arrival fires it alongside every later Ally.
+ */
+val ChasmGuide = card("Chasm Guide") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Scout Ally"
+    power = 3
+    toughness = 2
+    oracleText = "Rally — Whenever this creature or another Ally you control enters, creatures you control gain " +
+        "haste until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Ally").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Patterns.Group.grantKeywordToAll(
+            Keyword.HASTE,
+            Filters.Group.creaturesYouControl,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "143"
+        artist = "Johannes Voss"
+        flavorText = "With a single act of bravery, she went from expendable to indispensable."
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fbd0fad7-264d-40fc-a616-a88dc94fa4d7.jpg?1783938195"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/CliffsideLookout.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/CliffsideLookout.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cliffside Lookout
+ * {W}
+ * Creature — Kor Scout Ally
+ * 1/1
+ * {4}{W}: Creatures you control get +1/+1 until end of turn.
+ */
+val CliffsideLookout = card("Cliffside Lookout") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kor Scout Ally"
+    power = 1
+    toughness = 1
+    oracleText = "{4}{W}: Creatures you control get +1/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{W}")
+        effect = Patterns.Group.modifyStatsForAll(1, 1, Filters.Group.creaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "Eric Deschamps"
+        flavorText = "Though losses run high among the scouts of the Stone Havens, they never flinch from their " +
+            "duty."
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8c755ae6-badc-4dc8-bfa6-fdebcb00bfba.jpg?1783938221"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/CloudManta.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/CloudManta.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cloud Manta
+ * {3}{U}
+ * Creature — Fish
+ * 3/2
+ * Flying
+ */
+val CloudManta = card("Cloud Manta") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Fish"
+    power = 3
+    toughness = 2
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "71"
+        artist = "Mike Bierek"
+        flavorText = "When Emeria's worshippers learned that she was no more than a twisted memory of Emrakul, " +
+            "they abandoned their temples to the god. The deserted shrines now serve as breeding grounds " +
+            "for the mantas."
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/1854f819-d08e-4a23-bedb-4618b79623e9.jpg?1783938210"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/CompleteDisregard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/CompleteDisregard.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Complete Disregard
+ * {2}{B}
+ * Instant
+ * Devoid (This card has no color.)
+ * Exile target creature with power 3 or less.
+ *
+ * Devoid is a characteristic-defining ability the SDK derives in `CardDefinition.colors`,
+ * so the keyword alone is enough — the card is colorless in every zone while its colour
+ * identity stays black.
+ */
+val CompleteDisregard = card("Complete Disregard") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Devoid (This card has no color.)\n" +
+        "Exile target creature with power 3 or less."
+
+    keywords(Keyword.DEVOID)
+
+    spell {
+        val creature = target("target creature", Targets.CreatureWithPowerAtMost(3))
+        effect = Effects.Exile(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "90"
+        artist = "Peter Mohrbacher"
+        flavorText = "\"We returned to the field and found poor Len, every detail of his final moment perfectly " +
+            "cast in that awful dust.\"\n" +
+            "—Javad Nasrin, outrider captain"
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d94e878-6c49-4420-9d34-f9ee64e811ba.jpg?1783938206"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/CoralhelmGuide.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/CoralhelmGuide.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Coralhelm Guide
+ * {1}{U}
+ * Creature — Merfolk Scout Ally
+ * 2/1
+ * {4}{U}: Target creature can't be blocked this turn.
+ */
+val CoralhelmGuide = card("Coralhelm Guide") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Scout Ally"
+    power = 2
+    toughness = 1
+    oracleText = "{4}{U}: Target creature can't be blocked this turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{U}")
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "74"
+        artist = "Viktor Titov"
+        flavorText = "\"She knows every step of this coastline, both above and below the surface, and she has " +
+            "hideouts all along the way. She will get you there.\"\n" +
+            "—Jori En, expedition leader"
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/33787a5b-d1d1-4d60-ba09-d9c98025e9b3.jpg?1783938210"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/CourierGriffin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/CourierGriffin.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Courier Griffin
+ * {3}{W}
+ * Creature — Griffin
+ * 2/3
+ * Flying
+ * When this creature enters, you gain 2 life.
+ */
+val CourierGriffin = card("Courier Griffin") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Griffin"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\n" +
+        "When this creature enters, you gain 2 life."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "21"
+        artist = "Kieran Yanner"
+        flavorText = "\"Sea Gate has fallen. Survivors are on the move. Will send another griffin when we find " +
+            "refuge. Stay hidden. Stay safe.\"\n" +
+            "—Message from Tars Olan, kor world-gift"
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4d3afc71-f5db-45c3-96b2-8454b7f33542.jpg?1783938222"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/DesolationTwin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/DesolationTwin.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Desolation Twin
+ * {10}
+ * Creature — Eldrazi
+ * 10/10
+ * When you cast this spell, create a 10/10 colorless Eldrazi creature token.
+ *
+ * "When you cast this spell" is a cast trigger, so the 10/10 token arrives while the
+ * Twin is still on the stack — countering the Twin does not undo it.
+ */
+val DesolationTwin = card("Desolation Twin") {
+    manaCost = "{10}"
+    colorIdentity = ""
+    typeLine = "Creature — Eldrazi"
+    power = 10
+    toughness = 10
+    oracleText = "When you cast this spell, create a 10/10 colorless Eldrazi creature token."
+
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        effect = Effects.CreateToken(
+            power = 10,
+            toughness = 10,
+            creatureTypes = setOf("Eldrazi"),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "6"
+        artist = "Jack Wang"
+        flavorText = "\"With precise coordination and enough blood spilled, one can be driven off, even brought " +
+            "down. But two . . . that's a lot of blood.\"\n" +
+            "—Munda, ambush leader"
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4d229d8d-5e64-4403-a4ae-a0a186a83935.jpg?1783938224"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/DispelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/DispelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dispel reprint in BFZ. Canonical CardDefinition lives in its earliest set.
+ */
+val DispelReprint = Printing(
+    oracleId = "6d7be242-a072-40ce-b540-95880506cccd",
+    name = "Dispel",
+    setCode = "BFZ",
+    collectorNumber = "76",
+    scryfallId = "bceab6b3-6b64-4964-a501-ce806a6c13ad",
+    artist = "Chase Stone",
+    imageUri = "https://cards.scryfall.io/normal/front/b/c/bceab6b3-6b64-4964-a501-ce806a6c13ad.jpg",
+    releaseDate = "2015-10-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/DragonmasterOutcastReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/DragonmasterOutcastReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonmaster Outcast reprint in BFZ. Canonical CardDefinition lives in its earliest set.
+ */
+val DragonmasterOutcastReprint = Printing(
+    oracleId = "b6fb79c3-cd32-4045-8177-e52841eea65b",
+    name = "Dragonmaster Outcast",
+    setCode = "BFZ",
+    collectorNumber = "144",
+    scryfallId = "314d1424-03c8-443b-a3bc-14bb168e32c9",
+    artist = "Raymond Swanland",
+    imageUri = "https://cards.scryfall.io/normal/front/3/1/314d1424-03c8-443b-a3bc-14bb168e32c9.jpg",
+    releaseDate = "2015-10-02",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/DranasEmissary.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/DranasEmissary.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Drana's Emissary
+ * {1}{W}{B}
+ * Creature — Vampire Cleric Ally
+ * 2/2
+ * Flying
+ * At the beginning of your upkeep, each opponent loses 1 life and you gain 1 life.
+ */
+val DranasEmissary = card("Drana's Emissary") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "BW"
+    typeLine = "Creature — Vampire Cleric Ally"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "At the beginning of your upkeep, each opponent loses 1 life and you gain 1 life."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "210"
+        artist = "Karl Kopinski"
+        flavorText = "\"The taste of freedom is sweeter than blood.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/99e82d47-9bbb-4bf9-a935-2c0b27b64a84.jpg?1783938180"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/EldraziDevastator.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/EldraziDevastator.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eldrazi Devastator
+ * {8}
+ * Creature — Eldrazi
+ * 8/9
+ * Trample
+ */
+val EldraziDevastator = card("Eldrazi Devastator") {
+    manaCost = "{8}"
+    colorIdentity = ""
+    typeLine = "Creature — Eldrazi"
+    power = 8
+    toughness = 9
+    oracleText = "Trample"
+
+    keywords(Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "7"
+        artist = "Joseph Meehan"
+        flavorText = "\"No matter how big your champion, theirs is bigger. No matter how great your numbers, theirs " +
+            "are greater. No matter how voracious your appetite, they are hungrier. That is why the " +
+            "Eldrazi will win.\"\n" +
+            "—Kalitas, thrall of Ulamog"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04b13e32-01b9-4a86-a3df-ca8b784c6a6c.jpg?1783938225"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/EndlessOne.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/EndlessOne.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Endless One
+ * {X}
+ * Creature — Eldrazi
+ * 0/0
+ * This creature enters with X +1/+1 counters on it.
+ *
+ * The X is the value announced as the spell was cast ([DynamicAmount.XValue]), so a copy of
+ * Endless One made on the stack keeps it and one made on the battlefield enters as a 0/0.
+ */
+val EndlessOne = card("Endless One") {
+    manaCost = "{X}"
+    colorIdentity = ""
+    typeLine = "Creature — Eldrazi"
+    power = 0
+    toughness = 0
+    oracleText = "This creature enters with X +1/+1 counters on it."
+
+    replacementEffect(EntersWithDynamicCounters(count = DynamicAmount.XValue))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "8"
+        artist = "Jason Felix"
+        flavorText = "It embodies all possible meanings of the word \"infinite.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64820f4f-1f78-4338-beb8-5ed5a447cfe4.jpg?1783938224"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/FiremantleMage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/FiremantleMage.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Firemantle Mage
+ * {2}{R}
+ * Creature — Human Shaman Ally
+ * 2/2
+ * Rally — Whenever this creature or another Ally you control enters, creatures you control gain menace until end of turn. (A creature with menace can't be blocked except by two or more creatures.)
+ *
+ * Rally is an ability word, not a keyword: the trigger is an ANY-bound enters trigger over
+ * Allies you control, so the creature's own arrival fires it alongside every later Ally.
+ */
+val FiremantleMage = card("Firemantle Mage") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Shaman Ally"
+    power = 2
+    toughness = 2
+    oracleText = "Rally — Whenever this creature or another Ally you control enters, creatures you control gain " +
+        "menace until end of turn. (A creature with menace can't be blocked except by two or more " +
+        "creatures.)"
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Ally").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Patterns.Group.grantKeywordToAll(
+            Keyword.MENACE,
+            Filters.Group.creaturesYouControl,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "145"
+        artist = "Chris Rahn"
+        flavorText = "\"Come on, you twisted things! Don't you want to get acquainted?\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/197411bf-3307-4056-a7d4-31db0d4b8f9a.jpg?1783938195"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/FortifiedRampart.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/FortifiedRampart.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fortified Rampart
+ * {1}{W}
+ * Creature — Wall
+ * 0/6
+ * Defender
+ */
+val FortifiedRampart = card("Fortified Rampart") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Wall"
+    power = 0
+    toughness = 6
+    oracleText = "Defender"
+
+    keywords(Keyword.DEFENDER)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "27"
+        artist = "David Gaillet"
+        flavorText = "The refuge's defenses allow new recruits to see lesser Eldrazi up close, steeling their " +
+            "stomachs for what's to come."
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/5095e2ab-a7f5-45bc-8b2f-31198ea27bba.jpg?1783938220"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/GeyserfieldStalker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/GeyserfieldStalker.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Geyserfield Stalker
+ * {4}{B}
+ * Creature — Elemental
+ * 3/2
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ * Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.
+ *
+ * Landfall is a plain [Triggers.LandYouControlEnters] — ANY binding, because the printed line never says "another".
+ */
+val GeyserfieldStalker = card("Geyserfield Stalker") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Elemental"
+    power = 3
+    toughness = 2
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "Deruchenko Alexander"
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d4d1e1e1-fa24-4e78-a77c-4d41a58b8aa0.jpg?1783938203"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/GhostlySentinel.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/GhostlySentinel.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ghostly Sentinel
+ * {4}{W}
+ * Creature — Kor Spirit
+ * 3/3
+ * Flying, vigilance
+ */
+val GhostlySentinel = card("Ghostly Sentinel") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kor Spirit"
+    power = 3
+    toughness = 3
+    oracleText = "Flying, vigilance"
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "28"
+        artist = "Daarken"
+        flavorText = "Mystics of the Stone Havens call upon the spirits of fallen heroes to defend the refuges."
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/de867066-df5c-4412-9d51-56626b6d0220.jpg?1783938220"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/GiantMantisReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/GiantMantisReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Giant Mantis reprint in BFZ. Canonical CardDefinition lives in its earliest set.
+ */
+val GiantMantisReprint = Printing(
+    oracleId = "481ede6a-3ac3-45bc-85aa-311b3dbefc40",
+    name = "Giant Mantis",
+    setCode = "BFZ",
+    collectorNumber = "173",
+    scryfallId = "98518e4a-d1d0-4e41-bae7-242c779f06a1",
+    artist = "Lake Hurwitz",
+    imageUri = "https://cards.scryfall.io/normal/front/9/8/98518e4a-d1d0-4e41-bae7-242c779f06a1.jpg",
+    releaseDate = "2015-10-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/GideonsReproach.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/GideonsReproach.kt
@@ -1,4 +1,4 @@
-package com.wingedsheep.mtg.sets.definitions.dom.cards
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
 
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
@@ -11,6 +11,9 @@ import com.wingedsheep.sdk.scripting.targets.TargetPermanent
  * {1}{W}
  * Instant
  * Gideon's Reproach deals 4 damage to target attacking or blocking creature.
+ *
+ * Battle for Zendikar (2015) is the earliest printing; Dominaria (2018), where the canonical used
+ * to live, now carries a [com.wingedsheep.sdk.model.Printing] row instead.
  */
 val GideonsReproach = card("Gideon's Reproach") {
     manaCost = "{1}{W}"
@@ -25,9 +28,10 @@ val GideonsReproach = card("Gideon's Reproach") {
 
     metadata {
         rarity = Rarity.COMMON
-        collectorNumber = "19"
-        artist = "Izzy"
-        flavorText = "\"On Amonkhet, Gideon lost both his sural and his faith in himself. But he can still throw a punch.\""
-        imageUri = "https://cards.scryfall.io/normal/front/7/b/7b771f44-ce32-41a2-b219-738924b7f42d.jpg?1562738270"
+        collectorNumber = "30"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"Suddenly, Gideon was there with us, clearing the way so that we could escape.\"\n" +
+            "—*The War Diaries*"
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/453d8ec3-15ae-4851-9efb-161ca2ee6019.jpg?1783938218"
     }
 }

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/GoblinWarPaintReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/GoblinWarPaintReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin War Paint reprint in BFZ. Canonical CardDefinition lives in its earliest set.
+ */
+val GoblinWarPaintReprint = Printing(
+    oracleId = "67ca79d7-9064-4605-8625-b1cfe5cb1b45",
+    name = "Goblin War Paint",
+    setCode = "BFZ",
+    collectorNumber = "146",
+    scryfallId = "b6ff3183-c273-4a61-ad25-526db29111c8",
+    artist = "Karl Kopinski",
+    imageUri = "https://cards.scryfall.io/normal/front/b/6/b6ff3183-c273-4a61-ad25-526db29111c8.jpg",
+    releaseDate = "2015-10-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/GroveRumbler.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/GroveRumbler.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Grove Rumbler
+ * {2}{R}{G}
+ * Creature — Elemental
+ * 3/3
+ * Trample
+ * Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.
+ *
+ * Landfall is a plain [Triggers.LandYouControlEnters] — ANY binding, because the printed line never says "another".
+ */
+val GroveRumbler = card("Grove Rumbler") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Elemental"
+    power = 3
+    toughness = 3
+    oracleText = "Trample\n" +
+        "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "211"
+        artist = "Greg Opalinski"
+        flavorText = "\"The land will not wait for the enemy to arrive.\"\n" +
+            "—Nissa Revane"
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/012b8eff-cdf3-423e-ae17-72a909e7ebd3.jpg?1783938181"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/GrovetenderDruids.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/GrovetenderDruids.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Grovetender Druids
+ * {2}{G}{W}
+ * Creature — Elf Druid Ally
+ * 3/3
+ * Rally — Whenever this creature or another Ally you control enters, you may pay {1}. If you do, create a 1/1 green Plant creature token.
+ *
+ * Rally is an ability word, not a keyword: the trigger is an ANY-bound enters trigger over
+ * Allies you control, so the creature's own arrival fires it alongside every later Ally.
+ */
+val GrovetenderDruids = card("Grovetender Druids") {
+    manaCost = "{2}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Elf Druid Ally"
+    power = 3
+    toughness = 3
+    oracleText = "Rally — Whenever this creature or another Ally you control enters, you may pay {1}. If you do, " +
+        "create a 1/1 green Plant creature token."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Ally").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}"),
+            effect = Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.GREEN),
+                creatureTypes = setOf("Plant"),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "212"
+        artist = "Chase Stone"
+        flavorText = "\"The seedlings scream for us to loose them upon the Eldrazi, and we shall oblige.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5c2fd3a4-e09a-4fe5-93eb-2276a65c4911.jpg?1783938179"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/HagraSharpshooter.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/HagraSharpshooter.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hagra Sharpshooter
+ * {2}{B}
+ * Creature — Human Assassin Ally
+ * 2/2
+ * {4}{B}: Target creature gets -1/-1 until end of turn.
+ */
+val HagraSharpshooter = card("Hagra Sharpshooter") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Assassin Ally"
+    power = 2
+    toughness = 2
+    oracleText = "{4}{B}: Target creature gets -1/-1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{B}")
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-1, -1, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "113"
+        artist = "Josu Hernaiz"
+        flavorText = "\"It's hard to find their weak points, but I very much enjoy the discovery process.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a706b2e3-bd0e-4111-8b68-976869c7d707.jpg?1783938201"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/HeroOfGomaFada.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/HeroOfGomaFada.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Hero of Goma Fada
+ * {4}{W}
+ * Creature — Human Knight Ally
+ * 4/3
+ * Rally — Whenever this creature or another Ally you control enters, creatures you control gain indestructible until end of turn.
+ *
+ * Rally is an ability word, not a keyword: the trigger is an ANY-bound enters trigger over
+ * Allies you control, so the creature's own arrival fires it alongside every later Ally.
+ */
+val HeroOfGomaFada = card("Hero of Goma Fada") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight Ally"
+    power = 4
+    toughness = 3
+    oracleText = "Rally — Whenever this creature or another Ally you control enters, creatures you control gain " +
+        "indestructible until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Ally").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Patterns.Group.grantKeywordToAll(
+            Keyword.INDESTRUCTIBLE,
+            Filters.Group.creaturesYouControl,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "31"
+        artist = "Lake Hurwitz"
+        flavorText = "\"They seek to break us. Let us show them our strength!\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4ca3400c-0687-4a92-9236-f5a0d7eae337.jpg?1783938218"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/InspiredChargeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/InspiredChargeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inspired Charge reprint in BFZ. Canonical CardDefinition lives in its earliest set.
+ */
+val InspiredChargeReprint = Printing(
+    oracleId = "d465a3d6-5830-456c-8e7a-908b464db846",
+    name = "Inspired Charge",
+    setCode = "BFZ",
+    collectorNumber = "32",
+    scryfallId = "0b42ef87-8147-4124-9086-0279d42589c9",
+    artist = "Willian Murai",
+    imageUri = "https://cards.scryfall.io/normal/front/0/b/0b42ef87-8147-4124-9086-0279d42589c9.jpg",
+    releaseDate = "2015-10-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/JaddiOffshoot.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/JaddiOffshoot.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jaddi Offshoot
+ * {G}
+ * Creature — Plant
+ * 0/3
+ * Defender
+ * Landfall — Whenever a land you control enters, you gain 1 life.
+ *
+ * Landfall is a plain [Triggers.LandYouControlEnters] — ANY binding, because the printed line never says "another".
+ */
+val JaddiOffshoot = card("Jaddi Offshoot") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant"
+    power = 0
+    toughness = 3
+    oracleText = "Defender\n" +
+        "Landfall — Whenever a land you control enters, you gain 1 life."
+
+    keywords(Keyword.DEFENDER)
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "176"
+        artist = "Daarken"
+        flavorText = "On Murasa, even the trees grow trees."
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/aca704d5-b6e0-4726-8856-0b3a6732bbd8.jpg?1783938188"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/KalastriaHealer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/KalastriaHealer.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kalastria Healer
+ * {1}{B}
+ * Creature — Vampire Cleric Ally
+ * 1/2
+ * Rally — Whenever this creature or another Ally you control enters, each opponent loses 1 life and you gain 1 life.
+ *
+ * Rally is an ability word, not a keyword: the trigger is an ANY-bound enters trigger over
+ * Allies you control, so the creature's own arrival fires it alongside every later Ally.
+ *
+ * "Each opponent loses 1 life and you gain 1 life" is a composite of the two halves, not
+ * [Effects.DrainLife] — the life you gain is a printed 1, not the life lost this way.
+ */
+val KalastriaHealer = card("Kalastria Healer") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Cleric Ally"
+    power = 1
+    toughness = 2
+    oracleText = "Rally — Whenever this creature or another Ally you control enters, each opponent loses 1 life " +
+        "and you gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Ally").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.Composite(
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "114"
+        artist = "Anthony Palumbo"
+        flavorText = "\"Time and again, I have demonstrated my skills as a healer. Why, then, are you so ill at " +
+            "ease?\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42c21cb3-21f4-4a8d-8068-52649f2a1846.jpg?1783938201"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/KalastriaNightwatch.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/KalastriaNightwatch.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kalastria Nightwatch
+ * {4}{B}
+ * Creature — Vampire Warrior Ally
+ * 4/5
+ * Whenever you gain life, this creature gains flying until end of turn.
+ */
+val KalastriaNightwatch = card("Kalastria Nightwatch") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Warrior Ally"
+    power = 4
+    toughness = 5
+    oracleText = "Whenever you gain life, this creature gains flying until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "Jama Jurabaev"
+        flavorText = "\"Kalitas may have returned to mindless servitude beneath the Eldrazi, but we say never " +
+            "again.\"\n" +
+            "—Drana, Kalastria bloodchief"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13989bf2-fd02-4702-9170-4b066837de65.jpg?1783938200"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/KitesailScout.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/KitesailScout.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kitesail Scout
+ * {W}
+ * Creature — Kor Scout
+ * 1/1
+ * Flying
+ */
+val KitesailScout = card("Kitesail Scout") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kor Scout"
+    power = 1
+    toughness = 1
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "33"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"The wind in one's hair, the sun on one's back, the joy of open skies . . . the next " +
+            "generation of kor must know this kind of peace.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/68a07aad-4ed5-47ae-b04c-9b9919000f6c.jpg?1783938218"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/KorBladewhirl.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/KorBladewhirl.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Kor Bladewhirl
+ * {1}{W}
+ * Creature — Kor Soldier Ally
+ * 2/2
+ * Rally — Whenever this creature or another Ally you control enters, creatures you control gain first strike until end of turn.
+ *
+ * Rally is an ability word, not a keyword: the trigger is an ANY-bound enters trigger over
+ * Allies you control, so the creature's own arrival fires it alongside every later Ally.
+ */
+val KorBladewhirl = card("Kor Bladewhirl") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kor Soldier Ally"
+    power = 2
+    toughness = 2
+    oracleText = "Rally — Whenever this creature or another Ally you control enters, creatures you control gain " +
+        "first strike until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Ally").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Patterns.Group.grantKeywordToAll(
+            Keyword.FIRST_STRIKE,
+            Filters.Group.creaturesYouControl,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "34"
+        artist = "Steven Belledin"
+        flavorText = "The high-pitched whirl of a hook is the only battle cry she needs."
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e31b12c7-df11-4450-95e1-b9a5aa97af0e.jpg?1783938218"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/KorEntanglers.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/KorEntanglers.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Kor Entanglers
+ * {4}{W}
+ * Creature — Kor Soldier Ally
+ * 3/4
+ * Rally — Whenever this creature or another Ally you control enters, tap target creature an opponent controls.
+ *
+ * Rally is an ability word, not a keyword: the trigger is an ANY-bound enters trigger over
+ * Allies you control, so the creature's own arrival fires it alongside every later Ally.
+ */
+val KorEntanglers = card("Kor Entanglers") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kor Soldier Ally"
+    power = 3
+    toughness = 4
+    oracleText = "Rally — Whenever this creature or another Ally you control enters, tap target creature an " +
+        "opponent controls."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Ally").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        val creature = target("target creature", Targets.CreatureOpponentControls)
+        effect = Effects.Tap(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "36"
+        artist = "Jason Rainville"
+        flavorText = "\"We came into this world together. We fight for this world together. We'll leave this world " +
+            "together.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/0039ead5-2afa-49d6-ae4a-45ae2118188a.jpg?1783938218"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/KozileksChanneler.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/KozileksChanneler.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Kozilek's Channeler
+ * {5}
+ * Creature — Eldrazi
+ * 4/4
+ * {T}: Add {C}{C}.
+ */
+val KozileksChanneler = card("Kozilek's Channeler") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Creature — Eldrazi"
+    power = 4
+    toughness = 4
+    oracleText = "{T}: Add {C}{C}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(2)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "Jason Felix"
+        flavorText = "\"In the dark places of our world, something horrible is growing. I fear our foes may be more " +
+            "numerous than we had imagined.\"\n" +
+            "—Nissa Revane"
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c550d179-32ec-4ad8-91c2-d79320a21cba.jpg?1783938223"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/LanternScout.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/LanternScout.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Lantern Scout
+ * {2}{W}
+ * Creature — Human Scout Ally
+ * 3/2
+ * Rally — Whenever this creature or another Ally you control enters, creatures you control gain lifelink until end of turn.
+ *
+ * Rally is an ability word, not a keyword: the trigger is an ANY-bound enters trigger over
+ * Allies you control, so the creature's own arrival fires it alongside every later Ally.
+ */
+val LanternScout = card("Lantern Scout") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Scout Ally"
+    power = 3
+    toughness = 2
+    oracleText = "Rally — Whenever this creature or another Ally you control enters, creatures you control gain " +
+        "lifelink until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Ally").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Patterns.Group.grantKeywordToAll(
+            Keyword.LIFELINK,
+            Filters.Group.creaturesYouControl,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "37"
+        artist = "Steven Belledin"
+        flavorText = "Hedron lanterns fend off more than just the darkness."
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/fea3b271-226d-4223-8be8-51b5b2b7cae8.jpg?1783938218"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/LifespringDruid.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/LifespringDruid.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Lifespring Druid
+ * {2}{G}
+ * Creature — Elf Druid
+ * 2/1
+ * {T}: Add one mana of any color.
+ */
+val LifespringDruid = card("Lifespring Druid") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid"
+    power = 2
+    toughness = 1
+    oracleText = "{T}: Add one mana of any color."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "177"
+        artist = "Willian Murai"
+        flavorText = "\"The land is not dead, merely sick. I will nurse it back to health.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3657719-7d4d-46db-a5f4-699ee2032ebe.jpg?1783938187"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/LoomingSpires.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/LoomingSpires.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Looming Spires
+ * Land
+ * This land enters tapped.
+ * When this land enters, target creature gets +1/+1 and gains first strike until end of turn.
+ * {T}: Add {R}.
+ */
+val LoomingSpires = card("Looming Spires") {
+    manaCost = ""
+    colorIdentity = "R"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "When this land enters, target creature gets +1/+1 and gains first strike until end of turn.\n" +
+        "{T}: Add {R}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 1, creature),
+            Effects.GrantKeyword(Keyword.FIRST_STRIKE, creature),
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "238"
+        artist = "Florian de Gesincourt"
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b88177a2-de41-417d-a8f1-07edf005b453.jpg?1783938174"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/MakindiPatrol.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/MakindiPatrol.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Makindi Patrol
+ * {2}{W}
+ * Creature — Human Knight Ally
+ * 2/3
+ * Rally — Whenever this creature or another Ally you control enters, creatures you control gain vigilance until end of turn.
+ *
+ * Rally is an ability word, not a keyword: the trigger is an ANY-bound enters trigger over
+ * Allies you control, so the creature's own arrival fires it alongside every later Ally.
+ */
+val MakindiPatrol = card("Makindi Patrol") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight Ally"
+    power = 2
+    toughness = 3
+    oracleText = "Rally — Whenever this creature or another Ally you control enters, creatures you control gain " +
+        "vigilance until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Ally").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Patterns.Group.grantKeywordToAll(
+            Keyword.VIGILANCE,
+            Filters.Group.creaturesYouControl,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "David Palumbo"
+        flavorText = "Working with his noble mount, he notices every form on the horizon, every scent in the air, " +
+            "every tremor in the earth."
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae03f018-3062-4b1c-99b8-13fcffd70b49.jpg?1783938218"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/MakindiSliderunner.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/MakindiSliderunner.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Makindi Sliderunner
+ * {1}{R}
+ * Creature — Beast
+ * 2/1
+ * Trample
+ * Landfall — Whenever a land you control enters, this creature gets +1/+1 until end of turn.
+ *
+ * Landfall is a plain [Triggers.LandYouControlEnters] — ANY binding, because the printed line never says "another".
+ */
+val MakindiSliderunner = card("Makindi Sliderunner") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Beast"
+    power = 2
+    toughness = 1
+    oracleText = "Trample\n" +
+        "Landfall — Whenever a land you control enters, this creature gets +1/+1 until end of turn."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Matt Stewart"
+        flavorText = "After a battle, it breaks the hillsides into manageable pieces to prepare for next time."
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e6da400-ee4e-44d1-887d-1e2fb59b9322.jpg?1783938193"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/MalakirFamiliar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/MalakirFamiliar.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Malakir Familiar
+ * {2}{B}
+ * Creature — Bat
+ * 2/1
+ * Flying, deathtouch
+ * Whenever you gain life, this creature gets +1/+1 until end of turn.
+ */
+val MalakirFamiliar = card("Malakir Familiar") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Bat"
+    power = 2
+    toughness = 1
+    oracleText = "Flying, deathtouch\n" +
+        "Whenever you gain life, this creature gets +1/+1 until end of turn."
+
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "116"
+        artist = "Alejandro Mirabal"
+        flavorText = "\"They are deadly, and they are loyal. We can spare them a little blood.\"\n" +
+            "—Harak, Malakir bloodwitch"
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f03b00a-f6d0-419a-abfd-fa8bc63226db.jpg?1783938200"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/MurasaRanger.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/MurasaRanger.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Murasa Ranger
+ * {3}{G}
+ * Creature — Human Warrior Ranger
+ * 3/3
+ * Landfall — Whenever a land you control enters, you may pay {3}{G}. If you do, put two +1/+1 counters on this creature.
+ *
+ * "You may pay {3}{G}. If you do" is the flat [MayPayManaEffect] gate — a mana
+ * [com.wingedsheep.sdk.scripting.effects.Gate.MayPay] with no `otherwise`, which is the
+ * shape the engine recognises for manual mana-source selection at resolution.
+ */
+val MurasaRanger = card("Murasa Ranger") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Warrior Ranger"
+    power = 3
+    toughness = 3
+    oracleText = "Landfall — Whenever a land you control enters, you may pay {3}{G}. If you do, put two +1/+1 " +
+        "counters on this creature."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{3}{G}"),
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "178"
+        artist = "Eric Deschamps"
+        flavorText = "\"If you're not prepared to fight, you'd best be prepared to die.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c4a3c02b-b576-4099-9016-15449f93bb09.jpg?1783938187"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/NirkanaAssassin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/NirkanaAssassin.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Nirkana Assassin
+ * {2}{B}
+ * Creature — Vampire Assassin Ally
+ * 2/3
+ * Whenever you gain life, this creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)
+ */
+val NirkanaAssassin = card("Nirkana Assassin") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Assassin Ally"
+    power = 2
+    toughness = 3
+    oracleText = "Whenever you gain life, this creature gains deathtouch until end of turn. (Any amount of damage " +
+        "it deals to a creature is enough to destroy it.)"
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Viktor Titov"
+        flavorText = "Nirkana assassins craft incurable concoctions by mixing basilisk marrow and deathwillow sap " +
+            "with the vital fluids of a dozen other poisonous species."
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2ca43ea1-ba7b-4dc7-b6f6-a0c92321ebe1.jpg?1783938200"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/OmnathLocusOfRage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/OmnathLocusOfRage.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Omnath, Locus of Rage
+ * {3}{R}{R}{G}{G}
+ * Legendary Creature — Elemental
+ * 5/5
+ * Landfall — Whenever a land you control enters, create a 5/5 red and green Elemental creature token.
+ * Whenever Omnath or another Elemental you control dies, Omnath deals 3 damage to any target.
+ *
+ * The dies trigger is ANY-bound over Elementals you control, so Omnath's own death and every
+ * token it made fire it — the tokens are Elementals, which is what makes a board wipe
+ * with Omnath out lethal.
+ */
+val OmnathLocusOfRage = card("Omnath, Locus of Rage") {
+    manaCost = "{3}{R}{R}{G}{G}"
+    colorIdentity = "GR"
+    typeLine = "Legendary Creature — Elemental"
+    power = 5
+    toughness = 5
+    oracleText = "Landfall — Whenever a land you control enters, create a 5/5 red and green Elemental creature " +
+        "token.\n" +
+        "Whenever Omnath or another Elemental you control dies, Omnath deals 3 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.CreateToken(
+            power = 5,
+            toughness = 5,
+            colors = setOf(Color.RED, Color.GREEN),
+            creatureTypes = setOf("Elemental"),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Elemental").youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY,
+        )
+        val victim = target("any target", Targets.Any)
+        effect = Effects.DealDamage(3, victim)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "217"
+        artist = "Brad Rigney"
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/58f311e7-7ebf-4428-b5a3-154255eb3ba1.jpg?1783938179"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/OnduChampion.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/OnduChampion.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Ondu Champion
+ * {2}{R}{R}
+ * Creature — Minotaur Warrior Ally
+ * 4/3
+ * Rally — Whenever this creature or another Ally you control enters, creatures you control gain trample until end of turn.
+ *
+ * Rally is an ability word, not a keyword: the trigger is an ANY-bound enters trigger over
+ * Allies you control, so the creature's own arrival fires it alongside every later Ally.
+ */
+val OnduChampion = card("Ondu Champion") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Warrior Ally"
+    power = 4
+    toughness = 3
+    oracleText = "Rally — Whenever this creature or another Ally you control enters, creatures you control gain " +
+        "trample until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Ally").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Patterns.Group.grantKeywordToAll(
+            Keyword.TRAMPLE,
+            Filters.Group.creaturesYouControl,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "149"
+        artist = "Volkan Baǵa"
+        flavorText = "\"Put a minotaur at the head of an army and suddenly all the soldiers act like they have " +
+            "horns.\"\n" +
+            "—Gideon Jura"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/708e1979-902b-410a-ae46-3fd1d2acc31d.jpg?1783938194"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/OnduGreathorn.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/OnduGreathorn.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ondu Greathorn
+ * {3}{W}
+ * Creature — Beast
+ * 2/3
+ * First strike
+ * Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.
+ *
+ * Landfall is a plain [Triggers.LandYouControlEnters] — ANY binding, because the printed line never says "another".
+ */
+val OnduGreathorn = card("Ondu Greathorn") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Beast"
+    power = 2
+    toughness = 3
+    oracleText = "First strike\n" +
+        "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "Aaron Miller"
+        flavorText = "\"May your horns get lodged in an Eldrazi's bony face, ornery brute!\"\n" +
+            "—Bruse Tarl, Goma Fada nomad"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/95d9668e-05dc-41c4-9326-ef4c0e15dd80.jpg?1783938217"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/OranRiefInvoker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/OranRiefInvoker.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Oran-Rief Invoker
+ * {1}{G}
+ * Creature — Human Shaman
+ * 2/2
+ * {8}: This creature gets +5/+5 and gains trample until end of turn.
+ */
+val OranRiefInvoker = card("Oran-Rief Invoker") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "{8}: This creature gets +5/+5 and gains trample until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{8}")
+        effect = Effects.Composite(
+            Effects.ModifyStats(5, 5, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "182"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "\"The world was not hostile to us—we were beneath its notice, and presented no danger.\"\n" +
+            "—*The Invokers' Tales*"
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/0957875c-e1a2-4d14-8b61-c806903fc760.jpg?1783938186"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/PlatedCrusher.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/PlatedCrusher.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plated Crusher
+ * {4}{G}{G}{G}
+ * Creature — Beast
+ * 7/6
+ * Trample
+ * Hexproof (This creature can't be the target of spells or abilities your opponents control.)
+ */
+val PlatedCrusher = card("Plated Crusher") {
+    manaCost = "{4}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 7
+    toughness = 6
+    oracleText = "Trample\n" +
+        "Hexproof (This creature can't be the target of spells or abilities your opponents control.)"
+
+    keywords(Keyword.TRAMPLE, Keyword.HEXPROOF)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "183"
+        artist = "Jama Jurabaev"
+        flavorText = "\"It might fight the Eldrazi, but don't mistake it for a companion, Gideon. It's not " +
+            "interested in your concept of strength through unity.\"\n" +
+            "—Najiya, leader of the Tajuru"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd68e01c-4a09-450b-bfa0-8fbac8721764.jpg?1783938186"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/PlummetReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/PlummetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet reprint in BFZ. Canonical CardDefinition lives in its earliest set.
+ */
+val PlummetReprint = Printing(
+    oracleId = "85bde6ac-3dd4-4946-8b57-24f57e3eae2b",
+    name = "Plummet",
+    setCode = "BFZ",
+    collectorNumber = "184",
+    scryfallId = "5f6acb5b-b087-4cad-b40f-2de37029847c",
+    artist = "Aaron Miller",
+    imageUri = "https://cards.scryfall.io/normal/front/5/f/5f6acb5b-b087-4cad-b40f-2de37029847c.jpg",
+    releaseDate = "2015-10-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ResoluteBlademaster.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ResoluteBlademaster.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Resolute Blademaster
+ * {3}{R}{W}
+ * Creature — Human Soldier Ally
+ * 2/2
+ * Rally — Whenever this creature or another Ally you control enters, creatures you control gain double strike until end of turn.
+ *
+ * Rally is an ability word, not a keyword: the trigger is an ANY-bound enters trigger over
+ * Allies you control, so the creature's own arrival fires it alongside every later Ally.
+ */
+val ResoluteBlademaster = card("Resolute Blademaster") {
+    manaCost = "{3}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Human Soldier Ally"
+    power = 2
+    toughness = 2
+    oracleText = "Rally — Whenever this creature or another Ally you control enters, creatures you control gain " +
+        "double strike until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Ally").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Patterns.Group.grantKeywordToAll(
+            Keyword.DOUBLE_STRIKE,
+            Filters.Group.creaturesYouControl,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "218"
+        artist = "Joseph Meehan"
+        flavorText = "\"Great steel is born in the hottest forges. Great soldiers are born in war.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/bea96f8d-0c57-448d-8145-51f9cca04432.jpg?1783938178"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/RetreatToHagra.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/RetreatToHagra.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Retreat to Hagra
+ * {2}{B}
+ * Enchantment
+ * Landfall — Whenever a land you control enters, choose one —
+ * • Target creature gets +1/+0 and gains deathtouch until end of turn.
+ * • Each opponent loses 1 life and you gain 1 life.
+ *
+ * A modal *triggered* ability: the mode is chosen as the ability goes on the stack (CR 603.3c),
+ * so the target is locked in before any land-drop response.
+ */
+val RetreatToHagra = card("Retreat to Hagra") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Landfall — Whenever a land you control enters, choose one —\n" +
+        "• Target creature gets +1/+0 and gains deathtouch until end of turn.\n" +
+        "• Each opponent loses 1 life and you gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = ModalEffect.chooseOne(
+            Mode.withTarget(
+                Effects.Composite(
+                    Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0)),
+                    Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.ContextTarget(0)),
+                ),
+                TargetCreature(),
+                "Target creature gets +1/+0 and gains deathtouch until end of turn",
+            ),
+            Mode.noTarget(
+                Effects.Composite(
+                    Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                    Effects.GainLife(1),
+                ),
+                "Each opponent loses 1 life and you gain 1 life",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "121"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48505c90-ee73-40ad-b774-a6f4bfffff4b.jpg?1783938199"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/RetreatToKazanduReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/RetreatToKazanduReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Retreat to Kazandu reprint in BFZ. Canonical CardDefinition lives in its earliest set.
+ */
+val RetreatToKazanduReprint = Printing(
+    oracleId = "3f8e5ff1-af89-427e-924c-19a44f9a3788",
+    name = "Retreat to Kazandu",
+    setCode = "BFZ",
+    collectorNumber = "186",
+    scryfallId = "53884f2a-6749-4d85-be64-82919eb30e39",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/5/3/53884f2a-6749-4d85-be64-82919eb30e39.jpg",
+    releaseDate = "2015-10-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/RetreatToValakut.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/RetreatToValakut.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Retreat to Valakut
+ * {2}{R}
+ * Enchantment
+ * Landfall — Whenever a land you control enters, choose one —
+ * • Target creature gets +2/+0 until end of turn.
+ * • Target creature can't block this turn.
+ */
+val RetreatToValakut = card("Retreat to Valakut") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Landfall — Whenever a land you control enters, choose one —\n" +
+        "• Target creature gets +2/+0 until end of turn.\n" +
+        "• Target creature can't block this turn."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = ModalEffect.chooseOne(
+            Mode.withTarget(
+                Effects.ModifyStats(2, 0, EffectTarget.ContextTarget(0)),
+                TargetCreature(),
+                "Target creature gets +2/+0 until end of turn",
+            ),
+            Mode.withTarget(
+                Effects.CantBlock(EffectTarget.ContextTarget(0)),
+                TargetCreature(),
+                "Target creature can't block this turn",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "153"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7a9ce97-ef6d-468c-b389-8d19c76174c2.jpg?1783938193"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ScourFromExistence.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ScourFromExistence.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scour from Existence
+ * {7}
+ * Instant
+ * Exile target permanent.
+ */
+val ScourFromExistence = card("Scour from Existence") {
+    manaCost = "{7}"
+    colorIdentity = ""
+    typeLine = "Instant"
+    oracleText = "Exile target permanent."
+
+    spell {
+        val permanent = target("target permanent", Targets.Permanent)
+        effect = Effects.Exile(permanent)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "13"
+        artist = "Clint Cearley"
+        flavorText = "\"Our people and our very lands disappear as if they never were. We no longer fight for " +
+            "glory, or honor. We battle now for the right to exist.\"\n" +
+            "—General Tazri, allied commander"
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6e47edb2-e43d-479f-a911-e72b67a06c3b.jpg?1783938222"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ScytheLeopard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ScytheLeopard.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Scythe Leopard
+ * {G}
+ * Creature — Cat
+ * 1/1
+ * Landfall — Whenever a land you control enters, this creature gets +1/+1 until end of turn.
+ *
+ * Landfall is a plain [Triggers.LandYouControlEnters] — ANY binding, because the printed line never says "another".
+ */
+val ScytheLeopard = card("Scythe Leopard") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat"
+    power = 1
+    toughness = 1
+    oracleText = "Landfall — Whenever a land you control enters, this creature gets +1/+1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "188"
+        artist = "Daniel Ljunggren"
+        flavorText = "Eldrazi are not the leopard's preferred prey, but they are better than no prey at all."
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/89ef0054-a290-4c41-846d-12f8119c52ae.jpg?1783938185"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SeekTheWilds.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SeekTheWilds.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Seek the Wilds
+ * {1}{G}
+ * Sorcery
+ * Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.
+ *
+ * "…in any order" is [CardOrder.ControllerChooses], not the recipe's default random order.
+ */
+val SeekTheWilds = card("Seek the Wilds") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top four cards of your library. You may reveal a creature or land card from among " +
+        "them and put it into your hand. Put the rest on the bottom of your library in any order."
+
+    spell {
+        effect = Patterns.Library.lookAtTopRevealMatchingToHand(
+            count = DynamicAmount.Fixed(4),
+            filter = GameObjectFilter.CreatureOrLand,
+            prompt = "You may reveal a creature or land card from among them and put it into your hand",
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+            restOrder = CardOrder.ControllerChooses,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "189"
+        artist = "Anna Steinbauer"
+        flavorText = "\"In my downtime I used to paint the vistas. Now the vistas disappear faster than my " +
+            "downtime.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/824f44fe-ee16-4b15-a308-5c620cfd3d93.jpg?1783938185"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SereneSteward.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SereneSteward.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Serene Steward
+ * {1}{W}
+ * Creature — Human Cleric Ally
+ * 2/2
+ * Whenever you gain life, you may pay {W}. If you do, put a +1/+1 counter on target creature.
+ */
+val SereneSteward = card("Serene Steward") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric Ally"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever you gain life, you may pay {W}. If you do, put a +1/+1 counter on target creature."
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        val creature = target("target creature", Targets.Creature)
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{W}"),
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "46"
+        artist = "Magali Villeneuve"
+        flavorText = "\"I can give you strength, but you'll have to bring your own courage.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/702f5dd4-4dc7-4e2c-a30b-9286499433d8.jpg?1783938216"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ShadowGlider.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ShadowGlider.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shadow Glider
+ * {2}{W}
+ * Creature — Kor Soldier
+ * 2/2
+ * Flying
+ */
+val ShadowGlider = card("Shadow Glider") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kor Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "47"
+        artist = "Steve Prescott"
+        flavorText = "A few bands of kor sought refuge from the Eldrazi in Zendikar's vast cave networks, relying " +
+            "on their ability to survive in harsh vertical landscapes."
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b4ffaf62-2e12-4b1d-a590-f63aacb4a30b.jpg?1783938215"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ShatterskullRecruit.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ShatterskullRecruit.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shatterskull Recruit
+ * {3}{R}{R}
+ * Creature — Giant Warrior Ally
+ * 4/4
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ */
+val ShatterskullRecruit = card("Shatterskull Recruit") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant Warrior Ally"
+    power = 4
+    toughness = 4
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)"
+
+    keywords(Keyword.MENACE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "155"
+        artist = "David Palumbo"
+        flavorText = "Saved from certain death by the kor, he considers himself bound to them by an unbreakable " +
+            "blood oath."
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c8add5f2-4ccf-4505-86f6-cc36aff1c3fe.jpg?1783938192"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/StoneHavenMedic.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/StoneHavenMedic.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stone Haven Medic
+ * {1}{W}
+ * Creature — Kor Cleric
+ * 1/3
+ * {W}, {T}: You gain 1 life.
+ */
+val StoneHavenMedic = card("Stone Haven Medic") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kor Cleric"
+    power = 1
+    toughness = 3
+    oracleText = "{W}, {T}: You gain 1 life."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "51"
+        artist = "Anna Steinbauer"
+        flavorText = "\"These days, soldiers never stick around long enough for a proper healing. They just want me " +
+            "to knit them up so they can hurry back to the fight.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/3956563b-bde3-4aec-93fe-e03bade49458.jpg?1783938214"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SylvanScryingReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SylvanScryingReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sylvan Scrying reprint in BFZ. Canonical CardDefinition lives in its earliest set.
+ */
+val SylvanScryingReprint = Printing(
+    oracleId = "ee24bf27-484d-4e1c-998e-6a74e3d3f6c4",
+    name = "Sylvan Scrying",
+    setCode = "BFZ",
+    collectorNumber = "192",
+    scryfallId = "d1b93087-e6a0-4ba9-83ba-a0ed2e396dc7",
+    artist = "Daniel Ljunggren",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d1b93087-e6a0-4ba9-83ba-a0ed2e396dc7.jpg",
+    releaseDate = "2015-10-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/TajuruBeastmaster.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/TajuruBeastmaster.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Tajuru Beastmaster
+ * {5}{G}
+ * Creature — Elf Warrior Ally
+ * 5/5
+ * Rally — Whenever this creature or another Ally you control enters, creatures you control get +1/+1 until end of turn.
+ *
+ * Rally is an ability word, not a keyword: the trigger is an ANY-bound enters trigger over
+ * Allies you control, so the creature's own arrival fires it alongside every later Ally.
+ */
+val TajuruBeastmaster = card("Tajuru Beastmaster") {
+    manaCost = "{5}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior Ally"
+    power = 5
+    toughness = 5
+    oracleText = "Rally — Whenever this creature or another Ally you control enters, creatures you control get " +
+        "+1/+1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Ally").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Patterns.Group.modifyStatsForAll(1, 1, Filters.Group.creaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "193"
+        artist = "Greg Opalinski"
+        flavorText = "\"My mount needs neither reins nor bridle. We both share a common purpose.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/3447b4af-2eb2-48ae-a12e-2fdf83d4cb70.jpg?1783938184"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/TajuruWarcaller.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/TajuruWarcaller.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Tajuru Warcaller
+ * {3}{G}{G}
+ * Creature — Elf Warrior Ally
+ * 2/1
+ * Rally — Whenever this creature or another Ally you control enters, creatures you control get +2/+2 until end of turn.
+ *
+ * Rally is an ability word, not a keyword: the trigger is an ANY-bound enters trigger over
+ * Allies you control, so the creature's own arrival fires it alongside every later Ally.
+ */
+val TajuruWarcaller = card("Tajuru Warcaller") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior Ally"
+    power = 2
+    toughness = 1
+    oracleText = "Rally — Whenever this creature or another Ally you control enters, creatures you control get " +
+        "+2/+2 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype("Ally").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Patterns.Group.modifyStatsForAll(2, 2, Filters.Group.creaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "195"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "Her rallying cry reaches far beyond the Tajuru elves, inspiring all those who hear it."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/762501fe-5102-4c21-8ad5-430590a59830.jpg?1783938183"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/TandemTactics.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/TandemTactics.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tandem Tactics
+ * {1}{W}
+ * Instant
+ * Up to two target creatures each get +1/+2 until end of turn. You gain 2 life.
+ *
+ * "Up to two target creatures **each** get +1/+2" is a plural requirement, so the pump runs
+ * once per chosen target ([ForEachTargetEffect] over `ContextTarget(0)`) rather than once
+ * against the requirement as a whole.
+ */
+val TandemTactics = card("Tandem Tactics") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Up to two target creatures each get +1/+2 until end of turn. You gain 2 life."
+
+    spell {
+        target("target creature", Targets.UpToCreatures(2))
+        effect = Effects.Composite(
+            ForEachTargetEffect(listOf(Effects.ModifyStats(1, 2, EffectTarget.ContextTarget(0)))),
+            Effects.GainLife(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "David Gaillet"
+        flavorText = "In times of infestation and war, Zendikar favors the blades that strike in unison."
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6a8aaf9c-9aa5-44db-9610-402389a3ddc5.jpg?1783938214"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/TerritorialBalothReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/TerritorialBalothReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Territorial Baloth reprint in BFZ. Canonical CardDefinition lives in its earliest set.
+ */
+val TerritorialBalothReprint = Printing(
+    oracleId = "f772e767-a931-4891-94eb-d92a8ca7f8c1",
+    name = "Territorial Baloth",
+    setCode = "BFZ",
+    collectorNumber = "196",
+    scryfallId = "0c3d4afc-5bb7-4159-9a11-f9c989dd9043",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/0/c/0c3d4afc-5bb7-4159-9a11-f9c989dd9043.jpg",
+    releaseDate = "2015-10-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/TunnelingGeopede.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/TunnelingGeopede.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tunneling Geopede
+ * {2}{R}
+ * Creature — Insect
+ * 3/2
+ * Landfall — Whenever a land you control enters, this creature deals 1 damage to each opponent.
+ *
+ * Landfall is a plain [Triggers.LandYouControlEnters] — ANY binding, because the printed line never says "another".
+ */
+val TunnelingGeopede = card("Tunneling Geopede") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Insect"
+    power = 3
+    toughness = 2
+    oracleText = "Landfall — Whenever a land you control enters, this creature deals 1 damage to each opponent."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "158"
+        artist = "Tomasz Jedruszek"
+        flavorText = "As Ulamog's brood reduces the earth to dust, geopedes burst from their tunnels in search of " +
+            "solid ground."
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d4071152-5e64-4133-88a2-8fa5cb0eeb6c.jpg?1783938191"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ValakutPredator.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ValakutPredator.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Valakut Predator
+ * {2}{R}
+ * Creature — Elemental
+ * 2/2
+ * Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.
+ *
+ * Landfall is a plain [Triggers.LandYouControlEnters] — ANY binding, because the printed line never says "another".
+ */
+val ValakutPredator = card("Valakut Predator") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 2
+    toughness = 2
+    oracleText = "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "160"
+        artist = "Kev Walker"
+        flavorText = "\"Whatever volcanoes dream of, it seems like they always wake up grumpy.\"\n" +
+            "—Raff Slugeater, goblin shortcutter"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88318272-8192-4d6d-a22a-eca87abb480d.jpg?1783938191"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/VestigeOfEmrakul.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/VestigeOfEmrakul.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vestige of Emrakul
+ * {3}{R}
+ * Creature — Eldrazi Drone
+ * 3/4
+ * Devoid (This card has no color.)
+ * Trample
+ */
+val VestigeOfEmrakul = card("Vestige of Emrakul") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Eldrazi Drone"
+    power = 3
+    toughness = 4
+    oracleText = "Devoid (This card has no color.)\n" +
+        "Trample"
+
+    keywords(Keyword.DEVOID, Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "136"
+        artist = "Tyler Jacobson"
+        flavorText = "Emrakul has not been seen in months. Though her brood's numbers have dwindled in her " +
+            "absence, each drone is still a deadly threat."
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a5d84986-64a1-4bd1-a4f6-3eb147aca357.jpg?1783938196"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/VolcanicUpheaval.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/VolcanicUpheaval.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Volcanic Upheaval
+ * {3}{R}
+ * Instant
+ * Destroy target land.
+ */
+val VolcanicUpheaval = card("Volcanic Upheaval") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Destroy target land."
+
+    spell {
+        val land = target("target land", Targets.Land)
+        effect = Effects.Destroy(land)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "161"
+        artist = "Yeong-Hao Han"
+        flavorText = "Like a living organism, Zendikar rids itself of infection, and it does so abruptly and " +
+            "ruthlessly."
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d90bd68-0521-4db3-b590-a4e007da9f2e.jpg?1783938191"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/VoraciousNull.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/VoraciousNull.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Voracious Null
+ * {2}{B}
+ * Creature — Zombie
+ * 2/2
+ * {1}{B}, Sacrifice another creature: Put two +1/+1 counters on this creature. Activate only as a sorcery.
+ */
+val VoraciousNull = card("Voracious Null") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 2
+    oracleText = "{1}{B}, Sacrifice another creature: Put two +1/+1 counters on this creature. Activate only as a " +
+        "sorcery."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{B}"),
+            Costs.SacrificeAnother(GameObjectFilter.Creature),
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "125"
+        artist = "Karl Kopinski"
+        flavorText = "\"These days, there's no shortage of food for the nulls of Guul Draz.\"\n" +
+            "—Drana, Kalastria bloodchief"
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/74364056-f4ee-46d3-834d-a5157ec312b9.jpg?1783938198"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/WaveWingElemental.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/WaveWingElemental.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wave-Wing Elemental
+ * {5}{U}
+ * Creature — Elemental
+ * 3/4
+ * Flying
+ * Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.
+ *
+ * Landfall is a plain [Triggers.LandYouControlEnters] — ANY binding, because the printed line never says "another".
+ */
+val WaveWingElemental = card("Wave-Wing Elemental") {
+    manaCost = "{5}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental"
+    power = 3
+    toughness = 4
+    oracleText = "Flying\n" +
+        "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "88"
+        artist = "John Severin Brassell"
+        flavorText = "\"Do you see? All of Tazeem strains at its tether.\"\n" +
+            "—Noyan Dar, Tazeem roilmage"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11b45809-87fc-409d-942a-1f31f68d27ac.jpg?1783938206"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ZulaportCutthroat.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ZulaportCutthroat.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Zulaport Cutthroat
+ * {1}{B}
+ * Creature — Human Rogue Ally
+ * 1/1
+ * Whenever this creature or another creature you control dies, each opponent loses 1 life and you gain 1 life.
+ *
+ * ANY binding, because the printed line says "this creature **or** another creature you
+ * control" — the Cutthroat's own death has to fire it too.
+ */
+val ZulaportCutthroat = card("Zulaport Cutthroat") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Rogue Ally"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever this creature or another creature you control dies, each opponent loses 1 life and you " +
+        "gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.Composite(
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "126"
+        artist = "Jason Rainville"
+        flavorText = "\"Eldrazi? Ha! Try walking through Zulaport at night with your pockets full. Now *that's* " +
+            "dangerous.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5c963d97-c948-45d9-84cc-58e246d35970.jpg?1783938198"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/AltarSReapReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/AltarSReapReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Altar's Reap reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val AltarSReapReprint = Printing(
+    oracleId = "6a125750-2b8c-4f9d-8173-ac8d14c91ddb",
+    name = "Altar's Reap",
+    setCode = "C15",
+    collectorNumber = "112",
+    scryfallId = "7a7f0900-331b-4676-bb61-cc197500505a",
+    artist = "Donato Giancola",
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7a7f0900-331b-4676-bb61-cc197500505a.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/DuelDecksZendikarVsEldraziSet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/DuelDecksZendikarVsEldraziSet.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ddp
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Duel Decks: Zendikar vs. Eldrazi (2015)
+ *
+ * Scaffolded so that the cards this product printed *first* can hold their canonical
+ * definitions. Retreat to Kazandu is one: the duel deck shipped five weeks before Battle for
+ * Zendikar, so DDP — not BFZ — is its earliest real printing.
+ *
+ * The other 69 cards are reprints and are not authored here yet, hence [incomplete].
+ *
+ * [sealedSupported] stays false: a duel deck is two fixed 60-card decks, not a draftable product.
+ *
+ * Set Code: DDP
+ * Release Date: 2015-08-28
+ */
+object DuelDecksZendikarVsEldraziSet : MtgSet {
+
+    override val code = "DDP"
+    override val displayName = "Duel Decks: Zendikar vs. Eldrazi"
+    override val releaseDate = "2015-08-28"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.ddp.cards"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/AkoumRefugeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/AkoumRefugeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Akoum Refuge reprint in DDP. Canonical CardDefinition lives in its earliest set.
+ */
+val AkoumRefugeReprint = Printing(
+    oracleId = "354fecd1-2371-49e3-81c6-7e47728dbb1f",
+    name = "Akoum Refuge",
+    setCode = "DDP",
+    collectorNumber = "67",
+    scryfallId = "2a110d58-3576-48cb-a446-8351e0f33a16",
+    artist = "Fred Fields",
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2a110d58-3576-48cb-a446-8351e0f33a16.jpg",
+    releaseDate = "2015-08-28",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/ArtisanOfKozilekReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/ArtisanOfKozilekReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Artisan of Kozilek reprint in DDP. Canonical CardDefinition lives in its earliest set.
+ */
+val ArtisanOfKozilekReprint = Printing(
+    oracleId = "19409704-09c4-4a4b-a5a7-f95120b425db",
+    name = "Artisan of Kozilek",
+    setCode = "DDP",
+    collectorNumber = "42",
+    scryfallId = "c861b386-20e4-42ae-b4db-392217c4f6d1",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c861b386-20e4-42ae-b4db-392217c4f6d1.jpg",
+    releaseDate = "2015-08-28",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/GrazingGladehartReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/GrazingGladehartReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grazing Gladehart reprint in DDP. Canonical CardDefinition lives in its earliest set.
+ */
+val GrazingGladehartReprint = Printing(
+    oracleId = "f19f28e5-9cad-4398-b2d4-9e7fefb23cb4",
+    name = "Grazing Gladehart",
+    setCode = "DDP",
+    collectorNumber = "14",
+    scryfallId = "06dda49d-25a2-4fa3-80f2-0d784e1ad30f",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/06dda49d-25a2-4fa3-80f2-0d784e1ad30f.jpg",
+    releaseDate = "2015-08-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/RetreatToKazandu.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/RetreatToKazandu.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Retreat to Kazandu
+ * {2}{G}
+ * Enchantment
+ * Landfall — Whenever a land you control enters, choose one —
+ * • Put a +1/+1 counter on target creature.
+ * • You gain 2 life.
+ *
+ * The canonical printing is Duel Decks: Zendikar vs. Eldrazi (2015-08-28), five weeks ahead of
+ * Battle for Zendikar, which gets a [com.wingedsheep.sdk.model.Printing] row instead.
+ *
+ * A modal *triggered* ability: the mode is chosen as the ability goes on the stack (CR 603.3c).
+ */
+val RetreatToKazandu = card("Retreat to Kazandu") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Landfall — Whenever a land you control enters, choose one —\n" +
+        "• Put a +1/+1 counter on target creature.\n" +
+        "• You gain 2 life."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = ModalEffect.chooseOne(
+            Mode.withTarget(
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0)),
+                TargetCreature(),
+                "Put a +1/+1 counter on target creature",
+            ),
+            Mode.noTarget(
+                Effects.GainLife(2),
+                "You gain 2 life",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "21"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4d3a089f-2049-406f-aa7e-2fdcbc59a826.jpg?1783938253"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/SeerSSundialReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/SeerSSundialReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seer's Sundial reprint in DDP. Canonical CardDefinition lives in its earliest set.
+ */
+val SeerSSundialReprint = Printing(
+    oracleId = "9929d7ba-cdc5-4099-a0ee-3a15073336f3",
+    name = "Seer's Sundial",
+    setCode = "DDP",
+    collectorNumber = "29",
+    scryfallId = "8e5b04a0-8b0a-4b7c-92aa-6ad701851604",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/8/e/8e5b04a0-8b0a-4b7c-92aa-6ad701851604.jpg",
+    releaseDate = "2015-08-28",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/StoneworkPumaReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/StoneworkPumaReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stonework Puma reprint in DDP. Canonical CardDefinition lives in its earliest set.
+ */
+val StoneworkPumaReprint = Printing(
+    oracleId = "841b1010-a7d3-415e-b76d-7b50fea909cb",
+    name = "Stonework Puma",
+    setCode = "DDP",
+    collectorNumber = "30",
+    scryfallId = "35155ed9-35f4-4b20-8885-c72b8372fa1d",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/35155ed9-35f4-4b20-8885-c72b8372fa1d.jpg",
+    releaseDate = "2015-08-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/TerritorialBalothReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/TerritorialBalothReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Territorial Baloth reprint in DDP. Canonical CardDefinition lives in its earliest set.
+ */
+val TerritorialBalothReprint = Printing(
+    oracleId = "f772e767-a931-4891-94eb-d92a8ca7f8c1",
+    name = "Territorial Baloth",
+    setCode = "DDP",
+    collectorNumber = "24",
+    scryfallId = "9d53ca35-f585-4d19-87fe-c2e27652f0b4",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/9/d/9d53ca35-f585-4d19-87fe-c2e27652f0b4.jpg",
+    releaseDate = "2015-08-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/VampireNighthawkReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/VampireNighthawkReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vampire Nighthawk reprint in DDP. Canonical CardDefinition lives in its earliest set.
+ */
+val VampireNighthawkReprint = Printing(
+    oracleId = "feb244f8-bcb1-44cf-9940-2719221a7309",
+    name = "Vampire Nighthawk",
+    setCode = "DDP",
+    collectorNumber = "58",
+    scryfallId = "93933cd6-dfc9-4901-be1c-2bf05c1785ec",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/9/3/93933cd6-dfc9-4901-be1c-2bf05c1785ec.jpg",
+    releaseDate = "2015-08-28",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/WildheartInvokerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/WildheartInvokerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wildheart Invoker reprint in DDP. Canonical CardDefinition lives in its earliest set.
+ */
+val WildheartInvokerReprint = Printing(
+    oracleId = "ff8fb796-af5d-4d64-ab3c-7f2469dfa6bf",
+    name = "Wildheart Invoker",
+    setCode = "DDP",
+    collectorNumber = "26",
+    scryfallId = "ede96507-a325-4866-976b-51a824fadc5e",
+    artist = "Erica Yang",
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/ede96507-a325-4866-976b-51a824fadc5e.jpg",
+    releaseDate = "2015-08-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/InspiredChargeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/InspiredChargeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inspired Charge reprint in KLD. Canonical CardDefinition lives in its earliest set.
+ */
+val InspiredChargeReprint = Printing(
+    oracleId = "d465a3d6-5830-456c-8e7a-908b464db846",
+    name = "Inspired Charge",
+    setCode = "KLD",
+    collectorNumber = "20",
+    scryfallId = "eca67eb3-44e7-4315-9808-870057915a84",
+    artist = "Deruchenko Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/e/c/eca67eb3-44e7-4315-9808-870057915a84.jpg",
+    releaseDate = "2016-09-30",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/PlummetReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/PlummetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet reprint in M11. Canonical CardDefinition lives in its earliest set.
+ */
+val PlummetReprint = Printing(
+    oracleId = "85bde6ac-3dd4-4946-8b57-24f57e3eae2b",
+    name = "Plummet",
+    setCode = "M11",
+    collectorNumber = "190",
+    scryfallId = "5923f9d4-c2ec-466f-9e5b-17d24bda7f37",
+    artist = "Pete Venters",
+    imageUri = "https://cards.scryfall.io/normal/front/5/9/5923f9d4-c2ec-466f-9e5b-17d24bda7f37.jpg",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/GoblinWarPaintReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/GoblinWarPaintReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin War Paint reprint in M12. Canonical CardDefinition lives in its earliest set.
+ */
+val GoblinWarPaintReprint = Printing(
+    oracleId = "67ca79d7-9064-4605-8625-b1cfe5cb1b45",
+    name = "Goblin War Paint",
+    setCode = "M12",
+    collectorNumber = "143",
+    scryfallId = "fde711c9-fdef-4024-8269-a59ee0748f95",
+    artist = "Austin Hsu",
+    imageUri = "https://cards.scryfall.io/normal/front/f/d/fde711c9-fdef-4024-8269-a59ee0748f95.jpg",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/PlummetReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/PlummetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet reprint in M12. Canonical CardDefinition lives in its earliest set.
+ */
+val PlummetReprint = Printing(
+    oracleId = "85bde6ac-3dd4-4946-8b57-24f57e3eae2b",
+    name = "Plummet",
+    setCode = "M12",
+    collectorNumber = "187",
+    scryfallId = "54a1a949-c874-4739-9c7d-ad6fcd2aad44",
+    artist = "Pete Venters",
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/54a1a949-c874-4739-9c7d-ad6fcd2aad44.jpg",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/PlummetReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/PlummetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet reprint in M13. Canonical CardDefinition lives in its earliest set.
+ */
+val PlummetReprint = Printing(
+    oracleId = "85bde6ac-3dd4-4946-8b57-24f57e3eae2b",
+    name = "Plummet",
+    setCode = "M13",
+    collectorNumber = "179",
+    scryfallId = "a96d7d96-5a86-45ef-a30b-b11ece22f060",
+    artist = "Pete Venters",
+    imageUri = "https://cards.scryfall.io/normal/front/a/9/a96d7d96-5a86-45ef-a30b-b11ece22f060.jpg",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/AltarSReapReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/AltarSReapReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Altar's Reap reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val AltarSReapReprint = Printing(
+    oracleId = "6a125750-2b8c-4f9d-8173-ac8d14c91ddb",
+    name = "Altar's Reap",
+    setCode = "M14",
+    collectorNumber = "84",
+    scryfallId = "f3053af2-715c-4549-9003-bf4279029a95",
+    artist = "Donato Giancola",
+    imageUri = "https://cards.scryfall.io/normal/front/f/3/f3053af2-715c-4549-9003-bf4279029a95.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/PlummetReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/PlummetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val PlummetReprint = Printing(
+    oracleId = "85bde6ac-3dd4-4946-8b57-24f57e3eae2b",
+    name = "Plummet",
+    setCode = "M14",
+    collectorNumber = "188",
+    scryfallId = "7cbac2e5-cc3a-4be1-9891-6098b1066de8",
+    artist = "Pete Venters",
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7cbac2e5-cc3a-4be1-9891-6098b1066de8.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/InspiredChargeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/InspiredChargeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inspired Charge reprint in M15. Canonical CardDefinition lives in its earliest set.
+ */
+val InspiredChargeReprint = Printing(
+    oracleId = "d465a3d6-5830-456c-8e7a-908b464db846",
+    name = "Inspired Charge",
+    setCode = "M15",
+    collectorNumber = "272",
+    scryfallId = "1a28c4e2-7b9b-436d-95cf-9c757eacf091",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/1/a/1a28c4e2-7b9b-436d-95cf-9c757eacf091.jpg",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/PlummetReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/PlummetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet reprint in M15. Canonical CardDefinition lives in its earliest set.
+ */
+val PlummetReprint = Printing(
+    oracleId = "85bde6ac-3dd4-4946-8b57-24f57e3eae2b",
+    name = "Plummet",
+    setCode = "M15",
+    collectorNumber = "192",
+    scryfallId = "ce3de170-fdc5-4d46-9421-bb12460225ca",
+    artist = "Pete Venters",
+    imageUri = "https://cards.scryfall.io/normal/front/c/e/ce3de170-fdc5-4d46-9421-bb12460225ca.jpg",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/PlummetReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/PlummetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val PlummetReprint = Printing(
+    oracleId = "85bde6ac-3dd4-4946-8b57-24f57e3eae2b",
+    name = "Plummet",
+    setCode = "ORI",
+    collectorNumber = "286",
+    scryfallId = "fa8bee44-410b-46a9-be40-03f000cad9a9",
+    artist = "Pete Venters",
+    imageUri = "https://cards.scryfall.io/normal/front/f/a/fa8bee44-410b-46a9-be40-03f000cad9a9.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/DispelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/DispelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dispel reprint in RTR. Canonical CardDefinition lives in its earliest set.
+ */
+val DispelReprint = Printing(
+    oracleId = "6d7be242-a072-40ce-b540-95880506cccd",
+    name = "Dispel",
+    setCode = "RTR",
+    collectorNumber = "36",
+    scryfallId = "08d4a8d7-c136-472f-8146-a1100701ca4f",
+    artist = "Chase Stone",
+    imageUri = "https://cards.scryfall.io/normal/front/0/8/08d4a8d7-c136-472f-8146-a1100701ca4f.jpg",
+    releaseDate = "2012-10-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/Dispel.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/Dispel.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.wwk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetSpell
+
+/**
+ * Dispel
+ * {U}
+ * Instant
+ * Counter target instant spell.
+ */
+val Dispel = card("Dispel") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target instant spell."
+
+    spell {
+        target("target instant spell", TargetSpell(filter = TargetFilter.InstantSpellOnStack))
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "26"
+        artist = "Vance Kovacs"
+        flavorText = "The Jwari winds undo reality as easily as they scatter a pile of leaves."
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f178d0cc-5dd1-41ab-a2e8-218ece6f2a86.jpg?1783942063"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/GoblinWarPaint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/GoblinWarPaint.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Goblin War Paint
+ * {1}{R}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +2/+2 and has haste.
+ */
+val GoblinWarPaint = card("Goblin War Paint") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +2/+2 and has haste."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "129"
+        artist = "Austin Hsu"
+        flavorText = "War paint made from kolya fruit heightens senses and lessens fear. Unfortunately, fear is " +
+            "usually what keeps you alive."
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/4388e57e-0c87-4d66-a862-58261d76c5ac.jpg?1783942144"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/TerritorialBaloth.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/TerritorialBaloth.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Territorial Baloth
+ * {4}{G}
+ * Creature — Beast
+ * 4/4
+ * Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.
+ *
+ * Landfall is a plain [Triggers.LandYouControlEnters] — ANY binding, because the printed line
+ * never says "another".
+ */
+val TerritorialBaloth = card("Territorial Baloth") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 4
+    toughness = 4
+    oracleText = "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "188"
+        artist = "Jesper Ejsing"
+        flavorText = "Its territory is defined by wherever it is at the moment."
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/45033b8a-f3a8-4a23-b6b0-e011e3e7a4c1.jpg?1783942130"
+    }
+}

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/KalastriaHealerScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/KalastriaHealerScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Kalastria Healer — the first *rally* card in the corpus.
+ *
+ * Rally is an ability word, not a keyword: "Whenever this creature **or another** Ally you control
+ * enters" is an ANY-bound enters trigger filtered to Allies you control. The binding is the whole
+ * mechanic — under `OTHER` the Healer's own arrival would silently not fire it, which is the half
+ * of rally that is easiest to get wrong and invisible on the card text.
+ */
+class KalastriaHealerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Kalastria Healer") {
+
+            test("rally fires on the Healer's own arrival") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Kalastria Healer")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .build()
+
+                val startingOpponentLife = game.getLifeTotal(2)
+                val startingOwnLife = game.getLifeTotal(1)
+
+                game.castSpell(1, "Kalastria Healer").error shouldBe null
+                game.resolveStack()
+
+                withClue("the Healer is an Ally, so its own entry triggers rally") {
+                    game.getLifeTotal(2) shouldBe startingOpponentLife - 1
+                    game.getLifeTotal(1) shouldBe startingOwnLife + 1
+                }
+            }
+
+            test("rally fires again when another Ally enters") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Kalastria Healer")
+                    .withCardInHand(1, "Cliffside Lookout")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .build()
+
+                val startingOpponentLife = game.getLifeTotal(2)
+                val startingOwnLife = game.getLifeTotal(1)
+
+                game.castSpell(1, "Cliffside Lookout").error shouldBe null
+                game.resolveStack()
+
+                withClue("Cliffside Lookout is a Kor Scout Ally, so it re-triggers the Healer") {
+                    game.getLifeTotal(2) shouldBe startingOpponentLife - 1
+                    game.getLifeTotal(1) shouldBe startingOwnLife + 1
+                }
+            }
+
+            test("a non-Ally creature entering does not trigger rally") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Kalastria Healer")
+                    .withCardInHand(1, "Cloud Manta")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .build()
+
+                val startingOpponentLife = game.getLifeTotal(2)
+                val startingOwnLife = game.getLifeTotal(1)
+
+                game.castSpell(1, "Cloud Manta").error shouldBe null
+                game.resolveStack()
+
+                withClue("Cloud Manta is a Fish, not an Ally") {
+                    game.getLifeTotal(2) shouldBe startingOpponentLife
+                    game.getLifeTotal(1) shouldBe startingOwnLife
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/afr/cards/PlummetReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/afr/cards/PlummetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.afr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet reprint in AFR. Canonical CardDefinition lives in its earliest set.
+ */
+val PlummetReprint = Printing(
+    oracleId = "85bde6ac-3dd4-4946-8b57-24f57e3eae2b",
+    name = "Plummet",
+    setCode = "AFR",
+    collectorNumber = "199",
+    scryfallId = "4be85ceb-be98-43ce-9565-a72990797437",
+    artist = "Alix Branwyn",
+    imageUri = "https://cards.scryfall.io/normal/front/4/b/4be85ceb-be98-43ce-9565-a72990797437.jpg",
+    releaseDate = "2021-07-23",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ZulaportCutthroatReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/ZulaportCutthroatReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zulaport Cutthroat reprint in CLB. Canonical CardDefinition lives in its earliest set.
+ */
+val ZulaportCutthroatReprint = Printing(
+    oracleId = "76b003e0-15af-4f22-bdf2-1ade5430964a",
+    name = "Zulaport Cutthroat",
+    setCode = "CLB",
+    collectorNumber = "775",
+    scryfallId = "52ef00c1-613a-4cbd-8972-77c41f649431",
+    artist = "Jason Rainville",
+    imageUri = "https://cards.scryfall.io/normal/front/5/2/52ef00c1-613a-4cbd-8972-77c41f649431.jpg",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/AngelicGiftReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/AngelicGiftReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angelic Gift reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val AngelicGiftReprint = Printing(
+    oracleId = "e5e04968-d9b7-4bd5-b826-be9502360cd3",
+    name = "Angelic Gift",
+    setCode = "CMR",
+    collectorNumber = "7",
+    scryfallId = "db0775f2-3fd9-42aa-80e3-edac67764fa2",
+    artist = "Josu Hernaiz",
+    imageUri = "https://cards.scryfall.io/normal/front/d/b/db0775f2-3fd9-42aa-80e3-edac67764fa2.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/RetreatToKazanduReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/RetreatToKazanduReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Retreat to Kazandu reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val RetreatToKazanduReprint = Printing(
+    oracleId = "3f8e5ff1-af89-427e-924c-19a44f9a3788",
+    name = "Retreat to Kazandu",
+    setCode = "CMR",
+    collectorNumber = "435",
+    scryfallId = "553ac818-f476-43fd-841c-c91d78c2506e",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/553ac818-f476-43fd-841c-c91d78c2506e.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/GideonsReproachReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/GideonsReproachReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.dom.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gideon's Reproach reprint in Dominaria. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in the Battle for Zendikar (`bfz`) `cards/` package; this file contributes only
+ * presentation data.
+ */
+val GideonsReproachReprint = Printing(
+    oracleId = "ec43d67c-2254-4782-8bd4-3318b25907e6",
+    name = "Gideon's Reproach",
+    setCode = "DOM",
+    collectorNumber = "19",
+    scryfallId = "7b771f44-ce32-41a2-b219-738924b7f42d",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/7/b/7b771f44-ce32-41a2-b219-738924b7f42d.jpg?1783935051",
+    releaseDate = "2018-04-27",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/PlummetReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/PlummetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val PlummetReprint = Printing(
+    oracleId = "85bde6ac-3dd4-4946-8b57-24f57e3eae2b",
+    name = "Plummet",
+    setCode = "IKO",
+    collectorNumber = "169",
+    scryfallId = "d884b2f2-946e-4d5d-b8cf-ef035726a188",
+    artist = "Sidharth Chaturvedi",
+    imageUri = "https://cards.scryfall.io/normal/front/d/8/d884b2f2-946e-4d5d-b8cf-ef035726a188.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BloodbondVampireReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BloodbondVampireReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bloodbond Vampire reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val BloodbondVampireReprint = Printing(
+    oracleId = "a2057118-9fd1-431d-9441-fef198d67ff2",
+    name = "Bloodbond Vampire",
+    setCode = "J22",
+    collectorNumber = "380",
+    scryfallId = "2937cc19-d0bb-4695-b4c1-5e72000e08b4",
+    artist = "Anna Steinbauer",
+    imageUri = "https://cards.scryfall.io/normal/front/2/9/2937cc19-d0bb-4695-b4c1-5e72000e08b4.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KalastriaNightwatchReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KalastriaNightwatchReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kalastria Nightwatch reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val KalastriaNightwatchReprint = Printing(
+    oracleId = "f610748a-8b2c-4c7d-b495-b4677ff4c423",
+    name = "Kalastria Nightwatch",
+    setCode = "J22",
+    collectorNumber = "429",
+    scryfallId = "2ccdadf8-d4f2-4273-b7b6-02866ba54610",
+    artist = "Jama Jurabaev",
+    imageUri = "https://cards.scryfall.io/normal/front/2/c/2ccdadf8-d4f2-4273-b7b6-02866ba54610.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/NirkanaAssassinReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/NirkanaAssassinReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nirkana Assassin reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val NirkanaAssassinReprint = Printing(
+    oracleId = "efb64da9-1ca7-4686-a427-e0d67101030c",
+    name = "Nirkana Assassin",
+    setCode = "J22",
+    collectorNumber = "449",
+    scryfallId = "959fb12c-3ea2-4caa-80d9-2a844e83ba0f",
+    artist = "Viktor Titov",
+    imageUri = "https://cards.scryfall.io/normal/front/9/5/959fb12c-3ea2-4caa-80d9-2a844e83ba0f.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SereneStewardReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SereneStewardReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Serene Steward reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val SereneStewardReprint = Printing(
+    oracleId = "559463f8-396f-40e0-9515-a1be6397ca31",
+    name = "Serene Steward",
+    setCode = "J22",
+    collectorNumber = "241",
+    scryfallId = "746381e7-1695-40c0-a830-ab58bb240180",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/7/4/746381e7-1695-40c0-a830-ab58bb240180.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BloodbondVampireReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BloodbondVampireReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bloodbond Vampire reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val BloodbondVampireReprint = Printing(
+    oracleId = "a2057118-9fd1-431d-9441-fef198d67ff2",
+    name = "Bloodbond Vampire",
+    setCode = "JMP",
+    collectorNumber = "209",
+    scryfallId = "b1c6df1d-7709-41e4-a79f-0dc722600191",
+    artist = "Anna Steinbauer",
+    imageUri = "https://cards.scryfall.io/normal/front/b/1/b1c6df1d-7709-41e4-a79f-0dc722600191.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/KalastriaNightwatchReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/KalastriaNightwatchReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kalastria Nightwatch reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val KalastriaNightwatchReprint = Printing(
+    oracleId = "f610748a-8b2c-4c7d-b495-b4677ff4c423",
+    name = "Kalastria Nightwatch",
+    setCode = "JMP",
+    collectorNumber = "245",
+    scryfallId = "98527faa-9d06-4f46-b2f7-c78aedacc3a4",
+    artist = "Jama Jurabaev",
+    imageUri = "https://cards.scryfall.io/normal/front/9/8/98527faa-9d06-4f46-b2f7-c78aedacc3a4.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MalakirFamiliarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/MalakirFamiliarReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Malakir Familiar reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val MalakirFamiliarReprint = Printing(
+    oracleId = "12eeabe1-a02c-42a3-aa87-6774c4de7093",
+    name = "Malakir Familiar",
+    setCode = "JMP",
+    collectorNumber = "253",
+    scryfallId = "24fe5c92-7da2-47b5-ad13-f95590e93ac2",
+    artist = "Alejandro Mirabal",
+    imageUri = "https://cards.scryfall.io/normal/front/2/4/24fe5c92-7da2-47b5-ad13-f95590e93ac2.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/TandemTacticsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/TandemTacticsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tandem Tactics reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val TandemTacticsReprint = Printing(
+    oracleId = "e42cd4da-f049-4304-a16f-911769985e6c",
+    name = "Tandem Tactics",
+    setCode = "JMP",
+    collectorNumber = "135",
+    scryfallId = "7acd58e4-7dc7-4ca0-8750-2558ff97b5da",
+    artist = "David Gaillet",
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7acd58e4-7dc7-4ca0-8750-2558ff97b5da.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/InspiredChargeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/InspiredChargeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inspired Charge reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val InspiredChargeReprint = Printing(
+    oracleId = "d465a3d6-5830-456c-8e7a-908b464db846",
+    name = "Inspired Charge",
+    setCode = "M19",
+    collectorNumber = "15",
+    scryfallId = "812cf63f-aa3d-405b-92e1-7ffa31352481",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/812cf63f-aa3d-405b-92e1-7ffa31352481.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/PlummetReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/PlummetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val PlummetReprint = Printing(
+    oracleId = "85bde6ac-3dd4-4946-8b57-24f57e3eae2b",
+    name = "Plummet",
+    setCode = "M19",
+    collectorNumber = "193",
+    scryfallId = "78a29ddb-fc76-407a-aa58-ec92d011bd44",
+    artist = "Pete Venters",
+    imageUri = "https://cards.scryfall.io/normal/front/7/8/78a29ddb-fc76-407a-aa58-ec92d011bd44.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/AngelicGiftReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/AngelicGiftReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angelic Gift reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val AngelicGiftReprint = Printing(
+    oracleId = "e5e04968-d9b7-4bd5-b826-be9502360cd3",
+    name = "Angelic Gift",
+    setCode = "M20",
+    collectorNumber = "5",
+    scryfallId = "35100197-7914-450e-9205-57cb4fc345d6",
+    artist = "Josu Hernaiz",
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/35100197-7914-450e-9205-57cb4fc345d6.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/BoneSplintersReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/BoneSplintersReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bone Splinters reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val BoneSplintersReprint = Printing(
+    oracleId = "0c936582-d4c0-4da8-bc7e-49da5a433939",
+    name = "Bone Splinters",
+    setCode = "M20",
+    collectorNumber = "92",
+    scryfallId = "7e75a7e9-902a-4733-8cd4-767247174a4c",
+    artist = "Cole Eastburn",
+    imageUri = "https://cards.scryfall.io/normal/front/7/e/7e75a7e9-902a-4733-8cd4-767247174a4c.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/InspiredChargeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/InspiredChargeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inspired Charge reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val InspiredChargeReprint = Printing(
+    oracleId = "d465a3d6-5830-456c-8e7a-908b464db846",
+    name = "Inspired Charge",
+    setCode = "M20",
+    collectorNumber = "24",
+    scryfallId = "43479f67-57b2-4a99-8928-10fc9dde33b9",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/4/3/43479f67-57b2-4a99-8928-10fc9dde33b9.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/PlummetReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/PlummetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val PlummetReprint = Printing(
+    oracleId = "85bde6ac-3dd4-4946-8b57-24f57e3eae2b",
+    name = "Plummet",
+    setCode = "M20",
+    collectorNumber = "188",
+    scryfallId = "4a1a0c7b-ce1c-4284-9362-04b21861f69d",
+    artist = "Filip Burburan",
+    imageUri = "https://cards.scryfall.io/normal/front/4/a/4a1a0c7b-ce1c-4284-9362-04b21861f69d.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/PlummetReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/PlummetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet reprint in MID. Canonical CardDefinition lives in its earliest set.
+ */
+val PlummetReprint = Printing(
+    oracleId = "85bde6ac-3dd4-4946-8b57-24f57e3eae2b",
+    name = "Plummet",
+    setCode = "MID",
+    collectorNumber = "193",
+    scryfallId = "5469e696-bbf1-43e3-9c25-fe089b36caed",
+    artist = "Nicholas Gregory",
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/5469e696-bbf1-43e3-9c25-fe089b36caed.jpg",
+    releaseDate = "2021-09-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/PlummetReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/PlummetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet reprint in RIX. Canonical CardDefinition lives in its earliest set.
+ */
+val PlummetReprint = Printing(
+    oracleId = "85bde6ac-3dd4-4946-8b57-24f57e3eae2b",
+    name = "Plummet",
+    setCode = "RIX",
+    collectorNumber = "143",
+    scryfallId = "54a0afaa-f99f-4c7a-9fa1-c6a46dfb2a29",
+    artist = "Filip Burburan",
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/54a0afaa-f99f-4c7a-9fa1-c6a46dfb2a29.jpg",
+    releaseDate = "2018-01-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/PlummetReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/PlummetReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plummet reprint in THB. Canonical CardDefinition lives in its earliest set.
+ */
+val PlummetReprint = Printing(
+    oracleId = "85bde6ac-3dd4-4946-8b57-24f57e3eae2b",
+    name = "Plummet",
+    setCode = "THB",
+    collectorNumber = "194",
+    scryfallId = "a8b2f186-4e04-49cb-a206-257cfb7e9361",
+    artist = "Bayard Wu",
+    imageUri = "https://cards.scryfall.io/normal/front/a/8/a8b2f186-4e04-49cb-a206-257cfb7e9361.jpg",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/ZulaportCutthroatReprint.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/ZulaportCutthroatReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.blc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zulaport Cutthroat reprint in BLC. Canonical CardDefinition lives in its earliest set.
+ */
+val ZulaportCutthroatReprint = Printing(
+    oracleId = "76b003e0-15af-4f22-bdf2-1ade5430964a",
+    name = "Zulaport Cutthroat",
+    setCode = "BLC",
+    collectorNumber = "190",
+    scryfallId = "340efd40-6e1d-440e-b209-9b4993884e1d",
+    artist = "Jason Rainville",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/340efd40-6e1d-440e-b209-9b4993884e1d.jpg",
+    releaseDate = "2024-08-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/ARC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARC.json
@@ -1,3 +1,40 @@
+// Plummet
+{
+    "name": "Plummet",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature with flying.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature with flying"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature kw:flying"
+                },
+                "id": "target creature with flying"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "artist": "Pete Venters",
+        "flavorText": "\"You are the grandest of all,\" said the archdruid to the trees. They became so proud of bark and branch that they suffered no creature to fly overhead or perch upon a bough.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a67bb585-cc4f-4cbc-9a5a-d31df98c07ae.jpg?1783941902"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Reassembling Skeleton
 {
     "name": "Reassembling Skeleton",

--- a/mtg-sets/src/test/resources/snapshots/cards/BFZ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BFZ.json
@@ -1,3 +1,445 @@
+// Ally Encampment
+{
+    "name": "Ally Encampment",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast an Ally spell.\n{1}, {T}, Sacrifice this land: Return target Ally you control to its owner's hand.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "restriction": {
+                        "type": "SubtypeSpellsOnly",
+                        "subtypes": [
+                            "Ally"
+                        ]
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Ally you control"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent Ally ctrl:you"
+                        },
+                        "id": "target Ally you control"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "rarity": "RARE",
+        "artist": "Jonas De Ro",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bcb7124c-ba69-4da8-ad81-58f00fd0181d.jpg?1783938175"
+    },
+    "colorIdentityOverride": []
+}
+
+// Angel of Renewal
+{
+    "name": "Angel of Renewal",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Angel Ally",
+    "oracleText": "Flying\nWhen this creature enters, you gain 1 life for each creature you control.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "rarity": "UNCOMMON",
+        "artist": "Todd Lockwood",
+        "flavorText": "\"No more fear. No more failure. No more death. No more!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f882ac2-3cbc-4548-8c83-d2a7443991df.jpg?1783938222"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Angelic Gift
+{
+    "name": "Angelic Gift",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, draw a card.\nEnchanted creature has flying.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Josu Hernaiz",
+        "flavorText": "\"Zendikar will triumph this day, and our armies will fly with angels.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/4941246b-7d6a-4b2d-8144-f36ac890a389.jpg?1783938222"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Beastcaller Savant
+{
+    "name": "Beastcaller Savant",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Shaman Ally",
+    "oracleText": "Haste\n{T}: Add one mana of any color. Spend this mana only to cast a creature spell.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "restriction": "CreatureSpellsOnly"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "rarity": "RARE",
+        "artist": "Anthony Palumbo",
+        "flavorText": "\"They come because I call. They stay because I listen.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cca9f5da-986c-43ab-a2ec-efb8b098c17c.jpg?1783938191"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Belligerent Whiptail
+{
+    "name": "Belligerent Whiptail",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Wurm",
+    "oracleText": "Landfall — Whenever a land you control enters, this creature gains first strike until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "141",
+        "artist": "Jakub Kasper",
+        "flavorText": "\"Whiptails can sense a traveler's footsteps from a great distance. Measuring that distance has been . . . difficult.\"\n—Jalun, Affa sentry",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a5b5b7d2-acb8-4aca-b9e7-67e59aeb384b.jpg?1783938195"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Blighted Cataract
+{
+    "name": "Blighted Cataract",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{5}{U}, {T}, Sacrifice this land: Draw two cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}{U}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "229",
+        "rarity": "UNCOMMON",
+        "artist": "Vincent Proce",
+        "flavorText": "Once, water ran here. Now only dust and ash fall from the clifftops.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/8908b6b0-a488-426c-954d-458456be0651.jpg?1783938175"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Blighted Gorge
+{
+    "name": "Blighted Gorge",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{4}{R}, {T}, Sacrifice this land: It deals 2 damage to any target.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{R}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "rarity": "UNCOMMON",
+        "artist": "Jung Park",
+        "flavorText": "The land is dying, but it will not go peacefully.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88cbfe5d-79b7-45db-b3cd-4ae7a9964a37.jpg?1783938175"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Blighted Steppe
+{
+    "name": "Blighted Steppe",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{3}{W}, {T}, Sacrifice this land: You gain 2 life for each creature you control.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{W}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Multiply",
+                        "amount": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "creature"
+                        },
+                        "multiplier": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "232",
+        "rarity": "UNCOMMON",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "\"When a limb is gangrenous, you cut it off. This is no different.\"\n—Greenweaver Mina",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f43df8ee-d3e4-419e-aed0-1059d95f9cab.jpg?1783938175"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Blighted Woodland
 {
     "name": "Blighted Woodland",
@@ -86,6 +528,43 @@
     ]
 }
 
+// Bloodbond Vampire
+{
+    "name": "Bloodbond Vampire",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Vampire Shaman Ally",
+    "oracleText": "Whenever you gain life, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "104",
+        "rarity": "UNCOMMON",
+        "artist": "Anna Steinbauer",
+        "flavorText": "\"Let the vampires join us. In this war, we no longer have the luxury of choosing our comrades.\"\n—General Tazri, allied commander",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/ca31ce70-24c5-4fb2-8d88-c9ffa8474c8f.jpg?1783938203"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Broodhunter Wurm
 {
     "name": "Broodhunter Wurm",
@@ -145,6 +624,55 @@
     ]
 }
 
+// Chasm Guide
+{
+    "name": "Chasm Guide",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Goblin Scout Ally",
+    "oracleText": "Rally — Whenever this creature or another Ally you control enters, creatures you control gain haste until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Ally ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "HASTE",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "rarity": "UNCOMMON",
+        "artist": "Johannes Voss",
+        "flavorText": "With a single act of bravery, she went from expendable to indispensable.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fbd0fad7-264d-40fc-a616-a88dc94fa4d7.jpg?1783938195"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Cinder Glade
 {
     "name": "Cinder Glade",
@@ -181,6 +709,219 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Cliffside Lookout
+{
+    "name": "Cliffside Lookout",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Kor Scout Ally",
+    "oracleText": "{4}{W}: Creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "Eric Deschamps",
+        "flavorText": "Though losses run high among the scouts of the Stone Havens, they never flinch from their duty.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8c755ae6-badc-4dc8-bfa6-fdebcb00bfba.jpg?1783938221"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Cloud Manta
+{
+    "name": "Cloud Manta",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Fish",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "71",
+        "artist": "Mike Bierek",
+        "flavorText": "When Emeria's worshippers learned that she was no more than a twisted memory of Emrakul, they abandoned their temples to the god. The deserted shrines now serve as breeding grounds for the mantas.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/1854f819-d08e-4a23-bedb-4618b79623e9.jpg?1783938210"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Complete Disregard
+{
+    "name": "Complete Disregard",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Devoid (This card has no color.)\nExile target creature with power 3 or less.",
+    "keywords": [
+        "DEVOID"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature pow<=3"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "artist": "Peter Mohrbacher",
+        "flavorText": "\"We returned to the field and found poor Len, every detail of his final moment perfectly cast in that awful dust.\"\n—Javad Nasrin, outrider captain",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d94e878-6c49-4420-9d34-f9ee64e811ba.jpg?1783938206"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Coralhelm Guide
+{
+    "name": "Coralhelm Guide",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk Scout Ally",
+    "oracleText": "{4}{U}: Target creature can't be blocked this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "artist": "Viktor Titov",
+        "flavorText": "\"She knows every step of this coastline, both above and below the surface, and she has hideouts all along the way. She will get you there.\"\n—Jori En, expedition leader",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33787a5b-d1d1-4d60-ba09-d9c98025e9b3.jpg?1783938210"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Courier Griffin
+{
+    "name": "Courier Griffin",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Griffin",
+    "oracleText": "Flying\nWhen this creature enters, you gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"Sea Gate has fallen. Survivors are on the move. Will send another griffin when we find refuge. Stay hidden. Stay safe.\"\n—Message from Tars Olan, kor world-gift",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4d3afc71-f5db-45c3-96b2-8454b7f33542.jpg?1783938222"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -225,6 +966,154 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Desolation Twin
+{
+    "name": "Desolation Twin",
+    "manaCost": "{10}",
+    "typeLine": "Creature — Eldrazi",
+    "oracleText": "When you cast this spell, create a 10/10 colorless Eldrazi creature token.",
+    "creatureStats": {
+        "power": 10,
+        "toughness": 10
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 10,
+                    "toughness": 10,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Eldrazi"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "RARE",
+        "artist": "Jack Wang",
+        "flavorText": "\"With precise coordination and enough blood spilled, one can be driven off, even brought down. But two . . . that's a lot of blood.\"\n—Munda, ambush leader",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4d229d8d-5e64-4403-a4ae-a0a186a83935.jpg?1783938224"
+    },
+    "colorIdentityOverride": []
+}
+
+// Drana's Emissary
+{
+    "name": "Drana's Emissary",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Creature — Vampire Cleric Ally",
+    "oracleText": "Flying\nAt the beginning of your upkeep, each opponent loses 1 life and you gain 1 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "rarity": "UNCOMMON",
+        "artist": "Karl Kopinski",
+        "flavorText": "\"The taste of freedom is sweeter than blood.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/99e82d47-9bbb-4bf9-a935-2c0b27b64a84.jpg?1783938180"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Eldrazi Devastator
+{
+    "name": "Eldrazi Devastator",
+    "manaCost": "{8}",
+    "typeLine": "Creature — Eldrazi",
+    "oracleText": "Trample",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 9
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "7",
+        "artist": "Joseph Meehan",
+        "flavorText": "\"No matter how big your champion, theirs is bigger. No matter how great your numbers, theirs are greater. No matter how voracious your appetite, they are hungrier. That is why the Eldrazi will win.\"\n—Kalitas, thrall of Ulamog",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/04b13e32-01b9-4a86-a3df-ca8b784c6a6c.jpg?1783938225"
+    },
+    "colorIdentityOverride": []
+}
+
+// Endless One
+{
+    "name": "Endless One",
+    "manaCost": "{X}",
+    "typeLine": "Creature — Eldrazi",
+    "oracleText": "This creature enters with X +1/+1 counters on it.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": "XValue"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "rarity": "RARE",
+        "artist": "Jason Felix",
+        "flavorText": "It embodies all possible meanings of the word \"infinite.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/64820f4f-1f78-4338-beb8-5ed5a447cfe4.jpg?1783938224"
+    },
+    "colorIdentityOverride": []
 }
 
 // Expedition Envoy
@@ -295,6 +1184,372 @@
     ]
 }
 
+// Firemantle Mage
+{
+    "name": "Firemantle Mage",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Shaman Ally",
+    "oracleText": "Rally — Whenever this creature or another Ally you control enters, creatures you control gain menace until end of turn. (A creature with menace can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Ally ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "MENACE",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Rahn",
+        "flavorText": "\"Come on, you twisted things! Don't you want to get acquainted?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/197411bf-3307-4056-a7d4-31db0d4b8f9a.jpg?1783938195"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Fortified Rampart
+{
+    "name": "Fortified Rampart",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 6
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "metadata": {
+        "collectorNumber": "27",
+        "artist": "David Gaillet",
+        "flavorText": "The refuge's defenses allow new recruits to see lesser Eldrazi up close, steeling their stomachs for what's to come.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/5095e2ab-a7f5-45bc-8b2f-31198ea27bba.jpg?1783938220"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Geyserfield Stalker
+{
+    "name": "Geyserfield Stalker",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\nLandfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "artist": "Deruchenko Alexander",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d4d1e1e1-fa24-4e78-a77c-4d41a58b8aa0.jpg?1783938203"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Ghostly Sentinel
+{
+    "name": "Ghostly Sentinel",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Kor Spirit",
+    "oracleText": "Flying, vigilance",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "28",
+        "artist": "Daarken",
+        "flavorText": "Mystics of the Stone Havens call upon the spirits of fallen heroes to defend the refuges.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de867066-df5c-4412-9d51-56626b6d0220.jpg?1783938220"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Gideon's Reproach
+{
+    "name": "Gideon's Reproach",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Gideon's Reproach deals 4 damage to target attacking or blocking creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"Suddenly, Gideon was there with us, clearing the way so that we could escape.\"\n—*The War Diaries*",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/453d8ec3-15ae-4851-9efb-161ca2ee6019.jpg?1783938218"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Grove Rumbler
+{
+    "name": "Grove Rumbler",
+    "manaCost": "{2}{R}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Trample\nLandfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "UNCOMMON",
+        "artist": "Greg Opalinski",
+        "flavorText": "\"The land will not wait for the enemy to arrive.\"\n—Nissa Revane",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/012b8eff-cdf3-423e-ae17-72a909e7ebd3.jpg?1783938181"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Grovetender Druids
+{
+    "name": "Grovetender Druids",
+    "manaCost": "{2}{G}{W}",
+    "typeLine": "Creature — Elf Druid Ally",
+    "oracleText": "Rally — Whenever this creature or another Ally you control enters, you may pay {1}. If you do, create a 1/1 green Plant creature token.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Ally ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "GREEN"
+                        ],
+                        "creatureTypes": [
+                            "Plant"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "212",
+        "rarity": "UNCOMMON",
+        "artist": "Chase Stone",
+        "flavorText": "\"The seedlings scream for us to loose them upon the Eldrazi, and we shall oblige.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5c2fd3a4-e09a-4fe5-93eb-2276a65c4911.jpg?1783938179"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Hagra Sharpshooter
+{
+    "name": "Hagra Sharpshooter",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Assassin Ally",
+    "oracleText": "{4}{B}: Target creature gets -1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "rarity": "UNCOMMON",
+        "artist": "Josu Hernaiz",
+        "flavorText": "\"It's hard to find their weak points, but I very much enjoy the discovery process.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a706b2e3-bd0e-4111-8b68-976869c7d707.jpg?1783938201"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Hedron Archive
 {
     "name": "Hedron Archive",
@@ -352,6 +1607,399 @@
     "colorIdentityOverride": []
 }
 
+// Hero of Goma Fada
+{
+    "name": "Hero of Goma Fada",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Human Knight Ally",
+    "oracleText": "Rally — Whenever this creature or another Ally you control enters, creatures you control gain indestructible until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Ally ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "INDESTRUCTIBLE",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "31",
+        "rarity": "RARE",
+        "artist": "Lake Hurwitz",
+        "flavorText": "\"They seek to break us. Let us show them our strength!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4ca3400c-0687-4a92-9236-f5a0d7eae337.jpg?1783938218"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Jaddi Offshoot
+{
+    "name": "Jaddi Offshoot",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Plant",
+    "oracleText": "Defender\nLandfall — Whenever a land you control enters, you gain 1 life.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "176",
+        "rarity": "UNCOMMON",
+        "artist": "Daarken",
+        "flavorText": "On Murasa, even the trees grow trees.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/aca704d5-b6e0-4726-8856-0b3a6732bbd8.jpg?1783938188"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Kalastria Healer
+{
+    "name": "Kalastria Healer",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Vampire Cleric Ally",
+    "oracleText": "Rally — Whenever this creature or another Ally you control enters, each opponent loses 1 life and you gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Ally ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "artist": "Anthony Palumbo",
+        "flavorText": "\"Time and again, I have demonstrated my skills as a healer. Why, then, are you so ill at ease?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42c21cb3-21f4-4a8d-8068-52649f2a1846.jpg?1783938201"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Kalastria Nightwatch
+{
+    "name": "Kalastria Nightwatch",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Vampire Warrior Ally",
+    "oracleText": "Whenever you gain life, this creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "Jama Jurabaev",
+        "flavorText": "\"Kalitas may have returned to mindless servitude beneath the Eldrazi, but we say never again.\"\n—Drana, Kalastria bloodchief",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13989bf2-fd02-4702-9170-4b066837de65.jpg?1783938200"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Kitesail Scout
+{
+    "name": "Kitesail Scout",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Kor Scout",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "33",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"The wind in one's hair, the sun on one's back, the joy of open skies . . . the next generation of kor must know this kind of peace.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/68a07aad-4ed5-47ae-b04c-9b9919000f6c.jpg?1783938218"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Kor Bladewhirl
+{
+    "name": "Kor Bladewhirl",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Kor Soldier Ally",
+    "oracleText": "Rally — Whenever this creature or another Ally you control enters, creatures you control gain first strike until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Ally ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "FIRST_STRIKE",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "rarity": "UNCOMMON",
+        "artist": "Steven Belledin",
+        "flavorText": "The high-pitched whirl of a hook is the only battle cry she needs.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e31b12c7-df11-4450-95e1-b9a5aa97af0e.jpg?1783938218"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Kor Entanglers
+{
+    "name": "Kor Entanglers",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Kor Soldier Ally",
+    "oracleText": "Rally — Whenever this creature or another Ally you control enters, tap target creature an opponent controls.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Ally ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Rainville",
+        "flavorText": "\"We came into this world together. We fight for this world together. We'll leave this world together.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/0039ead5-2afa-49d6-ae4a-45ae2118188a.jpg?1783938218"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Kozilek's Channeler
+{
+    "name": "Kozilek's Channeler",
+    "manaCost": "{5}",
+    "typeLine": "Creature — Eldrazi",
+    "oracleText": "{T}: Add {C}{C}.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "artist": "Jason Felix",
+        "flavorText": "\"In the dark places of our world, something horrible is growing. I fear our foes may be more numerous than we had imagined.\"\n—Nissa Revane",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c550d179-32ec-4ad8-91c2-d79320a21cba.jpg?1783938223"
+    },
+    "colorIdentityOverride": []
+}
+
+// Lantern Scout
+{
+    "name": "Lantern Scout",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Scout Ally",
+    "oracleText": "Rally — Whenever this creature or another Ally you control enters, creatures you control gain lifelink until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Ally ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "LIFELINK",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "rarity": "RARE",
+        "artist": "Steven Belledin",
+        "flavorText": "Hedron lanterns fend off more than just the darkness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/e/fea3b271-226d-4223-8be8-51b5b2b7cae8.jpg?1783938218"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Lavastep Raider
 {
     "name": "Lavastep Raider",
@@ -396,6 +2044,571 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Lifespring Druid
+{
+    "name": "Lifespring Druid",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "{T}: Add one mana of any color.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "artist": "Willian Murai",
+        "flavorText": "\"The land is not dead, merely sick. I will nurse it back to health.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3657719-7d4d-46db-a5f4-699ee2032ebe.jpg?1783938187"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Looming Spires
+{
+    "name": "Looming Spires",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\nWhen this land enters, target creature gets +1/+1 and gains first strike until end of turn.\n{T}: Add {R}.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FIRST_STRIKE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "artist": "Florian de Gesincourt",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b88177a2-de41-417d-a8f1-07edf005b453.jpg?1783938174"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Makindi Patrol
+{
+    "name": "Makindi Patrol",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Knight Ally",
+    "oracleText": "Rally — Whenever this creature or another Ally you control enters, creatures you control gain vigilance until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Ally ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "VIGILANCE",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "David Palumbo",
+        "flavorText": "Working with his noble mount, he notices every form on the horizon, every scent in the air, every tremor in the earth.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae03f018-3062-4b1c-99b8-13fcffd70b49.jpg?1783938218"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Makindi Sliderunner
+{
+    "name": "Makindi Sliderunner",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Trample\nLandfall — Whenever a land you control enters, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "artist": "Matt Stewart",
+        "flavorText": "After a battle, it breaks the hillsides into manageable pieces to prepare for next time.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e6da400-ee4e-44d1-887d-1e2fb59b9322.jpg?1783938193"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Malakir Familiar
+{
+    "name": "Malakir Familiar",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Bat",
+    "oracleText": "Flying, deathtouch\nWhenever you gain life, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "116",
+        "rarity": "UNCOMMON",
+        "artist": "Alejandro Mirabal",
+        "flavorText": "\"They are deadly, and they are loyal. We can spare them a little blood.\"\n—Harak, Malakir bloodwitch",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f03b00a-f6d0-419a-abfd-fa8bc63226db.jpg?1783938200"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Murasa Ranger
+{
+    "name": "Murasa Ranger",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Human Warrior Ranger",
+    "oracleText": "Landfall — Whenever a land you control enters, you may pay {3}{G}. If you do, put two +1/+1 counters on this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{3}{G}"
+                        }
+                    },
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 2,
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Deschamps",
+        "flavorText": "\"If you're not prepared to fight, you'd best be prepared to die.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c4a3c02b-b576-4099-9016-15449f93bb09.jpg?1783938187"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Nirkana Assassin
+{
+    "name": "Nirkana Assassin",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Vampire Assassin Ally",
+    "oracleText": "Whenever you gain life, this creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Viktor Titov",
+        "flavorText": "Nirkana assassins craft incurable concoctions by mixing basilisk marrow and deathwillow sap with the vital fluids of a dozen other poisonous species.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2ca43ea1-ba7b-4dc7-b6f6-a0c92321ebe1.jpg?1783938200"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Omnath, Locus of Rage
+{
+    "name": "Omnath, Locus of Rage",
+    "manaCost": "{3}{R}{R}{G}{G}",
+    "typeLine": "Legendary Creature — Elemental",
+    "oracleText": "Landfall — Whenever a land you control enters, create a 5/5 red and green Elemental creature token.\nWhenever Omnath or another Elemental you control dies, Omnath deals 3 damage to any target.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 5,
+                    "toughness": 5,
+                    "colors": [
+                        "RED",
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Elemental"
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Elemental ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "217",
+        "rarity": "MYTHIC",
+        "artist": "Brad Rigney",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/58f311e7-7ebf-4428-b5a3-154255eb3ba1.jpg?1783938179"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Ondu Champion
+{
+    "name": "Ondu Champion",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Minotaur Warrior Ally",
+    "oracleText": "Rally — Whenever this creature or another Ally you control enters, creatures you control gain trample until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Ally ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "TRAMPLE",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "149",
+        "artist": "Volkan Baǵa",
+        "flavorText": "\"Put a minotaur at the head of an army and suddenly all the soldiers act like they have horns.\"\n—Gideon Jura",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/708e1979-902b-410a-ae46-3fd1d2acc31d.jpg?1783938194"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Ondu Greathorn
+{
+    "name": "Ondu Greathorn",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "First strike\nLandfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "artist": "Aaron Miller",
+        "flavorText": "\"May your horns get lodged in an Eldrazi's bony face, ornery brute!\"\n—Bruse Tarl, Goma Fada nomad",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/95d9668e-05dc-41c4-9326-ef4c0e15dd80.jpg?1783938217"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Oran-Rief Invoker
+{
+    "name": "Oran-Rief Invoker",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "{8}: This creature gets +5/+5 and gains trample until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{8}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 5
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 5
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "TRAMPLE",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "\"The world was not hostile to us—we were beneath its notice, and presented no danger.\"\n—*The Invokers' Tales*",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/0957875c-e1a2-4d14-8b61-c806903fc760.jpg?1783938186"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -445,6 +2658,32 @@
     ]
 }
 
+// Plated Crusher
+{
+    "name": "Plated Crusher",
+    "manaCost": "{4}{G}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Trample\nHexproof (This creature can't be the target of spells or abilities your opponents control.)",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 6
+    },
+    "keywords": [
+        "TRAMPLE",
+        "HEXPROOF"
+    ],
+    "metadata": {
+        "collectorNumber": "183",
+        "rarity": "UNCOMMON",
+        "artist": "Jama Jurabaev",
+        "flavorText": "\"It might fight the Eldrazi, but don't mistake it for a companion, Gideon. It's not interested in your concept of strength through unity.\"\n—Najiya, leader of the Tajuru",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd68e01c-4a09-450b-bfa0-8fbac8721764.jpg?1783938186"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Prairie Stream
 {
     "name": "Prairie Stream",
@@ -481,6 +2720,235 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLUE"
+    ]
+}
+
+// Resolute Blademaster
+{
+    "name": "Resolute Blademaster",
+    "manaCost": "{3}{R}{W}",
+    "typeLine": "Creature — Human Soldier Ally",
+    "oracleText": "Rally — Whenever this creature or another Ally you control enters, creatures you control gain double strike until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Ally ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "DOUBLE_STRIKE",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "rarity": "UNCOMMON",
+        "artist": "Joseph Meehan",
+        "flavorText": "\"Great steel is born in the hottest forges. Great soldiers are born in war.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/bea96f8d-0c57-448d-8145-51f9cca04432.jpg?1783938178"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Retreat to Hagra
+{
+    "name": "Retreat to Hagra",
+    "manaCost": "{2}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Landfall — Whenever a land you control enters, choose one —\n• Target creature gets +1/+0 and gains deathtouch until end of turn.\n• Each opponent loses 1 life and you gain 1 life.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "ModifyStats",
+                                        "powerModifier": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "toughnessModifier": {
+                                            "type": "Fixed",
+                                            "amount": 0
+                                        },
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    },
+                                    {
+                                        "type": "GrantKeyword",
+                                        "keyword": "DEATHTOUCH",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    }
+                                ]
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature"
+                                    }
+                                }
+                            ],
+                            "description": "Target creature gets +1/+0 and gains deathtouch until end of turn"
+                        },
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "LoseLife",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "EachOpponent"
+                                        }
+                                    },
+                                    {
+                                        "type": "GainLife",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    }
+                                ]
+                            },
+                            "description": "Each opponent loses 1 life and you gain 1 life"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "UNCOMMON",
+        "artist": "Kieran Yanner",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48505c90-ee73-40ad-b774-a6f4bfffff4b.jpg?1783938199"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Retreat to Valakut
+{
+    "name": "Retreat to Valakut",
+    "manaCost": "{2}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Landfall — Whenever a land you control enters, choose one —\n• Target creature gets +2/+0 until end of turn.\n• Target creature can't block this turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature"
+                                    }
+                                }
+                            ],
+                            "description": "Target creature gets +2/+0 until end of turn"
+                        },
+                        {
+                            "effect": {
+                                "type": "CantBlockTargetCreatures",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature"
+                                    }
+                                }
+                            ],
+                            "description": "Target creature can't block this turn"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "rarity": "UNCOMMON",
+        "artist": "Kieran Yanner",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7a9ce97-ef6d-468c-b389-8d19c76174c2.jpg?1783938193"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -558,6 +3026,262 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Scour from Existence
+{
+    "name": "Scour from Existence",
+    "manaCost": "{7}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target permanent.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target permanent"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "permanent"
+                },
+                "id": "target permanent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "artist": "Clint Cearley",
+        "flavorText": "\"Our people and our very lands disappear as if they never were. We no longer fight for glory, or honor. We battle now for the right to exist.\"\n—General Tazri, allied commander",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/e/6e47edb2-e43d-479f-a911-e72b67a06c3b.jpg?1783938222"
+    },
+    "colorIdentityOverride": []
+}
+
+// Scythe Leopard
+{
+    "name": "Scythe Leopard",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Landfall — Whenever a land you control enters, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "188",
+        "rarity": "UNCOMMON",
+        "artist": "Daniel Ljunggren",
+        "flavorText": "Eldrazi are not the leopard's preferred prey, but they are better than no prey at all.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/89ef0054-a290-4c41-846d-12f8119c52ae.jpg?1783938185"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Seek the Wilds
+{
+    "name": "Seek the Wilds",
+    "manaCost": "{1}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "creature|land",
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "prompt": "You may reveal a creature or land card from among them and put it into your hand",
+                    "showAllCards": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "ControllerChooses"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "189",
+        "artist": "Anna Steinbauer",
+        "flavorText": "\"In my downtime I used to paint the vistas. Now the vistas disappear faster than my downtime.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/824f44fe-ee16-4b15-a308-5c620cfd3d93.jpg?1783938185"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Serene Steward
+{
+    "name": "Serene Steward",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Cleric Ally",
+    "oracleText": "Whenever you gain life, you may pay {W}. If you do, put a +1/+1 counter on target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{W}"
+                        }
+                    },
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "UNCOMMON",
+        "artist": "Magali Villeneuve",
+        "flavorText": "\"I can give you strength, but you'll have to bring your own courage.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/702f5dd4-4dc7-4e2c-a30b-9286499433d8.jpg?1783938216"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Shadow Glider
+{
+    "name": "Shadow Glider",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Kor Soldier",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "47",
+        "artist": "Steve Prescott",
+        "flavorText": "A few bands of kor sought refuge from the Eldrazi in Zendikar's vast cave networks, relying on their ability to survive in harsh vertical landscapes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b4ffaf62-2e12-4b1d-a590-f63aacb4a30b.jpg?1783938215"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Shatterskull Recruit
+{
+    "name": "Shatterskull Recruit",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Giant Warrior Ally",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "metadata": {
+        "collectorNumber": "155",
+        "artist": "David Palumbo",
+        "flavorText": "Saved from certain death by the kor, he considers himself bound to them by an unbreakable blood oath.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c8add5f2-4ccf-4505-86f6-cc36aff1c3fe.jpg?1783938192"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -732,6 +3456,54 @@
     ]
 }
 
+// Stone Haven Medic
+{
+    "name": "Stone Haven Medic",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Kor Cleric",
+    "oracleText": "{W}, {T}: You gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "artist": "Anna Steinbauer",
+        "flavorText": "\"These days, soldiers never stick around long enough for a proper healing. They just want me to knit them up so they can hurry back to the fight.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/3956563b-bde3-4aec-93fe-e03bade49458.jpg?1783938214"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Stonefury
 {
     "name": "Stonefury",
@@ -861,6 +3633,224 @@
         "artist": "Jakub Kasper",
         "flavorText": "To survive imminent doom, it sometimes takes a foolhardy soul who acts first and fears later.",
         "imageUri": "https://cards.scryfall.io/normal/front/0/7/074dd176-4608-42ca-8fc3-c7040cd7b32e.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Tajuru Beastmaster
+{
+    "name": "Tajuru Beastmaster",
+    "manaCost": "{5}{G}",
+    "typeLine": "Creature — Elf Warrior Ally",
+    "oracleText": "Rally — Whenever this creature or another Ally you control enters, creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Ally ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "artist": "Greg Opalinski",
+        "flavorText": "\"My mount needs neither reins nor bridle. We both share a common purpose.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/4/3447b4af-2eb2-48ae-a12e-2fdf83d4cb70.jpg?1783938184"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Tajuru Warcaller
+{
+    "name": "Tajuru Warcaller",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Elf Warrior Ally",
+    "oracleText": "Rally — Whenever this creature or another Ally you control enters, creatures you control get +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Ally ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "rarity": "UNCOMMON",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "Her rallying cry reaches far beyond the Tajuru elves, inspiring all those who hear it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/762501fe-5102-4c21-8ad5-430590a59830.jpg?1783938183"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Tandem Tactics
+{
+    "name": "Tandem Tactics",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Up to two target creatures each get +1/+2 until end of turn. You gain 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "David Gaillet",
+        "flavorText": "In times of infestation and war, Zendikar favors the blades that strike in unison.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6a8aaf9c-9aa5-44db-9610-402389a3ddc5.jpg?1783938214"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Tunneling Geopede
+{
+    "name": "Tunneling Geopede",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Landfall — Whenever a land you control enters, this creature deals 1 damage to each opponent.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "rarity": "UNCOMMON",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "As Ulamog's brood reduces the earth to dust, geopedes burst from their tunnels in search of solid ground.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d4071152-5e64-4133-88a2-8fa5cb0eeb6c.jpg?1783938191"
     },
     "colorIdentityOverride": [
         "RED"
@@ -1012,6 +4002,52 @@
     ]
 }
 
+// Valakut Predator
+{
+    "name": "Valakut Predator",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "artist": "Kev Walker",
+        "flavorText": "\"Whatever volcanoes dream of, it seems like they always wake up grumpy.\"\n—Raff Slugeater, goblin shortcutter",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88318272-8192-4d6d-a22a-eca87abb480d.jpg?1783938191"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Vampiric Rites
 {
     "name": "Vampiric Rites",
@@ -1075,6 +4111,172 @@
     ]
 }
 
+// Vestige of Emrakul
+{
+    "name": "Vestige of Emrakul",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Eldrazi Drone",
+    "oracleText": "Devoid (This card has no color.)\nTrample",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEVOID",
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "136",
+        "artist": "Tyler Jacobson",
+        "flavorText": "Emrakul has not been seen in months. Though her brood's numbers have dwindled in her absence, each drone is still a deadly threat.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a5d84986-64a1-4bd1-a4f6-3eb147aca357.jpg?1783938196"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Volcanic Upheaval
+{
+    "name": "Volcanic Upheaval",
+    "manaCost": "{3}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target land.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target land"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "land"
+                },
+                "id": "target land"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "161",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "Like a living organism, Zendikar rids itself of infection, and it does so abruptly and ruthlessly.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d90bd68-0521-4db3-b590-a4e007da9f2e.jpg?1783938191"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Voracious Null
+{
+    "name": "Voracious Null",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "{1}{B}, Sacrifice another creature: Put two +1/+1 counters on this creature. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": "Self"
+                },
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "artist": "Karl Kopinski",
+        "flavorText": "\"These days, there's no shortage of food for the nulls of Guul Draz.\"\n—Drana, Kalastria bloodchief",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/74364056-f4ee-46d3-834d-a5157ec312b9.jpg?1783938198"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Wave-Wing Elemental
+{
+    "name": "Wave-Wing Elemental",
+    "manaCost": "{5}{U}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Flying\nLandfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "artist": "John Severin Brassell",
+        "flavorText": "\"Do you see? All of Tazeem strains at its tether.\"\n—Noyan Dar, Tazeem roilmage",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11b45809-87fc-409d-942a-1f31f68d27ac.jpg?1783938206"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Windrider Patrol
 {
     "name": "Windrider Patrol",
@@ -1113,5 +4315,64 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Zulaport Cutthroat
+{
+    "name": "Zulaport Cutthroat",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Rogue Ally",
+    "oracleText": "Whenever this creature or another creature you control dies, each opponent loses 1 life and you gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "126",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Rainville",
+        "flavorText": "\"Eldrazi? Ha! Try walking through Zulaport at night with your pockets full. Now *that's* dangerous.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5c963d97-c948-45d9-84cc-58e246d35970.jpg?1783938198"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/DDP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DDP.json
@@ -1,0 +1,63 @@
+// Retreat to Kazandu
+{
+    "name": "Retreat to Kazandu",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Landfall — Whenever a land you control enters, choose one —\n• Put a +1/+1 counter on target creature.\n• You gain 2 life.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature"
+                                    }
+                                }
+                            ],
+                            "description": "Put a +1/+1 counter on target creature"
+                        },
+                        {
+                            "effect": {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "rarity": "UNCOMMON",
+        "artist": "Kieran Yanner",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4d3a089f-2049-406f-aa7e-2fdcbc59a826.jpg?1783938253"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -4605,58 +4605,6 @@
     ]
 }
 
-// Gideon's Reproach
-{
-    "name": "Gideon's Reproach",
-    "manaCost": "{1}{W}",
-    "typeLine": "Instant",
-    "oracleText": "Gideon's Reproach deals 4 damage to target attacking or blocking creature.",
-    "script": {
-        "spellEffect": {
-            "type": "DealDamage",
-            "amount": {
-                "type": "Fixed",
-                "amount": 4
-            },
-            "target": {
-                "type": "BoundVariable",
-                "name": "target"
-            }
-        },
-        "targetRequirements": [
-            {
-                "type": "TargetObject",
-                "filter": {
-                    "baseFilter": {
-                        "cardPredicates": [
-                            "IsCreature"
-                        ],
-                        "statePredicates": [
-                            {
-                                "type": "StateOr",
-                                "predicates": [
-                                    "IsAttacking",
-                                    "IsBlocking"
-                                ]
-                            }
-                        ]
-                    }
-                },
-                "id": "target"
-            }
-        ]
-    },
-    "metadata": {
-        "collectorNumber": "19",
-        "artist": "Izzy",
-        "flavorText": "\"On Amonkhet, Gideon lost both his sural and his faith in himself. But he can still throw a punch.\"",
-        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7b771f44-ce32-41a2-b219-738924b7f42d.jpg?1562738270"
-    },
-    "colorIdentityOverride": [
-        "WHITE"
-    ]
-}
-
 // Gift of Growth
 {
     "name": "Gift of Growth",

--- a/mtg-sets/src/test/resources/snapshots/cards/WWK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WWK.json
@@ -57,6 +57,36 @@
     "colorIdentityOverride": []
 }
 
+// Dispel
+{
+    "name": "Dispel",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target instant spell.",
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "instant",
+                    "zone": "Stack"
+                },
+                "id": "target instant spell"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "artist": "Vance Kovacs",
+        "flavorText": "The Jwari winds undo reality as easily as they scatter a pile of leaves.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f178d0cc-5dd1-41ab-a2e8-218ece6f2a86.jpg?1783942063"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dragonmaster Outcast
 {
     "name": "Dragonmaster Outcast",

--- a/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
@@ -794,6 +794,42 @@
     ]
 }
 
+// Goblin War Paint
+{
+    "name": "Goblin War Paint",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +2/+2 and has haste.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "artist": "Austin Hsu",
+        "flavorText": "War paint made from kolya fruit heightens senses and lessens fear. Unfortunately, fear is usually what keeps you alive.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/4388e57e-0c87-4d66-a862-58261d76c5ac.jpg?1783942144"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Grazing Gladehart
 {
     "name": "Grazing Gladehart",
@@ -1831,6 +1867,52 @@
         "imageUri": "https://cards.scryfall.io/normal/front/0/5/05460615-4c24-487f-841a-ca14106e5688.jpg?1783942125"
     },
     "colorIdentityOverride": []
+}
+
+// Territorial Baloth
+{
+    "name": "Territorial Baloth",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "188",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Its territory is defined by wherever it is at the moment.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/45033b8a-f3a8-4a23-b6b0-e011e3e7a4c1.jpg?1783942130"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
 }
 
 // Vampire Nighthawk


### PR DESCRIPTION
BFZ's Assay-ready count goes **84 → 0**.

## The four-way split

| Bucket | Count | Work |
|---|---|---|
| `original` | 67 | canonical authored in BFZ |
| `elsewhere` | 4 | canonical authored in its earliest real printing, `Printing` row in BFZ — Dispel → WWK, Goblin War Paint → ZEN, Territorial Baloth → ZEN, Plummet → ARC |
| `row-only` | 7 | `Printing` row in BFZ only |
| `basic` | 5 | a `basicLand(...)` file plus the `basicLands` override |
| `unscaffolded` | 1 | **unblocked** — see below |
| reprint tail | 36 | rows the new canonicals owe in 22 other sets |

The tail lands in AFR, AVR, BLC, C15, CLB, CMR, IKO, J22, JMP, KLD, M11, M12, M13, M14, M15, M19, M20, MID, ORI, RIX, RTR and THB. Plummet alone owes 13 of them.

## Two placement problems this surfaced

**DDP was unscaffolded, and that was the only thing blocking Retreat to Kazandu.** Duel Decks: Zendikar vs. Eldrazi shipped 2015-08-28, five weeks ahead of BFZ, so DDP is the card's earliest real printing. Rather than file the canonical in the wrong set, DDP is scaffolded (a minimal `MtgSet`, `incomplete = true`, `sealedSupported = false`) and holds the canonical; BFZ and CMR get rows.

**Gideon's Reproach had its canonical in the wrong set.** It lived in DOM (2018) while BFZ (2015) is its earliest printing — so `generate-reprints.py` correctly refused to write BFZ a row pointing at a *later* set, and `assay-ready` still read 1 after the first pass. The canonical moved to BFZ; DOM got the `Printing` row. This is the failure mode where the badge and the tool disagree: `assay-ready` classifies from *where the canonical currently is*, not from where it belongs.

**BFZ stops borrowing Portal's basics.** It prints five full-art variants of each type (250–274); one representative per type is registered here, so `basicLandsFallback = PortalSet` is gone.

## No new SDK vocabulary

The capability pre-flight found every construct engine-live:

- **Rally** is an ability word, not a keyword — an ANY-bound enters trigger over `GameObjectFilter.Permanent.withSubtype("Ally").youControl()`. Thirteen cards on one shape.
- **Landfall** is `Triggers.LandYouControlEnters` (already ANY-bound for exactly this reason).
- **Devoid** is already a CDA in `CardDefinition.colors` (#1985), so the keyword alone is enough.
- `CantBlockEffect`, `EntersWithDynamicCounters`, `ManaRestriction.SubtypeSpellsOnly`, `AggregateBattlefield`, `Patterns.Library.lookAtTopRevealMatchingToHand` all have prior corpus users and live executors.

Rally is nonetheless **first in the corpus**, so it earns a scenario test even without new vocabulary. `KalastriaHealerScenarioTest` proves the binding: fires on the Healer's own arrival, fires again for a later Ally, stays quiet for a non-Ally. Under `OTHER` the first case would silently do nothing and the card text would give no hint.

## Verification

- `just build` green (compile + `:mtg-sets:test`).
- Card snapshots reblessed — only ARC, BFZ, DDP, DOM, WWK, ZEN moved.
- **Assay differential: 4426 / 4377 / 49 before → 4498 / 4449 / 49 after.** +72 compared, +72 confirmed, **zero new divergences** — every card was authored to `assay compile`'s JSON rather than to the oracle text.
- `check-card-printing` clean for all 73 authored canonicals.
- `just assay-ready BFZ` **on this branch: 0 Assay-ready** (re-run, not inferred).
- `KalastriaHealerScenarioTest`: 3/3 passing.

## Findings not fixed here

BFZ's remaining 143 missing cards are **all** `LINE_DECLINED` — awaken, ingest, converge, the processor "exile from opponent's graveyard" cost, and the Eldrazi Scion/Spawn sacrifice-for-mana line. That tail is grammar work for the Assay bands, not authoring work.

A handful of the tail rows (Altar's Reap ×2, Bone Splinters ×2, Inspired Charge ×4) are pre-existing debt on `row-only` cards whose canonicals already existed before this sweep. They are correct rows for cards this PR touches in BFZ, so they ride along rather than being left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)