### PR TITLE
Add 82 Assay-ready cards to Shards of Alara

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/GoblinMountaineer.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/GoblinMountaineer.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Mountaineer
+ * {R}
+ * Creature — Goblin Scout
+ * 1 / 1
+ * Mountainwalk (This creature can't be blocked as long as defending player controls a Mountain.)
+ *
+ * Landwalk is engine-live as a plain keyword: [Keyword.MOUNTAINWALK] via `keywords(...)` is read by
+ * the block-legality rules against the defending player's battlefield, so no static ability or filter
+ * has to be spelled out. Portal Second Age is this card's earliest real printing, hence the `p02`
+ * package.
+ */
+val GoblinMountaineer = card("Goblin Mountaineer") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Scout"
+    power = 1
+    toughness = 1
+    oracleText = "Mountainwalk (This creature can't be blocked as long as defending player controls a Mountain.)"
+
+    keywords(Keyword.MOUNTAINWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "101"
+        artist = "DiTerlizzi"
+        flavorText = "Goblin mountaineer, barely keeps his family fed."
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f841fe25-237f-4303-b75e-392b82767eea.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/GoblinMountaineerReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/GoblinMountaineerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Mountaineer reprint in S99. Canonical CardDefinition lives in its earliest set.
+ */
+val GoblinMountaineerReprint = Printing(
+    oracleId = "356e2df2-2b41-4d9d-8723-3e6a17a090e8",
+    name = "Goblin Mountaineer",
+    setCode = "S99",
+    collectorNumber = "105",
+    scryfallId = "66a072ec-717c-453e-a331-49056e3d917d",
+    artist = "DiTerlizzi",
+    imageUri = "https://cards.scryfall.io/normal/front/6/6/66a072ec-717c-453e-a331-49056e3d917d.jpg",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/ShardsOfAlaraSet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/ShardsOfAlaraSet.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.ala
 
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
@@ -23,11 +22,14 @@ object ShardsOfAlaraSet : MtgSet {
     override val displayName = "Shards of Alara"
     override val releaseDate = "2008-10-03"
     override val block = "Alara"
-    override val basicLandsFallback = PortalSet
     override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/Angelsong.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/Angelsong.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Angelsong
+ * {1}{W}
+ * Instant
+ * Prevent all combat damage that would be dealt this turn.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * A Fog with a cycling line. [Effects.PreventAllCombatDamage] is the whole spell — one untargeted
+ * `PreventDamageEffect` with `PreventionScope.CombatOnly` and no recipient narrowing, so it shields
+ * every source and every recipient; its default `Duration.EndOfTurn` is the printed "this turn".
+ * The second line is [KeywordAbility.cycling] rather than a bare `Keyword.CYCLING`, because the
+ * cost is a parameter the ability has to carry.
+ */
+val Angelsong = card("Angelsong") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Prevent all combat damage that would be dealt this turn.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        effect = Effects.PreventAllCombatDamage()
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "4"
+        artist = "Sal Villagran"
+        flavorText = "Clash of sword and cry of beast fall mute when angels sound the call to prayer."
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/0832e87f-afef-41a5-ba36-3eaf65551576.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ArchdemonOfUnx.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ArchdemonOfUnx.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Archdemon of Unx
+ * {5}{B}{B}
+ * Creature — Demon
+ * 6 / 6
+ * Flying, trample
+ * At the beginning of your upkeep, sacrifice a non-Zombie creature, then create a 2/2 black Zombie creature token.
+ *
+ * [Triggers.YourUpkeep] over a two-step composite. The printed "sacrifice a non-Zombie creature" is
+ * the bare imperative — the ability's own controller sacrifices and no player is named — so it is
+ * [Effects.SacrificeOwn], not the `Sacrifice` that names a player; the "non-Zombie" half is a
+ * predicate on the filter (`Creature.notSubtype(ZOMBIE)`), which keeps the exclusion in the choice
+ * the player is offered rather than in the effect. The `then` is plain sequencing, so the token is
+ * created after the sacrifice resolves even when there was nothing to sacrifice.
+ */
+val ArchdemonOfUnx = card("Archdemon of Unx") {
+    manaCost = "{5}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Demon"
+    power = 6
+    toughness = 6
+    oracleText = "Flying, trample\n" +
+        "At the beginning of your upkeep, sacrifice a non-Zombie creature, then create a 2/2 black Zombie creature token."
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.SacrificeOwn(GameObjectFilter.Creature.notSubtype(Subtype.ZOMBIE)) then
+            Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.BLACK),
+                creatureTypes = setOf("Zombie"),
+                imageUri = "https://cards.scryfall.io/normal/front/b/a/ba9b6612-5372-4e6f-841f-20009f71a736.jpg"
+            )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "64"
+        artist = "Dave Allsop"
+        flavorText = "The necropolis at Unx was once a living city, its streets untrodden by death."
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b260fbe1-21cb-4a66-aca3-e504b67ed712.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BantBattlemage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BantBattlemage.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bant Battlemage
+ * {2}{W}
+ * Creature — Human Wizard
+ * 2 / 2
+ * {G}, {T}: Target creature gains trample until end of turn.
+ * {U}, {T}: Target creature gains flying until end of turn.
+ *
+ * Two independent activated abilities rather than one modal one — the printed card prices them
+ * separately and each taps the Battlemage, so they can't both be used in a turn without an untapper.
+ * Each cost is [Costs.Composite] of a coloured [Costs.Mana] and [Costs.Tap], and each effect is
+ * [Effects.GrantKeyword] on the ability's own bound target, whose default `Duration.EndOfTurn` is
+ * the printed "until end of turn". The off-colour activation costs are what put G and U into the
+ * card's colour identity.
+ */
+val BantBattlemage = card("Bant Battlemage") {
+    manaCost = "{2}{W}"
+    colorIdentity = "GUW"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "{G}, {T}: Target creature gains trample until end of turn.\n" +
+        "{U}, {T}: Target creature gains flying until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.Tap)
+        val creature = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.TRAMPLE, creature)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap)
+        val creature = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.FLYING, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "5"
+        artist = "Donato Giancola"
+        flavorText = "\"A night attack will be easy. We'll make an air raid over the Akrasan border. Just get me some flint to light the war torches.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2c597b1d-d8b5-4922-a3f2-1f173a73ea2a.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BlisterBeetle.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BlisterBeetle.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blister Beetle
+ * {1}{B}
+ * Creature — Insect
+ * 1 / 1
+ * When this creature enters, target creature gets -1/-1 until end of turn.
+ *
+ * A plain [Triggers.EntersBattlefield] (SELF binding) with one named target. The shrink is
+ * [Effects.ModifyStats] with negative modifiers rather than a counter effect — the printed line
+ * says "until end of turn", which is a floating layer-7c modification and the effect's default
+ * `Duration.EndOfTurn`, not a -1/-1 counter.
+ */
+val BlisterBeetle = card("Blister Beetle") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature enters, target creature gets -1/-1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(-1, -1, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Anthony S. Waters"
+        flavorText = "Warriors of the Rip Clan wear their beetle-acid scars proudly, even modifying clothing and armor to better display the trophy."
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f42bdeb-5a51-4303-96d8-9722f95d2905.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BloodpyreElemental.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BloodpyreElemental.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Bloodpyre Elemental
+ * {4}{R}
+ * Creature — Elemental
+ * 4 / 1
+ * Sacrifice this creature: It deals 4 damage to target creature. Activate only as a sorcery.
+ *
+ * [Costs.SacrificeSelf] is the whole cost, so the Elemental is already gone by the time the ability
+ * resolves — "it deals 4 damage" is the ability's source dealing it, which is
+ * [Effects.DealDamage]'s default source, so no explicit `damageSource` is needed. "Activate only
+ * as a sorcery" is the ability's [TimingRule.SorcerySpeed], a timing rule rather than an
+ * activation restriction.
+ */
+val BloodpyreElemental = card("Bloodpyre Elemental") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 4
+    toughness = 1
+    oracleText = "Sacrifice this creature: It deals 4 damage to target creature. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        val creature = target("target", Targets.Creature)
+        effect = Effects.DealDamage(4, creature)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "93"
+        artist = "Trevor Claxton"
+        flavorText = "Elementals born of Jund are as cruel and unstable as the plane itself."
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/89e39677-5e04-45af-8f4c-1d4b6e737213.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BloodthornTaunter.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BloodthornTaunter.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Bloodthorn Taunter
+ * {1}{R}
+ * Creature — Human Scout
+ * 1 / 1
+ * Haste
+ * {T}: Target creature with power 5 or greater gains haste until end of turn.
+ *
+ * A bare [Costs.Tap] activated ability — the Taunter's own haste is what lets it be used the turn
+ * it arrives. The power threshold is a restriction on the *target* rather than a condition on the
+ * effect: `TargetFilter.Creature.powerAtLeast(5)`, so it is checked on announcement and rechecked
+ * on resolution against projected state. The grant is [Effects.GrantKeyword] with its default
+ * `Duration.EndOfTurn`.
+ */
+val BloodthornTaunter = card("Bloodthorn Taunter") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Scout"
+    power = 1
+    toughness = 1
+    oracleText = "Haste\n" +
+        "{T}: Target creature with power 5 or greater gains haste until end of turn."
+
+    keywords(Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        val creature = target("target", TargetCreature(filter = TargetFilter.Creature.powerAtLeast(5)))
+        effect = Effects.GrantKeyword(Keyword.HASTE, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "94"
+        artist = "Jesper Ejsing"
+        flavorText = "Naya's celebrants stoke the gargantuans into a rage, loosing a tide of muscle with the precision of an arrow."
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/8769e8f6-15ad-4f1b-bb4d-848ae6b7549e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BranchingBolt.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BranchingBolt.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Branching Bolt
+ * {1}{R}{G}
+ * Instant
+ * Choose one or both —
+ * • Branching Bolt deals 3 damage to target creature with flying.
+ * • Branching Bolt deals 3 damage to target creature without flying.
+ *
+ * "Choose one or both" is a *count*, not a third mode: `modal(chooseCount = 2, minChooseCount = 1)`
+ * (CR 700.2). Each mode carries its own target, so picking both asks for two creatures and each
+ * mode's legality is checked independently. The flying split is a predicate pair on the target
+ * filters — `withKeyword(FLYING)` and `withoutKeyword(FLYING)` — which reads projected state, so a
+ * creature that gains or loses flying in response changes which mode can still see it.
+ */
+val BranchingBolt = card("Branching Bolt") {
+    manaCost = "{1}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Instant"
+    oracleText = "Choose one or both —\n" +
+        "• Branching Bolt deals 3 damage to target creature with flying.\n" +
+        "• Branching Bolt deals 3 damage to target creature without flying."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Branching Bolt deals 3 damage to target creature with flying") {
+                val flier = target(
+                    "target",
+                    TargetCreature(filter = TargetFilter.Creature.withKeyword(Keyword.FLYING))
+                )
+                effect = Effects.DealDamage(3, flier)
+            }
+            mode("Branching Bolt deals 3 damage to target creature without flying") {
+                val grounded = target(
+                    "target",
+                    TargetCreature(filter = TargetFilter.Creature.withoutKeyword(Keyword.FLYING))
+                )
+                effect = Effects.DealDamage(3, grounded)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "158"
+        artist = "Vance Kovacs"
+        flavorText = "\"Lightning lives in everything, in living flesh and growing things. It must be set free.\"\n—Rakka Mar"
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e7468876-f401-4a75-81c0-bed09cdda3e1.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BroodmateDragon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BroodmateDragon.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Broodmate Dragon
+ * {3}{B}{R}{G}
+ * Creature — Dragon
+ * 4 / 4
+ * Flying
+ * When this creature enters, create a 4/4 red Dragon creature token with flying.
+ *
+ * A plain [Triggers.EntersBattlefield] (SELF binding) over a single [Effects.CreateToken] — one
+ * token, the mate; the pair of Dragons on the board is the Broodmate plus its token, not two
+ * tokens. The token's flying is a keyword on the token itself rather than a granted continuous
+ * effect, so it survives the trigger finishing resolution.
+ */
+val BroodmateDragon = card("Broodmate Dragon") {
+    manaCost = "{3}{B}{R}{G}"
+    colorIdentity = "BGR"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When this creature enters, create a 4/4 red Dragon creature token with flying."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 4,
+            toughness = 4,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Dragon"),
+            keywords = setOf(Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/c/b/cbb3e91d-9cae-49c8-ba92-087ad8171b9d.jpg"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "160"
+        artist = "Vance Kovacs"
+        flavorText = "Frozen in fear, the goblins stared upward at the circling hunter—and were promptly eaten by its diving mate."
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/aea1360e-7c6b-400c-893a-82d93e53101e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BullCerodon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/BullCerodon.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bull Cerodon
+ * {4}{R}{W}
+ * Creature — Beast
+ * 5 / 5
+ * Vigilance, haste
+ *
+ * A vanilla-plus Naya beater: both printed words are engine-live simple keywords, so the whole card
+ * is one `keywords` declaration with no script at all.
+ */
+val BullCerodon = card("Bull Cerodon") {
+    manaCost = "{4}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 5
+    oracleText = "Vigilance, haste"
+
+    keywords(Keyword.VIGILANCE, Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "161"
+        artist = "Jesper Ejsing"
+        flavorText = "It holds motionless vigil, watching Naya in silence through the screen of the whitecover. When it senses anything amiss, it launches forward with the uncanny sound of torn fog."
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bbae0fe2-5d52-434c-8ad1-4a5e42f4b7c4.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/CalderaHellion.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/CalderaHellion.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDevour
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Caldera Hellion
+ * {3}{R}{R}
+ * Creature — Hellion
+ * 3 / 3
+ * Devour 1 (As this creature enters, you may sacrifice any number of creatures. It enters with that many +1/+1 counters on it.)
+ * When this creature enters, it deals 3 damage to each creature.
+ *
+ * Devour is two declarations, not one: [KeywordAbility.devour] gives the printed line (and the
+ * keyword the rest of the engine reads), while the [EntersWithDevour] replacement effect is what
+ * actually offers the sacrifice and stamps the +1/+1 counters as the creature enters — its defaults
+ * are the plain creature filter and the unnamed variant, exactly the printed "devour 1". The sweep
+ * clause is a plain [Triggers.EntersBattlefield] over
+ * [Effects.ForEachInGroup] of every creature — including the Hellion itself, which is why it usually
+ * eats its own devour counters — with [DealDamageEffect] bound to [EffectTarget.Self], the
+ * per-iteration member.
+ */
+val CalderaHellion = card("Caldera Hellion") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Hellion"
+    power = 3
+    toughness = 3
+    oracleText = "Devour 1 (As this creature enters, you may sacrifice any number of creatures. It enters with that many +1/+1 counters on it.)\n" +
+        "When this creature enters, it deals 3 damage to each creature."
+
+    keywords(Keyword.DEVOUR)
+    keywordAbility(KeywordAbility.devour(1))
+
+    replacementEffect(EntersWithDevour(multiplier = 1))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature),
+            DealDamageEffect(3, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "95"
+        artist = "Raymond Swanland"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88866ce7-0b81-4b6c-a17e-ce5e51a0f2da.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/CavernThoctar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/CavernThoctar.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cavern Thoctar
+ * {5}{G}
+ * Creature — Beast
+ * 5 / 5
+ * {1}{R}: This creature gets +1/+0 until end of turn.
+ *
+ * Firebreathing with an off-colour activation cost. There is no target — "this creature" is the
+ * source — so the pump is [Effects.ModifyStats] on [EffectTarget.Self], whose default
+ * `Duration.EndOfTurn` is the printed "until end of turn"; the red pip in the cost is what carries
+ * the card's `GR` colour identity.
+ */
+val CavernThoctar = card("Cavern Thoctar") {
+    manaCost = "{5}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 5
+    oracleText = "{1}{R}: This creature gets +1/+0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "125"
+        artist = "Jean-Sébastien Rossbach"
+        flavorText = "Natives of Naya know better than to loiter near the mouth of a cave. Two glowing red eyes and the stench of foul breath are all the warning you're likely to get."
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/34748acb-7045-42b6-a93f-a3f11a1bc839.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/CloudheathDrake.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/CloudheathDrake.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cloudheath Drake
+ * {4}{U}
+ * Artifact Creature — Drake
+ * 3 / 3
+ * Flying
+ * {1}{W}: This creature gains vigilance until end of turn.
+ *
+ * An Esper artifact creature with one of the cycle's off-colour activations. Flying is a plain
+ * keyword; the grant is untargeted — "this creature" is the source — so it is
+ * [Effects.GrantKeyword] on [EffectTarget.Self], whose default `Duration.EndOfTurn` is the printed
+ * "until end of turn".
+ */
+val CloudheathDrake = card("Cloudheath Drake") {
+    manaCost = "{4}{U}"
+    colorIdentity = "UW"
+    typeLine = "Artifact Creature — Drake"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "{1}{W}: This creature gains vigilance until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}")
+        effect = Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "35"
+        artist = "Izzy"
+        flavorText = "A permanent storm rages over the plain of Cloudheath, and drakes ride its currents—two reminders that some elements of Esper will not be controlled."
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f71ec76-47e1-4f55-bc57-e7b1c88baedd.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/CouriersCapsule.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/CouriersCapsule.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Courier's Capsule
+ * {1}{U}
+ * Artifact
+ * {1}{U}, {T}, Sacrifice this artifact: Draw two cards.
+ *
+ * The blue member of the Alara capsule cycle, and structurally identical to [DispellersCapsule]: a
+ * three-part [Costs.Composite] of mana, [Costs.Tap] and [Costs.SacrificeSelf] paying for an
+ * untargeted [Effects.DrawCards].
+ */
+val CouriersCapsule = card("Courier's Capsule") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "{1}{U}, {T}, Sacrifice this artifact: Draw two cards."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "37"
+        artist = "Andrew Murray"
+        flavorText = "In ages past, Esper couriers bore messages written on ornate scrolls. The medium has grown more sophisticated, but the principle remains the same."
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/39ae12ff-8039-4aac-aa50-f879376888a1.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/CrucibleOfFire.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/CrucibleOfFire.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Crucible of Fire
+ * {3}{R}
+ * Enchantment
+ * Dragon creatures you control get +3/+3.
+ *
+ * A layer-7c lord as a single [ModifyStats] static ability. The enchantment is not itself a Dragon,
+ * so the printed line has no "other" and the [GroupFilter] keeps its default `excludeSelf = false`;
+ * the filter is read against projected state, so a creature that only becomes a Dragon later is
+ * picked up on the next projection.
+ */
+val CrucibleOfFire = card("Crucible of Fire") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Dragon creatures you control get +3/+3."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 3,
+            toughnessBonus = 3,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.DRAGON).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "96"
+        artist = "Dominick Domingo"
+        flavorText = "\"The dragon is a perfect marriage of power and the will to use it.\"\n—Sarkhan Vol"
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/38a2d4ba-7bd0-4852-aad3-dfdaf5368e3e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/DeftDuelist.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/DeftDuelist.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deft Duelist
+ * {W}{U}
+ * Creature — Human Rogue
+ * 2 / 1
+ * First strike
+ * Shroud (This creature can't be the target of spells or abilities.)
+ *
+ * Both lines are simple keywords the engine already reads — shroud's reminder text is only reminder
+ * text — so the card is a `keywords` declaration and nothing else.
+ */
+val DeftDuelist = card("Deft Duelist") {
+    manaCost = "{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Creature — Human Rogue"
+    power = 2
+    toughness = 1
+    oracleText = "First strike\n" +
+        "Shroud (This creature can't be the target of spells or abilities.)"
+
+    keywords(Keyword.FIRST_STRIKE, Keyword.SHROUD)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "165"
+        artist = "David Palumbo"
+        flavorText = "Some Serul Cove rogues traffic in stolen sigils, which fetch a high price from those who would rather pay for honor than earn it."
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c4885a83-9410-4c88-b45e-1e1626fe90ea.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/DruidOfTheAnima.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/DruidOfTheAnima.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Druid of the Anima
+ * {1}{G}
+ * Creature — Elf Druid
+ * 1 / 1
+ * {T}: Add {R}, {G}, or {W}.
+ *
+ * The Naya answer to the shard obelisks. The printed "or" is a choice between three separate mana
+ * abilities, so it is authored as three [Effects.AddMana] abilities sharing [Costs.Tap] — the same
+ * shape as [ObeliskOfEsper] — each flagged `manaAbility` with [TimingRule.ManaAbility] so it never
+ * uses the stack.
+ */
+val DruidOfTheAnima = card("Druid of the Anima") {
+    manaCost = "{1}{G}"
+    colorIdentity = "GRW"
+    typeLine = "Creature — Elf Druid"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Add {R}, {G}, or {W}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "128"
+        artist = "Jim Murray"
+        flavorText = "Although the Anima herself remains at the Sacellum, her druids roam Naya, collecting mana bonds with every location in the world."
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/de32bf78-73c2-4cd4-b3b3-ef8be53e1e5e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/EsperBattlemage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/EsperBattlemage.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Esper Battlemage
+ * {2}{U}
+ * Artifact Creature — Human Wizard
+ * 2 / 2
+ * {W}, {T}: Prevent the next 2 damage that would be dealt to you this turn.
+ * {B}, {T}: Target creature gets -1/-1 until end of turn.
+ *
+ * The Alara battlemage cycle: two off-colour activated abilities sharing one tap. Both costs are a
+ * [Costs.Composite] of a single coloured pip and [Costs.Tap], so only one may be used per turn.
+ * "Dealt to you" is [Effects.PreventNextDamage] pointed at [EffectTarget.Controller] — a shield with
+ * an amount rather than a scope, so it soaks any 2 damage from any source, combat or not, and needs
+ * no target requirement. The black half is a plain [Effects.ModifyStats] whose `-1/-1` runs for the
+ * default end-of-turn duration.
+ */
+val EsperBattlemage = card("Esper Battlemage") {
+    manaCost = "{2}{U}"
+    colorIdentity = "BUW"
+    typeLine = "Artifact Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "{W}, {T}: Prevent the next 2 damage that would be dealt to you this turn.\n" +
+        "{B}, {T}: Target creature gets -1/-1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        effect = Effects.PreventNextDamage(2, EffectTarget.Controller)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}"), Costs.Tap)
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.ModifyStats(-1, -1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "40"
+        artist = "Matt Cavotta"
+        flavorText = "She can heal the flesh, or exploit its many weaknesses."
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2cac0076-8bd5-4fe2-bac8-fd102688fdcb.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/EsperCharm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/EsperCharm.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Esper Charm
+ * {W}{U}{B}
+ * Instant
+ * Choose one —
+ * • Destroy target enchantment.
+ * • Draw two cards.
+ * • Target player discards two cards.
+ *
+ * The Alara charm cycle: a `modal(chooseCount = 1)` block whose three modes each own their own
+ * targets, so only the chosen mode's target is picked on the stack. Mode one is [Effects.Destroy]
+ * (a graveyard move flagged `byDestruction`, so indestructible and regeneration still apply); mode
+ * two is a bare [Effects.DrawCards]; mode three is [Patterns.Hand].discardCards pointed at the
+ * targeted player — the gather → select → move pipeline, with the *target* doing the choosing.
+ */
+val EsperCharm = card("Esper Charm") {
+    manaCost = "{W}{U}{B}"
+    colorIdentity = "BUW"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Destroy target enchantment.\n" +
+        "• Draw two cards.\n" +
+        "• Target player discards two cards."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Destroy target enchantment") {
+                val t = target("target", TargetPermanent(filter = TargetFilter.Enchantment))
+                effect = Effects.Destroy(t)
+            }
+            mode("Draw two cards") {
+                effect = Effects.DrawCards(2)
+            }
+            mode("Target player discards two cards") {
+                val t = target("target", TargetPlayer())
+                effect = Patterns.Hand.discardCards(2, t)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "167"
+        artist = "Michael Bruinsma"
+        flavorText = "\"Thoughts are commodities. Someone will pay a good price for them. Even ones as simplistic as yours . . .\"\n—Ennor, mentalist"
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3d70a07-8d91-462c-aa96-901cc9a81531.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/EtheriumAstrolabe.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/EtheriumAstrolabe.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Etherium Astrolabe
+ * {2}{U}
+ * Artifact
+ * Flash
+ * {B}, {T}, Sacrifice an artifact: Draw a card.
+ *
+ * Flash is the parameterless keyword, so it goes in `keywords(...)` rather than a
+ * `keywordAbilities` entry. The ability is a three-atom [Costs.Composite] — mana, tap, and a
+ * [Costs.Sacrifice] over [GameObjectFilter.Artifact]. The sacrifice filter is *not* `excludeSelf`,
+ * so the Astrolabe may eat itself (it is an artifact); the tap and the sacrifice are separate
+ * atoms, so it must be untapped to pay even when the thing sacrificed is something else.
+ */
+val EtheriumAstrolabe = card("Etherium Astrolabe") {
+    manaCost = "{2}{U}"
+    colorIdentity = "BU"
+    typeLine = "Artifact"
+    oracleText = "Flash\n" +
+        "{B}, {T}, Sacrifice an artifact: Draw a card."
+
+    keywords(Keyword.FLASH)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}"), Costs.Tap, Costs.Sacrifice(GameObjectFilter.Artifact))
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "41"
+        artist = "Michael Bruinsma"
+        flavorText = "\"Speculation is foolish when the tools of certainty are available.\"\n—Cinna, vedalken consul"
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d60731c6-7a25-4f2b-8ed1-2469a2d300c6.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/EtheriumSculptor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/EtheriumSculptor.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Etherium Sculptor
+ * {1}{U}
+ * Artifact Creature — Vedalken Artificer
+ * 1 / 2
+ * Artifact spells you cast cost {1} less to cast.
+ *
+ * A plain generic-cost reduction on the controller's own artifact spells
+ * ([SpellCostTarget.YouCast] over [GameObjectFilter.Artifact] + [CostModification.ReduceGeneric]).
+ * Generic-only, so it never shaves a coloured pip, and — like every cost static — it functions only
+ * while the Sculptor is on the battlefield, so it never discounts itself.
+ */
+val EtheriumSculptor = card("Etherium Sculptor") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Vedalken Artificer"
+    power = 1
+    toughness = 2
+    oracleText = "Artifact spells you cast cost {1} less to cast."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Artifact),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "42"
+        artist = "Steven Belledin"
+        flavorText = "The greatest masters of the craft abandon tools altogether, shaping metal with hand and mind alone."
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0d050f2d-bd65-4ab9-9ea6-9deba91b2792.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/Excommunicate.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/Excommunicate.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Excommunicate
+ * {2}{W}
+ * Sorcery
+ * Put target creature on top of its owner's library.
+ *
+ * Time Ebb in white: one [TargetCreature] and [Effects.PutOnTopOfLibrary], the forced (no player
+ * choice) top-of-library move. The destination is the *owner's* library, which the zone move
+ * derives on its own — nothing on the effect needs to name the player.
+ */
+val Excommunicate = card("Excommunicate") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Put target creature on top of its owner's library."
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.PutOnTopOfLibrary(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Matt Stewart"
+        flavorText = "Rebels and other malcontents forced into the ritual awake lost in Topa's vast savannahs. Those who find their way back return humble and repentant."
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6fe080bc-e642-4fce-b4ee-bbe25d735673.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ExecutionersCapsule.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ExecutionersCapsule.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Executioner's Capsule
+ * {B}
+ * Artifact
+ * {1}{B}, {T}, Sacrifice this artifact: Destroy target nonblack creature.
+ *
+ * The black member of the Alara capsule cycle — Dispeller's Capsule with a different filter. The
+ * cost is a [Costs.Composite] of mana, [Costs.Tap] and [Costs.SacrificeSelf], so the shell is spent
+ * to fire it. "Nonblack creature" is [TargetFilter.Creature]`.notColor(BLACK)`, evaluated against
+ * projected state, and [Effects.Destroy] is the `byDestruction` graveyard move so indestructible and
+ * regeneration still apply.
+ */
+val ExecutionersCapsule = card("Executioner's Capsule") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "{1}{B}, {T}, Sacrifice this artifact: Destroy target nonblack creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{B}"), Costs.Tap, Costs.SacrificeSelf)
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.notColor(Color.BLACK)))
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "75"
+        artist = "Warren Mahy"
+        flavorText = "There is always a moment of trepidation before opening a message capsule, for fear of the judgment that might be contained within."
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48185059-fff9-47b0-9774-ad37dee345ed.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/FiligreeSages.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/FiligreeSages.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Filigree Sages
+ * {3}{U}
+ * Artifact Creature — Vedalken Wizard
+ * 2 / 3
+ * {2}{U}: Untap target artifact.
+ *
+ * A single mana-only activated ability — no tap in the cost, so it can be used repeatedly and on
+ * the Sages themselves. [Effects.Untap] over a [TargetPermanent] filtered to artifacts; the
+ * battlefield filter reads projected state, so a permanent that is only *currently* an artifact
+ * (an animated Vedalken Shackles, say) is a legal target.
+ */
+val FiligreeSages = card("Filigree Sages") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Vedalken Wizard"
+    power = 2
+    toughness = 3
+    oracleText = "{2}{U}: Untap target artifact."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{U}")
+        val t = target("target", TargetPermanent(filter = TargetFilter.Artifact))
+        effect = Effects.Untap(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "44"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"We of the Sanctum Arcanum have pondered every word on every page of the Filigree Texts. If you can't say the same, don't bother speaking.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/08790aaf-0142-4b20-89cf-cdaffeea4582.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/GlazeFiend.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/GlazeFiend.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Glaze Fiend
+ * {1}{B}
+ * Artifact Creature — Illusion
+ * 0 / 1
+ * Flying
+ * Whenever another artifact you control enters, this creature gets +2/+2 until end of turn.
+ *
+ * The trigger is a raw [TriggerSpec] over a [ZoneChangeEvent] into [Zone.BATTLEFIELD] filtered to
+ * `GameObjectFilter.Artifact.youControl()`; because Glaze Fiend is itself an artifact, the printed
+ * "another" is [TriggerBinding.OTHER], which excludes the source's own entry. The pump is the plain
+ * [Effects.ModifyStats] on [EffectTarget.Self], whose default `Duration.EndOfTurn` is exactly the
+ * printed "until end of turn" — so a turn with several artifact drops stacks one floating +2/+2 per
+ * trigger.
+ */
+val GlazeFiend = card("Glaze Fiend") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact Creature — Illusion"
+    power = 0
+    toughness = 1
+    oracleText = "Flying\n" +
+        "Whenever another artifact you control enters, this creature gets +2/+2 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(
+                filter = GameObjectFilter.Artifact.youControl(),
+                to = Zone.BATTLEFIELD
+            ),
+            binding = TriggerBinding.OTHER
+        )
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "77"
+        artist = "Joshua Hagler"
+        flavorText = "Before the zealots of the Ethersworn came to power, Esper illusionists dreamed up creations to mimic a variety of substances."
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e030fb1-12a8-4c28-836f-8097ec753271.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/GoblinDeathraiders.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/GoblinDeathraiders.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Deathraiders
+ * {B}{R}
+ * Creature — Goblin Warrior
+ * 3 / 1
+ * Trample
+ *
+ * A vanilla body with one evergreen keyword — [Keyword.TRAMPLE] via `keywords(...)`, which the engine
+ * reads directly in combat damage assignment. No script at all.
+ */
+val GoblinDeathraiders = card("Goblin Deathraiders") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Goblin Warrior"
+    power = 3
+    toughness = 1
+    oracleText = "Trample"
+
+    keywords(Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "169"
+        artist = "Raymond Swanland"
+        flavorText = "Every once in a while, when they aren't getting incinerated in lava, crushed under rock slides, or devoured by dragons, goblins experience moments of unmitigated glory in battle."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/76fd1253-1af1-42a7-9875-4d6ac9ce722c.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/GoblinMountaineerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/GoblinMountaineerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Mountaineer reprint in ALA. Canonical CardDefinition lives in its earliest set.
+ */
+val GoblinMountaineerReprint = Printing(
+    oracleId = "356e2df2-2b41-4d9d-8723-3e6a17a090e8",
+    name = "Goblin Mountaineer",
+    setCode = "ALA",
+    collectorNumber = "102",
+    scryfallId = "1afa1475-797d-4cdc-93d6-e186c25e0bf5",
+    artist = "Michael Ryan",
+    imageUri = "https://cards.scryfall.io/normal/front/1/a/1afa1475-797d-4cdc-93d6-e186c25e0bf5.jpg",
+    releaseDate = "2008-10-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/Godtoucher.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/Godtoucher.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PreventDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Godtoucher
+ * {3}{G}
+ * Creature — Elf Cleric
+ * 2 / 2
+ * {1}{W}, {T}: Prevent all damage that would be dealt to target creature with power 5 or greater this turn.
+ *
+ * The activated cost is a [Costs.Composite] of mana plus [Costs.Tap]. The power threshold rides the
+ * target itself — [TargetFilter.Creature]`.powerAtLeast(5)` — so it is checked on announcement and
+ * rechecked on resolution. The shield is [PreventDamageEffect] with every field left at its default:
+ * a null `amount` means "prevent all", `PreventionScope.AllDamage` covers non-combat damage too,
+ * `PreventionDirection.ToTarget` is the printed "dealt to", and `Duration.EndOfTurn` is "this turn".
+ */
+val Godtoucher = card("Godtoucher") {
+    manaCost = "{3}{G}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Elf Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "{1}{W}, {T}: Prevent all damage that would be dealt to target creature with power 5 or greater this turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}"), Costs.Tap)
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.powerAtLeast(5)))
+        effect = PreventDamageEffect(target = t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "133"
+        artist = "Jesper Ejsing"
+        flavorText = "\"Gargantuans die not in moments but in moons. There is still time to aid this noble ancient.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/032059cb-c1ad-4cc9-a89d-d68289800312.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/GrixisBattlemage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/GrixisBattlemage.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grixis Battlemage
+ * {2}{B}
+ * Creature — Human Wizard
+ * 2 / 2
+ * {U}, {T}: Draw a card, then discard a card.
+ * {R}, {T}: Target creature can't block this turn.
+ *
+ * Two independent activated abilities, each a [Costs.Composite] of an off-colour mana pip plus
+ * [Costs.Tap] — so only one can be used per untap step. The loot is literal composition,
+ * [Effects.DrawCards] `then` [Effects.Discard], the latter lowering to the shared Gather → Select →
+ * Move (Discard) hand pipeline; the combat half is [Effects.CantBlock] on the bound target, whose
+ * default `Duration.EndOfTurn` is the printed "this turn".
+ */
+val GrixisBattlemage = card("Grixis Battlemage") {
+    manaCost = "{2}{B}"
+    colorIdentity = "BRU"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "{U}, {T}: Draw a card, then discard a card.\n" +
+        "{R}, {T}: Target creature can't block this turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap)
+        effect = Effects.DrawCards(1) then Effects.Discard(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.CantBlock(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "78"
+        artist = "Nils Hamm"
+        flavorText = "Vitals of Grixis who eschew undeath must scrape and scratch to retain their mortality. The result is a breed of inventive mages."
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4dbd260c-a625-42a4-8192-27e42e18ac0f.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/GustriderExuberant.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/GustriderExuberant.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gustrider Exuberant
+ * {2}{W}
+ * Creature — Human Wizard
+ * 1 / 2
+ * Flying
+ * Sacrifice this creature: Creatures you control with power 5 or greater gain flying until end of turn.
+ *
+ * The cost is the bare [Costs.SacrificeSelf] atom — no mana, no tap — so the ability is usable at
+ * instant speed even the turn it lands. The grant is [Effects.ForEachInGroup] over a snapshot of
+ * `GameObjectFilter.Creature.youControl().powerAtLeast(5)`, with [EffectTarget.Self] inside the body
+ * bound to the current iteration entity; each iteration is a separate
+ * [Effects.GrantKeyword] whose default `Duration.EndOfTurn` is the printed duration. Snapshotting
+ * before iteration is what makes the grant a one-shot on the creatures present at resolution rather
+ * than a continuous "creatures with power 5 or greater have flying".
+ */
+val GustriderExuberant = card("Gustrider Exuberant") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 2
+    oracleText = "Flying\n" +
+        "Sacrifice this creature: Creatures you control with power 5 or greater gain flying until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.ForEachInGroup(
+            filter = GroupFilter(GameObjectFilter.Creature.youControl().powerAtLeast(5)),
+            effect = Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "13"
+        artist = "Wayne Reynolds"
+        flavorText = "\"The elves claim the canopy. The nacatl claim the mountains. I suppose you think we ought to stay on the jungle floor?\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/5343e6f2-7db7-4731-8e1b-70bf74316a79.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/HellkiteOverlordReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/HellkiteOverlordReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hellkite Overlord reprint in ALA. Canonical CardDefinition lives in its earliest set.
+ */
+val HellkiteOverlordReprint = Printing(
+    oracleId = "1d05e441-84d4-482f-95a8-7842e776cad2",
+    name = "Hellkite Overlord",
+    setCode = "ALA",
+    collectorNumber = "172",
+    scryfallId = "89185829-5c93-4fd9-8c56-11820be6a970",
+    artist = "Justin Sweet",
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/89185829-5c93-4fd9-8c56-11820be6a970.jpg",
+    releaseDate = "2008-10-03",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/JhessianInfiltrator.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/JhessianInfiltrator.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jhessian Infiltrator
+ * {G}{U}
+ * Creature — Human Rogue
+ * 2 / 2
+ * This creature can't be blocked.
+ *
+ * Unconditional evasion on a creature is the card-level [AbilityFlag.CANT_BE_BLOCKED] flag, which the
+ * block-legality rules read straight off the projected permanent. (The
+ * [com.wingedsheep.sdk.scripting.CantBeBlocked] static ability is only needed when the restriction is
+ * conditional, or when it lives on an attachment and must name `GroupFilter.attachedCreature()`.)
+ */
+val JhessianInfiltrator = card("Jhessian Infiltrator") {
+    manaCost = "{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Human Rogue"
+    power = 2
+    toughness = 2
+    oracleText = "This creature can't be blocked."
+
+    flags(AbilityFlag.CANT_BE_BLOCKED)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "174"
+        artist = "Donato Giancola"
+        flavorText = "The Jhessian navy makes successful raids on Valeron's coastal towns thanks to their spies planted during peacetime."
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/1761d867-2eb0-406b-b175-97a90c457844.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/JundBattlemage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/JundBattlemage.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jund Battlemage
+ * {2}{R}
+ * Creature — Human Shaman
+ * 2 / 2
+ * {B}, {T}: Target player loses 1 life.
+ * {G}, {T}: Create a 1/1 green Saproling creature token.
+ *
+ * One of the Alara shard battlemages: a mono-coloured body with two off-colour activated abilities,
+ * so each is a [Costs.Composite] of a single [Costs.Mana] pip plus [Costs.Tap]. The tap is shared,
+ * which is what makes the two modes exclusive on any given turn. "Target player" is unrestricted
+ * ([Targets.Player]) — it may be pointed at yourself — and the Saproling is spelled entirely by its
+ * printed characteristics through the shared [Effects.CreateToken] facade, so no bespoke token
+ * definition is needed.
+ */
+val JundBattlemage = card("Jund Battlemage") {
+    manaCost = "{2}{R}"
+    colorIdentity = "BGR"
+    typeLine = "Creature — Human Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "{B}, {T}: Target player loses 1 life.\n" +
+        "{G}, {T}: Create a 1/1 green Saproling creature token."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}"), Costs.Tap)
+        val t = target("target", Targets.Player)
+        effect = Effects.LoseLife(1, t)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.Tap)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling"),
+            imageUri = "https://cards.scryfall.io/normal/front/6/2/622759a9-e68b-48c1-8e03-beaab0a52556.jpg"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "106"
+        artist = "Vance Kovacs"
+        flavorText = "\"Of your blood I will make my mead, an offering to the thirsty jungle.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/ee8c962f-11b0-48f7-bbba-a2212e41990f.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/JungleWeaver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/JungleWeaver.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Jungle Weaver
+ * {5}{G}{G}
+ * Creature — Spider
+ * 5 / 6
+ * Reach (This creature can block creatures with flying.)
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * Vanilla body plus two keywords, and the split between them is the point: reach is a plain
+ * evasion-defeating keyword ([Keyword.REACH] via `keywords`), while cycling carries a cost and so is
+ * a [KeywordAbility.cycling] entry rather than a bare keyword — it lowers to the discard-for-a-card
+ * activated ability the reminder text spells out, playable only from hand.
+ */
+val JungleWeaver = card("Jungle Weaver") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider"
+    power = 5
+    toughness = 6
+    oracleText = "Reach (This creature can block creatures with flying.)\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    keywords(Keyword.REACH)
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "134"
+        artist = "Trevor Hairsine"
+        flavorText = "Weavers' webs wall off swaths of territory more effectively than any portcullis made of iron."
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f46870b-3d8d-4aae-8d59-6bd88a50b37c.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/KederektCreeper.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/KederektCreeper.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kederekt Creeper
+ * {U}{B}{R}
+ * Creature — Horror
+ * 2 / 3
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ * Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)
+ *
+ * A two-keyword body, no script. It was printed with "can't be blocked except by two or more
+ * creatures"; current Oracle errata folds that into [Keyword.MENACE], which is what is authored
+ * here, so both abilities are a single `keywords` declaration and the engine's blocking and damage
+ * rules carry them.
+ */
+val KederektCreeper = card("Kederekt Creeper") {
+    manaCost = "{U}{B}{R}"
+    colorIdentity = "BRU"
+    typeLine = "Creature — Horror"
+    power = 2
+    toughness = 3
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)"
+
+    keywords(Keyword.MENACE, Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "176"
+        artist = "Mark Hyzer"
+        flavorText = "Bloated with venom, it crawls Grixis looking for victims to ooze onto."
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/701498e5-1d4d-42f4-9dd0-5d4cf78f0e68.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/KnightCaptainOfEos.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/KnightCaptainOfEos.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Knight-Captain of Eos
+ * {4}{W}
+ * Creature — Human Knight
+ * 2 / 2
+ * When this creature enters, create two 1/1 white Soldier creature tokens.
+ * {W}, Sacrifice a Soldier: Prevent all combat damage that would be dealt this turn.
+ *
+ * The entry trigger is [Triggers.EntersBattlefield] with a single [Effects.CreateToken] carrying
+ * `count = 2` — one effect making two tokens, not two effects. The fog is the tokens' payoff: "a
+ * Soldier" is a bare tribal noun, so the sacrifice cost filters *permanents* with the subtype
+ * (`GameObjectFilter.Permanent.withSubtype`) rather than creatures, and the Knight-Captain's own
+ * Soldiers pay for it. [Effects.PreventAllCombatDamage] is the un-targeted, board-wide shield —
+ * `PreventionScope.CombatOnly` for the turn, both players' creatures alike.
+ */
+val KnightCaptainOfEos = card("Knight-Captain of Eos") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, create two 1/1 white Soldier creature tokens.\n" +
+        "{W}, Sacrifice a Soldier: Prevent all combat damage that would be dealt this turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Soldier"),
+            count = 2,
+            imageUri = "https://cards.scryfall.io/normal/front/9/2/927580e6-353a-46bb-ac05-52a5fa78a959.jpg"
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{W}"),
+            Costs.Sacrifice(GameObjectFilter.Permanent.withSubtype("Soldier"))
+        )
+        effect = Effects.PreventAllCombatDamage()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "17"
+        artist = "Chris Rahn"
+        flavorText = "The strength of Bant's caste system is the unfailing loyalty of its meekest members."
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02ef25ce-4d6a-45ff-8b6b-fd5c29307099.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/KnightOfTheSkywardEye.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/KnightOfTheSkywardEye.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Knight of the Skyward Eye
+ * {1}{W}
+ * Creature — Human Knight
+ * 2 / 2
+ * {3}{G}: This creature gets +3/+3 until end of turn. Activate only once each turn.
+ *
+ * A plain [Costs.Mana] pump on itself — [Effects.ModifyStats] over [EffectTarget.Self], whose
+ * default `Duration.EndOfTurn` is the printed "until end of turn", so no duration is spelled.
+ * "Activate only once each turn" is [ActivationRestriction.OncePerTurn], a restriction checked at
+ * activation rather than a triggered-ability flag. The off-colour {G} in the cost is why the card's
+ * colour identity is green-white even though the card itself is mono-white.
+ */
+val KnightOfTheSkywardEye = card("Knight of the Skyward Eye") {
+    manaCost = "{1}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 2
+    oracleText = "{3}{G}: This creature gets +3/+3 until end of turn. Activate only once each turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{G}")
+        effect = Effects.ModifyStats(3, 3, EffectTarget.Self)
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "15"
+        artist = "Matt Stewart"
+        flavorText = "The Order of the Skyward Eye does the bidding of an evil force, unwittingly stirring fear and mistrust across Bant in accordance with his plans."
+        imageUri = "https://cards.scryfall.io/normal/front/1/d/1d56e2bf-1937-42c1-8f61-1fd93e84cef7.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/LightningTalons.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/LightningTalons.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Lightning Talons
+ * {2}{R}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +3/+0 and has first strike. (It deals combat damage before creatures without first strike.)
+ *
+ * "Enchant creature" is the aura's attachment restriction *and* its cast-time target, so it is
+ * `auraTarget = `[Targets.Creature] rather than a `target()` handle. The printed "and" joins two
+ * independent grants in different layers — a P/T modification (layer 7c) and an ability grant
+ * (layer 6) — so it is two [ModifyStats] / [GrantKeyword] static abilities over the implicit
+ * enchanted permanent, not one fused effect.
+ */
+val LightningTalons = card("Lightning Talons") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +3/+0 and has first strike. (It deals combat damage before creatures without first strike.)"
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(3, 0)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FIRST_STRIKE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "107"
+        artist = "Pete Venters"
+        flavorText = "\"This is going to hurt a lot, but on the bright side, you'll be dead soon.\"\n—Sedris, the Traitor King"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8fc1ad4c-b394-48b9-9a5a-ec9f42bf6a00.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/MarbleChalice.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/MarbleChalice.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Marble Chalice
+ * {2}{W}
+ * Artifact
+ * {T}: You gain 1 life.
+ *
+ * One of Shards of Alara's coloured artifacts. A bare [Costs.Tap] activated ability whose effect is
+ * [Effects.GainLife] — "you" is the ability's controller, which is already the facade's default
+ * target, so no `EffectTarget` is spelled. It is not a mana ability, so it uses the ordinary
+ * sorcery-speed-free activation timing and goes on the stack.
+ */
+val MarbleChalice = card("Marble Chalice") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "{T}: You gain 1 life."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Howard Lyon"
+        flavorText = "The cup was a gift from the sphinx Tameron, who hoped that those who drank from it would live long enough to decrypt the sphinxes' wisdom."
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b76e9580-9154-476b-923f-b23bf55db026.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/MasterOfEtherium.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/MasterOfEtherium.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Master of Etherium
+ * {2}{U}
+ * Artifact Creature — Vedalken Wizard
+ * * / *
+ * Master of Etherium's power and toughness are each equal to the number of artifacts you control.
+ * Other artifact creatures you control get +1/+1.
+ *
+ * Two halves that must not be confused. The P/T is a characteristic-defining ability (CR 604.3):
+ * `dynamicStats` over [DynamicAmount.AggregateBattlefield], no printed base P/T, and it counts
+ * *artifacts* — the Master itself included, since it is an artifact on the battlefield. The lord is
+ * an ordinary layer-7c static: [ModifyStats] over a [GroupFilter] of
+ * `GameObjectFilter.ArtifactCreature.youControl()` with `excludeSelf = true` for the printed
+ * "other", so the Master never pumps itself on top of its own CDA.
+ */
+val MasterOfEtherium = card("Master of Etherium") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Vedalken Wizard"
+    oracleText = "Master of Etherium's power and toughness are each equal to the number of artifacts you control.\n" +
+        "Other artifact creatures you control get +1/+1."
+
+    dynamicStats(
+        DynamicAmount.AggregateBattlefield(
+            Player.You,
+            GameObjectFilter.Artifact
+        )
+    )
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.ArtifactCreature.youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "49"
+        artist = "Matt Cavotta"
+        flavorText = "\"Only a mind unfettered with the concerns of the flesh can see the world as it truly is.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/322cdf67-5b36-43f9-99b3-f0e24d423314.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/Metallurgeon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/Metallurgeon.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+
+/**
+ * Metallurgeon
+ * {1}{W}
+ * Artifact Creature — Human Artificer
+ * 1 / 2
+ * {W}, {T}: Regenerate target artifact.
+ *
+ * A repeatable regeneration on a body. The cost is the usual [Costs.Composite] of a coloured
+ * [Costs.Mana] atom and [Costs.Tap]; the named target is [Targets.Artifact] (a battlefield
+ * `TargetObject` over `TargetFilter.Artifact`) and the effect is the plain [RegenerateEffect]
+ * pointed at that bound variable rather than at the source.
+ */
+val Metallurgeon = card("Metallurgeon") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Human Artificer"
+    power = 1
+    toughness = 2
+    oracleText = "{W}, {T}: Regenerate target artifact."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val t = target("target", Targets.Artifact)
+        effect = RegenerateEffect(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "19"
+        artist = "Warren Mahy"
+        flavorText = "\"By the time I got there, the heart had stopped. Fortunately, I was able to replace it with something better.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4ad9f9d5-62c1-4dae-a2c8-5552210a70a4.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/MightyEmergence.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/MightyEmergence.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mighty Emergence
+ * {2}{G}
+ * Enchantment
+ * Whenever a creature you control with power 5 or greater enters, you may put two +1/+1 counters on it.
+ *
+ * The watcher is [Triggers.entersBattlefield] over `GameObjectFilter.Creature.youControl().powerAtLeast(5)`
+ * with [TriggerBinding.ANY] — the enchantment can never be the creature that entered, and the printed
+ * line says "a creature", not "another". The counters land on [EffectTarget.TriggeringEntity] (the
+ * creature that entered, not a fresh target), and `optional = true` lowers the printed "you may" into
+ * the same `Gate.MayDecide` a hand-written `MayEffect` would build.
+ */
+val MightyEmergence = card("Mighty Emergence") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a creature you control with power 5 or greater enters, you may put two +1/+1 counters on it."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl().powerAtLeast(5),
+            binding = TriggerBinding.ANY
+        )
+        optional = true
+        effect = Effects.AddCounters("+1/+1", 2, EffectTarget.TriggeringEntity)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "137"
+        artist = "Steve Prescott"
+        flavorText = "Why settle for mere enormity?"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8ee66318-4dbb-49a3-a3c8-ee0e1a9f02b7.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/Mosstodon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/Mosstodon.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Mosstodon
+ * {4}{G}
+ * Creature — Plant Elephant
+ * 5 / 3
+ * {1}: Target creature with power 5 or greater gains trample until end of turn.
+ *
+ * A bare [Costs.Mana] activation with no tap, so it can be used repeatedly. "with power 5 or
+ * greater" is a predicate on the target itself — `GameObjectFilter.Creature.powerAtLeast(5)`
+ * wrapped in a [TargetFilter] — and the grant is [Effects.GrantKeyword], whose default duration
+ * is already until end of turn.
+ */
+val Mosstodon = card("Mosstodon") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Elephant"
+    power = 5
+    toughness = 3
+    oracleText = "{1}: Target creature with power 5 or greater gains trample until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        val t = target("target", TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.powerAtLeast(5))))
+        effect = Effects.GrantKeyword(Keyword.TRAMPLE, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "139"
+        artist = "Paolo Parente"
+        flavorText = "Whether gargantuans are the manifested will of Progenitus or simply the result of overabundant resources is moot when a herd of them is thundering at you."
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/05afd921-ef3b-40fe-a1a8-582ee94ed3f0.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/NayaBattlemage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/NayaBattlemage.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+
+/**
+ * Naya Battlemage
+ * {2}{G}
+ * Creature — Human Shaman
+ * 2 / 2
+ * {R}, {T}: Target creature gets +2/+0 until end of turn.
+ * {W}, {T}: Tap target creature.
+ *
+ * The Invasion "apprentice" shape: two independent activated abilities that share the tap symbol,
+ * each gated behind an off-colour mana atom (the shard's other two colours, which is why the
+ * colour identity is GRW on a mono-green cost). The first is [Effects.ModifyStats] with the default
+ * end-of-turn duration; the second is [TapUntapEffect] with `tap = true`. Each names its own
+ * [Targets.Creature] target.
+ */
+val NayaBattlemage = card("Naya Battlemage") {
+    manaCost = "{2}{G}"
+    colorIdentity = "GRW"
+    typeLine = "Creature — Human Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "{R}, {T}: Target creature gets +2/+0 until end of turn.\n" +
+        "{W}, {T}: Tap target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(2, 0, t)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = TapUntapEffect(target = t, tap = true)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "142"
+        artist = "Steve Argyle"
+        flavorText = "\"I have trained in all three schools of magic.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4fe73f62-2e80-4d5f-b7b5-c54c895a3e4d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ObeliskOfBant.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ObeliskOfBant.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Obelisk of Bant
+ * {3}
+ * Artifact
+ * {T}: Add {G}, {W}, or {U}.
+ *
+ * One of the Alara shard obelisks, and a direct sibling of `ObeliskOfEsper`. The printed "or" is a
+ * choice between three mana abilities, so it is authored as three separate [Effects.AddMana]
+ * abilities on [Costs.Tap], each flagged `manaAbility` with [TimingRule.ManaAbility].
+ */
+val ObeliskOfBant = card("Obelisk of Bant") {
+    manaCost = "{3}"
+    colorIdentity = "GUW"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {G}, {W}, or {U}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "212"
+        artist = "David Palumbo"
+        flavorText = "Whether incorporated into the structure of castles or admired as lone symbols, the obelisks stand for Bant's values of loyalty, honor, and truth."
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0cefe6ab-c018-4b87-8948-295a28f63cb1.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ObeliskOfNaya.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ObeliskOfNaya.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Obelisk of Naya
+ * {3}
+ * Artifact
+ * {T}: Add {R}, {G}, or {W}.
+ *
+ * One of the Alara shard obelisks, and a direct sibling of `ObeliskOfEsper`. The printed "or" is a
+ * choice between three mana abilities, so it is authored as three separate [Effects.AddMana]
+ * abilities on [Costs.Tap], each flagged `manaAbility` with [TimingRule.ManaAbility].
+ */
+val ObeliskOfNaya = card("Obelisk of Naya") {
+    manaCost = "{3}"
+    colorIdentity = "GRW"
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {R}, {G}, or {W}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "216"
+        artist = "Steve Prescott"
+        flavorText = "Centuries have passed since the plane shattered, yet the obelisks of each shard faithfully serve their long-forgotten purpose."
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df6317b0-15fd-4924-9302-41bed2354546.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/OnyxGoblet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/OnyxGoblet.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Onyx Goblet
+ * {2}{B}
+ * Artifact
+ * {T}: Target player loses 1 life.
+ *
+ * A coloured artifact whose only ability is a bare [Costs.Tap] activation. The target is a plain
+ * [TargetPlayer] (any player, not just an opponent) and the drain is [Effects.LoseLife] with a
+ * fixed amount pointed at that bound variable — no life gain rider, so nothing composes here.
+ */
+val OnyxGoblet = card("Onyx Goblet") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "{T}: Target player loses 1 life."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", TargetPlayer())
+        effect = Effects.LoseLife(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "81"
+        artist = "rk post"
+        flavorText = "The goblet was a gift from the sphinx Gorael, who hoped humans and vedalken would eventually destroy each other to acquire it, leaving all of Esper to her own kind."
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/3686eb57-e9c8-480f-8ab4-2894e1b5fe20.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/PredatorDragon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/PredatorDragon.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDevour
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Predator Dragon
+ * {3}{R}{R}{R}
+ * Creature — Dragon
+ * 4 / 4
+ * Flying, haste
+ * Devour 2 (As this creature enters, you may sacrifice any number of creatures. It enters with twice that many +1/+1 counters on it.)
+ *
+ * Devour is two halves that must both be authored: [KeywordAbility.devour] is the printed keyword
+ * (it carries the multiplier and renders the reminder text), and [EntersWithDevour] is the
+ * replacement effect that actually does the work as the permanent enters — offering the sacrifice
+ * and multiplying the count into +1/+1 counters. Its defaults are already this card's variant
+ * (a creature sacrifice filter, no variant word), so only the multiplier is passed.
+ */
+val PredatorDragon = card("Predator Dragon") {
+    manaCost = "{3}{R}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying, haste\n" +
+        "Devour 2 (As this creature enters, you may sacrifice any number of creatures. It enters with twice that many +1/+1 counters on it.)"
+
+    keywords(Keyword.FLYING, Keyword.HASTE, Keyword.DEVOUR)
+    keywordAbility(KeywordAbility.devour(2))
+
+    replacementEffect(EntersWithDevour(multiplier = 2))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "109"
+        artist = "Raymond Swanland"
+        flavorText = "Dragons make for spiteful gods."
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/352c3c86-1662-4055-b814-026826632cff.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ProtomatterPowder.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ProtomatterPowder.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Protomatter Powder
+ * {2}{U}
+ * Artifact
+ * {4}{W}, {T}, Sacrifice this artifact: Return target artifact card from your graveyard to the battlefield.
+ *
+ * The three printed cost atoms compose through [Costs.Composite] — [Costs.Mana], [Costs.Tap] and
+ * [Costs.SacrificeSelf] — and the target is a [TargetObject] over
+ * `GameObjectFilter.Artifact.ownedByYou()` scoped to [Zone.GRAVEYARD], the same shape Sharuum the
+ * Hegemon uses. The recursion is [Effects.PutOntoBattlefieldFromGraveyard], the `fromZone`-guarded
+ * sibling of `PutOntoBattlefield`, so the move is skipped if the card has left the graveyard by the
+ * time the ability resolves.
+ */
+val ProtomatterPowder = card("Protomatter Powder") {
+    manaCost = "{2}{U}"
+    colorIdentity = "UW"
+    typeLine = "Artifact"
+    oracleText = "{4}{W}, {T}, Sacrifice this artifact: Return target artifact card from your graveyard to the battlefield."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{W}"), Costs.Tap, Costs.SacrificeSelf)
+        val t = target(
+            "target",
+            TargetObject(
+                filter = TargetFilter(GameObjectFilter.Artifact.ownedByYou(), zone = Zone.GRAVEYARD)
+            )
+        )
+        effect = Effects.PutOntoBattlefieldFromGraveyard(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "53"
+        artist = "Francis Tsai"
+        flavorText = "\"There is no such thing as scrap metal. All such material can be repaired with the proper bonding agent.\"\n—Quennus, metallurgeon"
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/273e2198-5549-4e82-8580-8769284d729d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/RangerOfEos.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/RangerOfEos.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Ranger of Eos
+ * {3}{W}
+ * Creature — Human Soldier Ranger
+ * 3 / 2
+ * When this creature enters, you may search your library for up to two creature cards with mana value 1 or less, reveal them, put them into your hand, then shuffle.
+ *
+ * The whole printed search is one [Patterns.Library].`searchLibrary` call: the gather/select/move
+ * pipeline, the trailing shuffle and the CR 701.23 "searched their library" event all come from its
+ * defaults, with `count = 2` giving the "up to two" and `reveal = true` the reveal. The cap is a
+ * filter predicate — `GameObjectFilter.Creature.manaValueAtMost(1)` — and `optional = true` lowers
+ * the printed "you may" into a [com.wingedsheep.sdk.scripting.effects.Gate.MayDecide] gate around it.
+ */
+val RangerOfEos = card("Ranger of Eos") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier Ranger"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, you may search your library for up to two creature cards with mana value 1 or less, reveal them, put them into your hand, then shuffle."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Creature.manaValueAtMost(1),
+            count = 2,
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "21"
+        artist = "Volkan Baǵa"
+        flavorText = "At his side, humble beasts become weapons more deadly than sharpened steel."
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a30ee26-5f78-4ac2-9105-1baa9ece8a21.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ResoundingRoar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ResoundingRoar.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Resounding Roar
+ * {1}{G}
+ * Instant
+ * Target creature gets +3/+3 until end of turn.
+ * Cycling {5}{R}{G}{W} ({5}{R}{G}{W}, Discard this card: Draw a card.)
+ * When you cycle this card, target creature gets +6/+6 until end of turn.
+ *
+ * The Alara "Resounding" shape, and the same three-part composition as the Onslaught cycling cycle:
+ * a `spell { }` body, [KeywordAbility.cycling] for the expensive wedge-coloured cycling cost, and a
+ * [Triggers.YouCycleThis] triggered ability carrying the larger effect. Both halves are
+ * [Effects.ModifyStats], whose default `Duration.EndOfTurn` is the printed "until end of turn", and
+ * each declares its own creature target — the trigger targets when it goes on the stack, so the
+ * cycled card's own spell target is never involved. Unlike the Onslaught cycle there is no printed
+ * "you may", so the trigger is not optional.
+ */
+val ResoundingRoar = card("Resounding Roar") {
+    manaCost = "{1}{G}"
+    colorIdentity = "GRW"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+3 until end of turn.\n" +
+        "Cycling {5}{R}{G}{W} ({5}{R}{G}{W}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, target creature gets +6/+6 until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(3, 3, t)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{5}{R}{G}{W}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(6, 6, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "144"
+        artist = "Steve Prescott"
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/217bf237-a758-4500-b221-5e88fed9d0fc.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ResoundingSilence.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ResoundingSilence.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Resounding Silence
+ * {3}{W}
+ * Instant
+ * Exile target attacking creature.
+ * Cycling {5}{G}{W}{U} ({5}{G}{W}{U}, Discard this card: Draw a card.)
+ * When you cycle this card, exile up to two target attacking creatures.
+ *
+ * The white member of the Alara "Resounding" cycle, composed like the Onslaught cycling cycle: a
+ * `spell { }` body, [KeywordAbility.cycling] for the wedge-coloured cycling cost, and a
+ * [Triggers.YouCycleThis] triggered ability carrying the larger effect. The spell half is a single
+ * [Effects.Exile]; the trigger declares a `count = 2`, `optional = true` [TargetCreature] over
+ * [TargetFilter.AttackingCreature] — that pair is exactly "up to two target" — and fans the exile
+ * out with [ForEachTargetEffect] so each chosen creature is moved independently.
+ */
+val ResoundingSilence = card("Resounding Silence") {
+    manaCost = "{3}{W}"
+    colorIdentity = "GUW"
+    typeLine = "Instant"
+    oracleText = "Exile target attacking creature.\n" +
+        "Cycling {5}{G}{W}{U} ({5}{G}{W}{U}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, exile up to two target attacking creatures."
+
+    spell {
+        val t = target("target", Targets.AttackingCreature)
+        effect = Effects.Exile(t)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{5}{G}{W}{U}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        target(
+            "target",
+            TargetCreature(count = 2, optional = true, filter = TargetFilter.AttackingCreature)
+        )
+        effect = ForEachTargetEffect(
+            effects = listOf(Effects.Exile(EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "22"
+        artist = "Mark Zug"
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5b3b0908-5408-41fd-8e69-2bc785e19304.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ResoundingThunder.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ResoundingThunder.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Resounding Thunder
+ * {2}{R}
+ * Instant
+ * Resounding Thunder deals 3 damage to any target.
+ * Cycling {5}{B}{R}{G} ({5}{B}{R}{G}, Discard this card: Draw a card.)
+ * When you cycle this card, it deals 6 damage to any target.
+ *
+ * The red member of the Alara "Resounding" cycle, composed like the Onslaught cycling cycle: a
+ * `spell { }` body, [KeywordAbility.cycling] for the wedge-coloured cycling cost, and a
+ * [Triggers.YouCycleThis] triggered ability carrying the larger effect. Both halves are
+ * [Effects.DealDamage] over a [Targets].`Any` requirement declared on their own ability, and the
+ * damage source is left implicit so it resolves to the card itself. Unlike the Onslaught cycle there
+ * is no printed "you may", so the trigger is not optional.
+ */
+val ResoundingThunder = card("Resounding Thunder") {
+    manaCost = "{2}{R}"
+    colorIdentity = "BGR"
+    typeLine = "Instant"
+    oracleText = "Resounding Thunder deals 3 damage to any target.\n" +
+        "Cycling {5}{B}{R}{G} ({5}{B}{R}{G}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, it deals 6 damage to any target."
+
+    spell {
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(3, t)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{5}{B}{R}{G}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(6, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "110"
+        artist = "Jon Foster"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/680b7955-d939-4195-aba8-b46a8c925616.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ResoundingWave.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ResoundingWave.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Resounding Wave
+ * {2}{U}
+ * Instant
+ * Return target permanent to its owner's hand.
+ * Cycling {5}{W}{U}{B} ({5}{W}{U}{B}, Discard this card: Draw a card.)
+ * When you cycle this card, return two target permanents to their owners' hands.
+ *
+ * The blue member of the Alara "Resounding" cycle, composed like the Onslaught cycling cycle: a
+ * `spell { }` body, [KeywordAbility.cycling] for the wedge-coloured cycling cost, and a
+ * [Triggers.YouCycleThis] triggered ability carrying the larger effect. The spell half is a single
+ * [Effects.ReturnToHand]; the trigger declares a `count = 2` [TargetPermanent] requirement and fans
+ * the bounce out with [ForEachTargetEffect] so each chosen permanent is moved independently — one
+ * illegal target on resolution no longer costs the other its bounce. Unlike the Onslaught cycle
+ * there is no printed "you may", so the trigger is not optional, and "two target permanents" is a
+ * hard count rather than "up to two".
+ */
+val ResoundingWave = card("Resounding Wave") {
+    manaCost = "{2}{U}"
+    colorIdentity = "BUW"
+    typeLine = "Instant"
+    oracleText = "Return target permanent to its owner's hand.\n" +
+        "Cycling {5}{W}{U}{B} ({5}{W}{U}{B}, Discard this card: Draw a card.)\n" +
+        "When you cycle this card, return two target permanents to their owners' hands."
+
+    spell {
+        val t = target("target", Targets.Permanent)
+        effect = Effects.ReturnToHand(t)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{5}{W}{U}{B}"))
+
+    triggeredAbility {
+        trigger = Triggers.YouCycleThis
+        target("target", TargetPermanent(count = 2))
+        effect = ForEachTargetEffect(
+            effects = listOf(Effects.ReturnToHand(EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "Izzy"
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f3eca679-076d-42f0-9ec0-b8116a94e373.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/RhoxWarMonk.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/RhoxWarMonk.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rhox War Monk
+ * {G}{W}{U}
+ * Creature — Rhino Monk
+ * 3 / 4
+ * Lifelink
+ *
+ * A keyword-only creature: `keywords(Keyword.LIFELINK)` is the whole script, and the engine's
+ * damage pipeline reads the keyword off projected state, so no ability wiring is required.
+ */
+val RhoxWarMonk = card("Rhox War Monk") {
+    manaCost = "{G}{W}{U}"
+    colorIdentity = "GUW"
+    typeLine = "Creature — Rhino Monk"
+    power = 3
+    toughness = 4
+    oracleText = "Lifelink"
+
+    keywords(Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "188"
+        artist = "Dan Dos Santos"
+        flavorText = "Rhox monks are dedicated to spiritual growth and learning, and most bear the sigils of many students. However, they do not gladly suffer fools or those who disagree with their carefully wrought dogma."
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/19fb67e1-b791-4246-aebc-49fcf0f92c6c.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/RidgeRannet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/RidgeRannet.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Ridge Rannet
+ * {5}{R}{R}
+ * Creature — Beast
+ * 6 / 4
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * A vanilla body plus one keyword ability. [KeywordAbility.cycling] carries the whole printed
+ * reminder text — the discard-and-draw activated ability that only works from hand — so no
+ * `keywords(Keyword.CYCLING)` display flag is needed beside it.
+ */
+val RidgeRannet = card("Ridge Rannet") {
+    manaCost = "{5}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Beast"
+    power = 6
+    toughness = 4
+    oracleText = "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "Jim Murray"
+        flavorText = "\"Only those with the strength to seize their destiny deserve to have one.\"\n—Nacatl scratchforms"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/4275a8dd-f777-4160-b773-9a868e743218.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/RipClanCrasher.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/RipClanCrasher.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rip-Clan Crasher
+ * {R}{G}
+ * Creature — Human Warrior
+ * 2 / 2
+ * Haste
+ *
+ * A single printed keyword and no script: `keywords(Keyword.HASTE)` stamps both the projected
+ * keyword set the summoning-sickness check reads and the simple keyword ability the rules text
+ * renders from.
+ */
+val RipClanCrasher = card("Rip-Clan Crasher") {
+    manaCost = "{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "Haste"
+
+    keywords(Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "189"
+        artist = "Justin Sweet"
+        flavorText = "If you breathe, she will fight you. If you breathe fire, she must fight you."
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d61c4a0-054b-479e-82d9-dc60c5c708e2.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/RockcasterPlatoon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/RockcasterPlatoon.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rockcaster Platoon
+ * {5}{W}{W}
+ * Creature — Rhino Soldier
+ * 5 / 7
+ * {4}{G}: This creature deals 2 damage to each creature with flying and each player.
+ *
+ * "Each creature with flying and each player" is two iterations, not one — the Thrashing Wumpus
+ * idiom. A group pass over [GroupFilter.AllCreatures]`.withKeyword(FLYING)` deals the damage to
+ * [EffectTarget.Self] (the current iteration entity), and a [Effects.ForEachPlayer] pass over
+ * [Player.Each] rebinds the controller each time so [EffectTarget.Controller] is the player being
+ * processed. The activation cost is a plain off-colour [Costs.Mana].
+ */
+val RockcasterPlatoon = card("Rockcaster Platoon") {
+    manaCost = "{5}{W}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Rhino Soldier"
+    power = 5
+    toughness = 7
+    oracleText = "{4}{G}: This creature deals 2 damage to each creature with flying and each player."
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{G}")
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                GroupFilter.AllCreatures.withKeyword(Keyword.FLYING),
+                Effects.DealDamage(2, EffectTarget.Self)
+            ),
+            Effects.ForEachPlayer(
+                Player.Each,
+                listOf(Effects.DealDamage(2, EffectTarget.Controller))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "23"
+        artist = "David Palumbo"
+        flavorText = "\"Aven bandits can be sly. You've got to fill the sky with boulders—and then seek cover immediately.\"\n—Knight-Captain Wyhorn"
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4ab62812-acc5-4b4b-97d3-106e399d69da.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SangriteSurge.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SangriteSurge.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sangrite Surge
+ * {4}{R}{G}
+ * Sorcery
+ * Target creature gets +3/+3 and gains double strike until end of turn.
+ *
+ * One target, two riders: [Effects.ModifyStats] and [Effects.GrantKeyword] both point at the same
+ * bound target and both take their default `Duration.EndOfTurn`, which is exactly the printed
+ * "until end of turn" governing the whole sentence. Composing them keeps the pump and the grant
+ * as separate continuous effects, so each lands in its own layer.
+ */
+val SangriteSurge = card("Sangrite Surge") {
+    manaCost = "{4}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Sorcery"
+    oracleText = "Target creature gets +3/+3 and gains double strike until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 3, t),
+            Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "190"
+        artist = "Jarreau Wimberly"
+        flavorText = "Some believe the spiky crystal called sangrite is concentrated dragon's breath. Others think it's crystallized life energy. The clans care only about the power it unleashes when crushed."
+        imageUri = "https://cards.scryfall.io/normal/front/1/6/16b4527e-e449-45d0-a551-634e2ceb21c4.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SavageHunger.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SavageHunger.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Savage Hunger
+ * {2}{G}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +1/+0 and has trample.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * "Enchant creature" is the `auraTarget`, without which the Aura would have nothing to attach to.
+ * The two granted characteristics are two statics whose `filter` defaults to
+ * `GroupFilter.attachedCreature()` — [ModifyStats] for the pump and [GrantKeyword] for trample —
+ * so each applies in its own layer to whatever the Aura is currently on. Cycling is the
+ * [KeywordAbility.cycling] keyword ability, never a plain `Keyword` entry.
+ */
+val SavageHunger = card("Savage Hunger") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +1/+0 and has trample.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(1, 0)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "147"
+        artist = "Trevor Claxton"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/0367fac8-6990-4544-ac7d-ed363b55a9cf.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/Shadowfeed.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/Shadowfeed.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Shadowfeed
+ * {B}
+ * Instant
+ * Exile target card from a graveyard. You gain 3 life.
+ *
+ * "A graveyard" is any graveyard, so the target is [TargetFilter.CardInGraveyard] — an unrestricted
+ * object filter scoped to [Zone.GRAVEYARD] — and the exile is [Effects.Move] to [Zone.EXILE]. The
+ * life gain is a second, untargeted clause, so it is composed after the move and resolves even if
+ * the card has already left the graveyard.
+ */
+val Shadowfeed = card("Shadowfeed") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Exile target card from a graveyard. You gain 3 life."
+
+    spell {
+        val t = target("target", TargetObject(filter = TargetFilter.CardInGraveyard))
+        effect = Effects.Composite(
+            Effects.Move(t, Zone.EXILE),
+            Effects.GainLife(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86"
+        artist = "Dave Kendall"
+        flavorText = "\"The future is a snake, devouring your life backwards through time. And when you die, believe me, it doesn't stop feeding.\"\n—Sedris, the Traitor King"
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/19ccd8c7-7472-47df-9d3e-1b5fb1431118.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ShardsOfAlaraBasicLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ShardsOfAlaraBasicLands.kt
@@ -1,0 +1,155 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Shards of Alara Basic Lands
+ *
+ * Four art variants of each basic land type, collector numbers 230-249.
+ */
+
+val AlaPlains230 = basicLand("Plains") {
+    collectorNumber = "230"
+    artist = "Zoltan Boros & Gabor Szikszai"
+    imageUri = "https://cards.scryfall.io/normal/front/e/9/e94e2710-7b95-46d0-8261-0afa6b192e70.jpg"
+}
+
+val AlaPlains231 = basicLand("Plains") {
+    collectorNumber = "231"
+    artist = "Michael Komarck"
+    imageUri = "https://cards.scryfall.io/normal/front/2/e/2ef285a1-dbd0-4e41-9f04-a9120a0421f7.jpg"
+}
+
+val AlaPlains232 = basicLand("Plains") {
+    collectorNumber = "232"
+    artist = "Michael Komarck"
+    imageUri = "https://cards.scryfall.io/normal/front/b/c/bcdd1595-d94d-46b1-b87f-b910ae35fa3a.jpg"
+}
+
+val AlaPlains233 = basicLand("Plains") {
+    collectorNumber = "233"
+    artist = "Chippy"
+    imageUri = "https://cards.scryfall.io/normal/front/2/0/20aec487-ac03-4912-969b-f537864902ce.jpg"
+}
+
+val AlaIsland234 = basicLand("Island") {
+    collectorNumber = "234"
+    artist = "Michael Komarck"
+    imageUri = "https://cards.scryfall.io/normal/front/2/f/2fdcf679-4269-4ed9-84f1-1ac7a513f475.jpg"
+}
+
+val AlaIsland235 = basicLand("Island") {
+    collectorNumber = "235"
+    artist = "Chippy"
+    imageUri = "https://cards.scryfall.io/normal/front/7/e/7e659905-5f87-4181-8fc8-59ab2138b7fc.jpg"
+}
+
+val AlaIsland236 = basicLand("Island") {
+    collectorNumber = "236"
+    artist = "Chippy"
+    imageUri = "https://cards.scryfall.io/normal/front/2/b/2bf6f14a-99d1-4abd-b36f-a5819718a43f.jpg"
+}
+
+val AlaIsland237 = basicLand("Island") {
+    collectorNumber = "237"
+    artist = "Mark Tedin"
+    imageUri = "https://cards.scryfall.io/normal/front/a/f/afb31304-eff0-44f9-b240-b7fa631ea4ce.jpg"
+}
+
+val AlaSwamp238 = basicLand("Swamp") {
+    collectorNumber = "238"
+    artist = "Chippy"
+    imageUri = "https://cards.scryfall.io/normal/front/4/5/45cbe554-ffdc-4de6-bf27-57790b71effb.jpg"
+}
+
+val AlaSwamp239 = basicLand("Swamp") {
+    collectorNumber = "239"
+    artist = "Mark Tedin"
+    imageUri = "https://cards.scryfall.io/normal/front/e/8/e809db1f-12d7-4556-bdd2-db832f991cd0.jpg"
+}
+
+val AlaSwamp240 = basicLand("Swamp") {
+    collectorNumber = "240"
+    artist = "Mark Tedin"
+    imageUri = "https://cards.scryfall.io/normal/front/b/c/bc6ec4ca-ab4c-4d5f-98df-aa166b60bb1d.jpg"
+}
+
+val AlaSwamp241 = basicLand("Swamp") {
+    collectorNumber = "241"
+    artist = "Aleksi Briclot"
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e3133726-0eda-480c-9d67-64719cb77f1d.jpg"
+}
+
+val AlaMountain242 = basicLand("Mountain") {
+    collectorNumber = "242"
+    artist = "Mark Tedin"
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7c2cc19c-84ce-4c0b-b56f-7a2b3878a26e.jpg"
+}
+
+val AlaMountain243 = basicLand("Mountain") {
+    collectorNumber = "243"
+    artist = "Aleksi Briclot"
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fcfb1db3-c0ea-4f8d-8208-5f8895ff686d.jpg"
+}
+
+val AlaMountain244 = basicLand("Mountain") {
+    collectorNumber = "244"
+    artist = "Aleksi Briclot"
+    imageUri = "https://cards.scryfall.io/normal/front/9/6/969d5979-8ae8-4442-a3a5-3412ffeb5af8.jpg"
+}
+
+val AlaMountain245 = basicLand("Mountain") {
+    collectorNumber = "245"
+    artist = "Zoltan Boros & Gabor Szikszai"
+    imageUri = "https://cards.scryfall.io/normal/front/b/6/b64e4622-e905-49da-948f-aeba1ba674ce.jpg"
+}
+
+val AlaForest246 = basicLand("Forest") {
+    collectorNumber = "246"
+    artist = "Aleksi Briclot"
+    imageUri = "https://cards.scryfall.io/normal/front/1/2/12495cfa-ab19-4e9e-a49e-a94499f664a2.jpg"
+}
+
+val AlaForest247 = basicLand("Forest") {
+    collectorNumber = "247"
+    artist = "Zoltan Boros & Gabor Szikszai"
+    imageUri = "https://cards.scryfall.io/normal/front/a/f/af8a605e-73a6-4666-ae08-ec6e9845e629.jpg"
+}
+
+val AlaForest248 = basicLand("Forest") {
+    collectorNumber = "248"
+    artist = "Zoltan Boros & Gabor Szikszai"
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/368be73f-24d2-44db-a55e-d04176db3142.jpg"
+}
+
+val AlaForest249 = basicLand("Forest") {
+    collectorNumber = "249"
+    artist = "Michael Komarck"
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2a0bc8e3-b106-43bb-acf6-885328d24a65.jpg"
+}
+
+/**
+ * All Shards of Alara basic land variants.
+ */
+val ShardsOfAlaraBasicLands = listOf(
+    AlaPlains230,
+    AlaPlains231,
+    AlaPlains232,
+    AlaPlains233,
+    AlaIsland234,
+    AlaIsland235,
+    AlaIsland236,
+    AlaIsland237,
+    AlaSwamp238,
+    AlaSwamp239,
+    AlaSwamp240,
+    AlaSwamp241,
+    AlaMountain242,
+    AlaMountain243,
+    AlaMountain244,
+    AlaMountain245,
+    AlaForest246,
+    AlaForest247,
+    AlaForest248,
+    AlaForest249,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ShoreSnapper.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ShoreSnapper.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shore Snapper
+ * {2}{B}
+ * Creature — Beast
+ * 2 / 2
+ * {U}: This creature gains islandwalk until end of turn. (It can't be blocked as long as defending player controls an Island.)
+ *
+ * The Deeptread Merrow shape: a bare off-colour [Costs.Mana] activation whose effect is
+ * [Effects.GrantKeyword] of [Keyword.ISLANDWALK] on [EffectTarget.Self]. The grant's default
+ * `Duration.EndOfTurn` is the printed "until end of turn"; the landwalk evasion itself is read by
+ * the blocker-legality check, so no separate can't-be-blocked rider is needed.
+ */
+val ShoreSnapper = card("Shore Snapper") {
+    manaCost = "{2}{B}"
+    colorIdentity = "BU"
+    typeLine = "Creature — Beast"
+    power = 2
+    toughness = 2
+    oracleText = "{U}: This creature gains islandwalk until end of turn. (It can't be blocked as long as defending player controls an Island.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{U}")
+        effect = Effects.GrantKeyword(Keyword.ISLANDWALK, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Dave Kendall"
+        flavorText = "Kathari, the sickly aven of Grixis, have learned that the corpses by the shoreline are more trap than treat."
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/157e5763-4892-47e4-8fd5-f576844c0a0d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SkeletalKathari.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SkeletalKathari.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Skeletal Kathari
+ * {4}{B}
+ * Creature — Bird Skeleton
+ * 3 / 2
+ * Flying
+ * {B}, Sacrifice a creature: Regenerate this creature.
+ *
+ * Flying is a printed [Keyword]. The regeneration ability pairs a [Costs.Mana] atom with a
+ * [Costs.Sacrifice] over [GameObjectFilter.Creature] — "a creature", not "another", so the
+ * Kathari may eat itself — and the effect is [RegenerateEffect] on [EffectTarget.Self], which has
+ * no `Effects` facade entry and so is imported directly.
+ */
+val SkeletalKathari = card("Skeletal Kathari") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Bird Skeleton"
+    power = 3
+    toughness = 2
+    oracleText = "Flying\n" +
+        "{B}, Sacrifice a creature: Regenerate this creature."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{B}"),
+            Costs.Sacrifice(GameObjectFilter.Creature)
+        )
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "88"
+        artist = "Carl Critchlow"
+        flavorText = "Undeath doesn't end the kathari's search for carrion; it only removes one corpse from the Dregscape."
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3e7e593-e5b0-4348-b8e5-20173d41aa39.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SpearbreakerBehemoth.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SpearbreakerBehemoth.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Spearbreaker Behemoth
+ * {5}{G}{G}
+ * Creature — Beast
+ * 5 / 5
+ * Indestructible
+ * {1}: Target creature with power 5 or greater gains indestructible until end of turn.
+ *
+ * The Rakeclaw Gargantuan shape with its own keyword to hand out: the power threshold is a filter
+ * on the target itself — [TargetFilter.Creature]`.powerAtLeast(5)` — so legality is checked on
+ * announcement and rechecked on resolution, and the grant is [Effects.GrantKeyword] on the bound
+ * target with its default `Duration.EndOfTurn`. The Behemoth's own indestructibility is the
+ * printed [Keyword.INDESTRUCTIBLE], separate from the ability.
+ */
+val SpearbreakerBehemoth = card("Spearbreaker Behemoth") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 5
+    oracleText = "Indestructible\n" +
+        "{1}: Target creature with power 5 or greater gains indestructible until end of turn."
+
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.powerAtLeast(5)))
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "150"
+        artist = "Christopher Moeller"
+        flavorText = "Few Nayans dare hunt the gargantuans. They're regarded not as animals but as forces of nature, like landslides or typhoons."
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/132367ee-22e9-48e2-82e0-62ad9aaa62f3.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/StewardOfValeron.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/StewardOfValeron.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Steward of Valeron
+ * {G}{W}
+ * Creature — Human Druid Knight
+ * 2 / 2
+ * Vigilance
+ * {T}: Add {G}.
+ *
+ * A mana creature that keeps guard: `keywords(`[Keyword.VIGILANCE]`)` (from which the builder
+ * derives the simple keyword ability), and a single [Effects.AddMana]`(`[Color.GREEN]`)` on
+ * [Costs.Tap] flagged `manaAbility` with [TimingRule.ManaAbility] so it never uses the stack —
+ * the same one-colour shape as [DruidOfTheAnima]'s three abilities.
+ */
+val StewardOfValeron = card("Steward of Valeron") {
+    manaCost = "{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Human Druid Knight"
+    power = 2
+    toughness = 2
+    oracleText = "Vigilance\n" +
+        "{T}: Add {G}."
+
+    keywords(Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "198"
+        artist = "Greg Staples"
+        flavorText = "Knight-stewards guard the Sun-Dappled Court, a grove of immense, sculptured olive trees that represent Valeron's twelve noble families."
+        imageUri = "https://cards.scryfall.io/normal/front/9/2/92e21ff9-0030-4e53-8ddf-86d8e78e347f.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SunseedNurturer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SunseedNurturer.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Sunseed Nurturer
+ * {2}{W}
+ * Creature — Human Druid Wizard
+ * 1 / 1
+ * At the beginning of your end step, if you control a creature with power 5 or greater, you may gain 2 life.
+ * {T}: Add {C}.
+ *
+ * The printed "if …" is an intervening-if on [Triggers.YourEndStep], so it is checked both when the
+ * ability would trigger and again on resolution — [Conditions.YouControl] over
+ * `GameObjectFilter.Creature.powerAtLeast(5)`, the mere-existence form (never
+ * `YouControlAtLeast(1, …)`). "You may" is the `optional = true` shorthand, which lowers to a
+ * [com.wingedsheep.sdk.scripting.effects.Gate.MayDecide] around [Effects.GainLife]. The mana
+ * ability is [Effects.AddColorlessMana]`(1)` on [Costs.Tap], flagged `manaAbility` with
+ * [TimingRule.ManaAbility].
+ */
+val SunseedNurturer = card("Sunseed Nurturer") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Druid Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "At the beginning of your end step, if you control a creature with power 5 or greater, you may gain 2 life.\n" +
+        "{T}: Add {C}."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        interveningIf = Conditions.YouControl(GameObjectFilter.Creature.powerAtLeast(5))
+        optional = true
+        effect = Effects.GainLife(2)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "29"
+        artist = "Steve Argyle"
+        flavorText = "Sunseeders quest for areas of open sky. They train plowbeasts to beat back the dense jungle long enough to cultivate a crop."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d44447e-09d1-450f-907f-42f79b004fe7.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ThornThrashViashino.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ThornThrashViashino.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDevour
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Thorn-Thrash Viashino
+ * {3}{R}
+ * Creature — Lizard Warrior
+ * 2 / 2
+ * Devour 2 (As this creature enters, you may sacrifice any number of creatures. It enters with twice that many +1/+1 counters on it.)
+ * {G}: This creature gains trample until end of turn.
+ *
+ * Devour is two declarations, not one: [KeywordAbility.devour] supplies the printed line and the
+ * keyword the rest of the engine reads, while the [EntersWithDevour] replacement effect is what
+ * actually offers the sacrifice and stamps the +1/+1 counters as the creature enters — its
+ * defaults (plain creature filter, unnamed variant) are exactly the printed "devour 2". The
+ * off-colour pump is a plain [Costs.Mana] ability over [Effects.GrantKeyword] bound to
+ * [EffectTarget.Self], whose default `Duration.EndOfTurn` is the printed "until end of turn".
+ */
+val ThornThrashViashino = card("Thorn-Thrash Viashino") {
+    manaCost = "{3}{R}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Lizard Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "Devour 2 (As this creature enters, you may sacrifice any number of creatures. It enters with twice that many +1/+1 counters on it.)\n" +
+        "{G}: This creature gains trample until end of turn."
+
+    keywords(Keyword.DEVOUR)
+    keywordAbility(KeywordAbility.devour(2))
+
+    replacementEffect(EntersWithDevour(multiplier = 2))
+
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        effect = Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "116"
+        artist = "Jon Foster"
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e7987de9-d812-4615-845a-3a90572d9b44.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ThunderThrashElder.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ThunderThrashElder.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDevour
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Thunder-Thrash Elder
+ * {2}{R}
+ * Creature — Lizard Warrior
+ * 1 / 1
+ * Devour 3 (As this creature enters, you may sacrifice any number of creatures. It enters with three times that many +1/+1 counters on it.)
+ *
+ * A vanilla body plus devour, and devour is two declarations rather than one:
+ * [KeywordAbility.devour] gives the printed line and the keyword the rest of the engine reads,
+ * while the [EntersWithDevour] replacement effect is what actually offers the sacrifice and stamps
+ * `3 ×` that many +1/+1 counters as the creature enters. Its defaults — the plain creature filter
+ * and the unnamed variant — are exactly the printed "devour 3".
+ */
+val ThunderThrashElder = card("Thunder-Thrash Elder") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "Devour 3 (As this creature enters, you may sacrifice any number of creatures. It enters with three times that many +1/+1 counters on it.)"
+
+    keywords(Keyword.DEVOUR)
+    keywordAbility(KeywordAbility.devour(3))
+
+    replacementEffect(EntersWithDevour(multiplier = 3))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "117"
+        artist = "Brandon Kitkouski"
+        flavorText = "Viashino thrashes are led by elders who have survived countless challenges."
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/5552da28-01a3-4277-9e69-b297c3874ea4.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/TitanicUltimatum.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/TitanicUltimatum.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Titanic Ultimatum
+ * {R}{R}{G}{G}{G}{W}{W}
+ * Sorcery
+ * Until end of turn, creatures you control get +5/+5 and gain first strike, trample, and lifelink.
+ *
+ * The Naya ultimatum is Overrun's shape with three keywords instead of one, so it is a single
+ * [Effects.ForEachInGroup] over [GroupFilter.AllCreaturesYouControl] whose body is one
+ * [Effects.Composite] — the printed sentence names its group once, and gathering it once is what
+ * keeps a power-reading filter from matching a different set on a second pass.
+ * `Patterns.Group.pumpAndGrantToAll` is the two-clause facade for this sentence but carries only a
+ * single keyword, so the body is spelled out: [Effects.ModifyStats]`(5, 5)` plus one
+ * [Effects.GrantKeyword] per keyword, each bound to [EffectTarget.Self] — the per-iteration member —
+ * and each defaulting to `Duration.EndOfTurn`, the fronted "until end of turn".
+ */
+val TitanicUltimatum = card("Titanic Ultimatum") {
+    manaCost = "{R}{R}{G}{G}{G}{W}{W}"
+    colorIdentity = "GRW"
+    typeLine = "Sorcery"
+    oracleText = "Until end of turn, creatures you control get +5/+5 and gain first strike, trample, and lifelink."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreaturesYouControl,
+            Effects.Composite(
+                Effects.ModifyStats(5, 5, EffectTarget.Self),
+                Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self),
+                Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self),
+                Effects.GrantKeyword(Keyword.LIFELINK, EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "204"
+        artist = "Steve Prescott"
+        flavorText = "\"Retribution is best delivered by claws and rage, with both magnified.\"\n—Ajani"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d28fd77-1f7c-47b4-b9ff-55835a7f2526.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/TopanAscetic.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/TopanAscetic.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Topan Ascetic
+ * {2}{G}
+ * Creature — Human Monk
+ * 2 / 2
+ * Tap an untapped creature you control: This creature gets +1/+1 until end of turn.
+ *
+ * The whole ability is a cost with no mana in it: [Costs.TapPermanents]`(count = 1, filter = `
+ * [GameObjectFilter.Creature]`)` is the atomic "tap N untapped permanents you control" primitive,
+ * and because the printed line says no "another" it leaves `excludeSelf` false — the Ascetic may
+ * tap itself. The payoff is [Effects.ModifyStats]`(1, 1)` on [EffectTarget.Self], whose default
+ * `Duration.EndOfTurn` is the printed "until end of turn".
+ */
+val TopanAscetic = card("Topan Ascetic") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Monk"
+    power = 2
+    toughness = 2
+    oracleText = "Tap an untapped creature you control: This creature gets +1/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.TapPermanents(count = 1, filter = GameObjectFilter.Creature)
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "151"
+        artist = "Sal Villagran"
+        flavorText = "Monks from Topa wander all of Bant, encouraging the Unbeholden to find their place in society through honorable combat."
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6d0952ed-efc7-4ff5-a233-e64c0f11119b.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/TortoiseFormation.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/TortoiseFormation.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Tortoise Formation
+ * {3}{U}
+ * Instant
+ * Creatures you control gain shroud until end of turn. (They can't be the targets of spells or abilities.)
+ *
+ * One group, one thing said about it, so it is the single-clause group facade:
+ * [Patterns.Group]`.grantKeywordToAll(`[Keyword.SHROUD]`, `[GroupFilter.AllCreaturesYouControl]`)`,
+ * which lowers to one `ForEachInGroup` granting the keyword to each member with the default
+ * `Duration.EndOfTurn`. The group is snapshotted before iteration, so a creature that enters after
+ * the spell resolves gains nothing — exactly the printed one-shot.
+ */
+val TortoiseFormation = card("Tortoise Formation") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Creatures you control gain shroud until end of turn. (They can't be the targets of spells or abilities.)"
+
+    spell {
+        effect = Patterns.Group.grantKeywordToAll(Keyword.SHROUD, GroupFilter.AllCreaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "61"
+        artist = "Mark Zug"
+        flavorText = "At sea, the Jhessian fleet strikes swiftly and decisively. On land, facing the elite cavalry of Valeron, its marines must rely on more cautious strategies."
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/59ff8324-42b8-4eeb-8d0b-ea679c984933.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/VectisSilencers.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/VectisSilencers.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vectis Silencers
+ * {2}{U}
+ * Artifact Creature — Human Rogue
+ * 1 / 2
+ * {2}{B}: This creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy that creature.)
+ *
+ * An Esper common with an off-colour activation: a plain [Costs.Mana]`("{2}{B}")` ability over
+ * [Effects.GrantKeyword] bound to [EffectTarget.Self], whose default `Duration.EndOfTurn` is the
+ * printed "until end of turn". The black in the activation cost is why the card's colour identity
+ * is BU while its own colour is blue.
+ */
+val VectisSilencers = card("Vectis Silencers") {
+    manaCost = "{2}{U}"
+    colorIdentity = "BU"
+    typeLine = "Artifact Creature — Human Rogue"
+    power = 1
+    toughness = 2
+    oracleText = "{2}{B}: This creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy that creature.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{B}")
+        effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "62"
+        artist = "Steven Belledin"
+        flavorText = "Even on Esper, there are those who eschew the use of magic in favor of simpler methods."
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c0198220-073f-4479-a1c4-1bd626891e28.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ViashinoSkeleton.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ViashinoSkeleton.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Viashino Skeleton
+ * {3}{R}
+ * Creature — Lizard Skeleton
+ * 2 / 1
+ * {1}{B}, Discard a card: Regenerate this creature.
+ *
+ * A single activated ability. The printed price is two cost atoms joined by [Costs.Composite] —
+ * [Costs.Mana] for the `{1}{B}` and the parameterless [Costs.DiscardCard], whose defaults (one
+ * card, any card, chosen by the player) are exactly what "Discard a card" means. The effect is
+ * [RegenerateEffect] on [EffectTarget.Self]: regeneration is a shield the engine already knows how
+ * to hang on the source, so no new vocabulary is involved.
+ */
+val ViashinoSkeleton = card("Viashino Skeleton") {
+    manaCost = "{3}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Lizard Skeleton"
+    power = 2
+    toughness = 1
+    oracleText = "{1}{B}, Discard a card: Regenerate this creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{B}"), Costs.DiscardCard)
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Cole Eastburn"
+        flavorText = "Underneath the Dregscape lay the remains of creatures long extinct from Grixis."
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9451a62-31a4-4aaf-beef-2bf149f25ae3.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ViolentUltimatum.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/ViolentUltimatum.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Violent Ultimatum
+ * {B}{B}{R}{R}{R}{G}{G}
+ * Sorcery
+ * Destroy three target permanents.
+ *
+ * The count lives entirely on the target requirement — one [TargetPermanent] with `count = 3` — and
+ * the effect is fanned out over it with [ForEachTargetEffect], so each chosen permanent is destroyed
+ * in its own iteration with [EffectTarget.ContextTarget] `(0)` bound to it. That keeps
+ * indestructible and regeneration per-permanent (they are three separate [Effects.Destroy]
+ * applications, not one group destroy) and means the number of targets is owned by the requirement
+ * rather than duplicated on the effect.
+ */
+val ViolentUltimatum = card("Violent Ultimatum") {
+    manaCost = "{B}{B}{R}{R}{R}{G}{G}"
+    colorIdentity = "BGR"
+    typeLine = "Sorcery"
+    oracleText = "Destroy three target permanents."
+
+    spell {
+        target = TargetPermanent(count = 3)
+        effect = ForEachTargetEffect(
+            effects = listOf(Effects.Destroy(EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "206"
+        artist = "Raymond Swanland"
+        flavorText = "\"Words are a waste of time. Destruction is a language everyone understands.\"\n—Sarkhan Vol"
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e6ac9ce-e163-426f-8fbd-5ee1ec177dc1.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/VolcanicSubmersion.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/VolcanicSubmersion.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Volcanic Submersion
+ * {4}{R}
+ * Sorcery
+ * Destroy target artifact or land.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * The spell half is one named target over [Targets.ArtifactOrLand] — the shared "artifact or land"
+ * union filter, not a hand-rolled `Or` — consumed by [Effects.Destroy], which is the
+ * `byDestruction` move to the graveyard so indestructible and regeneration still apply. Cycling is
+ * declared as [KeywordAbility.cycling], which carries its own cost and lowers to the discard-and-draw
+ * activated ability; no `keywords(...)` entry is needed alongside it.
+ */
+val VolcanicSubmersion = card("Volcanic Submersion") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target artifact or land.\n" +
+        "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        val t = target("target", Targets.ArtifactOrLand)
+        effect = Effects.Destroy(t)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "121"
+        artist = "Trevor Claxton"
+        flavorText = "A dragon's death is almost as feared as its life. Old, dying dragons throw themselves into volcanoes, causing massive upheaval and widespread disaster."
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0ec1f1fa-41c9-4bc0-9171-902cd456aa73.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/WelkinGuide.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/WelkinGuide.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Welkin Guide
+ * {4}{W}
+ * Creature — Bird Cleric
+ * 2 / 2
+ * Flying
+ * When this creature enters, target creature gets +2/+2 and gains flying until end of turn.
+ *
+ * The printed flying is a bare [Keyword.FLYING] on the card's keyword set. The enters trigger is
+ * [Triggers.EntersBattlefield] with one named [Targets.Creature] slot, and its effect is the pair
+ * [Effects.ModifyStats] `then` [Effects.GrantKeyword] over that same bound target — both take the
+ * default [com.wingedsheep.sdk.scripting.Duration.EndOfTurn], which is the printed "until end of
+ * turn" for the whole sentence.
+ */
+val WelkinGuide = card("Welkin Guide") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "When this creature enters, target creature gets +2/+2 and gains flying until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(2, 2, t)
+            .then(Effects.GrantKeyword(Keyword.FLYING, t))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "30"
+        artist = "David Palumbo"
+        flavorText = "\"Those talons really dig into your skin, but it's better than being dropped.\"\n—Rafiq of the Many"
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/198363f2-1a19-4954-b527-6d10ac277719.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/WildNacatl.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/WildNacatl.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Wild Nacatl
+ * {G}
+ * Creature — Cat Warrior
+ * 1 / 1
+ * This creature gets +1/+1 as long as you control a Mountain.
+ * This creature gets +1/+1 as long as you control a Plains.
+ *
+ * Two printed lines, so **two** separate [ConditionalStaticAbility] entries rather than one folded
+ * +2/+2 — each buff has its own land condition and either can be live on its own. Both wrap the same
+ * [ModifyStats] over [Filters.Self] (the source-scoped group filter), gated by
+ * [Exists] on [Player.You]'s battlefield for a land with the named basic subtype. Being statics they
+ * re-evaluate through the layer projection every time the board changes, so the pump appears and
+ * disappears with the land.
+ */
+val WildNacatl = card("Wild Nacatl") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "This creature gets +1/+1 as long as you control a Mountain.\n" +
+        "This creature gets +1/+1 as long as you control a Plains."
+
+    // +1/+1 as long as you control a Mountain
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 1, toughnessBonus = 1, filter = Filters.Self),
+            condition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Mountain"))
+        )
+    }
+
+    // +1/+1 as long as you control a Plains
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 1, toughnessBonus = 1, filter = Filters.Self),
+            condition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Plains"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "152"
+        artist = "Wayne Reynolds"
+        flavorText = "\"The Cloud Nacatl sit and think, a bunch of soft paws. We are the Claws of Marisi, stalking, pouncing, drawing blood.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5eb18038-eb6a-4d27-ba52-52a1cee6b512.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/YokedPlowbeast.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/YokedPlowbeast.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Yoked Plowbeast
+ * {5}{W}{W}
+ * Creature — Beast
+ * 5 / 5
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * A vanilla body plus one parameterized keyword, so the whole script is a single
+ * [KeywordAbility.cycling] entry — it carries the `{2}` cost itself and lowers to the
+ * discard-and-draw ability from hand. Nothing goes on the card's `keywords` set: a cycling cost is
+ * not a bare evergreen keyword.
+ */
+val YokedPlowbeast = card("Yoked Plowbeast") {
+    manaCost = "{5}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 5
+    oracleText = "Cycling {2} ({2}, Discard this card: Draw a card.)"
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "31"
+        artist = "Steve Argyle"
+        flavorText = "\"It is sacrilege to confine a gargantuan to the grinding of straight lines. I will pray that it remembers who is the master of this land.\"\n—Syeena, elvish godtoucher"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/ddbbc7dc-efdf-46e8-bf19-0daa4034f6ec.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/BranchingBoltReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/BranchingBoltReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Branching Bolt reprint in ARC. Canonical CardDefinition lives in its earliest set.
+ */
+val BranchingBoltReprint = Printing(
+    oracleId = "13f63b98-40b0-499b-bb5d-640b95a6ea1c",
+    name = "Branching Bolt",
+    setCode = "ARC",
+    collectorNumber = "82",
+    scryfallId = "9ee5d78d-fdfb-436a-82e1-1d021db69b6f",
+    artist = "Vance Kovacs",
+    imageUri = "https://cards.scryfall.io/normal/front/9/e/9ee5d78d-fdfb-436a-82e1-1d021db69b6f.jpg",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/MetallurgeonReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/MetallurgeonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Metallurgeon reprint in ARC. Canonical CardDefinition lives in its earliest set.
+ */
+val MetallurgeonReprint = Printing(
+    oracleId = "09373283-a5c1-4d8e-ad25-19cd55b1e869",
+    name = "Metallurgeon",
+    setCode = "ARC",
+    collectorNumber = "2",
+    scryfallId = "8667b405-b871-4d66-936a-55569ac7d682",
+    artist = "Warren Mahy",
+    imageUri = "https://cards.scryfall.io/normal/front/8/6/8667b405-b871-4d66-936a-55569ac7d682.jpg",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/EtheriumSculptorReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/EtheriumSculptorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Etherium Sculptor reprint in C16. Canonical CardDefinition lives in its earliest set.
+ */
+val EtheriumSculptorReprint = Printing(
+    oracleId = "96b87445-6362-4a17-91b2-cbf203fd03fd",
+    name = "Etherium Sculptor",
+    setCode = "C16",
+    collectorNumber = "89",
+    scryfallId = "86e072aa-4234-416d-b83e-cdc4f511a6d9",
+    artist = "Steven Belledin",
+    imageUri = "https://cards.scryfall.io/normal/front/8/6/86e072aa-4234-416d-b83e-cdc4f511a6d9.jpg",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/ExecutionerSCapsuleReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/ExecutionerSCapsuleReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Executioner's Capsule reprint in C16. Canonical CardDefinition lives in its earliest set.
+ */
+val ExecutionerSCapsuleReprint = Printing(
+    oracleId = "c9cd266c-7ecf-4beb-b9da-69b88f33abd3",
+    name = "Executioner's Capsule",
+    setCode = "C16",
+    collectorNumber = "109",
+    scryfallId = "81c1fe5e-375a-4ca0-a0fe-a3b0d36b0e7c",
+    artist = "Warren Mahy",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/81c1fe5e-375a-4ca0-a0fe-a3b0d36b0e7c.jpg",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/MasterOfEtheriumReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/MasterOfEtheriumReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Master of Etherium reprint in C16. Canonical CardDefinition lives in its earliest set.
+ */
+val MasterOfEtheriumReprint = Printing(
+    oracleId = "181e6b3e-c33e-49e7-acb8-67473289a856",
+    name = "Master of Etherium",
+    setCode = "C16",
+    collectorNumber = "92",
+    scryfallId = "35b9acb3-2a41-41b9-b443-86684e12af2f",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/35b9acb3-2a41-41b9-b443-86684e12af2f.jpg",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drb/FromTheVaultDragonsSet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drb/FromTheVaultDragonsSet.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.drb
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * From the Vault: Dragons
+ *
+ * A fifteen-card premium reprint product, all dragons, all foil. It carries no boosters and no
+ * basic lands, so it is not a sealed/draft environment — but it is the earliest real printing of
+ * Hellkite Overlord, which Shards of Alara later reprinted.
+ *
+ * Set Code: DRB
+ * Release Date: August 29, 2008
+ */
+object FromTheVaultDragonsSet : MtgSet {
+
+    override val code = "DRB"
+    override val displayName = "From the Vault: Dragons"
+    override val releaseDate = "2008-08-29"
+    override val incomplete = true
+    override val sealedSupported = false
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.drb.cards"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drb/cards/HellkiteOverlord.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drb/cards/HellkiteOverlord.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.drb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hellkite Overlord
+ * {4}{B}{R}{R}{G}
+ * Creature — Dragon
+ * 8 / 8
+ * Flying, trample, haste
+ * {R}: This creature gets +1/+0 until end of turn.
+ * {B}{G}: Regenerate this creature.
+ *
+ * Three evergreen keywords plus two bare-mana activated abilities, neither of which taps: the firebreathing
+ * is [Effects.ModifyStats] on [EffectTarget.Self] with its default `Duration.EndOfTurn`, and the shield is
+ * [RegenerateEffect] on the same target. From the Vault: Dragons is this card's earliest real printing,
+ * hence the `drb` package; Shards of Alara carries it as a reprint row.
+ */
+val HellkiteOverlord = card("Hellkite Overlord") {
+    manaCost = "{4}{B}{R}{R}{G}"
+    colorIdentity = "BRG"
+    typeLine = "Creature — Dragon"
+    power = 8
+    toughness = 8
+    oracleText = "Flying, trample, haste\n" +
+        "{R}: This creature gets +1/+0 until end of turn.\n" +
+        "{B}{G}: Regenerate this creature."
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE, Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{B}{G}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "8"
+        artist = "Justin Sweet"
+        flavorText = "\"The dragon has no pretense of compassion, no false mask of civilization—just hunger, heat, and need.\"\n—Sarkhan Vol"
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e3c4f96-4a43-440d-b75f-2cdb7c24b92e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/ExcommunicateReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/ExcommunicateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Excommunicate reprint in M10. Canonical CardDefinition lives in its earliest set.
+ */
+val ExcommunicateReprint = Printing(
+    oracleId = "6c2cf22e-5dbb-4fa9-8ece-17069e6f1d7f",
+    name = "Excommunicate",
+    setCode = "M10",
+    collectorNumber = "10",
+    scryfallId = "12aad375-653e-47ed-b8e3-34dd90d43420",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/1/2/12aad375-653e-47ed-b8e3-34dd90d43420.jpg",
+    releaseDate = "2009-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/ExcommunicateReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/ExcommunicateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Excommunicate reprint in M11. Canonical CardDefinition lives in its earliest set.
+ */
+val ExcommunicateReprint = Printing(
+    oracleId = "6c2cf22e-5dbb-4fa9-8ece-17069e6f1d7f",
+    name = "Excommunicate",
+    setCode = "M11",
+    collectorNumber = "14",
+    scryfallId = "8aec6e3f-bc90-4e21-a087-330f7e072fc6",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8aec6e3f-bc90-4e21-a087-330f7e072fc6.jpg",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/LightningTalonsReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/LightningTalonsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Talons reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val LightningTalonsReprint = Printing(
+    oracleId = "4a2a7eca-3477-4858-9dab-ba80d4d704cd",
+    name = "Lightning Talons",
+    setCode = "M14",
+    collectorNumber = "144",
+    scryfallId = "87186a8a-45da-4cde-a167-c16a6abc4d24",
+    artist = "Johann Bodin",
+    imageUri = "https://cards.scryfall.io/normal/front/8/7/87186a8a-45da-4cde-a167-c16a6abc4d24.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/CrucibleOfFireReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/CrucibleOfFireReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crucible of Fire reprint in M15. Canonical CardDefinition lives in its earliest set.
+ */
+val CrucibleOfFireReprint = Printing(
+    oracleId = "0c572396-4e53-4c86-9b04-f41341dcea05",
+    name = "Crucible of Fire",
+    setCode = "M15",
+    collectorNumber = "139",
+    scryfallId = "cdd0f742-5cdc-4fa9-b995-df6380c1755e",
+    artist = "Dominick Domingo",
+    imageUri = "https://cards.scryfall.io/normal/front/c/d/cdd0f742-5cdc-4fa9-b995-df6380c1755e.jpg",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/ThornThrashViashinoReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/ThornThrashViashinoReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thorn-Thrash Viashino reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val ThornThrashViashinoReprint = Printing(
+    oracleId = "83d9a5a2-09b0-44bf-b0b8-82a5fc53b00a",
+    name = "Thorn-Thrash Viashino",
+    setCode = "PC2",
+    collectorNumber = "52",
+    scryfallId = "e3d44c65-d7f8-4325-9bd9-fa8786cf833e",
+    artist = "Jon Foster",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e3d44c65-d7f8-4325-9bd9-fa8786cf833e.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/ThunderThrashElderReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/ThunderThrashElderReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thunder-Thrash Elder reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val ThunderThrashElderReprint = Printing(
+    oracleId = "aef6c5b3-824f-4b7d-9671-1ed61d547717",
+    name = "Thunder-Thrash Elder",
+    setCode = "PC2",
+    collectorNumber = "53",
+    scryfallId = "3c5a5a2a-feec-43c4-9998-3f1e29202f04",
+    artist = "Brandon Kitkouski",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3c5a5a2a-feec-43c4-9998-3f1e29202f04.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/BroodmateDragonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/BroodmateDragonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Broodmate Dragon reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val BroodmateDragonReprint = Printing(
+    oracleId = "86529f12-6f0f-4b0d-96f1-785474f6763a",
+    name = "Broodmate Dragon",
+    setCode = "C17",
+    collectorNumber = "165",
+    scryfallId = "ea62ec34-be95-4682-a3fd-9a92a89103b5",
+    artist = "Vance Kovacs",
+    imageUri = "https://cards.scryfall.io/normal/front/e/a/ea62ec34-be95-4682-a3fd-9a92a89103b5.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/CrucibleOfFireReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/CrucibleOfFireReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crucible of Fire reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val CrucibleOfFireReprint = Printing(
+    oracleId = "0c572396-4e53-4c86-9b04-f41341dcea05",
+    name = "Crucible of Fire",
+    setCode = "C17",
+    collectorNumber = "133",
+    scryfallId = "ebf4ddbc-71c9-4dd3-8a29-0bf87f1e61b0",
+    artist = "Dominick Domingo",
+    imageUri = "https://cards.scryfall.io/normal/front/e/b/ebf4ddbc-71c9-4dd3-8a29-0bf87f1e61b0.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/ALA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ALA.json
@@ -1,3 +1,32 @@
+// Angelsong
+{
+    "name": "Angelsong",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Prevent all combat damage that would be dealt this turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "PreventDamageShield",
+            "scope": "CombatOnly"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "artist": "Sal Villagran",
+        "flavorText": "Clash of sword and cry of beast fall mute when angels sound the call to prayer.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/0832e87f-afef-41a5-ba36-3eaf65551576.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Arcane Sanctum
 {
     "name": "Arcane Sanctum",
@@ -55,6 +84,320 @@
     ]
 }
 
+// Archdemon of Unx
+{
+    "name": "Archdemon of Unx",
+    "manaCost": "{5}{B}{B}",
+    "typeLine": "Creature — Demon",
+    "oracleText": "Flying, trample\nAt the beginning of your upkeep, sacrifice a non-Zombie creature, then create a 2/2 black Zombie creature token.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Sacrifice",
+                            "filter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotSubtype",
+                                        "subtype": "Zombie"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "CreateToken",
+                            "power": 2,
+                            "toughness": 2,
+                            "colors": [
+                                "BLACK"
+                            ],
+                            "creatureTypes": [
+                                "Zombie"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba9b6612-5372-4e6f-841f-20009f71a736.jpg"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "64",
+        "rarity": "RARE",
+        "artist": "Dave Allsop",
+        "flavorText": "The necropolis at Unx was once a living city, its streets untrodden by death.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b260fbe1-21cb-4a66-aca3-e504b67ed712.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Bant Battlemage
+{
+    "name": "Bant Battlemage",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{G}, {T}: Target creature gains trample until end of turn.\n{U}, {T}: Target creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "UNCOMMON",
+        "artist": "Donato Giancola",
+        "flavorText": "\"A night attack will be easy. We'll make an air raid over the Akrasan border. Just get me some flint to light the war torches.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2c597b1d-d8b5-4922-a3f2-1f173a73ea2a.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Blister Beetle
+{
+    "name": "Blister Beetle",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "When this creature enters, target creature gets -1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "artist": "Anthony S. Waters",
+        "flavorText": "Warriors of the Rip Clan wear their beetle-acid scars proudly, even modifying clothing and armor to better display the trophy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f42bdeb-5a51-4303-96d8-9722f95d2905.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Bloodpyre Elemental
+{
+    "name": "Bloodpyre Elemental",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Sacrifice this creature: It deals 4 damage to target creature. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "93",
+        "artist": "Trevor Claxton",
+        "flavorText": "Elementals born of Jund are as cruel and unstable as the plane itself.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/89e39677-5e04-45af-8f4c-1d4b6e737213.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Bloodthorn Taunter
+{
+    "name": "Bloodthorn Taunter",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "Haste\n{T}: Target creature with power 5 or greater gains haste until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow>=5"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Naya's celebrants stoke the gargantuans into a rage, loosing a tide of muscle with the precision of an arrow.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/8769e8f6-15ad-4f1b-bb4d-848ae6b7549e.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Bone Splinters
 {
     "name": "Bone Splinters",
@@ -98,6 +441,398 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Branching Bolt
+{
+    "name": "Branching Bolt",
+    "manaCost": "{1}{R}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one or both —\n• Branching Bolt deals 3 damage to target creature with flying.\n• Branching Bolt deals 3 damage to target creature without flying.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature kw:flying"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Branching Bolt deals 3 damage to target creature with flying"
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        {
+                                            "type": "NotKeyword",
+                                            "keyword": "FLYING"
+                                        }
+                                    ]
+                                }
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Branching Bolt deals 3 damage to target creature without flying"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "artist": "Vance Kovacs",
+        "flavorText": "\"Lightning lives in everything, in living flesh and growing things. It must be set free.\"\n—Rakka Mar",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e7468876-f401-4a75-81c0-bed09cdda3e1.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Broodmate Dragon
+{
+    "name": "Broodmate Dragon",
+    "manaCost": "{3}{B}{R}{G}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nWhen this creature enters, create a 4/4 red Dragon creature token with flying.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 4,
+                    "toughness": 4,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Dragon"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/c/b/cbb3e91d-9cae-49c8-ba92-087ad8171b9d.jpg"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "rarity": "RARE",
+        "artist": "Vance Kovacs",
+        "flavorText": "Frozen in fear, the goblins stared upward at the circling hunter—and were promptly eaten by its diving mate.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/aea1360e-7c6b-400c-893a-82d93e53101e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Bull Cerodon
+{
+    "name": "Bull Cerodon",
+    "manaCost": "{4}{R}{W}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Vigilance, haste",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE",
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "161",
+        "rarity": "UNCOMMON",
+        "artist": "Jesper Ejsing",
+        "flavorText": "It holds motionless vigil, watching Naya in silence through the screen of the whitecover. When it senses anything amiss, it launches forward with the uncanny sound of torn fog.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bbae0fe2-5d52-434c-8ad1-4a5e42f4b7c4.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Caldera Hellion
+{
+    "name": "Caldera Hellion",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Hellion",
+    "oracleText": "Devour 1 (As this creature enters, you may sacrifice any number of creatures. It enters with that many +1/+1 counters on it.)\nWhen this creature enters, it deals 3 damage to each creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEVOUR"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Devour",
+            "multiplier": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithDevour",
+                "multiplier": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "rarity": "RARE",
+        "artist": "Raymond Swanland",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88866ce7-0b81-4b6c-a17e-ce5e51a0f2da.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Cavern Thoctar
+{
+    "name": "Cavern Thoctar",
+    "manaCost": "{5}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "{1}{R}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "artist": "Jean-Sébastien Rossbach",
+        "flavorText": "Natives of Naya know better than to loiter near the mouth of a cave. Two glowing red eyes and the stench of foul breath are all the warning you're likely to get.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/4/34748acb-7045-42b6-a93f-a3f11a1bc839.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Cloudheath Drake
+{
+    "name": "Cloudheath Drake",
+    "manaCost": "{4}{U}",
+    "typeLine": "Artifact Creature — Drake",
+    "oracleText": "Flying\n{1}{W}: This creature gains vigilance until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "35",
+        "artist": "Izzy",
+        "flavorText": "A permanent storm rages over the plain of Cloudheath, and drakes ride its currents—two reminders that some elements of Esper will not be controlled.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f71ec76-47e1-4f55-bc57-e7b1c88baedd.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Courier's Capsule
+{
+    "name": "Courier's Capsule",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}{U}, {T}, Sacrifice this artifact: Draw two cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "artist": "Andrew Murray",
+        "flavorText": "In ages past, Esper couriers bore messages written on ornate scrolls. The medium has grown more sophisticated, but the principle remains the same.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/39ae12ff-8039-4aac-aa50-f879376888a1.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Crucible of Fire
+{
+    "name": "Crucible of Fire",
+    "manaCost": "{3}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Dragon creatures you control get +3/+3.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 3,
+                "filter": {
+                    "baseFilter": "creature Dragon ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "96",
+        "rarity": "RARE",
+        "artist": "Dominick Domingo",
+        "flavorText": "\"The dragon is a perfect marriage of power and the will to use it.\"\n—Sarkhan Vol",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/38a2d4ba-7bd0-4852-aad3-dfdaf5368e3e.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -221,6 +956,32 @@
     ]
 }
 
+// Deft Duelist
+{
+    "name": "Deft Duelist",
+    "manaCost": "{W}{U}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "First strike\nShroud (This creature can't be the target of spells or abilities.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "SHROUD"
+    ],
+    "metadata": {
+        "collectorNumber": "165",
+        "artist": "David Palumbo",
+        "flavorText": "Some Serul Cove rogues traffic in stolen sigils, which fetch a high price from those who would rather pay for honor than earn it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c4885a83-9410-4c88-b45e-1e1626fe90ea.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
 // Dispeller's Capsule
 {
     "name": "Dispeller's Capsule",
@@ -332,6 +1093,63 @@
     ]
 }
 
+// Druid of the Anima
+{
+    "name": "Druid of the Anima",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "{T}: Add {R}, {G}, or {W}.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "artist": "Jim Murray",
+        "flavorText": "Although the Anima herself remains at the Sacellum, her druids roam Naya, collecting mana bonds with every location in the world.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de32bf78-73c2-4cd4-b3b3-ef8be53e1e5e.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Elvish Visionary
 {
     "name": "Elvish Visionary",
@@ -368,6 +1186,709 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Esper Battlemage
+{
+    "name": "Esper Battlemage",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact Creature — Human Wizard",
+    "oracleText": "{W}, {T}: Prevent the next 2 damage that would be dealt to you this turn.\n{B}, {T}: Target creature gets -1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Cavotta",
+        "flavorText": "She can heal the flesh, or exploit its many weaknesses.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2cac0076-8bd5-4fe2-bac8-fd102688fdcb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Esper Charm
+{
+    "name": "Esper Charm",
+    "manaCost": "{W}{U}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Destroy target enchantment.\n• Draw two cards.\n• Target player discards two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target enchantment"
+                },
+                {
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "description": "Draw two cards"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "chooser": "TargetPlayer",
+                                "storeSelected": "discarded",
+                                "prompt": "Choose 2 cards to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target player discards two cards"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "rarity": "UNCOMMON",
+        "artist": "Michael Bruinsma",
+        "flavorText": "\"Thoughts are commodities. Someone will pay a good price for them. Even ones as simplistic as yours . . .\"\n—Ennor, mentalist",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3d70a07-8d91-462c-aa96-901cc9a81531.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Etherium Astrolabe
+{
+    "name": "Etherium Astrolabe",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact",
+    "oracleText": "Flash\n{B}, {T}, Sacrifice an artifact: Draw a card.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "rarity": "UNCOMMON",
+        "artist": "Michael Bruinsma",
+        "flavorText": "\"Speculation is foolish when the tools of certainty are available.\"\n—Cinna, vedalken consul",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d60731c6-7a25-4f2b-8ed1-2469a2d300c6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
+// Etherium Sculptor
+{
+    "name": "Etherium Sculptor",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact Creature — Vedalken Artificer",
+    "oracleText": "Artifact spells you cast cost {1} less to cast.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "artifact"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "artist": "Steven Belledin",
+        "flavorText": "The greatest masters of the craft abandon tools altogether, shaping metal with hand and mind alone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0d050f2d-bd65-4ab9-9ea6-9deba91b2792.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Excommunicate
+{
+    "name": "Excommunicate",
+    "manaCost": "{2}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Put target creature on top of its owner's library.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Library",
+            "placement": "Top"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "artist": "Matt Stewart",
+        "flavorText": "Rebels and other malcontents forced into the ritual awake lost in Topa's vast savannahs. Those who find their way back return humble and repentant.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6fe080bc-e642-4fce-b4ee-bbe25d735673.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Executioner's Capsule
+{
+    "name": "Executioner's Capsule",
+    "manaCost": "{B}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}{B}, {T}, Sacrifice this artifact: Destroy target nonblack creature.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotColor",
+                                        "color": "BLACK"
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "artist": "Warren Mahy",
+        "flavorText": "There is always a moment of trepidation before opening a message capsule, for fear of the judgment that might be contained within.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48185059-fff9-47b0-9774-ad37dee345ed.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Filigree Sages
+{
+    "name": "Filigree Sages",
+    "manaCost": "{3}{U}",
+    "typeLine": "Artifact Creature — Vedalken Wizard",
+    "oracleText": "{2}{U}: Untap target artifact.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "tap": false
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"We of the Sanctum Arcanum have pondered every word on every page of the Filigree Texts. If you can't say the same, don't bother speaking.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/08790aaf-0142-4b20-89cf-cdaffeea4582.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Glaze Fiend
+{
+    "name": "Glaze Fiend",
+    "manaCost": "{1}{B}",
+    "typeLine": "Artifact Creature — Illusion",
+    "oracleText": "Flying\nWhenever another artifact you control enters, this creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "artist": "Joshua Hagler",
+        "flavorText": "Before the zealots of the Ethersworn came to power, Esper illusionists dreamed up creations to mimic a variety of substances.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e030fb1-12a8-4c28-836f-8097ec753271.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Goblin Deathraiders
+{
+    "name": "Goblin Deathraiders",
+    "manaCost": "{B}{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Trample",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "169",
+        "artist": "Raymond Swanland",
+        "flavorText": "Every once in a while, when they aren't getting incinerated in lava, crushed under rock slides, or devoured by dragons, goblins experience moments of unmitigated glory in battle.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/76fd1253-1af1-42a7-9875-4d6ac9ce722c.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Godtoucher
+{
+    "name": "Godtoucher",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf Cleric",
+    "oracleText": "{1}{W}, {T}: Prevent all damage that would be dealt to target creature with power 5 or greater this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow>=5"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "artist": "Jesper Ejsing",
+        "flavorText": "\"Gargantuans die not in moments but in moons. There is still time to aid this noble ancient.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/032059cb-c1ad-4cc9-a89d-d68289800312.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Grixis Battlemage
+{
+    "name": "Grixis Battlemage",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{U}, {T}: Draw a card, then discard a card.\n{R}, {T}: Target creature can't block this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CantBlockTargetCreatures",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "rarity": "UNCOMMON",
+        "artist": "Nils Hamm",
+        "flavorText": "Vitals of Grixis who eschew undeath must scrape and scratch to retain their mortality. The result is a breed of inventive mages.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4dbd260c-a625-42a4-8192-27e42e18ac0f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED",
+        "BLUE"
     ]
 }
 
@@ -483,6 +2004,52 @@
     ]
 }
 
+// Gustrider Exuberant
+{
+    "name": "Gustrider Exuberant",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Flying\nSacrifice this creature: Creatures you control with power 5 or greater gain flying until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature pow>=5 ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "FLYING",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "artist": "Wayne Reynolds",
+        "flavorText": "\"The elves claim the canopy. The nacatl claim the mountains. I suppose you think we ought to stay on the jungle floor?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/5343e6f2-7db7-4731-8e1b-70bf74316a79.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Incurable Ogre
 {
     "name": "Incurable Ogre",
@@ -503,6 +2070,32 @@
     ]
 }
 
+// Jhessian Infiltrator
+{
+    "name": "Jhessian Infiltrator",
+    "manaCost": "{G}{U}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "This creature can't be blocked.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "flags": [
+        "CANT_BE_BLOCKED"
+    ],
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "UNCOMMON",
+        "artist": "Donato Giancola",
+        "flavorText": "The Jhessian navy makes successful raids on Valeron's coastal towns thanks to their spies planted during peacetime.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/7/1761d867-2eb0-406b-b175-97a90c457844.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Jhessian Lookout
 {
     "name": "Jhessian Lookout",
@@ -520,6 +2113,95 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Jund Battlemage
+{
+    "name": "Jund Battlemage",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "{B}, {T}: Target player loses 1 life.\n{G}, {T}: Create a 1/1 green Saproling creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target"
+                    }
+                ]
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Saproling"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/6/2/622759a9-e68b-48c1-8e03-beaab0a52556.jpg"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "rarity": "UNCOMMON",
+        "artist": "Vance Kovacs",
+        "flavorText": "\"Of your blood I will make my mead, an offering to the thirsty jungle.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/ee8c962f-11b0-48f7-bbba-a2212e41990f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "RED"
     ]
 }
 
@@ -577,6 +2259,612 @@
         "WHITE",
         "RED",
         "GREEN"
+    ]
+}
+
+// Jungle Weaver
+{
+    "name": "Jungle Weaver",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Reach (This creature can block creatures with flying.)\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "134",
+        "artist": "Trevor Hairsine",
+        "flavorText": "Weavers' webs wall off swaths of territory more effectively than any portcullis made of iron.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f46870b-3d8d-4aae-8d59-6bd88a50b37c.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Kederekt Creeper
+{
+    "name": "Kederekt Creeper",
+    "manaCost": "{U}{B}{R}",
+    "typeLine": "Creature — Horror",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\nDeathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE",
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "176",
+        "artist": "Mark Hyzer",
+        "flavorText": "Bloated with venom, it crawls Grixis looking for victims to ooze onto.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/701498e5-1d4d-42f4-9dd0-5d4cf78f0e68.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED",
+        "BLUE"
+    ]
+}
+
+// Knight of the Skyward Eye
+{
+    "name": "Knight of the Skyward Eye",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "{3}{G}: This creature gets +3/+3 until end of turn. Activate only once each turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": "Self"
+                },
+                "restrictions": [
+                    "OncePerTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "artist": "Matt Stewart",
+        "flavorText": "The Order of the Skyward Eye does the bidding of an evil force, unwittingly stirring fear and mistrust across Bant in accordance with his plans.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/d/1d56e2bf-1937-42c1-8f61-1fd93e84cef7.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Knight-Captain of Eos
+{
+    "name": "Knight-Captain of Eos",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "When this creature enters, create two 1/1 white Soldier creature tokens.\n{W}, Sacrifice a Soldier: Prevent all combat damage that would be dealt this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Soldier"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/9/2/927580e6-353a-46bb-ac05-52a5fa78a959.jpg"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "permanent Soldier"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "scope": "CombatOnly"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "RARE",
+        "artist": "Chris Rahn",
+        "flavorText": "The strength of Bant's caste system is the unfailing loyalty of its meekest members.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02ef25ce-4d6a-45ff-8b6b-fd5c29307099.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Lightning Talons
+{
+    "name": "Lightning Talons",
+    "manaCost": "{2}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +3/+0 and has first strike. (It deals combat damage before creatures without first strike.)",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "artist": "Pete Venters",
+        "flavorText": "\"This is going to hurt a lot, but on the bright side, you'll be dead soon.\"\n—Sedris, the Traitor King",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8fc1ad4c-b394-48b9-9a5a-ec9f42bf6a00.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Marble Chalice
+{
+    "name": "Marble Chalice",
+    "manaCost": "{2}{W}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: You gain 1 life.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Howard Lyon",
+        "flavorText": "The cup was a gift from the sphinx Tameron, who hoped that those who drank from it would live long enough to decrypt the sphinxes' wisdom.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/7/b76e9580-9154-476b-923f-b23bf55db026.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Master of Etherium
+{
+    "name": "Master of Etherium",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact Creature — Vedalken Wizard",
+    "oracleText": "Master of Etherium's power and toughness are each equal to the number of artifacts you control.\nOther artifact creatures you control get +1/+1.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "artifact"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "artifact"
+            }
+        }
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "artifact creature ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "rarity": "RARE",
+        "artist": "Matt Cavotta",
+        "flavorText": "\"Only a mind unfettered with the concerns of the flesh can see the world as it truly is.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/322cdf67-5b36-43f9-99b3-f0e24d423314.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Metallurgeon
+{
+    "name": "Metallurgeon",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact Creature — Human Artificer",
+    "oracleText": "{W}, {T}: Regenerate target artifact.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "UNCOMMON",
+        "artist": "Warren Mahy",
+        "flavorText": "\"By the time I got there, the heart had stopped. Fortunately, I was able to replace it with something better.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4ad9f9d5-62c1-4dae-a2c8-5552210a70a4.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Mighty Emergence
+{
+    "name": "Mighty Emergence",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a creature you control with power 5 or greater enters, you may put two +1/+1 counters on it.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature pow>=5 ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 2,
+                        "target": "TriggeringEntity"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Prescott",
+        "flavorText": "Why settle for mere enormity?",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8ee66318-4dbb-49a3-a3c8-ee0e1a9f02b7.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Mosstodon
+{
+    "name": "Mosstodon",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Plant Elephant",
+    "oracleText": "{1}: Target creature with power 5 or greater gains trample until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow>=5"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "artist": "Paolo Parente",
+        "flavorText": "Whether gargantuans are the manifested will of Progenitus or simply the result of overabundant resources is moot when a herd of them is thundering at you.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/05afd921-ef3b-40fe-a1a8-582ee94ed3f0.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Naya Battlemage
+{
+    "name": "Naya Battlemage",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "{R}, {T}: Target creature gets +2/+0 until end of turn.\n{W}, {T}: Tap target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Argyle",
+        "flavorText": "\"I have trained in all three schools of magic.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4fe73f62-2e80-4d5f-b7b5-c54c895a3e4d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Obelisk of Bant
+{
+    "name": "Obelisk of Bant",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {G}, {W}, or {U}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "212",
+        "artist": "David Palumbo",
+        "flavorText": "Whether incorporated into the structure of castles or admired as lone symbols, the obelisks stand for Bant's values of loyalty, honor, and truth.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0cefe6ab-c018-4b87-8948-295a28f63cb1.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE",
+        "WHITE"
     ]
 }
 
@@ -739,6 +3027,201 @@
     ]
 }
 
+// Obelisk of Naya
+{
+    "name": "Obelisk of Naya",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {R}, {G}, or {W}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "artist": "Steve Prescott",
+        "flavorText": "Centuries have passed since the plane shattered, yet the obelisks of each shard faithfully serve their long-forgotten purpose.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/df6317b0-15fd-4924-9302-41bed2354546.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Onyx Goblet
+{
+    "name": "Onyx Goblet",
+    "manaCost": "{2}{B}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Target player loses 1 life.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "artist": "rk post",
+        "flavorText": "The goblet was a gift from the sphinx Gorael, who hoped humans and vedalken would eventually destroy each other to acquire it, leaving all of Esper to her own kind.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/3686eb57-e9c8-480f-8ab4-2894e1b5fe20.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Predator Dragon
+{
+    "name": "Predator Dragon",
+    "manaCost": "{3}{R}{R}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying, haste\nDevour 2 (As this creature enters, you may sacrifice any number of creatures. It enters with twice that many +1/+1 counters on it.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "HASTE",
+        "DEVOUR"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Devour",
+            "multiplier": 2
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDevour",
+                "multiplier": 2
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "rarity": "RARE",
+        "artist": "Raymond Swanland",
+        "flavorText": "Dragons make for spiteful gods.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/352c3c86-1662-4055-b814-026826632cff.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Protomatter Powder
+{
+    "name": "Protomatter Powder",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact",
+    "oracleText": "{4}{W}, {T}, Sacrifice this artifact: Return target artifact card from your graveyard to the battlefield.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{W}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "rarity": "UNCOMMON",
+        "artist": "Francis Tsai",
+        "flavorText": "\"There is no such thing as scrap metal. All such material can be repaired with the proper bonding agent.\"\n—Quennus, metallurgeon",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/273e2198-5549-4e82-8580-8769284d729d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
 // Rakeclaw Gargantuan
 {
     "name": "Rakeclaw Gargantuan",
@@ -796,6 +3279,514 @@
         "WHITE",
         "RED",
         "GREEN"
+    ]
+}
+
+// Ranger of Eos
+{
+    "name": "Ranger of Eos",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Soldier Ranger",
+    "oracleText": "When this creature enters, you may search your library for up to two creature cards with mana value 1 or less, reveal them, put them into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "creature mv<=1"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "rarity": "RARE",
+        "artist": "Volkan Baǵa",
+        "flavorText": "At his side, humble beasts become weapons more deadly than sharpened steel.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a30ee26-5f78-4ac2-9105-1baa9ece8a21.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Resounding Roar
+{
+    "name": "Resounding Roar",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+3 until end of turn.\nCycling {5}{R}{G}{W} ({5}{R}{G}{W}, Discard this card: Draw a card.)\nWhen you cycle this card, target creature gets +6/+6 until end of turn.",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{5}{R}{G}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ],
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 6
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 6
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "artist": "Steve Prescott",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/217bf237-a758-4500-b221-5e88fed9d0fc.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Resounding Silence
+{
+    "name": "Resounding Silence",
+    "manaCost": "{3}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target attacking creature.\nCycling {5}{G}{W}{U} ({5}{G}{W}{U}, Discard this card: Draw a card.)\nWhen you cycle this card, exile up to two target attacking creatures.",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{5}{G}{W}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature attacking"
+                },
+                "id": "target"
+            }
+        ],
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Exile"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature attacking"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "artist": "Mark Zug",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5b3b0908-5408-41fd-8e69-2bc785e19304.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Resounding Thunder
+{
+    "name": "Resounding Thunder",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Resounding Thunder deals 3 damage to any target.\nCycling {5}{B}{R}{G} ({5}{B}{R}{G}, Discard this card: Draw a card.)\nWhen you cycle this card, it deals 6 damage to any target.",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{5}{B}{R}{G}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ],
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 6
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "artist": "Jon Foster",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/680b7955-d939-4195-aba8-b46a8c925616.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Resounding Wave
+{
+    "name": "Resounding Wave",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target permanent to its owner's hand.\nCycling {5}{W}{U}{B} ({5}{W}{U}{B}, Discard this card: Draw a card.)\nWhen you cycle this card, return two target permanents to their owners' hands.",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{5}{W}{U}{B}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "permanent"
+                },
+                "id": "target"
+            }
+        ],
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CycleEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "artist": "Izzy",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f3eca679-076d-42f0-9ec0-b8116a94e373.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Rhox War Monk
+{
+    "name": "Rhox War Monk",
+    "manaCost": "{G}{W}{U}",
+    "typeLine": "Creature — Rhino Monk",
+    "oracleText": "Lifelink",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "188",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Dos Santos",
+        "flavorText": "Rhox monks are dedicated to spiritual growth and learning, and most bear the sigils of many students. However, they do not gladly suffer fools or those who disagree with their carefully wrought dogma.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/19fb67e1-b791-4246-aebc-49fcf0f92c6c.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Ridge Rannet
+{
+    "name": "Ridge Rannet",
+    "manaCost": "{5}{R}{R}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Cycling {2} ({2}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "111",
+        "artist": "Jim Murray",
+        "flavorText": "\"Only those with the strength to seize their destiny deserve to have one.\"\n—Nacatl scratchforms",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/4275a8dd-f777-4160-b773-9a868e743218.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Rip-Clan Crasher
+{
+    "name": "Rip-Clan Crasher",
+    "manaCost": "{R}{G}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Haste",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "189",
+        "artist": "Justin Sweet",
+        "flavorText": "If you breathe, she will fight you. If you breathe fire, she must fight you.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d61c4a0-054b-479e-82d9-dc60c5c708e2.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Rockcaster Platoon
+{
+    "name": "Rockcaster Platoon",
+    "manaCost": "{5}{W}{W}",
+    "typeLine": "Creature — Rhino Soldier",
+    "oracleText": "{4}{G}: This creature deals 2 damage to each creature with flying and each player.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 7
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature kw:flying"
+                                }
+                            },
+                            "body": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": "Each"
+                            },
+                            "body": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": "Controller"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "rarity": "UNCOMMON",
+        "artist": "David Palumbo",
+        "flavorText": "\"Aven bandits can be sly. You've got to fill the sky with boulders—and then seek cover immediately.\"\n—Knight-Captain Wyhorn",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4ab62812-acc5-4b4b-97d3-106e399d69da.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 
@@ -857,6 +3848,105 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Sangrite Surge
+{
+    "name": "Sangrite Surge",
+    "manaCost": "{4}{R}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target creature gets +3/+3 and gains double strike until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "190",
+        "rarity": "UNCOMMON",
+        "artist": "Jarreau Wimberly",
+        "flavorText": "Some believe the spiky crystal called sangrite is concentrated dragon's breath. Others think it's crystallized life energy. The clans care only about the power it unleashes when crushed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/6/16b4527e-e449-45d0-a551-634e2ceb21c4.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Savage Hunger
+{
+    "name": "Savage Hunger",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +1/+0 and has trample.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "artist": "Trevor Claxton",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/0367fac8-6990-4544-ac7d-ed363b55a9cf.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -974,6 +4064,55 @@
     ]
 }
 
+// Shadowfeed
+{
+    "name": "Shadowfeed",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target card from a graveyard. You gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Exile"
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Graveyard"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "artist": "Dave Kendall",
+        "flavorText": "\"The future is a snake, devouring your life backwards through time. And when you die, believe me, it doesn't stop feeding.\"\n—Sedris, the Traitor King",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/19ccd8c7-7472-47df-9d3e-1b5fb1431118.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Sharuum the Hegemon
 {
     "name": "Sharuum the Hegemon",
@@ -1039,6 +4178,157 @@
     ]
 }
 
+// Shore Snapper
+{
+    "name": "Shore Snapper",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "{U}: This creature gains islandwalk until end of turn. (It can't be blocked as long as defending player controls an Island.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "ISLANDWALK",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Dave Kendall",
+        "flavorText": "Kathari, the sickly aven of Grixis, have learned that the corpses by the shoreline are more trap than treat.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/157e5763-4892-47e4-8fd5-f576844c0a0d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
+// Skeletal Kathari
+{
+    "name": "Skeletal Kathari",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Bird Skeleton",
+    "oracleText": "Flying\n{B}, Sacrifice a creature: Regenerate this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "artist": "Carl Critchlow",
+        "flavorText": "Undeath doesn't end the kathari's search for carrion; it only removes one corpse from the Dregscape.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3e7e593-e5b0-4348-b8e5-20173d41aa39.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Spearbreaker Behemoth
+{
+    "name": "Spearbreaker Behemoth",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Indestructible\n{1}: Target creature with power 5 or greater gains indestructible until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow>=5"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "rarity": "RARE",
+        "artist": "Christopher Moeller",
+        "flavorText": "Few Nayans dare hunt the gargantuans. They're regarded not as animals but as forces of nature, like landslides or typhoons.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/132367ee-22e9-48e2-82e0-62ad9aaa62f3.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Sprouting Thrinax
 {
     "name": "Sprouting Thrinax",
@@ -1091,6 +4381,205 @@
     ]
 }
 
+// Steward of Valeron
+{
+    "name": "Steward of Valeron",
+    "manaCost": "{G}{W}",
+    "typeLine": "Creature — Human Druid Knight",
+    "oracleText": "Vigilance\n{T}: Add {G}.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "artist": "Greg Staples",
+        "flavorText": "Knight-stewards guard the Sun-Dappled Court, a grove of immense, sculptured olive trees that represent Valeron's twelve noble families.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/2/92e21ff9-0030-4e53-8ddf-86d8e78e347f.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Sunseed Nurturer
+{
+    "name": "Sunseed Nurturer",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Druid Wizard",
+    "oracleText": "At the beginning of your end step, if you control a creature with power 5 or greater, you may gain 2 life.\n{T}: Add {C}.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                },
+                "interveningIf": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature pow>=5"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Argyle",
+        "flavorText": "Sunseeders quest for areas of open sky. They train plowbeasts to beat back the dense jungle long enough to cultivate a crop.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d44447e-09d1-450f-907f-42f79b004fe7.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Thorn-Thrash Viashino
+{
+    "name": "Thorn-Thrash Viashino",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Lizard Warrior",
+    "oracleText": "Devour 2 (As this creature enters, you may sacrifice any number of creatures. It enters with twice that many +1/+1 counters on it.)\n{G}: This creature gains trample until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEVOUR"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Devour",
+            "multiplier": 2
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": "Self"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithDevour",
+                "multiplier": 2
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "116",
+        "artist": "Jon Foster",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e7987de9-d812-4615-845a-3a90572d9b44.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Thunder-Thrash Elder
+{
+    "name": "Thunder-Thrash Elder",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Lizard Warrior",
+    "oracleText": "Devour 3 (As this creature enters, you may sacrifice any number of creatures. It enters with three times that many +1/+1 counters on it.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEVOUR"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Devour",
+            "multiplier": 3
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDevour",
+                "multiplier": 3
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "rarity": "UNCOMMON",
+        "artist": "Brandon Kitkouski",
+        "flavorText": "Viashino thrashes are led by elders who have survived countless challenges.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/5552da28-01a3-4277-9e69-b297c3874ea4.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Tidehollow Strix
 {
     "name": "Tidehollow Strix",
@@ -1114,6 +4603,150 @@
     "colorIdentityOverride": [
         "BLUE",
         "BLACK"
+    ]
+}
+
+// Titanic Ultimatum
+{
+    "name": "Titanic Ultimatum",
+    "manaCost": "{R}{R}{G}{G}{G}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Until end of turn, creatures you control get +5/+5 and gain first strike, trample, and lifelink.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "target": "Self"
+                    },
+                    {
+                        "type": "GrantKeyword",
+                        "keyword": "FIRST_STRIKE",
+                        "target": "Self"
+                    },
+                    {
+                        "type": "GrantKeyword",
+                        "keyword": "TRAMPLE",
+                        "target": "Self"
+                    },
+                    {
+                        "type": "GrantKeyword",
+                        "keyword": "LIFELINK",
+                        "target": "Self"
+                    }
+                ]
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "rarity": "RARE",
+        "artist": "Steve Prescott",
+        "flavorText": "\"Retribution is best delivered by claws and rage, with both magnified.\"\n—Ajani",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d28fd77-1f7c-47b4-b9ff-55835a7f2526.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Topan Ascetic
+{
+    "name": "Topan Ascetic",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Monk",
+    "oracleText": "Tap an untapped creature you control: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "UNCOMMON",
+        "artist": "Sal Villagran",
+        "flavorText": "Monks from Topa wander all of Bant, encouraging the Unbeholden to find their place in society through honorable combat.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6d0952ed-efc7-4ff5-a233-e64c0f11119b.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Tortoise Formation
+{
+    "name": "Tortoise Formation",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Creatures you control gain shroud until end of turn. (They can't be the targets of spells or abilities.)",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "GrantKeyword",
+                "keyword": "SHROUD",
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "artist": "Mark Zug",
+        "flavorText": "At sea, the Jhessian fleet strikes swiftly and decisively. On land, facing the elite cavalry of Valeron, its marines must rely on more cautious strategies.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/59ff8324-42b8-4eeb-8d0b-ea679c984933.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -1144,6 +4777,314 @@
     ]
 }
 
+// Vectis Silencers
+{
+    "name": "Vectis Silencers",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact Creature — Human Rogue",
+    "oracleText": "{2}{B}: This creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy that creature.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "artist": "Steven Belledin",
+        "flavorText": "Even on Esper, there are those who eschew the use of magic in favor of simpler methods.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c0198220-073f-4479-a1c4-1bd626891e28.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
+// Viashino Skeleton
+{
+    "name": "Viashino Skeleton",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Lizard Skeleton",
+    "oracleText": "{1}{B}, Discard a card: Regenerate this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Cole Eastburn",
+        "flavorText": "Underneath the Dregscape lay the remains of creatures long extinct from Grixis.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9451a62-31a4-4aaf-beef-2bf149f25ae3.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// Violent Ultimatum
+{
+    "name": "Violent Ultimatum",
+    "manaCost": "{B}{B}{R}{R}{R}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy three target permanents.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                },
+                "destination": "Graveyard",
+                "byDestruction": true
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 3,
+                "filter": {
+                    "baseFilter": "permanent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "206",
+        "rarity": "RARE",
+        "artist": "Raymond Swanland",
+        "flavorText": "\"Words are a waste of time. Destruction is a language everyone understands.\"\n—Sarkhan Vol",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e6ac9ce-e163-426f-8fbd-5ee1ec177dc1.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Volcanic Submersion
+{
+    "name": "Volcanic Submersion",
+    "manaCost": "{4}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target artifact or land.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|land"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "artist": "Trevor Claxton",
+        "flavorText": "A dragon's death is almost as feared as its life. Old, dying dragons throw themselves into volcanoes, causing massive upheaval and widespread disaster.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0ec1f1fa-41c9-4bc0-9171-902cd456aa73.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Welkin Guide
+{
+    "name": "Welkin Guide",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Bird Cleric",
+    "oracleText": "Flying\nWhen this creature enters, target creature gets +2/+2 and gains flying until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FLYING",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "artist": "David Palumbo",
+        "flavorText": "\"Those talons really dig into your skin, but it's better than being dropped.\"\n—Rafiq of the Many",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/198363f2-1a19-4954-b527-6d10ac277719.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Wild Nacatl
+{
+    "name": "Wild Nacatl",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Cat Warrior",
+    "oracleText": "This creature gets +1/+1 as long as you control a Mountain.\nThis creature gets +1/+1 as long as you control a Plains.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "land Mountain"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "land Plains"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "artist": "Wayne Reynolds",
+        "flavorText": "\"The Cloud Nacatl sit and think, a bunch of soft paws. We are the Claws of Marisi, stalking, pouncing, drawing blood.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5eb18038-eb6a-4d27-ba52-52a1cee6b512.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Woolly Thoctar
 {
     "name": "Woolly Thoctar",
@@ -1164,5 +5105,32 @@
         "WHITE",
         "RED",
         "GREEN"
+    ]
+}
+
+// Yoked Plowbeast
+{
+    "name": "Yoked Plowbeast",
+    "manaCost": "{5}{W}{W}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Cycling {2} ({2}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "31",
+        "artist": "Steve Argyle",
+        "flavorText": "\"It is sacrilege to confine a gargantuan to the grinding of straight lines. I will pray that it remembers who is the master of this land.\"\n—Syeena, elvish godtoucher",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/ddbbc7dc-efdf-46e8-bf19-0daa4034f6ec.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/DRB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRB.json
@@ -1,0 +1,68 @@
+// Hellkite Overlord
+{
+    "name": "Hellkite Overlord",
+    "manaCost": "{4}{B}{R}{R}{G}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying, trample, haste\n{R}: This creature gets +1/+0 until end of turn.\n{B}{G}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE",
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "rarity": "RARE",
+        "artist": "Justin Sweet",
+        "flavorText": "\"The dragon has no pretense of compassion, no false mask of civilization—just hunger, heat, and need.\"\n—Sarkhan Vol",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e3c4f96-4a43-440d-b75f-2cdb7c24b92e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED",
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/P02.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/P02.json
@@ -227,6 +227,30 @@
     ]
 }
 
+// Goblin Mountaineer
+{
+    "name": "Goblin Mountaineer",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goblin Scout",
+    "oracleText": "Mountainwalk (This creature can't be blocked as long as defending player controls a Mountain.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "MOUNTAINWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "101",
+        "artist": "DiTerlizzi",
+        "flavorText": "Goblin mountaineer, barely keeps his family fed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f841fe25-237f-4303-b75e-392b82767eea.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Goblin Piker
 {
     "name": "Goblin Piker",


### PR DESCRIPTION
Sweeps the ⚡ Assay-ready backlog for Shards of Alara: **83 → 1**.

## The four-way split

From `just assay-ready ALA --names --tail` on `main`:

| bucket | count | work | landed |
|---|---|---|---|
| `original` | 76 | author the canonical in ALA | 75 |
| `elsewhere` | 1 | Goblin Mountaineer — canonical in **P02**, `Printing` row in ALA | 1 |
| `unscaffolded` | 1 | Hellkite Overlord — **DRB scaffolded**, canonical there, row in ALA | 1 |
| `basic` | 5 | 20 `basicLand(...)` art variants (collector 230–249) + the `basicLands` override | 5 |

Plus the **reprint tail**: 14 `Printing` rows across 9 other scaffolded sets — ARC 2, C16 3, C17 2, PC2 2, M10 1, M11 1, M14 1, M15 1, S99 1. Those rows are invisible to `check-card-printing` until the canonical exists, which is why they belong in this PR rather than a follow-up.

## Verification

| gate | result |
|---|---|
| `just build` | green (compile + `:mtg-sets:test` after rebless) |
| `just rebless-cards` | only `ALA.json` (+75) and `P02.json` (+1) moved; DRB is a new snapshot. No card removed — verified by name-set diff, the 689 deleted lines are pure re-ordering |
| `just assay-differential` | **4498 / 4449 / 49 → 4571 / 4522 / 49**. +73 compared, +73 confirmed, **zero new divergences** |
| `just check-card-printing` | run for all 77 authored canonicals — 0 findings |
| `just assay-ready ALA` | **83 → 1** (re-run on the branch, not inferred) |

Every card was authored to `assay compile`'s JSON rather than to the oracle text, which is why the differential delta is zero rather than the usual handful of `staticAbilities`-layer defects.

## Not shipped: Flameblast Dragon

Its trigger is "you may pay {X}{R}. If you do, it deals X damage to any target." That shape is **not engine-live**:

- `Gate.MayPayX` is a field-less `data object`, documented as generic-only ("the {X} cost is implicit") — it cannot carry the `{R}` rider.
- `Gate.MayPay(PayManaCostEffect("{X}{R}"))` routes to `resumeMayPayMana`, which pays via `manaPool.payPartial(cost)`. `ManaCost.resolveX` is never called on that path and `effectContext.xValue` is written in exactly one place in `ManaPaymentContinuationResumer.kt` — inside `resumeMayPayX`, i.e. only for `Gate.MayPayX`. So `DynamicAmount.XValue` in the `then` branch would read nothing and the dragon would deal **0** damage.
- No card in the corpus prints "you may pay {X}{colour}" — there is no precedent to copy.

That is new SDK vocabulary, so it is `add-feature` work and gets its own PR. Its two owed `Printing` rows (ARC, M12) go with it.

## Other findings

- **`basicLandsFallback = PortalSet` removed from `ShardsOfAlaraSet`.** `GameBeansConfig` resolves `basicLands = (basicLandsFallback ?: this).basicLands` — the fallback *wins* over a set's own basics, so leaving it would have made all 20 new ALA basics dead code. Worth a general check: any set that later grows its own basics has the same latent trap.
- **`exalted` and `unearth` are not implemented at all** — zero `rules-engine` hits, no `KeywordAbility` entry. Neither appears in this batch, but between them they are a large share of ALA's remaining 123 declined cards.
- **Token art was missing for the four token-makers.** Archdemon of Unx, Broodmate Dragon, Jund Battlemage and Knight-Captain of Eos now carry the ALA (`tala`) token `imageUri`. `imageUri` is in the differential's `PRESENTATION_KEYS`, so this is invisible to the gate — which is exactly why it gets forgotten.
- **`Effects.PreventDamageEffect` has no facade for "prevent all damage to target"** (Godtoucher). The family has `PreventNextDamage`, `PreventAllCombatDamageTo`, `PreventAllDamageDealtBy`, `PreventAllDamageToGroup` — but not this one, so the card uses the raw constructor, as `fem/cards/Heroism.kt` already does. Worth a facade if more turn up.
- **`Patterns.Group.pumpAndGrantToAll` carries only one keyword** (Titanic Ultimatum grants three), so that card composes `ForEachInGroup` + `Composite` by hand. A multi-keyword overload is the obvious follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
