### PR TITLE
Add 77 Assay-ready cards to Ice Age

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/AdarkarSentinel.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/AdarkarSentinel.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Adarkar Sentinel
+ * {5}
+ * Artifact Creature — Soldier
+ * 3/3
+ *
+ * {1}: This creature gets +0/+1 until end of turn.
+ *
+ * The firebreathing shape with the pump on the toughness half: a mana-only activated ability whose
+ * effect is `Effects.ModifyStats` onto `EffectTarget.Self`, taking the facade's default
+ * `Duration.EndOfTurn`.
+ */
+val AdarkarSentinel = card("Adarkar Sentinel") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "{1}: This creature gets +0/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        effect = Effects.ModifyStats(0, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "306"
+        artist = "Melissa A. Benson"
+        flavorText = "\"We encountered the Sentinels in the wastes, near no living thing. Their purpose was inscrutable.\"\n—Disa the Restless, journal entry"
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff62754b-f4f0-4731-8dd7-327a820f60a8.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/AltarOfBone.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/AltarOfBone.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Altar of Bone
+ * {G}{W}
+ * Sorcery
+ *
+ * As an additional cost to cast this spell, sacrifice a creature.
+ * Search your library for a creature card, reveal it, put it into your hand, then shuffle.
+ *
+ * The whole second line is `Patterns.Library.searchLibrary`'s recipe (gather → select → reveal-move
+ * → shuffle → `LibrarySearchedEvent`); `reveal = true` is a facade parameter, so restating those
+ * steps by hand is how the reveal gets dropped. Eladamri's Call is the same sentence. The first line
+ * is the shared sacrifice cost atom, exactly as Natural Order spells it.
+ */
+val AltarOfBone = card("Altar of Bone") {
+    manaCost = "{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature.\n" +
+        "Search your library for a creature card, reveal it, put it into your hand, then shuffle."
+
+    additionalCost(Costs.additional.SacrificePermanent(filter = GameObjectFilter.Creature))
+
+    spell {
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Creature,
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "281"
+        artist = "Melissa A. Benson"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75d5b014-8675-4d91-a539-ac5c31d44b35.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Anarchy.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Anarchy.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Anarchy
+ * {2}{R}{R}
+ * Sorcery
+ *
+ * Destroy all white permanents.
+ *
+ * `Effects.DestroyAll` rather than an iteration: the sweep lowers to the gather-then-move pipeline,
+ * whose gather reads the battlefield through *projected* state, so a permanent made white by a
+ * continuous effect is caught and one whose colour was changed away is not.
+ */
+val Anarchy = card("Anarchy") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all white permanents."
+
+    spell {
+        effect = Effects.DestroyAll(GameObjectFilter.Permanent.withColor(Color.WHITE))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "170"
+        artist = "Phil Foglio"
+        flavorText = "\"The Shaman waved the staff, and the land itself went mad.\"\n—Disa the Restless, journal entry"
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/28d941da-b5cb-4b7e-84f2-ece883f89af3.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/BatonOfMorale.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/BatonOfMorale.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Baton of Morale
+ * {2}
+ * Artifact
+ *
+ * {2}: Target creature gains banding until end of turn. (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding a player controls are blocking or being blocked by a creature, that player divides that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)
+ *
+ * A plain [Effects.GrantKeyword] at its default end-of-turn duration — the whole card is one
+ * mana-only activated ability, so no tap cost is written.
+ */
+val BatonOfMorale = card("Baton of Morale") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{2}: Target creature gains banding until end of turn. (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding a player controls are blocking or being blocked by a creature, that player divides that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.BANDING, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "313"
+        artist = "Douglas Shuler"
+        flavorText = "\"The Goblins would kill to get ahold of this one.\"\n—Arcum Dagsson, Soldevi Machinist"
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8bc29872-b1a2-4851-9eca-f3e67ae6e14c.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/BrineShaman.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/BrineShaman.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Brine Shaman
+ * {1}{B}
+ * Creature — Human Cleric Shaman
+ * 1/1
+ *
+ * {T}, Sacrifice a creature: Target creature gets +2/+2 until end of turn.
+ * {1}{U}{U}, Sacrifice a creature: Counter target creature spell.
+ *
+ * Two independent activated abilities, each a [Costs.Composite] whose printed comma joins the
+ * atoms in printed order — the first is Blighted Shaman's pump verbatim, the second pays mana
+ * instead of tapping and swaps the payoff for [Effects.CounterSpell]. "Target creature spell" is
+ * the stack-zone filter [Targets.CreatureSpell], so no extra condition is needed.
+ */
+val BrineShaman = card("Brine Shaman") {
+    manaCost = "{1}{B}"
+    colorIdentity = "BU"
+    typeLine = "Creature — Human Cleric Shaman"
+    power = 1
+    toughness = 1
+    oracleText = "{T}, Sacrifice a creature: Target creature gets +2/+2 until end of turn.\n" +
+        "{1}{U}{U}, Sacrifice a creature: Counter target creature spell."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.Sacrifice(GameObjectFilter.Creature))
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(2, 2, t)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}{U}"), Costs.Sacrifice(GameObjectFilter.Creature))
+        target("target", Targets.CreatureSpell)
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "Cornelius Brudi"
+        flavorText = "\"The Shamans of Marit Lage do her bidding in secret, but they do it gladly.\"\n—Halvor Arenson, Kjeldoran Priest"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f445962c-44a1-4f3f-88d4-17048f8ca9dc.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/CentaurArcher.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/CentaurArcher.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Centaur Archer
+ * {1}{R}{G}
+ * Creature — Centaur Archer
+ * 3/2
+ *
+ * {T}: This creature deals 1 damage to target creature with flying.
+ *
+ * Grapeshot Catapult's shape: the "with flying" restriction is a targeting predicate, so it rides
+ * [Targets.CreatureWithKeyword] rather than a condition on the effect. The damage source stays the
+ * ability's own source, which is [Effects.DealDamage]'s default.
+ */
+val CentaurArcher = card("Centaur Archer") {
+    manaCost = "{1}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Centaur Archer"
+    power = 3
+    toughness = 2
+    oracleText = "{T}: This creature deals 1 damage to target creature with flying."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", Targets.CreatureWithKeyword(Keyword.FLYING))
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "282"
+        artist = "Melissa A. Benson"
+        flavorText = "\"Centaurs will kill our Aesthir if they can; they've always been enemies. Destroy the horse-people on sight.\"\n—Arna Kennerüd, Skyknight"
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e275c295-72da-4a86-82c6-cfd75b38b19c.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Cooperation.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Cooperation.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Cooperation
+ * {2}{W}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature has banding.
+ *
+ * The plain keyword-granting Aura shape: `auraTarget = Targets.Creature` carries the enchant
+ * restriction, and `GrantKeyword` needs no filter because its default is
+ * `GroupFilter.attachedCreature()` — exactly "enchanted creature". Banding is engine-live, so the
+ * grant is real combat behaviour rather than a display keyword.
+ */
+val Cooperation = card("Cooperation") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has banding. (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding a player controls are blocking or being blocked by a creature, that player divides that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)"
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.BANDING)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Phil Foglio"
+        flavorText = "\"The Elves train our healers, and we keep the Orcs at bay. Most Elvish bargains aren't as fair.\"\n—General Jarkeld, the Arctic Fox"
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/21a815ed-c8b4-4414-8b27-ea612e2977e2.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/DeathWardReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/DeathWardReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Death Ward reprint in ICE. Canonical CardDefinition lives in its earliest set.
+ */
+val DeathWardReprint = Printing(
+    oracleId = "0544b707-ec67-43e3-a25d-fd7005ab673d",
+    name = "Death Ward",
+    setCode = "ICE",
+    collectorNumber = "19",
+    scryfallId = "c7b21d29-050d-4704-a4c8-93e3b55086ac",
+    artist = "Harold McNeill",
+    imageUri = "https://cards.scryfall.io/normal/front/c/7/c7b21d29-050d-4704-a4c8-93e3b55086ac.jpg",
+    releaseDate = "1995-06-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/DiabolicVision.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/DiabolicVision.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+
+/**
+ * Diabolic Vision
+ * {U}{B}
+ * Sorcery
+ *
+ * Look at the top five cards of your library. Put one of them into your hand and the rest on top of
+ * your library in any order.
+ *
+ * Both printed sentences are one `Patterns.Library.lookAtTopAndKeep` recipe — Stock Up's shape with
+ * the remainder going back on **top** instead of the bottom. The pile prompts ("Put in hand" / "Put
+ * on top") are derived from the two destinations by the facade, so they are never spelled here.
+ */
+val DiabolicVision = card("Diabolic Vision") {
+    manaCost = "{U}{B}"
+    colorIdentity = "BU"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top five cards of your library. Put one of them into your hand and the rest on top of your library in any order."
+
+    spell {
+        effect = Patterns.Library.lookAtTopAndKeep(
+            count = 5,
+            keepCount = 1,
+            keepDestination = CardDestination.ToZone(Zone.HAND),
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Top),
+            restOrder = CardOrder.ControllerChooses
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "284"
+        artist = "Anthony S. Waters"
+        flavorText = "\"I have seen the true path. I will not warm myself by the fire—I will become the flame.\"\n—Lim-Dûl, the Necromancer"
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1ea01324-1cfb-498c-8299-f690373864bd.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/DireWolves.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/DireWolves.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Dire Wolves
+ * {2}{G}
+ * Creature — Wolf
+ * 2/2
+ *
+ * This creature has banding as long as you control a Plains.
+ *
+ * The Kird Ape shape with a keyword instead of a stat bump: a `ConditionalStaticAbility` wrapping
+ * `GrantKeyword(BANDING, Filters.Self)`, gated on an `Exists` over your own battlefield. `Exists` is
+ * re-asked on every projection, so losing the Plains turns banding off mid-combat as the rules
+ * require.
+ */
+val DireWolves = card("Dire Wolves") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    power = 2
+    toughness = 2
+    oracleText = "This creature has banding as long as you control a Plains. (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)"
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.BANDING, Filters.Self),
+            condition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype("Plains"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "230"
+        artist = "Ron Spencer"
+        flavorText = "\"It's amazing how scared a city kid can get at a dog. Now, of course, I'd cross Terisiare alone, and keep no watch if I had a pack of greys hanging on my flanks as I went.\"\n—Oddveig Ulfsson, caravan scout"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a602c93d-e00f-4b4f-a7ff-95316b7e7641.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/FanaticalFever.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/FanaticalFever.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fanatical Fever
+ * {2}{G}{G}
+ * Instant
+ *
+ * Target creature gets +3/+0 and gains trample until end of turn.
+ *
+ * One target shared by two effects — the pump and the keyword grant both point at the same bound
+ * variable — so it is a `Composite` over one requirement rather than two separate clauses. Both
+ * primitives already default to `Duration.EndOfTurn`, which is what "until end of turn" means here.
+ */
+val FanaticalFever = card("Fanatical Fever") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+0 and gains trample until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 0, t),
+            Effects.GrantKeyword(Keyword.TRAMPLE, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "234"
+        artist = "Julie Baroh"
+        flavorText = "\"Let go your fury, and hone your anger. Become the fist of Freyalise!\"\n—Kolbjörn, Elder Druid of the Juniper Order"
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2abba7f1-5d07-4137-88a2-5967396a3e42.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/FlameSpirit.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/FlameSpirit.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Flame Spirit
+ * {4}{R}
+ * Creature — Elemental Spirit
+ * 2/3
+ *
+ * {R}: This creature gets +1/+0 until end of turn.
+ *
+ * Plain firebreathing: a mana-only activated ability whose effect is `Effects.ModifyStats` onto
+ * `EffectTarget.Self`, taking the facade's default `Duration.EndOfTurn`.
+ */
+val FlameSpirit = card("Flame Spirit") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental Spirit"
+    power = 2
+    toughness = 3
+    oracleText = "{R}: This creature gets +1/+0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "184"
+        artist = "Justin Hampton"
+        flavorText = "\"The spirit of the flame is the spirit of change.\"\n—Lovisa Coldeyes, Balduvian Chieftain"
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/add2b82a-9aa5-4d5c-a1c2-e313541f12c8.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/FolkOfThePines.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/FolkOfThePines.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Folk of the Pines
+ * {4}{G}
+ * Creature — Dryad
+ * 2/5
+ *
+ * {1}{G}: This creature gets +1/+0 until end of turn.
+ *
+ * Firebreathing in green: a mana-only activated ability whose effect is `Effects.ModifyStats` onto
+ * `EffectTarget.Self`, taking the facade's default `Duration.EndOfTurn`.
+ */
+val FolkOfThePines = card("Folk of the Pines") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dryad"
+    power = 2
+    toughness = 5
+    oracleText = "{1}{G}: This creature gets +1/+0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{G}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "235"
+        artist = "NéNé Thomas & Catherine Buck"
+        flavorText = "\"Our friends of the forest take many forms, yet all serve the will of Freyalise.\"\n—Laina of the Elvish Council"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c13311d-db83-483f-ba2b-4f54ceb8b026.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/FyndhornBow.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/FyndhornBow.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fyndhorn Bow
+ * {2}
+ * Artifact
+ *
+ * {3}, {T}: Target creature gains first strike until end of turn.
+ *
+ * The Ice Age keyword-granting equipment shape: mana + tap, then [Effects.GrantKeyword] at its
+ * default end-of-turn duration.
+ */
+val FyndhornBow = card("Fyndhorn Bow") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{3}, {T}: Target creature gains first strike until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "318"
+        artist = "Rob Alexander"
+        flavorText = "\"With a bow like this, the hunting is always good.\"\n—Taaveti of Kelsinko, Elvish Hunter"
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/65dd0a41-cc51-4728-b597-fdb2510accd8.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/FyndhornBrownie.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/FyndhornBrownie.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fyndhorn Brownie
+ * {2}{G}
+ * Creature — Ouphe
+ * 1/1
+ *
+ * {2}{G}, {T}: Untap target creature.
+ *
+ * Seeker of Skybreak with a mana cost bolted on: the printed comma is a [Costs.Composite] in mana
+ * then tap order, and the untap is the shared `TapUntap` primitive via [Effects.Untap].
+ */
+val FyndhornBrownie = card("Fyndhorn Brownie") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ouphe"
+    power = 1
+    toughness = 1
+    oracleText = "{2}{G}, {T}: Untap target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{G}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.Untap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "242"
+        artist = "Richard Thomas"
+        flavorText = "\"I've been insulted by drunks in a hundred inns, but never as skillfully or annoyingly as by those blasted Brownies.\"\n—General Jarkeld, the Arctic Fox"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/06204e82-9dfd-4334-a23a-f8240fc37772.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/GlacialWall.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/GlacialWall.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Glacial Wall
+ * {2}{U}
+ * Creature — Wall
+ * 0/7
+ *
+ * Defender (This creature can't attack.)
+ *
+ * A vanilla Wall: `Keyword.DEFENDER` is the whole card, and the engine reads it in
+ * `AttackRestrictionRules` rather than needing a can't-attack static.
+ */
+val GlacialWall = card("Glacial Wall") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Wall"
+    power = 0
+    toughness = 7
+    oracleText = "Defender (This creature can't attack.)"
+
+    keywords(Keyword.DEFENDER)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "71"
+        artist = "Dameon Willich"
+        flavorText = "\"We are farther west than any could have imagined possible, but I still wish to press on. Unfortunately, huge walls of ice block further travel. We can't believe they are natural.\"\n—Disa the Restless, journal entry"
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/07b71bc1-d9a2-4e99-a8fa-cd696925328d.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/HematiteTalisman.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/HematiteTalisman.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Hematite Talisman
+ * {2}
+ * Artifact
+ *
+ * Whenever a player casts a red spell, you may pay {3}. If you do, untap target permanent.
+ *
+ * One of Ice Age's five Talismans — the cycle is a single shape with the spell filter recoloured.
+ * "A player" is every player, this artifact's controller included, so the trigger is
+ * [Triggers.anyPlayerCasts] (binding ANY, `Player.Each`); the ransom is [MayPayManaEffect], whose
+ * yes/no and mana payment both happen on resolution. The permanent is a real target declared on the
+ * ability, so it is locked in when the trigger goes on the stack, before anyone decides to pay.
+ */
+val HematiteTalisman = card("Hematite Talisman") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever a player casts a red spell, you may pay {3}. If you do, untap target permanent."
+
+    triggeredAbility {
+        trigger = Triggers.anyPlayerCasts(GameObjectFilter.Any.withColor(Color.RED))
+        val permanent = target("target", Targets.Permanent)
+        effect = MayPayManaEffect(ManaCost.parse("{3}"), Effects.Untap(permanent))
+        description = "Whenever a player casts a red spell, you may pay {3}. " +
+            "If you do, untap target permanent."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "320"
+        artist = "Allen Williams"
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/83585337-56a9-44d2-9ed1-8a959bcfb010.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/HoarShade.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/HoarShade.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hoar Shade
+ * {3}{B}
+ * Creature — Shade
+ * 1/2
+ *
+ * {B}: This creature gets +1/+1 until end of turn.
+ *
+ * The classic Shade pump, identical in shape to Looming Shade: a mana-only activated ability whose
+ * effect is `Effects.ModifyStats` onto `EffectTarget.Self`, taking the facade's default
+ * `Duration.EndOfTurn`.
+ */
+val HoarShade = card("Hoar Shade") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Shade"
+    power = 1
+    toughness = 2
+    oracleText = "{B}: This creature gets +1/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "131"
+        artist = "Richard Thomas"
+        flavorText = "\"The creature we fought in the western waste was doubly dangerous: mortally wounded, it rebounded and attacked again.\"\n—Disa the Restless, journal entry"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72242dff-15ca-4da0-b3ae-9984d037b31f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/HyalopterousLemure.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/HyalopterousLemure.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hyalopterous Lemure
+ * {4}{B}
+ * Creature — Spirit
+ * 4/3
+ *
+ * {0}: This creature gets -1/-0 and gains flying until end of turn.
+ *
+ * The two printed halves are one `Effects.Composite` — the stat shrink and the keyword grant both
+ * point at `EffectTarget.Self` and both take the facade default `Duration.EndOfTurn`. Same shape as
+ * Hopping Automaton.
+ */
+val HyalopterousLemure = card("Hyalopterous Lemure") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit"
+    power = 4
+    toughness = 3
+    oracleText = "{0}: This creature gets -1/-0 and gains flying until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{0}")
+        effect = Effects.Composite(
+            Effects.ModifyStats(-1, 0, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "133"
+        artist = "Richard Thomas"
+        flavorText = "\"The Lemures looked harmless, until they descended on my troops. Within moments, only bones remained.\"\n—Lucilde Fiksdotter, Leader of the Order of the White Shield"
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d2c9e037-f4d5-46fd-b439-56bee6fb2ad3.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/IceAgeBasicLands.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/IceAgeBasicLands.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Ice Age Basic Lands
+ *
+ * Ice Age prints three art variants of each of the five basic land types (cards 364-383,
+ * interleaved with the set's four snow-covered basics). The snow-covered lands are *not* here:
+ * `basicLand(...)` hardcodes the "Basic Land — <type>" type line and cannot carry the Snow
+ * supertype, so each of those is a hand-written `card(...)` of its own.
+ */
+
+// =============================================================================
+// Plains (Cards 364-366)
+// =============================================================================
+
+val IceAgePlains364 = basicLand("Plains") {
+    collectorNumber = "364"
+    artist = "Christopher Rush"
+    imageUri = "https://cards.scryfall.io/normal/front/7/b/7b68bdb0-41cc-48f6-905e-7da1ff4ba5e0.jpg?1783947450"
+}
+
+val IceAgePlains365 = basicLand("Plains") {
+    collectorNumber = "365"
+    artist = "Christopher Rush"
+    imageUri = "https://cards.scryfall.io/normal/front/d/f/df3e94f7-9f97-4652-a1f1-381feb15f688.jpg?1783947450"
+}
+
+val IceAgePlains366 = basicLand("Plains") {
+    collectorNumber = "366"
+    artist = "Christopher Rush"
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/27ac1fc7-0698-4a94-8353-cc4c13bd6ffa.jpg?1783947450"
+}
+
+// =============================================================================
+// Island (Cards 368-370)
+// =============================================================================
+
+val IceAgeIsland368 = basicLand("Island") {
+    collectorNumber = "368"
+    artist = "Anson Maddocks"
+    imageUri = "https://cards.scryfall.io/normal/front/e/f/ef2d6fc9-ddad-4dd2-b218-afa1a5449b7e.jpg?1783947448"
+}
+
+val IceAgeIsland369 = basicLand("Island") {
+    collectorNumber = "369"
+    artist = "Anson Maddocks"
+    imageUri = "https://cards.scryfall.io/normal/front/6/1/61a467ab-4460-4e5e-94c1-8150bfe0c954.jpg?1783947448"
+}
+
+val IceAgeIsland370 = basicLand("Island") {
+    collectorNumber = "370"
+    artist = "Anson Maddocks"
+    imageUri = "https://cards.scryfall.io/normal/front/8/2/82f11c42-9d67-4833-9519-e165e6a7e9c4.jpg?1783947448"
+}
+
+// =============================================================================
+// Swamp (Cards 373-375)
+// =============================================================================
+
+val IceAgeSwamp373 = basicLand("Swamp") {
+    collectorNumber = "373"
+    artist = "Douglas Shuler"
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/4695653a-5c4c-4ff3-b80c-f4b6c685f370.jpg?1783947448"
+}
+
+val IceAgeSwamp374 = basicLand("Swamp") {
+    collectorNumber = "374"
+    artist = "Douglas Shuler"
+    imageUri = "https://cards.scryfall.io/normal/front/6/a/6a90b49f-53b3-4ce0-92c1-bcd76d6981ea.jpg?1783947447"
+}
+
+val IceAgeSwamp375 = basicLand("Swamp") {
+    collectorNumber = "375"
+    artist = "Douglas Shuler"
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/ddca7e2e-bb0a-47ed-ade3-31900da992dc.jpg?1783947447"
+}
+
+// =============================================================================
+// Mountain (Cards 376-378)
+// =============================================================================
+
+val IceAgeMountain376 = basicLand("Mountain") {
+    collectorNumber = "376"
+    artist = "Tom Wänerstrand"
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4ecf39c3-3b5f-4263-a7b5-9881bded3494.jpg?1783947446"
+}
+
+val IceAgeMountain377 = basicLand("Mountain") {
+    collectorNumber = "377"
+    artist = "Tom Wänerstrand"
+    imageUri = "https://cards.scryfall.io/normal/front/2/e/2eb15b42-be2a-4663-b064-aad6c7cb2714.jpg?1783947447"
+}
+
+val IceAgeMountain378 = basicLand("Mountain") {
+    collectorNumber = "378"
+    artist = "Tom Wänerstrand"
+    imageUri = "https://cards.scryfall.io/normal/front/1/7/17ac61e4-b543-4c37-9bfa-43f0c928152d.jpg?1783947446"
+}
+
+// =============================================================================
+// Forest (Cards 380-382)
+// =============================================================================
+
+val IceAgeForest380 = basicLand("Forest") {
+    collectorNumber = "380"
+    artist = "Pat Lewis"
+    imageUri = "https://cards.scryfall.io/normal/front/f/b/fbdcbd97-90a9-45ea-94f6-2a1c6faaf965.jpg?1783947446"
+}
+
+val IceAgeForest381 = basicLand("Forest") {
+    collectorNumber = "381"
+    artist = "Pat Lewis"
+    imageUri = "https://cards.scryfall.io/normal/front/b/3/b346b784-7bde-49d0-bfa9-56236cbe19d9.jpg?1783947445"
+}
+
+val IceAgeForest382 = basicLand("Forest") {
+    collectorNumber = "382"
+    artist = "Pat Lewis"
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/768c4d8f-5700-4f0a-9ff2-58422aeb1dac.jpg?1783947444"
+}
+
+/**
+ * All Ice Age basic land variants.
+ */
+val IceAgeBasicLands = listOf(
+    IceAgePlains364, IceAgePlains365, IceAgePlains366,
+    IceAgeIsland368, IceAgeIsland369, IceAgeIsland370,
+    IceAgeSwamp373, IceAgeSwamp374, IceAgeSwamp375,
+    IceAgeMountain376, IceAgeMountain377, IceAgeMountain378,
+    IceAgeForest380, IceAgeForest381, IceAgeForest382
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Iceberg.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Iceberg.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Iceberg
+ * {X}{U}{U}
+ * Enchantment
+ *
+ * This enchantment enters with X ice counters on it.
+ * {3}: Put an ice counter on this enchantment.
+ * Remove an ice counter from this enchantment: Add {C}.
+ *
+ * A mana battery, so the counters are the store and nothing else reads them: `Counters.ICE` is
+ * already in the `CounterType` enum, which keeps `CounterTypeFilter.Named` from failing open to
+ * +1/+1. The cast-time X reaches the permanent through [EntersWithDynamicCounters] with a
+ * [DynamicAmount.XValue] count — the replacement effect runs inside the permanent spell's own
+ * resolution, where X is still live. Withdrawals are a plain mana ability whose cost is
+ * `Costs.RemoveCounterFromSelf`, so they can be activated while paying for something else.
+ */
+val Iceberg = card("Iceberg") {
+    manaCost = "{X}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "This enchantment enters with X ice counters on it.\n" +
+        "{3}: Put an ice counter on this enchantment.\n" +
+        "Remove an ice counter from this enchantment: Add {C}."
+
+    replacementEffect(
+        EntersWithDynamicCounters(
+            counterType = CounterTypeFilter.Named(Counters.ICE),
+            count = DynamicAmount.XValue
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Mana("{3}")
+        effect = Effects.AddCounters(Counters.ICE, 1, EffectTarget.Self)
+        description = "{3}: Put an ice counter on this enchantment."
+    }
+
+    activatedAbility {
+        cost = Costs.RemoveCounterFromSelf(Counters.ICE)
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "Remove an ice counter from this enchantment: Add {C}."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "73"
+        artist = "Jeff A. Menges"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2f70e49-17fa-4033-bd45-63374f7f5ec5.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ImposingVisage.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ImposingVisage.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Imposing Visage
+ * {R}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature has menace.
+ *
+ * Same one-static Aura shape as [Cooperation]: `auraTarget = Targets.Creature` is the enchant
+ * restriction and `GrantKeyword`'s default `attachedCreature()` filter is "enchanted creature".
+ * Menace is read by the engine's block-legality rules, so no hand-rolled `CantBeBlockedByFewerThan`
+ * is needed — the printed keyword is the whole card.
+ */
+val ImposingVisage = card("Imposing Visage") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has menace. (It can't be blocked except by two or more creatures.)"
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.MENACE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "193"
+        artist = "Phil Foglio"
+        flavorText = "\"I can't believe they expect me to fight with this rabble. A Goblin in a big mask sends 'em running for cover.\"\n—Avram Garrisson, Leader of the Knights of Stromgald"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cca42b74-9b42-482b-b12a-79cafdcd087e.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/JuniperOrderDruid.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/JuniperOrderDruid.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Juniper Order Druid
+ * {2}{G}
+ * Creature — Human Cleric Druid
+ * 1/1
+ *
+ * {T}: Untap target land.
+ *
+ * Ley Druid's ability verbatim: [Costs.Tap] and [Effects.Untap] — the shared `TapUntap` primitive
+ * with `tap = false` — onto [Targets.Land].
+ */
+val JuniperOrderDruid = card("Juniper Order Druid") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Cleric Druid"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Untap target land."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", Targets.Land)
+        effect = Effects.Untap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "251"
+        artist = "Jeff A. Menges"
+        flavorText = "\"The filthy towns of Kjeldor are no place for anyone to live. Fyndhorn is our home now.\"\n—Kolbjörn, Elder Druid of the Juniper Order"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb211704-ff8e-498b-b7bb-f8384f198ffd.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KelsinkoRanger.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KelsinkoRanger.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kelsinko Ranger
+ * {W}
+ * Creature — Human Ranger
+ * 1/1
+ *
+ * {1}{W}: Target green creature gains first strike until end of turn.
+ *
+ * The "green" is a targeting predicate, so it rides [Targets.CreatureWithColor] rather than a
+ * condition; the grant is [Effects.GrantKeyword], taking its default `Duration.EndOfTurn`.
+ */
+val KelsinkoRanger = card("Kelsinko Ranger") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Ranger"
+    power = 1
+    toughness = 1
+    oracleText = "{1}{W}: Target green creature gains first strike until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}")
+        val t = target("target", Targets.CreatureWithColor(Color.GREEN))
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "33"
+        artist = "Mark Poole"
+        flavorText = "\"Rangers not trained by the Elves just aren't the same.\"\n—Lucilde Fiksdotter, Leader of the Order of the White Shield"
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/8402543e-5406-404f-95c4-800a1dce35f1.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KjeldoranDead.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KjeldoranDead.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kjeldoran Dead
+ * {B}
+ * Creature — Skeleton
+ * 3/1
+ *
+ * When this creature enters, sacrifice a creature.
+ * {B}: Regenerate this creature.
+ *
+ * The enters-trigger is the bare imperative "sacrifice a creature" — [Effects.SacrificeOwn], the
+ * spelling with no player named, so the ability's controller chooses (CR 701.17a); it is an effect,
+ * not an additional cost, and the printed line says "a creature", not "another", so this permanent
+ * is itself a legal choice. The regeneration is the same [RegenerateEffect] shape as its functional
+ * twin Spined Fluke.
+ */
+val KjeldoranDead = card("Kjeldoran Dead") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Skeleton"
+    power = 3
+    toughness = 1
+    oracleText = "When this creature enters, sacrifice a creature.\n" +
+        "{B}: Regenerate this creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.SacrificeOwn(GameObjectFilter.Creature)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "137"
+        artist = "Melissa A. Benson"
+        flavorText = "\"They shall kill those whom once they loved.\"\n—Lim-Dûl, the Necromancer"
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d3f7b614-6075-4b7c-acc7-ab63185b570b.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KjeldoranKnight.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KjeldoranKnight.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kjeldoran Knight
+ * {W}{W}
+ * Creature — Human Knight
+ * 1/1
+ *
+ * Banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)
+ * {1}{W}: This creature gets +1/+0 until end of turn.
+ * {W}{W}: This creature gets +0/+2 until end of turn.
+ *
+ * Banding is engine-live (`CombatDamageManager` consults it), so the bare `keywords(...)` entry is
+ * real behaviour. The two pumps are plain mana-cost [Effects.ModifyStats] on [EffectTarget.Self] —
+ * the same shape as the Order cycle, just split across power and toughness.
+ */
+val KjeldoranKnight = card("Kjeldoran Knight") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 1
+    toughness = 1
+    oracleText = "Banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)\n" +
+        "{1}{W}: This creature gets +1/+0 until end of turn.\n" +
+        "{W}{W}: This creature gets +0/+2 until end of turn."
+
+    keywords(Keyword.BANDING)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{W}{W}")
+        effect = Effects.ModifyStats(0, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "36"
+        artist = "Ron Spencer"
+        flavorText = "\"Those who do not ride the wind on Aesthir still command loyalty and respect.\"\n—Arna Kennerüd, Skyknight"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d5b9db8f-93b5-44e3-9e2b-728c80dfbb37.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KjeldoranPhalanx.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KjeldoranPhalanx.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kjeldoran Phalanx
+ * {5}{W}
+ * Creature — Human Soldier
+ * 2/5
+ *
+ * First strike; banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)
+ *
+ * Two printed keywords and nothing else. Banding is engine-live — `CombatDamageManager`
+ * and `CombatDamageUtils` both consult it for damage assignment — so declaring it is real behaviour.
+ */
+val KjeldoranPhalanx = card("Kjeldoran Phalanx") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 5
+    oracleText = "First strike; banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)"
+
+    keywords(Keyword.FIRST_STRIKE, Keyword.BANDING)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "37"
+        artist = "Richard Kane Ferguson"
+        flavorText = "\"There's nothing I like better than watching a street full of soldiers kicking down the doors of the guilty and the impure.\"\n—Avram Garrisson, Leader of the Knights of Stromgald"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6e91ba0-b229-4ab1-84f3-2a490dfa5051.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KjeldoranSkycaptain.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KjeldoranSkycaptain.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kjeldoran Skycaptain
+ * {4}{W}
+ * Creature — Human Soldier
+ * 2/2
+ *
+ * Flying; first strike; banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)
+ *
+ * Three printed keywords and nothing else; all three are read by the combat rules.
+ */
+val KjeldoranSkycaptain = card("Kjeldoran Skycaptain") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Flying; first strike; banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)"
+
+    keywords(Keyword.FLYING, Keyword.FIRST_STRIKE, Keyword.BANDING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "39"
+        artist = "Mark Poole"
+        flavorText = "\"If we do our duty and uphold our honor, Kjeldor shall stand for a thousand years.\"\n—Arna Kennerüd, Skyknight"
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cf0115e0-6192-48a9-9e58-f3ef77ef77c2.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KjeldoranSkyknight.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KjeldoranSkyknight.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kjeldoran Skyknight
+ * {2}{W}
+ * Creature — Human Knight
+ * 1/1
+ *
+ * Flying; first strike; banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)
+ *
+ * Three printed keywords and nothing else — the Skycaptain body one mana cheaper.
+ */
+val KjeldoranSkyknight = card("Kjeldoran Skyknight") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 1
+    toughness = 1
+    oracleText = "Flying; first strike; banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)"
+
+    keywords(Keyword.FLYING, Keyword.FIRST_STRIKE, Keyword.BANDING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "Mark Poole"
+        flavorText = "\"My Aesthir is my most trusted ally. We fight as one and live as one, and we will die as one.\"\n—Arna Kennerüd, Skyknight"
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f794665a-8353-482a-b065-2a0777a8acda.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KjeldoranWarrior.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KjeldoranWarrior.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kjeldoran Warrior
+ * {W}
+ * Creature — Human Warrior
+ * 1/1
+ *
+ * Banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)
+ *
+ * Banding alone. The reminder text is the keyword's, not a second ability.
+ */
+val KjeldoranWarrior = card("Kjeldoran Warrior") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "Banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)"
+
+    keywords(Keyword.BANDING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Mark Poole"
+        flavorText = "\"Give me a thousand such Warriors and I could change the world.\"\n—Avram Garrisson, Leader of the Knights of Stromgald"
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ce76f38f-566e-49ff-b197-510cfa1cb51c.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KnightOfStromgald.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/KnightOfStromgald.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Knight of Stromgald
+ * {B}{B}
+ * Creature — Human Knight
+ * 2/1
+ *
+ * Protection from white
+ * {B}: This creature gains first strike until end of turn.
+ * {B}{B}: This creature gets +1/+0 until end of turn.
+ *
+ * Functionally identical to [com.wingedsheep.mtg.sets.definitions.fem.cards.OrderOfTheEbonHand], so
+ * it reuses that shape exactly: protection is the structured [KeywordAbility.Protection] with a
+ * [ProtectionScope.Color] rather than a bare `keywords(...)` entry, and the two activations are
+ * plain mana-cost [Effects.GrantKeyword] / [Effects.ModifyStats] on [EffectTarget.Self].
+ */
+val KnightOfStromgald = card("Knight of Stromgald") {
+    manaCost = "{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 1
+    oracleText = "Protection from white\n" +
+        "{B}: This creature gains first strike until end of turn.\n" +
+        "{B}{B}: This creature gets +1/+0 until end of turn."
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.WHITE)))
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{B}{B}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "138"
+        artist = "Mark Poole"
+        flavorText = "\"Kjeldorans should rule supreme, and to the rest, death!\"\n—Avram Garrisson, Leader of the Knights of Stromgald"
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2b87069b-ebaf-4705-b5da-446932af9b73.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/LapisLazuliTalisman.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/LapisLazuliTalisman.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Lapis Lazuli Talisman
+ * {2}
+ * Artifact
+ *
+ * Whenever a player casts a blue spell, you may pay {3}. If you do, untap target permanent.
+ *
+ * One of Ice Age's five Talismans — the cycle is a single shape with the spell filter recoloured.
+ * "A player" is every player, this artifact's controller included, so the trigger is
+ * [Triggers.anyPlayerCasts] (binding ANY, `Player.Each`); the ransom is [MayPayManaEffect], whose
+ * yes/no and mana payment both happen on resolution. The permanent is a real target declared on the
+ * ability, so it is locked in when the trigger goes on the stack, before anyone decides to pay.
+ */
+val LapisLazuliTalisman = card("Lapis Lazuli Talisman") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever a player casts a blue spell, you may pay {3}. If you do, untap target permanent."
+
+    triggeredAbility {
+        trigger = Triggers.anyPlayerCasts(GameObjectFilter.Any.withColor(Color.BLUE))
+        val permanent = target("target", Targets.Permanent)
+        effect = MayPayManaEffect(ManaCost.parse("{3}"), Effects.Untap(permanent))
+        description = "Whenever a player casts a blue spell, you may pay {3}. " +
+            "If you do, untap target permanent."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "327"
+        artist = "Amy Weber"
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ce00bb19-983e-427d-be54-ae6daf0ccdde.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/LeshracsRite.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/LeshracsRite.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Leshrac's Rite
+ * {B}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature has swampwalk.
+ *
+ * The Cave Sense shape without the stat bump: one `GrantKeyword` on the default
+ * `attachedCreature()` filter, plus the `auraTarget` enchant restriction. Granted landwalk is
+ * engine-live — `BlockEvasionRules.LandwalkRule` reads the keyword out of projected state and maps
+ * `SWAMPWALK` to the Swamp subtype — so the grant behaves exactly like a printed one.
+ */
+val LeshracsRite = card("Leshrac's Rite") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature has swampwalk. (It can't be blocked as long as defending player controls a Swamp.)"
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.SWAMPWALK)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "143"
+        artist = "Richard Thomas"
+        flavorText = "\"Bind me to thee, my soul to thine. I am your servant and your slave. I shall hunger for your word and thirst for your blessing. Blood for blood, flesh for flesh, Leshrac, my lord.\"\n—Lim-Dûl, the Necromancer"
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4e0a6b4e-95b4-40f6-bb19-568dbd908a2b.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Lhurgoyf.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Lhurgoyf.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Lhurgoyf
+ * {2}{G}{G}
+ * Creature — Lhurgoyf
+ * Characteristic-defining power/toughness — see dynamicStats below.
+ *
+ * Lhurgoyf's power is equal to the number of creature cards in all graveyards and its toughness is
+ * equal to that number plus 1.
+ *
+ * The original *-body: a characteristic-defining ability (CR 604.3), so it is `dynamicStats` rather
+ * than a printed P/T plus a pump — one [DynamicAmount] feeds base power and base toughness in layer
+ * 7a and functions in every zone. [Player.Each] is what makes "all graveyards" all of them, and the
+ * "plus 1" is `toughnessOffset` on that same amount rather than a second value, so the two halves
+ * can never drift apart. Soulless One reads graveyards the same way.
+ */
+val Lhurgoyf = card("Lhurgoyf") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Lhurgoyf"
+    dynamicStats(
+        DynamicAmount.Count(Player.Each, Zone.GRAVEYARD, GameObjectFilter.Creature),
+        toughnessOffset = 1
+    )
+    oracleText = "Lhurgoyf's power is equal to the number of creature cards in all graveyards and " +
+        "its toughness is equal to that number plus 1."
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "252"
+        artist = "Pete Venters"
+        flavorText = "\"Ach! Hans, run! It's the Lhurgoyf!\"\n—Saffi Eriksdotter, last words"
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/fee6d385-d44b-4f1a-beb1-13aeebde063e.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/MalachiteTalisman.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/MalachiteTalisman.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Malachite Talisman
+ * {2}
+ * Artifact
+ *
+ * Whenever a player casts a green spell, you may pay {3}. If you do, untap target permanent.
+ *
+ * One of Ice Age's five Talismans — the cycle is a single shape with the spell filter recoloured.
+ * "A player" is every player, this artifact's controller included, so the trigger is
+ * [Triggers.anyPlayerCasts] (binding ANY, `Player.Each`); the ransom is [MayPayManaEffect], whose
+ * yes/no and mana payment both happen on resolution. The permanent is a real target declared on the
+ * ability, so it is locked in when the trigger goes on the stack, before anyone decides to pay.
+ */
+val MalachiteTalisman = card("Malachite Talisman") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever a player casts a green spell, you may pay {3}. If you do, untap target permanent."
+
+    triggeredAbility {
+        trigger = Triggers.anyPlayerCasts(GameObjectFilter.Any.withColor(Color.GREEN))
+        val permanent = target("target", Targets.Permanent)
+        effect = MayPayManaEffect(ManaCost.parse("{3}"), Effects.Untap(permanent))
+        description = "Whenever a player casts a green spell, you may pay {3}. " +
+            "If you do, untap target permanent."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "328"
+        artist = "Christopher Rush"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63fb8a24-ce53-4a69-be2a-55c6dbba5ee7.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/MoorFiend.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/MoorFiend.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moor Fiend
+ * {3}{B}
+ * Creature — Horror
+ * 3/3
+ *
+ * Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)
+ *
+ * Swampwalk alone. `BlockEvasionRules` maps `Keyword.SWAMPWALK` to `Subtype.SWAMP`, so the
+ * land-type check is the keyword's own rule and needs no static ability here.
+ */
+val MoorFiend = card("Moor Fiend") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror"
+    power = 3
+    toughness = 3
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)"
+
+    keywords(Keyword.SWAMPWALK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "153"
+        artist = "Anson Maddocks"
+        flavorText = "\"Let them close the gates of Krov from dusk until dawn if they so choose. It matters not. My fiends shall yet rend their flesh from their bones.\"\n—Lim-Dûl, the Necromancer"
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/57089dd4-e30d-498d-9341-43c104c6f3f9.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/NacreTalisman.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/NacreTalisman.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Nacre Talisman
+ * {2}
+ * Artifact
+ *
+ * Whenever a player casts a white spell, you may pay {3}. If you do, untap target permanent.
+ *
+ * One of Ice Age's five Talismans — the cycle is a single shape with the spell filter recoloured.
+ * "A player" is every player, this artifact's controller included, so the trigger is
+ * [Triggers.anyPlayerCasts] (binding ANY, `Player.Each`); the ransom is [MayPayManaEffect], whose
+ * yes/no and mana payment both happen on resolution. The permanent is a real target declared on the
+ * ability, so it is locked in when the trigger goes on the stack, before anyone decides to pay.
+ */
+val NacreTalisman = card("Nacre Talisman") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever a player casts a white spell, you may pay {3}. If you do, untap target permanent."
+
+    triggeredAbility {
+        trigger = Triggers.anyPlayerCasts(GameObjectFilter.Any.withColor(Color.WHITE))
+        val permanent = target("target", Targets.Permanent)
+        effect = MayPayManaEffect(ManaCost.parse("{3}"), Effects.Untap(permanent))
+        description = "Whenever a player casts a white spell, you may pay {3}. " +
+            "If you do, untap target permanent."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "329"
+        artist = "Mark Tedin"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/06912236-8225-4eb0-8086-c6a163c69892.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/OnyxTalisman.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/OnyxTalisman.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Onyx Talisman
+ * {2}
+ * Artifact
+ *
+ * Whenever a player casts a black spell, you may pay {3}. If you do, untap target permanent.
+ *
+ * One of Ice Age's five Talismans — the cycle is a single shape with the spell filter recoloured.
+ * "A player" is every player, this artifact's controller included, so the trigger is
+ * [Triggers.anyPlayerCasts] (binding ANY, `Player.Each`); the ransom is [MayPayManaEffect], whose
+ * yes/no and mana payment both happen on resolution. The permanent is a real target declared on the
+ * ability, so it is locked in when the trigger goes on the stack, before anyone decides to pay.
+ */
+val OnyxTalisman = card("Onyx Talisman") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever a player casts a black spell, you may pay {3}. If you do, untap target permanent."
+
+    triggeredAbility {
+        trigger = Triggers.anyPlayerCasts(GameObjectFilter.Any.withColor(Color.BLACK))
+        val permanent = target("target", Targets.Permanent)
+        effect = MayPayManaEffect(ManaCost.parse("{3}"), Effects.Untap(permanent))
+        description = "Whenever a player casts a black spell, you may pay {3}. " +
+            "If you do, untap target permanent."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "331"
+        artist = "Sandra Everingham"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a89b2368-1180-4821-bcb8-8161c18e5538.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/OrcishLumberjack.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/OrcishLumberjack.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Orcish Lumberjack
+ * {R}
+ * Creature — Orc
+ * 1/1
+ *
+ * {T}, Sacrifice a Forest: Add three mana in any combination of {R} and/or {G}.
+ *
+ * The same shape as Goblin Clearcutter: a two-atom activation cost ({T} plus a sacrifice whose
+ * filter is a Forest *land*, not merely something named Forest) over
+ * [Effects.AddManaInAnyCombination], which lets the player pick each of the three pips' colour at
+ * resolution. `manaAbility = true` with [TimingRule.ManaAbility] keeps it usable mid-payment, which
+ * is the whole point of the card.
+ */
+val OrcishLumberjack = card("Orcish Lumberjack") {
+    manaCost = "{R}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Orc"
+    power = 1
+    toughness = 1
+    oracleText = "{T}, Sacrifice a Forest: Add three mana in any combination of {R} and/or {G}."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.Sacrifice(GameObjectFilter.Land.withSubtype("Forest"))
+        )
+        effect = Effects.AddManaInAnyCombination(3, setOf(Color.RED, Color.GREEN))
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}, Sacrifice a Forest: Add three mana in any combination of {R} and/or {G}."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "210"
+        artist = "Dan Frazier"
+        flavorText = "\"How did I ever let myself get talked into this project?\"\n—Toothlicker Harj, Orcish Captain"
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/21ef13e3-658c-43a3-a290-4c5dde8e8b55.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/OrderOfTheWhiteShield.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/OrderOfTheWhiteShield.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Order of the White Shield
+ * {W}{W}
+ * Creature — Human Knight
+ * 2/1
+ *
+ * Protection from black
+ * {W}: This creature gains first strike until end of turn.
+ * {W}{W}: This creature gets +1/+0 until end of turn.
+ *
+ * The white mirror of [KnightOfStromgald], and functionally identical to
+ * [com.wingedsheep.mtg.sets.definitions.fem.cards.OrderOfLeitbur]: protection is the structured
+ * [KeywordAbility.Protection] with a [ProtectionScope.Color], and both activations are plain
+ * mana-cost effects on [EffectTarget.Self].
+ */
+val OrderOfTheWhiteShield = card("Order of the White Shield") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 1
+    oracleText = "Protection from black\n" +
+        "{W}: This creature gains first strike until end of turn.\n" +
+        "{W}{W}: This creature gets +1/+0 until end of turn."
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.BLACK)))
+
+    activatedAbility {
+        cost = Costs.Mana("{W}")
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{W}{W}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "46"
+        artist = "Ruth Thompson"
+        flavorText = "\"Shall we turn away a worthy soul because his parents were peasants? I think not.\"\n—Lucilde Fiksdotter, Leader of the Order of the White Shield"
+        imageUri = "https://cards.scryfall.io/normal/front/9/2/92e55b10-375f-4b4f-b676-3b9b8085fdd2.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/PaleBears.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/PaleBears.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pale Bears
+ * {2}{G}
+ * Creature — Bear
+ * 2/2
+ *
+ * Islandwalk (This creature can't be blocked as long as defending player controls an Island.)
+ *
+ * Islandwalk alone — the same `BlockEvasionRules` table entry as Moor Fiend's swampwalk.
+ */
+val PaleBears = card("Pale Bears") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Bear"
+    power = 2
+    toughness = 2
+    oracleText = "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)"
+
+    keywords(Keyword.ISLANDWALK)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "256"
+        artist = "Anthony S. Waters"
+        flavorText = "\"Daughter, on the day you have killed your Pale Bear, then will I give you your true name.\"\n—Lovisa Coldeyes, Balduvian Chieftain"
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f19c2a3-6403-4a78-bf45-6e339578d673.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/PitTrap.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/PitTrap.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Pit Trap
+ * {2}
+ * Artifact
+ *
+ * {2}, {T}, Sacrifice this artifact: Destroy target attacking creature without flying. It can't be regenerated.
+ *
+ * [Effects.Destroy] with `noRegenerate = true` is the facade that composes the can't-be-regenerated
+ * marker ahead of the destroy, so the rider is never hand-rolled; the target filter is the same
+ * "attacking creature without flying" shape Quicksand uses.
+ */
+val PitTrap = card("Pit Trap") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{2}, {T}, Sacrifice this artifact: Destroy target attacking creature without flying. It can't be regenerated."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.SacrificeSelf)
+        val t = target(
+            "target",
+            TargetCreature(filter = TargetFilter.Creature.withoutKeyword(Keyword.FLYING).attacking())
+        )
+        effect = Effects.Destroy(t, noRegenerate = true)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "333"
+        artist = "Anson Maddocks"
+        flavorText = "\"These traps are truly a symbol of great cruelty and sinister cunning.\"\n—Sorine Relicbane, Soldevi Heretic"
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c588fe7f-945d-4459-904c-67442f88b4e1.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/PygmyAllosaurus.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/PygmyAllosaurus.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pygmy Allosaurus
+ * {2}{G}
+ * Creature — Dinosaur
+ * 2/2
+ *
+ * Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)
+ *
+ * Swampwalk alone.
+ */
+val PygmyAllosaurus = card("Pygmy Allosaurus") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    power = 2
+    toughness = 2
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)"
+
+    keywords(Keyword.SWAMPWALK)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "257"
+        artist = "Anson Maddocks"
+        flavorText = "\"I don't understand the appeal of keeping these things as pets, unless you want your children eaten.\"\n—General Jarkeld, the Arctic Fox"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88a68767-9822-4f15-895e-32164e2159be.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Rally.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Rally.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rally
+ * {W}{W}
+ * Instant
+ *
+ * Blocking creatures get +1/+1 until end of turn.
+ *
+ * The untargeted group pump — Trumpet Blast's shape with `blocking()` in place of `attacking()`, so
+ * the set of creatures is decided by combat state at resolution rather than by a target chosen on
+ * announcement.
+ */
+val Rally = card("Rally") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Blocking creatures get +1/+1 until end of turn."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.blocking()),
+            Effects.ModifyStats(1, 1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Heather Hudson"
+        flavorText = "\"Stand your ground, troops! This shall be our finest hour!\"\n—General Jarkeld, the Arctic Fox, last words"
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e1e9f80e-5d75-45b7-9c66-c0f30996f4dc.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SeaSpirit.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SeaSpirit.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sea Spirit
+ * {4}{U}
+ * Creature — Elemental Spirit
+ * 2/3
+ *
+ * {U}: This creature gets +1/+0 until end of turn.
+ *
+ * Firebreathing in blue — the same shape as its red sibling Flame Spirit: a mana-only activated
+ * ability whose effect is `Effects.ModifyStats` onto `EffectTarget.Self`, taking the facade's
+ * default `Duration.EndOfTurn`.
+ */
+val SeaSpirit = card("Sea Spirit") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental Spirit"
+    power = 2
+    toughness = 3
+    oracleText = "{U}: This creature gets +1/+0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{U}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "95"
+        artist = "Rob Alexander"
+        flavorText = "\"It rose above our heads, above the ship, and still higher yet. No foggy, ice-laden sea in the world could frighten me more.\"\n—General Jarkeld, the Arctic Fox"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f2d93d05-98bc-4504-9045-dedb925895ae.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ShamblingStrider.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ShamblingStrider.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shambling Strider
+ * {4}{G}{G}
+ * Creature — Yeti
+ * 5/5
+ *
+ * {R}{G}: This creature gets +1/-1 until end of turn.
+ *
+ * Firebreathing that trades toughness for power — one `Effects.ModifyStats` onto
+ * `EffectTarget.Self` carries both halves, so the negative toughness modifier needs no separate
+ * effect. The off-colour {R} in the activation cost is why the colour identity is GR.
+ */
+val ShamblingStrider = card("Shambling Strider") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Yeti"
+    power = 5
+    toughness = 5
+    oracleText = "{R}{G}: This creature gets +1/-1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{R}{G}")
+        effect = Effects.ModifyStats(1, -1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "263"
+        artist = "Douglas Shuler"
+        flavorText = "Freyalise forbid that any stranger should wander into the Striders' territory."
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/8886ba2d-b25a-4b74-9299-911c509ae864.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ShieldBearer.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ShieldBearer.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shield Bearer
+ * {1}{W}
+ * Creature — Human Soldier
+ * 0/3
+ *
+ * Banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)
+ *
+ * Banding alone.
+ */
+val ShieldBearer = card("Shield Bearer") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 0
+    toughness = 3
+    oracleText = "Banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)"
+
+    keywords(Keyword.BANDING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Dan Frazier"
+        flavorText = "\"You have almost completed your four years, my son. Soon you shall be a Skyknight.\"\n—Arna Kennerüd, Skyknight"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/318ff2da-d309-469c-8e2f-fa3c7517a15a.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ShieldOfTheAges.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ShieldOfTheAges.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shield of the Ages
+ * {2}
+ * Artifact
+ *
+ * {2}: Prevent the next 1 damage that would be dealt to you this turn.
+ *
+ * [Effects.PreventNextDamage] onto the ability's controller is the whole card — the unified
+ * prevention shield already defaults to the end-of-turn duration and to any damage source.
+ */
+val ShieldOfTheAges = card("Shield of the Ages") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{2}: Prevent the next 1 damage that would be dealt to you this turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        effect = Effects.PreventNextDamage(1, EffectTarget.Controller)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "335"
+        artist = "Anson Maddocks"
+        flavorText = "\"This shield is a true rarity: an artifact whose purpose is obvious.\"\n—Arcum Dagsson, Soldevi Machinist"
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/7411ab40-47f6-44d1-8e33-9ff5301dcd9b.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SilverErne.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SilverErne.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silver Erne
+ * {3}{U}
+ * Creature — Bird
+ * 2/2
+ *
+ * Flying, trample
+ *
+ * Flying plus trample. Trample on a 1/3 flier is a printed oddity, not a transcription slip —
+ * it is what the card says.
+ */
+val SilverErne = card("Silver Erne") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    power = 2
+    toughness = 2
+    oracleText = "Flying, trample"
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "98"
+        artist = "Melissa A. Benson"
+        flavorText = "\"I've seen a larger Erne knock a Giant to the ground and stay airborne. They move not with the wind, but as the wind.\"\n—Arna Kennerüd, Skyknight"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/685076cc-098c-4f98-918c-0ad825eda10f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SkullCatapult.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SkullCatapult.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Skull Catapult
+ * {4}
+ * Artifact
+ *
+ * {1}, {T}, Sacrifice a creature: This artifact deals 2 damage to any target.
+ *
+ * The sacrifice is a cost atom rather than an effect, so the whole card is one composite cost plus
+ * a plain [Effects.DealDamage] — the damage source defaults to the artifact itself, so it is not
+ * restated.
+ */
+val SkullCatapult = card("Skull Catapult") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{1}, {T}, Sacrifice a creature: This artifact deals 2 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.Tap,
+            Costs.Sacrifice(GameObjectFilter.Creature)
+        )
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "336"
+        artist = "Bryon Wackwitz"
+        flavorText = "\"Let any who doubt the evil of using the ancient devices look at this infernal machine. What manner of fiend would design such a sadistic device?\"\n—Sorine Relicbane, Soldevi Heretic"
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/eb92a3e6-dc30-4a08-baba-e125290cadc5.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SnowCoveredForest.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SnowCoveredForest.kt
@@ -8,9 +8,9 @@ import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.TimingRule
 
 /**
- * Snow-Covered Island
- * Basic Snow Land — Island
- * ({T}: Add {U}.)
+ * Snow-Covered Forest
+ * Basic Snow Land — Forest
+ * ({T}: Add {G}.)
  *
  * Written with the plain [card] DSL rather than the `basicLand` helper: that helper hardcodes the
  * "Basic Land — <type>" type line and cannot carry the Snow supertype. The intrinsic mana ability is
@@ -21,24 +21,24 @@ import com.wingedsheep.sdk.scripting.TimingRule
  * `BoosterGenerator.getBasicLands` would offer this as a freely-addable basic during limited deck
  * building — which the card's own ruling forbids.
  */
-val SnowCoveredIsland = card("Snow-Covered Island") {
+val SnowCoveredForest = card("Snow-Covered Forest") {
     manaCost = ""
-    colorIdentity = "U"
-    typeLine = "Basic Snow Land — Island"
-    oracleText = "({T}: Add {U}.)"
+    colorIdentity = "G"
+    typeLine = "Basic Snow Land — Forest"
+    oracleText = "({T}: Add {G}.)"
 
     activatedAbility {
         cost = Costs.Tap
-        effect = Effects.AddMana(Color.BLUE)
+        effect = Effects.AddMana(Color.GREEN)
         manaAbility = true
         timing = TimingRule.ManaAbility
     }
 
     metadata {
         rarity = Rarity.COMMON
-        collectorNumber = "371"
-        artist = "Anson Maddocks"
-        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad8b77cf-b53e-4da3-9c27-3851b7b25a98.jpg?1783947448"
+        collectorNumber = "383"
+        artist = "Pat Lewis"
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c0ad95c-d62c-4138-ada0-fa39a63a449e.jpg?1783947443"
         inBooster = false
         ruling("2021-02-05", "Snow is a supertype, not a card type. It has no rules meaning or function by itself, but spells and abilities may refer to it.")
         ruling("2021-02-05", "The {S} symbol is a generic mana symbol. It represents a cost that can be paid by one mana that was produced by a snow source. That mana can be any color or colorless.")

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SnowCoveredMountain.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SnowCoveredMountain.kt
@@ -8,9 +8,9 @@ import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.TimingRule
 
 /**
- * Snow-Covered Island
- * Basic Snow Land — Island
- * ({T}: Add {U}.)
+ * Snow-Covered Mountain
+ * Basic Snow Land — Mountain
+ * ({T}: Add {R}.)
  *
  * Written with the plain [card] DSL rather than the `basicLand` helper: that helper hardcodes the
  * "Basic Land — <type>" type line and cannot carry the Snow supertype. The intrinsic mana ability is
@@ -21,24 +21,24 @@ import com.wingedsheep.sdk.scripting.TimingRule
  * `BoosterGenerator.getBasicLands` would offer this as a freely-addable basic during limited deck
  * building — which the card's own ruling forbids.
  */
-val SnowCoveredIsland = card("Snow-Covered Island") {
+val SnowCoveredMountain = card("Snow-Covered Mountain") {
     manaCost = ""
-    colorIdentity = "U"
-    typeLine = "Basic Snow Land — Island"
-    oracleText = "({T}: Add {U}.)"
+    colorIdentity = "R"
+    typeLine = "Basic Snow Land — Mountain"
+    oracleText = "({T}: Add {R}.)"
 
     activatedAbility {
         cost = Costs.Tap
-        effect = Effects.AddMana(Color.BLUE)
+        effect = Effects.AddMana(Color.RED)
         manaAbility = true
         timing = TimingRule.ManaAbility
     }
 
     metadata {
         rarity = Rarity.COMMON
-        collectorNumber = "371"
-        artist = "Anson Maddocks"
-        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad8b77cf-b53e-4da3-9c27-3851b7b25a98.jpg?1783947448"
+        collectorNumber = "379"
+        artist = "Tom Wänerstrand"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/ccd3afb3-5574-4f2d-adbe-969a428f1c63.jpg?1783947446"
         inBooster = false
         ruling("2021-02-05", "Snow is a supertype, not a card type. It has no rules meaning or function by itself, but spells and abilities may refer to it.")
         ruling("2021-02-05", "The {S} symbol is a generic mana symbol. It represents a cost that can be paid by one mana that was produced by a snow source. That mana can be any color or colorless.")

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SnowCoveredPlains.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SnowCoveredPlains.kt
@@ -8,9 +8,9 @@ import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.TimingRule
 
 /**
- * Snow-Covered Island
- * Basic Snow Land — Island
- * ({T}: Add {U}.)
+ * Snow-Covered Plains
+ * Basic Snow Land — Plains
+ * ({T}: Add {W}.)
  *
  * Written with the plain [card] DSL rather than the `basicLand` helper: that helper hardcodes the
  * "Basic Land — <type>" type line and cannot carry the Snow supertype. The intrinsic mana ability is
@@ -21,24 +21,24 @@ import com.wingedsheep.sdk.scripting.TimingRule
  * `BoosterGenerator.getBasicLands` would offer this as a freely-addable basic during limited deck
  * building — which the card's own ruling forbids.
  */
-val SnowCoveredIsland = card("Snow-Covered Island") {
+val SnowCoveredPlains = card("Snow-Covered Plains") {
     manaCost = ""
-    colorIdentity = "U"
-    typeLine = "Basic Snow Land — Island"
-    oracleText = "({T}: Add {U}.)"
+    colorIdentity = "W"
+    typeLine = "Basic Snow Land — Plains"
+    oracleText = "({T}: Add {W}.)"
 
     activatedAbility {
         cost = Costs.Tap
-        effect = Effects.AddMana(Color.BLUE)
+        effect = Effects.AddMana(Color.WHITE)
         manaAbility = true
         timing = TimingRule.ManaAbility
     }
 
     metadata {
         rarity = Rarity.COMMON
-        collectorNumber = "371"
-        artist = "Anson Maddocks"
-        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad8b77cf-b53e-4da3-9c27-3851b7b25a98.jpg?1783947448"
+        collectorNumber = "367"
+        artist = "Christopher Rush"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb3ac778-fb45-4fd3-a9af-8a0791f833e8.jpg?1783947448"
         inBooster = false
         ruling("2021-02-05", "Snow is a supertype, not a card type. It has no rules meaning or function by itself, but spells and abilities may refer to it.")
         ruling("2021-02-05", "The {S} symbol is a generic mana symbol. It represents a cost that can be paid by one mana that was produced by a snow source. That mana can be any color or colorless.")

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SnowCoveredSwamp.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SnowCoveredSwamp.kt
@@ -8,9 +8,9 @@ import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.TimingRule
 
 /**
- * Snow-Covered Island
- * Basic Snow Land — Island
- * ({T}: Add {U}.)
+ * Snow-Covered Swamp
+ * Basic Snow Land — Swamp
+ * ({T}: Add {B}.)
  *
  * Written with the plain [card] DSL rather than the `basicLand` helper: that helper hardcodes the
  * "Basic Land — <type>" type line and cannot carry the Snow supertype. The intrinsic mana ability is
@@ -21,24 +21,24 @@ import com.wingedsheep.sdk.scripting.TimingRule
  * `BoosterGenerator.getBasicLands` would offer this as a freely-addable basic during limited deck
  * building — which the card's own ruling forbids.
  */
-val SnowCoveredIsland = card("Snow-Covered Island") {
+val SnowCoveredSwamp = card("Snow-Covered Swamp") {
     manaCost = ""
-    colorIdentity = "U"
-    typeLine = "Basic Snow Land — Island"
-    oracleText = "({T}: Add {U}.)"
+    colorIdentity = "B"
+    typeLine = "Basic Snow Land — Swamp"
+    oracleText = "({T}: Add {B}.)"
 
     activatedAbility {
         cost = Costs.Tap
-        effect = Effects.AddMana(Color.BLUE)
+        effect = Effects.AddMana(Color.BLACK)
         manaAbility = true
         timing = TimingRule.ManaAbility
     }
 
     metadata {
         rarity = Rarity.COMMON
-        collectorNumber = "371"
-        artist = "Anson Maddocks"
-        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad8b77cf-b53e-4da3-9c27-3851b7b25a98.jpg?1783947448"
+        collectorNumber = "372"
+        artist = "Douglas Shuler"
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/65a3c27f-6b15-49b6-ac89-36cfb79b3b54.jpg?1783947447"
         inBooster = false
         ruling("2021-02-05", "Snow is a supertype, not a card type. It has no rules meaning or function by itself, but spells and abilities may refer to it.")
         ruling("2021-02-05", "The {S} symbol is a generic mana symbol. It represents a cost that can be paid by one mana that was produced by a snow source. That mana can be any color or colorless.")

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SoldeviMachinist.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SoldeviMachinist.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Soldevi Machinist
+ * {1}{U}
+ * Creature — Human Wizard Artificer
+ * 1/1
+ *
+ * {T}: Add {C}{C}. Spend this mana only to activate abilities of artifacts.
+ *
+ * The spend restriction is the axis, not a second effect: [ManaRestriction.CardTypeSpellsOrAbilitiesOnly]
+ * with `allowSpells = false` is exactly "abilities of artifacts and nothing else" — the narrower half
+ * of the same value Cargo Ship uses with both halves allowed. The mana itself is one
+ * [Effects.AddColorlessMana] of 2, and `manaAbility = true` keeps it activatable mid-payment.
+ */
+val SoldeviMachinist = card("Soldevi Machinist") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard Artificer"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Add {C}{C}. Spend this mana only to activate abilities of artifacts."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(
+            2,
+            restriction = ManaRestriction.CardTypeSpellsOrAbilitiesOnly(
+                cardType = CardType.ARTIFACT,
+                allowSpells = false,
+                allowAbilities = true,
+            ),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add {C}{C}. Spend this mana only to activate abilities of artifacts."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "102"
+        artist = "Jeff A. Menges"
+        flavorText = "\"Perhaps this time the power of the artificers shall be used wisely.\"\n—Arcum Dagsson, Soldevi Machinist"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f0999df-2f94-499e-b9af-fe377d515400.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Stampede.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Stampede.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stampede
+ * {1}{G}{G}
+ * Instant
+ *
+ * Attacking creatures get +1/+0 and gain trample until end of turn.
+ *
+ * Overrun's shape over the attackers instead of the creatures you control: **one** iteration
+ * carrying a `Composite` of both effects, not two passes over the same group — the sentence names
+ * its group once and says two things about those creatures.
+ */
+val Stampede = card("Stampede") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Attacking creatures get +1/+0 and gain trample until end of turn."
+
+    spell {
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.attacking()),
+            Effects.Composite(
+                Effects.ModifyStats(1, 0, EffectTarget.Self),
+                Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "265"
+        artist = "Jeff A. Menges"
+        flavorText = "\"We could see the horizon blacken with the great beasts, but it was too late. The icefield offered no immediate safety, but luckily most of us reached a crevasse in which we could take cover.\"\n—Disa the Restless, journal entry"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc8265a1-4621-4d25-8f7f-f0179951a694.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/StoneSpirit.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/StoneSpirit.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Stone Spirit
+ * {4}{R}
+ * Creature — Elemental Spirit
+ * 4/3
+ *
+ * This creature can't be blocked by creatures with flying.
+ *
+ * `CantBeBlockedBy` is the "excluded blockers" static — its `blockerFilter` names the creatures that
+ * *can't* block, and its own `filter` defaults to `GroupFilter.source()`, which is this creature. So
+ * the whole card is one facade call over `Creature.withKeyword(FLYING)`.
+ */
+val StoneSpirit = card("Stone Spirit") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental Spirit"
+    power = 4
+    toughness = 3
+    oracleText = "This creature can't be blocked by creatures with flying."
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.withKeyword(Keyword.FLYING))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "218"
+        artist = "Jeff A. Menges"
+        flavorText = "\"The spirit of the stone is the spirit of strength.\"\n—Lovisa Coldeyes, Balduvian Chieftain"
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/789dfae7-fe23-4e2e-9f5f-304535d22a78.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/StormSpirit.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/StormSpirit.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Storm Spirit
+ * {3}{G}{W}{U}
+ * Creature — Elemental Spirit
+ * 3/3
+ *
+ * Flying
+ * {T}: This creature deals 2 damage to target creature.
+ *
+ * A pinger: `Costs.Tap` plus `Effects.DealDamage` at the ability's own bound target. The damage
+ * source is left unset so it defaults to the ability's source, this creature.
+ */
+val StormSpirit = card("Storm Spirit") {
+    manaCost = "{3}{G}{W}{U}"
+    colorIdentity = "GUW"
+    typeLine = "Creature — Elemental Spirit"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "{T}: This creature deals 2 damage to target creature."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", Targets.Creature)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "303"
+        artist = "Pete Venters"
+        flavorText = "\"Come to us, with your lightning. Come to us, with your thunder. Serve us with your strength, and smite our foes with your power.\"\n—Steinar Icefist, Balduvian Shaman"
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a383a5f-4814-4b92-aa80-2a6440a719bc.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Stormbind.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Stormbind.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stormbind
+ * {1}{R}{G}
+ * Enchantment
+ *
+ * {2}, Discard a card at random: This enchantment deals 2 damage to any target.
+ *
+ * The Kris Mage shape on an enchantment: a `Costs.Composite` of the mana and the discard atom, with
+ * `atRandom = true` so the engine picks the card and the cost takes no player selection.
+ */
+val Stormbind = card("Stormbind") {
+    manaCost = "{1}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Enchantment"
+    oracleText = "{2}, Discard a card at random: This enchantment deals 2 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Discard(atRandom = true))
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "304"
+        artist = "NéNé Thomas & Phillip Mosness"
+        flavorText = "\"Once, our people could call down the storm itself to do our bidding.\"\n—Lovisa Coldeyes, Balduvian Chieftain"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2d5d91b-aeb4-4d7e-b748-77f9960da55f.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Tarpan.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Tarpan.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tarpan
+ * {G}
+ * Creature — Horse
+ * 1/1
+ *
+ * When this creature dies, you gain 1 life.
+ *
+ * [Triggers.Dies] is the SELF-bound battlefield-to-graveyard `ZoneChangeEvent`, so the trigger
+ * needs no last-known-information reads of its own — the payoff is a plain [Effects.GainLife]
+ * onto the controller, which is that facade's default target.
+ */
+val Tarpan = card("Tarpan") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Horse"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature dies, you gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "267"
+        artist = "Margaret Organ-Kean"
+        flavorText = "\"A good Tarpan will serve you, faithful and true. A bad one will kick you in the head.\"\n—General Jarkeld, the Arctic Fox"
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b1420ec5-367c-4514-86c5-3993bf339e37.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ThunderWall.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ThunderWall.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Thunder Wall
+ * {1}{U}{U}
+ * Creature — Wall
+ * 0/2
+ *
+ * Defender (This creature can't attack.)
+ * Flying
+ * {U}: This creature gets +1/+1 until end of turn.
+ *
+ * Two engine-live keywords plus firebreathing: the pump is `Effects.ModifyStats` onto
+ * `EffectTarget.Self` at the facade's default `Duration.EndOfTurn`.
+ */
+val ThunderWall = card("Thunder Wall") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Wall"
+    power = 0
+    toughness = 2
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "Flying\n" +
+        "{U}: This creature gets +1/+1 until end of turn."
+
+    keywords(Keyword.DEFENDER, Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{U}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "104"
+        artist = "Richard Thomas"
+        flavorText = "\"The Lemures had barely taken wing when the sky roared with thunder. The swarm of little beasts wavered, divided, and fell, crashing to the earth.\"\n—General Jarkeld, the Arctic Fox"
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4fc5d510-c4f7-4a09-bf86-83c3fa3f8928.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Trailblazer.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Trailblazer.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trailblazer
+ * {2}{G}{G}
+ * Instant
+ *
+ * Target creature can't be blocked this turn.
+ *
+ * "Can't be blocked" is an [AbilityFlag], not a CR 702 keyword — it names a whole sentence rather
+ * than a noun a creature can be said to gain — so this is the ordinary until-end-of-turn keyword
+ * grant over the flag, the same effect "gains flying until end of turn" builds.
+ */
+val Trailblazer = card("Trailblazer") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature can't be blocked this turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "272"
+        artist = "Julie Baroh"
+        flavorText = "\"Our Elvish Hunter Taaveti led us swiftly along hidden paths through the dense forest. We caught the Orcs from behind, and completely by surprise.\"\n—Lucilde Fiksdotter, Leader of the Order of the White Shield"
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/9194c69d-c849-4c4a-976c-d1382bd5cf32.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/WallOfLava.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/WallOfLava.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wall of Lava
+ * {1}{R}{R}
+ * Creature — Wall
+ * 1/3
+ *
+ * Defender (This creature can't attack.)
+ * {R}: This creature gets +1/+1 until end of turn.
+ *
+ * Defender plus firebreathing: the pump is `Effects.ModifyStats` onto `EffectTarget.Self` at the
+ * facade's default `Duration.EndOfTurn`.
+ */
+val WallOfLava = card("Wall of Lava") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Wall"
+    power = 1
+    toughness = 3
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "{R}: This creature gets +1/+1 until end of turn."
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "223"
+        artist = "Pete Venters"
+        flavorText = "\"Now *there's* something you don't see every day.\"\n—Jaya Ballard, Task Mage"
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b99d6d11-b3f7-4d73-967c-3049af82a9d8.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/WallOfPineNeedles.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/WallOfPineNeedles.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wall of Pine Needles
+ * {3}{G}
+ * Creature — Plant Wall
+ * 3/3
+ *
+ * Defender (This creature can't attack.)
+ * {G}: Regenerate this creature.
+ *
+ * Nothing bespoke: defender is engine-live via `keywords(...)`, and the regeneration is the shared
+ * [RegenerateEffect] on [EffectTarget.Self] behind a plain mana cost.
+ */
+val WallOfPineNeedles = card("Wall of Pine Needles") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Wall"
+    power = 3
+    toughness = 3
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "{G}: Regenerate this creature."
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "274"
+        artist = "Brian Snõddy"
+        flavorText = "The power of the forest takes a hundred forms. Some are more surprising than others."
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d879923-55fc-46ab-9306-5e1f10441c89.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/WallOfShields.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/WallOfShields.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wall of Shields
+ * {3}
+ * Artifact Creature — Wall
+ * 0/4
+ *
+ * Defender (This creature can't attack.)
+ * Banding (If any creatures with banding you control are blocking a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by.)
+ *
+ * An artifact creature Wall with defender and banding; both are engine-live keywords, so the
+ * card is its two keyword lines and nothing more.
+ */
+val WallOfShields = card("Wall of Shields") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Wall"
+    power = 0
+    toughness = 4
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "Banding (If any creatures with banding you control are blocking a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by.)"
+
+    keywords(Keyword.DEFENDER, Keyword.BANDING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "347"
+        artist = "Randy Gallegos"
+        flavorText = "\"It's the pokey bits that hurt the most.\"\n—Ib Halfheart, Goblin Tactician"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/6376c7c4-aaca-4625-83d4-a49f01aec535.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/WarChariot.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/WarChariot.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * War Chariot
+ * {3}
+ * Artifact
+ *
+ * {3}, {T}: Target creature gains trample until end of turn.
+ *
+ * Same shape as Fyndhorn Bow — mana + tap, then [Effects.GrantKeyword] at its default
+ * end-of-turn duration; only the keyword differs.
+ */
+val WarChariot = card("War Chariot") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{3}, {T}: Target creature gains trample until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.TRAMPLE, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "348"
+        artist = "Dameon Willich"
+        flavorText = "\"I wouldn't advise using it with a Woolly Mammoth, but it's quite appropriate for many other beasts.\"\n—Arcum Dagsson, Soldevi Machinist"
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d0ea0c6c-aa76-4b16-bc99-2ff46dc56d4e.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Warning.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/Warning.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PreventionScope
+
+/**
+ * Warning
+ * {W}
+ * Instant
+ *
+ * Prevent all combat damage that would be dealt by target attacking creature this turn.
+ *
+ * The shield is directional — it stops damage the target *deals*, not damage dealt to it — so it is
+ * `PreventAllDamageDealtBy` narrowed to combat damage, which is Safeguard's line word for word. The
+ * "attacking" restriction rides the target requirement, not the shield.
+ */
+val Warning = card("Warning") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Prevent all combat damage that would be dealt by target attacking creature this turn."
+
+    spell {
+        val t = target("target", Targets.AttackingCreature)
+        effect = Effects.PreventAllDamageDealtBy(t, scope = PreventionScope.CombatOnly)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "55"
+        artist = "Pat Lewis"
+        flavorText = "\"The folk of the Karplusan Mountains are impossible to ambush.\"\n—Lovisa Coldeyes, Balduvian Chieftain"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cca5b4a7-df11-4635-a147-df12cd13a67c.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/WhaleboneGlider.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/WhaleboneGlider.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Whalebone Glider
+ * {2}
+ * Artifact
+ *
+ * {2}, {T}: Target creature with power 3 or less gains flying until end of turn.
+ *
+ * The keyword-granting artifact shape with a narrowed target: [Targets.CreatureWithPowerAtMost]
+ * adds the power predicate on top of the creature filter, so only the target requirement differs
+ * from Fyndhorn Bow.
+ */
+val WhaleboneGlider = card("Whalebone Glider") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{2}, {T}: Target creature with power 3 or less gains flying until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        val t = target("target", Targets.CreatureWithPowerAtMost(3))
+        effect = Effects.GrantKeyword(Keyword.FLYING, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "349"
+        artist = "Amy Weber"
+        flavorText = "\"It's no Ornithopter, but then I'm no Urza.\"\n—Arcum Dagsson, Soldevi Machinist"
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b75adf0-9501-4776-a213-456c2b821070.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/WindSpirit.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/WindSpirit.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wind Spirit
+ * {4}{U}
+ * Creature — Elemental Spirit
+ * 3/2
+ *
+ * Flying
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ *
+ * Flying plus menace. Menace is the modern Oracle wording of the printed "can't be blocked
+ * except by two or more creatures"; `BlockPhaseManager` enforces it directly.
+ */
+val WindSpirit = card("Wind Spirit") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental Spirit"
+    power = 3
+    toughness = 2
+    oracleText = "Flying\n" +
+        "Menace (This creature can't be blocked except by two or more creatures.)"
+
+    keywords(Keyword.FLYING, Keyword.MENACE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "106"
+        artist = "Kaja Foglio"
+        flavorText = "\"To visit the sky requires bravery, and thought, and little else. To master the sky requires the binding of *its* masters, and little else.\"\n—Arnjlot Olasson, Sky Mage"
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4d882447-9594-4aab-b1a7-8bb275f250cf.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/WingsOfAesthir.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/WingsOfAesthir.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Wings of Aesthir
+ * {W}{U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets +1/+0 and has flying and first strike.
+ *
+ * The Serra's Embrace shape: one `ModifyStats` plus one `GrantKeyword` per printed keyword, each
+ * left on its default `attachedCreature()` filter so they all read "enchanted creature". Two
+ * separate grants rather than a combined one because the SDK models a keyword grant per keyword.
+ */
+val WingsOfAesthir = card("Wings of Aesthir") {
+    manaCost = "{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +1/+0 and has flying and first strike."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(1, 0)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FIRST_STRIKE)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "305"
+        artist = "Edward P. Beard, Jr."
+        flavorText = "\"For those of courage, even the sky holds no limit.\"\n—Arnjlot Olasson, Sky Mage"
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/eeb0282d-ccec-4556-8b70-b6f665077afe.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/YavimayaGnats.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/YavimayaGnats.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Yavimaya Gnats
+ * {2}{G}
+ * Creature — Insect
+ * 0/1
+ *
+ * Flying
+ * {G}: Regenerate this creature.
+ *
+ * A printed keyword plus the shared [RegenerateEffect] on [EffectTarget.Self] behind a plain mana
+ * cost — no new vocabulary.
+ */
+val YavimayaGnats = card("Yavimaya Gnats") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect"
+    power = 0
+    toughness = 1
+    oracleText = "Flying\n" +
+        "{G}: Regenerate this creature."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "280"
+        artist = "Dan Frazier"
+        flavorText = "\"It is our third day of travel on the Yavimaya River, and still these creatures plague us. Davin Lansson, our naturalist, has facetiously labeled them 'gnats,' and the name has stuck.\"\n—Disa the Restless, journal entry"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d8b7020-ca8f-4867-bc51-13d824daf154.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ZuranEnchanter.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ZuranEnchanter.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+
+/**
+ * Zuran Enchanter
+ * {1}{U}
+ * Creature — Human Wizard
+ * 1/1
+ *
+ * {2}{B}, {T}: Target player discards a card. Activate only during your turn.
+ *
+ * The discard is [Patterns.Hand]'s gather → select → move recipe with the *target player* as both
+ * the hand's owner and the chooser — restating those three steps by hand drops the `moveType` and
+ * the prompt. "Activate only during your turn" is an [ActivationRestriction], not a
+ * `TimingRule`: unlike Wall of Distortion's "only as a sorcery", this one still permits activation
+ * at instant speed during your own turn.
+ */
+val ZuranEnchanter = card("Zuran Enchanter") {
+    manaCost = "{1}{U}"
+    colorIdentity = "BU"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "{2}{B}, {T}: Target player discards a card. Activate only during your turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}"), Costs.Tap)
+        restrictions = listOf(ActivationRestriction.OnlyDuringYourTurn)
+        val t = target("target", Targets.Player)
+        effect = Patterns.Hand.discardCards(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "111"
+        artist = "Douglas Shuler"
+        flavorText = "\"We are Kjeldorans no more.\"\n—Zur the Enchanter"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/721edcef-f40a-4d43-9d80-26161dc425cb.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ZuranSpellcaster.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ZuranSpellcaster.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zuran Spellcaster
+ * {2}{U}
+ * Creature — Human Wizard
+ * 1/1
+ *
+ * {T}: This creature deals 1 damage to any target.
+ *
+ * The Prodigal Sorcerer shape: [Costs.Tap] plus [Effects.DealDamage] onto [Targets.Any].
+ * "This creature deals" is the ability's own source, which is the facade default — no
+ * `damageSource` rider.
+ */
+val ZuranSpellcaster = card("Zuran Spellcaster") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: This creature deals 1 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "112"
+        artist = "Edward P. Beard, Jr."
+        flavorText = "\"A mage must be precise as well as potent; cautious, as well as clever.\"\n—Zur the Enchanter"
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/152a72b1-a7b7-4e5c-8558-fab97465f549.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/DeathWard.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/DeathWard.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.lea.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+
+/**
+ * Death Ward
+ * {W}
+ * Instant
+ *
+ * Regenerate target creature.
+ *
+ * There is no `Effects.Regenerate` facade — [RegenerateEffect] is the shipped spelling (Reknit,
+ * Crypt Sliver) — and it is target-type-agnostic, so pointing it at `Targets.Creature` is the whole
+ * card. Ice Age reprints it; the canonical definition lives here, in its Alpha printing.
+ */
+val DeathWard = card("Death Ward") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Regenerate target creature."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = RegenerateEffect(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "17"
+        artist = "Mark Poole"
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fa5466cc-aa57-4a7f-8b21-d92b2fe02e13.jpg"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leb/cards/DeathWardReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leb/cards/DeathWardReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.leb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Death Ward reprint in LEB. Canonical CardDefinition lives in its earliest set.
+ */
+val DeathWardReprint = Printing(
+    oracleId = "0544b707-ec67-43e3-a25d-fd7005ab673d",
+    name = "Death Ward",
+    setCode = "LEB",
+    collectorNumber = "18",
+    scryfallId = "b119edd8-7801-475e-943a-6cbf10f2d303",
+    artist = "Mark Poole",
+    imageUri = "https://cards.scryfall.io/normal/front/b/1/b119edd8-7801-475e-943a-6cbf10f2d303.jpg",
+    releaseDate = "1993-10-04",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/usg/cards/PitTrapReprint.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/usg/cards/PitTrapReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.usg.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pit Trap reprint in USG. Canonical CardDefinition lives in its earliest set.
+ */
+val PitTrapReprint = Printing(
+    oracleId = "671c4677-fe0a-4bda-9674-f4dcd9069bfd",
+    name = "Pit Trap",
+    setCode = "USG",
+    collectorNumber = "307",
+    scryfallId = "4e2003c1-356b-4714-9a2a-4e12f782321e",
+    artist = "Brian Snõddy",
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4e2003c1-356b-4714-9a2a-4e12f782321e.jpg",
+    releaseDate = "1998-10-12",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/LhurgoyfReprint.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/LhurgoyfReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.`8ed`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lhurgoyf reprint in 8ED. Canonical CardDefinition lives in its earliest set.
+ */
+val LhurgoyfReprint = Printing(
+    oracleId = "0fe76004-b2f4-4b11-abce-75fd76f68b4d",
+    name = "Lhurgoyf",
+    setCode = "8ED",
+    collectorNumber = "259",
+    scryfallId = "a9d664dc-4477-46b3-9dd7-022c94090254",
+    artist = "Pete Venters",
+    imageUri = "https://cards.scryfall.io/normal/front/a/9/a9d664dc-4477-46b3-9dd7-022c94090254.jpg",
+    releaseDate = "2003-07-28",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/LhurgoyfReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/LhurgoyfReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lhurgoyf reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val LhurgoyfReprint = Printing(
+    oracleId = "0fe76004-b2f4-4b11-abce-75fd76f68b4d",
+    name = "Lhurgoyf",
+    setCode = "CMD",
+    collectorNumber = "165",
+    scryfallId = "0dccff7f-f4e4-4477-aa60-515110ade549",
+    artist = "Pete Venters",
+    imageUri = "https://cards.scryfall.io/normal/front/0/d/0dccff7f-f4e4-4477-aa60-515110ade549.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/ICE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ICE.json
@@ -1,3 +1,49 @@
+// Adarkar Sentinel
+{
+    "name": "Adarkar Sentinel",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Soldier",
+    "oracleText": "{1}: This creature gets +0/+1 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "306",
+        "rarity": "UNCOMMON",
+        "artist": "Melissa A. Benson",
+        "flavorText": "\"We encountered the Sentinels in the wastes, near no living thing. Their purpose was inscrutable.\"\n—Disa the Restless, journal entry",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff62754b-f4f0-4731-8dd7-327a820f60a8.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Adarkar Wastes
 {
     "name": "Adarkar Wastes",
@@ -85,6 +131,114 @@
     ]
 }
 
+// Altar of Bone
+{
+    "name": "Altar of Bone",
+    "manaCost": "{G}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a creature.\nSearch your library for a creature card, reveal it, put it into your hand, then shuffle.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": "creature"
+                    },
+                    "storeAs": "searchable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "searchable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "found"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "found",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                "ShuffleLibrary",
+                "EmitLibrarySearchedEvent"
+            ]
+        },
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "281",
+        "rarity": "RARE",
+        "artist": "Melissa A. Benson",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75d5b014-8675-4d91-a539-ac5c31d44b35.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Anarchy
+{
+    "name": "Anarchy",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy all white permanents.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "permanent white"
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "rarity": "UNCOMMON",
+        "artist": "Phil Foglio",
+        "flavorText": "\"The Shaman waved the staff, and the land itself went mad.\"\n—Disa the Restless, journal entry",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/28d941da-b5cb-4b7e-84f2-ece883f89af3.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Balduvian Barbarians
 {
     "name": "Balduvian Barbarians",
@@ -123,6 +277,53 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Baton of Morale
+{
+    "name": "Baton of Morale",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}: Target creature gains banding until end of turn. (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding a player controls are blocking or being blocked by a creature, that player divides that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "BANDING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "313",
+        "rarity": "UNCOMMON",
+        "artist": "Douglas Shuler",
+        "flavorText": "\"The Goblins would kill to get ahold of this one.\"\n—Arcum Dagsson, Soldevi Machinist",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8bc29872-b1a2-4851-9eca-f3e67ae6e14c.jpg"
+    },
+    "colorIdentityOverride": []
 }
 
 // Brainstorm
@@ -187,6 +388,105 @@
         "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d42d7aa-7f53-4cfc-842a-086aab2448d1.jpg?1783947518"
     },
     "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Brine Shaman
+{
+    "name": "Brine Shaman",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Cleric Shaman",
+    "oracleText": "{T}, Sacrifice a creature: Target creature gets +2/+2 until end of turn.\n{1}{U}{U}, Sacrifice a creature: Counter target creature spell.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}{U}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": "Counter",
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature",
+                            "zone": "Stack"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "Cornelius Brudi",
+        "flavorText": "\"The Shamans of Marit Lage do her bidding in secret, but they do it gladly.\"\n—Halvor Arenson, Kjeldoran Priest",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f445962c-44a1-4f3f-88d4-17048f8ca9dc.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
         "BLUE"
     ]
 }
@@ -351,6 +651,88 @@
     ]
 }
 
+// Centaur Archer
+{
+    "name": "Centaur Archer",
+    "manaCost": "{1}{R}{G}",
+    "typeLine": "Creature — Centaur Archer",
+    "oracleText": "{T}: This creature deals 1 damage to target creature with flying.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature kw:flying"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "282",
+        "rarity": "UNCOMMON",
+        "artist": "Melissa A. Benson",
+        "flavorText": "\"Centaurs will kill our Aesthir if they can; they've always been enemies. Destroy the horse-people on sight.\"\n—Arna Kennerüd, Skyknight",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e275c295-72da-4a86-82c6-cfd75b38b19c.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Cooperation
+{
+    "name": "Cooperation",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature has banding. (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding a player controls are blocking or being blocked by a creature, that player divides that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "BANDING"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Phil Foglio",
+        "flavorText": "\"The Elves train our healers, and we keep the Orcs at bay. Most Elvish bargains aren't as fair.\"\n—General Jarkeld, the Arctic Fox",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/21a815ed-c8b4-4414-8b27-ea612e2977e2.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Dark Banishing
 {
     "name": "Dark Banishing",
@@ -405,6 +787,381 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Diabolic Vision
+{
+    "name": "Diabolic Vision",
+    "manaCost": "{U}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top five cards of your library. Put one of them into your hand and the rest on top of your library in any order.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 5
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "selectedLabel": "Put in hand",
+                    "remainderLabel": "Put on top"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Top"
+                    },
+                    "order": "ControllerChooses"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "284",
+        "rarity": "UNCOMMON",
+        "artist": "Anthony S. Waters",
+        "flavorText": "\"I have seen the true path. I will not warm myself by the fire—I will become the flame.\"\n—Lim-Dûl, the Necromancer",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1ea01324-1cfb-498c-8299-f690373864bd.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
+// Dire Wolves
+{
+    "name": "Dire Wolves",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "This creature has banding as long as you control a Plains. (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "BANDING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "land Plains"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "230",
+        "artist": "Ron Spencer",
+        "flavorText": "\"It's amazing how scared a city kid can get at a dog. Now, of course, I'd cross Terisiare alone, and keep no watch if I had a pack of greys hanging on my flanks as I went.\"\n—Oddveig Ulfsson, caravan scout",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a602c93d-e00f-4b4f-a7ff-95316b7e7641.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Fanatical Fever
+{
+    "name": "Fanatical Fever",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+0 and gains trample until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "234",
+        "rarity": "UNCOMMON",
+        "artist": "Julie Baroh",
+        "flavorText": "\"Let go your fury, and hone your anger. Become the fist of Freyalise!\"\n—Kolbjörn, Elder Druid of the Juniper Order",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2abba7f1-5d07-4137-88a2-5967396a3e42.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Flame Spirit
+{
+    "name": "Flame Spirit",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Elemental Spirit",
+    "oracleText": "{R}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "rarity": "UNCOMMON",
+        "artist": "Justin Hampton",
+        "flavorText": "\"The spirit of the flame is the spirit of change.\"\n—Lovisa Coldeyes, Balduvian Chieftain",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/add2b82a-9aa5-4d5c-a1c2-e313541f12c8.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Folk of the Pines
+{
+    "name": "Folk of the Pines",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Dryad",
+    "oracleText": "{1}{G}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "235",
+        "artist": "NéNé Thomas & Catherine Buck",
+        "flavorText": "\"Our friends of the forest take many forms, yet all serve the will of Freyalise.\"\n—Laina of the Elvish Council",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c13311d-db83-483f-ba2b-4f54ceb8b026.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Fyndhorn Bow
+{
+    "name": "Fyndhorn Bow",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{3}, {T}: Target creature gains first strike until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "318",
+        "rarity": "UNCOMMON",
+        "artist": "Rob Alexander",
+        "flavorText": "\"With a bow like this, the hunting is always good.\"\n—Taaveti of Kelsinko, Elvish Hunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/65dd0a41-cc51-4728-b597-fdb2510accd8.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Fyndhorn Brownie
+{
+    "name": "Fyndhorn Brownie",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Ouphe",
+    "oracleText": "{2}{G}, {T}: Untap target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "tap": false
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "242",
+        "artist": "Richard Thomas",
+        "flavorText": "\"I've been insulted by drunks in a hundred inns, but never as skillfully or annoyingly as by those blasted Brownies.\"\n—General Jarkeld, the Arctic Fox",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/06204e82-9dfd-4334-a23a-f8240fc37772.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -477,6 +1234,343 @@
         "artist": "Justin Hampton",
         "flavorText": "\"Living side by side with the Elves for so long leaves me with no doubt that we serve the same goddess.\"\n—Kolbjörn, Elder Druid of the Juniper Order",
         "imageUri": "https://cards.scryfall.io/normal/front/3/b/3ba95ffa-990a-4013-98b7-5d8c0b34e9c4.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Glacial Wall
+{
+    "name": "Glacial Wall",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 7
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "metadata": {
+        "collectorNumber": "71",
+        "rarity": "UNCOMMON",
+        "artist": "Dameon Willich",
+        "flavorText": "\"We are farther west than any could have imagined possible, but I still wish to press on. Unfortunately, huge walls of ice block further travel. We can't believe they are natural.\"\n—Disa the Restless, journal entry",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/07b71bc1-d9a2-4e99-a8fa-cd696925328d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Hematite Talisman
+{
+    "name": "Hematite Talisman",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever a player casts a red spell, you may pay {3}. If you do, untap target permanent.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "RED"
+                            }
+                        ]
+                    },
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{3}"
+                        }
+                    },
+                    "then": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "tap": false
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever a player casts a red spell, you may pay {3}. If you do, untap target permanent."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "320",
+        "rarity": "UNCOMMON",
+        "artist": "Allen Williams",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/83585337-56a9-44d2-9ed1-8a959bcfb010.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Hoar Shade
+{
+    "name": "Hoar Shade",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Shade",
+    "oracleText": "{B}: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "artist": "Richard Thomas",
+        "flavorText": "\"The creature we fought in the western waste was doubly dangerous: mortally wounded, it rebounded and attacked again.\"\n—Disa the Restless, journal entry",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72242dff-15ca-4da0-b3ae-9984d037b31f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Hyalopterous Lemure
+{
+    "name": "Hyalopterous Lemure",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "{0}: This creature gets -1/-0 and gains flying until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{0}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": -1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FLYING",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "rarity": "UNCOMMON",
+        "artist": "Richard Thomas",
+        "flavorText": "\"The Lemures looked harmless, until they descended on my troops. Within moments, only bones remained.\"\n—Lucilde Fiksdotter, Leader of the Order of the White Shield",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d2c9e037-f4d5-46fd-b439-56bee6fb2ad3.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Iceberg
+{
+    "name": "Iceberg",
+    "manaCost": "{X}{U}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "This enchantment enters with X ice counters on it.\n{3}: Put an ice counter on this enchantment.\nRemove an ice counter from this enchantment: Add {C}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "ice",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "{3}: Put an ice counter on this enchantment."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomRemoveCounters",
+                        "counterType": "ice",
+                        "self": true
+                    }
+                },
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "Remove an ice counter from this enchantment: Add {C}."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "ice"
+                },
+                "count": "XValue"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "rarity": "UNCOMMON",
+        "artist": "Jeff A. Menges",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2f70e49-17fa-4033-bd45-63374f7f5ec5.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Imposing Visage
+{
+    "name": "Imposing Visage",
+    "manaCost": "{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature has menace. (It can't be blocked except by two or more creatures.)",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "MENACE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "artist": "Phil Foglio",
+        "flavorText": "\"I can't believe they expect me to fight with this rabble. A Goblin in a big mask sends 'em running for cover.\"\n—Avram Garrisson, Leader of the Knights of Stromgald",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cca42b74-9b42-482b-b12a-79cafdcd087e.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Juniper Order Druid
+{
+    "name": "Juniper Order Druid",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Cleric Druid",
+    "oracleText": "{T}: Untap target land.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "tap": false
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "251",
+        "artist": "Jeff A. Menges",
+        "flavorText": "\"The filthy towns of Kjeldor are no place for anyone to live. Fyndhorn is our home now.\"\n—Kolbjörn, Elder Druid of the Juniper Order",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cb211704-ff8e-498b-b7bb-f8384f198ffd.jpg"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -570,6 +1664,575 @@
     ]
 }
 
+// Kelsinko Ranger
+{
+    "name": "Kelsinko Ranger",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Ranger",
+    "oracleText": "{1}{W}: Target green creature gains first strike until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature green"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "artist": "Mark Poole",
+        "flavorText": "\"Rangers not trained by the Elves just aren't the same.\"\n—Lucilde Fiksdotter, Leader of the Order of the White Shield",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/8402543e-5406-404f-95c4-800a1dce35f1.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Kjeldoran Dead
+{
+    "name": "Kjeldoran Dead",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Skeleton",
+    "oracleText": "When this creature enters, sacrifice a creature.\n{B}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Sacrifice",
+                    "filter": "creature"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "artist": "Melissa A. Benson",
+        "flavorText": "\"They shall kill those whom once they loved.\"\n—Lim-Dûl, the Necromancer",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d3f7b614-6075-4b7c-acc7-ab63185b570b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Kjeldoran Knight
+{
+    "name": "Kjeldoran Knight",
+    "manaCost": "{W}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)\n{1}{W}: This creature gets +1/+0 until end of turn.\n{W}{W}: This creature gets +0/+2 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "BANDING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "RARE",
+        "artist": "Ron Spencer",
+        "flavorText": "\"Those who do not ride the wind on Aesthir still command loyalty and respect.\"\n—Arna Kennerüd, Skyknight",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d5b9db8f-93b5-44e3-9e2b-728c80dfbb37.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Kjeldoran Phalanx
+{
+    "name": "Kjeldoran Phalanx",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "First strike; banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "BANDING"
+    ],
+    "metadata": {
+        "collectorNumber": "37",
+        "rarity": "RARE",
+        "artist": "Richard Kane Ferguson",
+        "flavorText": "\"There's nothing I like better than watching a street full of soldiers kicking down the doors of the guilty and the impure.\"\n—Avram Garrisson, Leader of the Knights of Stromgald",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6e91ba0-b229-4ab1-84f3-2a490dfa5051.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Kjeldoran Skycaptain
+{
+    "name": "Kjeldoran Skycaptain",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Flying; first strike; banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "FIRST_STRIKE",
+        "BANDING"
+    ],
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Poole",
+        "flavorText": "\"If we do our duty and uphold our honor, Kjeldor shall stand for a thousand years.\"\n—Arna Kennerüd, Skyknight",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/f/cf0115e0-6192-48a9-9e58-f3ef77ef77c2.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Kjeldoran Skyknight
+{
+    "name": "Kjeldoran Skyknight",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Flying; first strike; banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "FIRST_STRIKE",
+        "BANDING"
+    ],
+    "metadata": {
+        "collectorNumber": "40",
+        "artist": "Mark Poole",
+        "flavorText": "\"My Aesthir is my most trusted ally. We fight as one and live as one, and we will die as one.\"\n—Arna Kennerüd, Skyknight",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f794665a-8353-482a-b065-2a0777a8acda.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Kjeldoran Warrior
+{
+    "name": "Kjeldoran Warrior",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "BANDING"
+    ],
+    "metadata": {
+        "collectorNumber": "41",
+        "artist": "Mark Poole",
+        "flavorText": "\"Give me a thousand such Warriors and I could change the world.\"\n—Avram Garrisson, Leader of the Knights of Stromgald",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce76f38f-566e-49ff-b197-510cfa1cb51c.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Knight of Stromgald
+{
+    "name": "Knight of Stromgald",
+    "manaCost": "{B}{B}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Protection from white\n{B}: This creature gains first strike until end of turn.\n{B}{B}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "WHITE"
+            }
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Poole",
+        "flavorText": "\"Kjeldorans should rule supreme, and to the rest, death!\"\n—Avram Garrisson, Leader of the Knights of Stromgald",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2b87069b-ebaf-4705-b5da-446932af9b73.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Lapis Lazuli Talisman
+{
+    "name": "Lapis Lazuli Talisman",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever a player casts a blue spell, you may pay {3}. If you do, untap target permanent.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "BLUE"
+                            }
+                        ]
+                    },
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{3}"
+                        }
+                    },
+                    "then": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "tap": false
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever a player casts a blue spell, you may pay {3}. If you do, untap target permanent."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "327",
+        "rarity": "UNCOMMON",
+        "artist": "Amy Weber",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce00bb19-983e-427d-be54-ae6daf0ccdde.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Leshrac's Rite
+{
+    "name": "Leshrac's Rite",
+    "manaCost": "{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature has swampwalk. (It can't be blocked as long as defending player controls a Swamp.)",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "SWAMPWALK"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "rarity": "UNCOMMON",
+        "artist": "Richard Thomas",
+        "flavorText": "\"Bind me to thee, my soul to thine. I am your servant and your slave. I shall hunger for your word and thirst for your blessing. Blood for blood, flesh for flesh, Leshrac, my lord.\"\n—Lim-Dûl, the Necromancer",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4e0a6b4e-95b4-40f6-bb19-568dbd908a2b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Lhurgoyf
+{
+    "name": "Lhurgoyf",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Lhurgoyf",
+    "oracleText": "Lhurgoyf's power is equal to the number of creature cards in all graveyards and its toughness is equal to that number plus 1.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Count",
+                "player": "Each",
+                "zone": "Graveyard",
+                "filter": "creature"
+            }
+        },
+        "toughness": {
+            "type": "DynamicWithOffset",
+            "source": {
+                "type": "Count",
+                "player": "Each",
+                "zone": "Graveyard",
+                "filter": "creature"
+            },
+            "offset": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "252",
+        "rarity": "RARE",
+        "artist": "Pete Venters",
+        "flavorText": "\"Ach! Hans, run! It's the Lhurgoyf!\"\n—Saffi Eriksdotter, last words",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/e/fee6d385-d44b-4f1a-beb1-13aeebde063e.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Malachite Talisman
+{
+    "name": "Malachite Talisman",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever a player casts a green spell, you may pay {3}. If you do, untap target permanent.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "GREEN"
+                            }
+                        ]
+                    },
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{3}"
+                        }
+                    },
+                    "then": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "tap": false
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever a player casts a green spell, you may pay {3}. If you do, untap target permanent."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "328",
+        "rarity": "UNCOMMON",
+        "artist": "Christopher Rush",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/63fb8a24-ce53-4a69-be2a-55c6dbba5ee7.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Moor Fiend
+{
+    "name": "Moor Fiend",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Horror",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "153",
+        "artist": "Anson Maddocks",
+        "flavorText": "\"Let them close the gates of Krov from dusk until dawn if they so choose. It matters not. My fiends shall yet rend their flesh from their bones.\"\n—Lim-Dûl, the Necromancer",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/57089dd4-e30d-498d-9341-43c104c6f3f9.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Mountain Goat
 {
     "name": "Mountain Goat",
@@ -591,6 +2254,67 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Nacre Talisman
+{
+    "name": "Nacre Talisman",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever a player casts a white spell, you may pay {3}. If you do, untap target permanent.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "WHITE"
+                            }
+                        ]
+                    },
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{3}"
+                        }
+                    },
+                    "then": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "tap": false
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever a player casts a white spell, you may pay {3}. If you do, untap target permanent."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "329",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Tedin",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/06912236-8225-4eb0-8086-c6a163c69892.jpg"
+    },
+    "colorIdentityOverride": []
 }
 
 // Nature's Lore
@@ -648,6 +2372,323 @@
     ]
 }
 
+// Onyx Talisman
+{
+    "name": "Onyx Talisman",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever a player casts a black spell, you may pay {3}. If you do, untap target permanent.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasColor",
+                                "color": "BLACK"
+                            }
+                        ]
+                    },
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{3}"
+                        }
+                    },
+                    "then": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "tap": false
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Whenever a player casts a black spell, you may pay {3}. If you do, untap target permanent."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "331",
+        "rarity": "UNCOMMON",
+        "artist": "Sandra Everingham",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a89b2368-1180-4821-bcb8-8161c18e5538.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Orcish Lumberjack
+{
+    "name": "Orcish Lumberjack",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Orc",
+    "oracleText": "{T}, Sacrifice a Forest: Add three mana in any combination of {R} and/or {G}.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "land Forest"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddDynamicMana",
+                    "amountSource": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "allowedColors": [
+                        "RED",
+                        "GREEN"
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}, Sacrifice a Forest: Add three mana in any combination of {R} and/or {G}."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "artist": "Dan Frazier",
+        "flavorText": "\"How did I ever let myself get talked into this project?\"\n—Toothlicker Harj, Orcish Captain",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/21ef13e3-658c-43a3-a290-4c5dde8e8b55.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Order of the White Shield
+{
+    "name": "Order of the White Shield",
+    "manaCost": "{W}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Protection from black\n{W}: This creature gains first strike until end of turn.\n{W}{W}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "BLACK"
+            }
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{W}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "UNCOMMON",
+        "artist": "Ruth Thompson",
+        "flavorText": "\"Shall we turn away a worthy soul because his parents were peasants? I think not.\"\n—Lucilde Fiksdotter, Leader of the Order of the White Shield",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/2/92e55b10-375f-4b4f-b676-3b9b8085fdd2.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Pale Bears
+{
+    "name": "Pale Bears",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Bear",
+    "oracleText": "Islandwalk (This creature can't be blocked as long as defending player controls an Island.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "ISLANDWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "256",
+        "rarity": "RARE",
+        "artist": "Anthony S. Waters",
+        "flavorText": "\"Daughter, on the day you have killed your Pale Bear, then will I give you your true name.\"\n—Lovisa Coldeyes, Balduvian Chieftain",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f19c2a3-6403-4a78-bf45-6e339578d673.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Pit Trap
+{
+    "name": "Pit Trap",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}, {T}, Sacrifice this artifact: Destroy target attacking creature without flying. It can't be regenerated.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CantBeRegenerated",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            },
+                            "destination": "Graveyard",
+                            "byDestruction": true
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotKeyword",
+                                        "keyword": "FLYING"
+                                    }
+                                ],
+                                "statePredicates": [
+                                    "IsAttacking"
+                                ]
+                            }
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "333",
+        "rarity": "UNCOMMON",
+        "artist": "Anson Maddocks",
+        "flavorText": "\"These traps are truly a symbol of great cruelty and sinister cunning.\"\n—Sorine Relicbane, Soldevi Heretic",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c588fe7f-945d-4459-904c-67442f88b4e1.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Pygmy Allosaurus
+{
+    "name": "Pygmy Allosaurus",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "metadata": {
+        "collectorNumber": "257",
+        "rarity": "RARE",
+        "artist": "Anson Maddocks",
+        "flavorText": "\"I don't understand the appeal of keeping these things as pets, unless you want your children eaten.\"\n—General Jarkeld, the Arctic Fox",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88a68767-9822-4f15-895e-32164e2159be.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Pyroclasm
 {
     "name": "Pyroclasm",
@@ -681,6 +2722,46 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Rally
+{
+    "name": "Rally",
+    "manaCost": "{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Blocking creatures get +1/+1 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature blocking"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "artist": "Heather Hudson",
+        "flavorText": "\"Stand your ground, troops! This shall be our finest hour!\"\n—General Jarkeld, the Arctic Fox, last words",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e1e9f80e-5d75-45b7-9c66-c0f30996f4dc.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -725,6 +2806,501 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Sea Spirit
+{
+    "name": "Sea Spirit",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Elemental Spirit",
+    "oracleText": "{U}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "rarity": "UNCOMMON",
+        "artist": "Rob Alexander",
+        "flavorText": "\"It rose above our heads, above the ship, and still higher yet. No foggy, ice-laden sea in the world could frighten me more.\"\n—General Jarkeld, the Arctic Fox",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2d93d05-98bc-4504-9045-dedb925895ae.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Shambling Strider
+{
+    "name": "Shambling Strider",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Yeti",
+    "oracleText": "{R}{G}: This creature gets +1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "263",
+        "artist": "Douglas Shuler",
+        "flavorText": "Freyalise forbid that any stranger should wander into the Striders' territory.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/8886ba2d-b25a-4b74-9299-911c509ae864.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Shield Bearer
+{
+    "name": "Shield Bearer",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Banding (Any creatures with banding, and up to one without, can attack in a band. Bands are blocked as a group. If any creatures with banding you control are blocking or being blocked by a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by or is blocking.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "keywords": [
+        "BANDING"
+    ],
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Dan Frazier",
+        "flavorText": "\"You have almost completed your four years, my son. Soon you shall be a Skyknight.\"\n—Arna Kennerüd, Skyknight",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/318ff2da-d309-469c-8e2f-fa3c7517a15a.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Shield of the Ages
+{
+    "name": "Shield of the Ages",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}: Prevent the next 1 damage that would be dealt to you this turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "335",
+        "rarity": "UNCOMMON",
+        "artist": "Anson Maddocks",
+        "flavorText": "\"This shield is a true rarity: an artifact whose purpose is obvious.\"\n—Arcum Dagsson, Soldevi Machinist",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/7411ab40-47f6-44d1-8e33-9ff5301dcd9b.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Silver Erne
+{
+    "name": "Silver Erne",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying, trample",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "98",
+        "rarity": "UNCOMMON",
+        "artist": "Melissa A. Benson",
+        "flavorText": "\"I've seen a larger Erne knock a Giant to the ground and stay airborne. They move not with the wind, but as the wind.\"\n—Arna Kennerüd, Skyknight",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/685076cc-098c-4f98-918c-0ad825eda10f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Skull Catapult
+{
+    "name": "Skull Catapult",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}, {T}, Sacrifice a creature: This artifact deals 2 damage to any target.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "336",
+        "rarity": "UNCOMMON",
+        "artist": "Bryon Wackwitz",
+        "flavorText": "\"Let any who doubt the evil of using the ancient devices look at this infernal machine. What manner of fiend would design such a sadistic device?\"\n—Sorine Relicbane, Soldevi Heretic",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/b/eb92a3e6-dc30-4a08-baba-e125290cadc5.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Soldevi Machinist
+{
+    "name": "Soldevi Machinist",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Wizard Artificer",
+    "oracleText": "{T}: Add {C}{C}. Spend this mana only to activate abilities of artifacts.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "restriction": {
+                        "type": "CardTypeSpellsOrAbilitiesOnly",
+                        "cardType": "ARTIFACT",
+                        "allowSpells": false,
+                        "allowAbilities": true
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {C}{C}. Spend this mana only to activate abilities of artifacts."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "rarity": "UNCOMMON",
+        "artist": "Jeff A. Menges",
+        "flavorText": "\"Perhaps this time the power of the artificers shall be used wisely.\"\n—Arcum Dagsson, Soldevi Machinist",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f0999df-2f94-499e-b9af-fe377d515400.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Stampede
+{
+    "name": "Stampede",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Attacking creatures get +1/+0 and gain trample until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature attacking"
+                }
+            },
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    },
+                    {
+                        "type": "GrantKeyword",
+                        "keyword": "TRAMPLE",
+                        "target": "Self"
+                    }
+                ]
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "265",
+        "rarity": "RARE",
+        "artist": "Jeff A. Menges",
+        "flavorText": "\"We could see the horizon blacken with the great beasts, but it was too late. The icefield offered no immediate safety, but luckily most of us reached a crevasse in which we could take cover.\"\n—Disa the Restless, journal entry",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc8265a1-4621-4d25-8f7f-f0179951a694.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Stone Spirit
+{
+    "name": "Stone Spirit",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Elemental Spirit",
+    "oracleText": "This creature can't be blocked by creatures with flying.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasKeyword",
+                            "keyword": "FLYING"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "rarity": "UNCOMMON",
+        "artist": "Jeff A. Menges",
+        "flavorText": "\"The spirit of the stone is the spirit of strength.\"\n—Lovisa Coldeyes, Balduvian Chieftain",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/789dfae7-fe23-4e2e-9f5f-304535d22a78.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Storm Spirit
+{
+    "name": "Storm Spirit",
+    "manaCost": "{3}{G}{W}{U}",
+    "typeLine": "Creature — Elemental Spirit",
+    "oracleText": "Flying\n{T}: This creature deals 2 damage to target creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "303",
+        "rarity": "RARE",
+        "artist": "Pete Venters",
+        "flavorText": "\"Come to us, with your lightning. Come to us, with your thunder. Serve us with your strength, and smite our foes with your power.\"\n—Steinar Icefist, Balduvian Shaman",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7a383a5f-4814-4b92-aa80-2a6440a719bc.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Stormbind
+{
+    "name": "Stormbind",
+    "manaCost": "{1}{R}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "{2}, Discard a card at random: This enchantment deals 2 damage to any target.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomDiscard",
+                                "random": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "304",
+        "rarity": "RARE",
+        "artist": "NéNé Thomas & Phillip Mosness",
+        "flavorText": "\"Once, our people could call down the storm itself to do our bidding.\"\n—Lovisa Coldeyes, Balduvian Chieftain",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2d5d91b-aeb4-4d7e-b748-77f9960da55f.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
     ]
 }
 
@@ -815,6 +3391,98 @@
     ]
 }
 
+// Tarpan
+{
+    "name": "Tarpan",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Horse",
+    "oracleText": "When this creature dies, you gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "267",
+        "artist": "Margaret Organ-Kean",
+        "flavorText": "\"A good Tarpan will serve you, faithful and true. A bad one will kick you in the head.\"\n—General Jarkeld, the Arctic Fox",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b1420ec5-367c-4514-86c5-3993bf339e37.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Thunder Wall
+{
+    "name": "Thunder Wall",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)\nFlying\n{U}: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEFENDER",
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "104",
+        "rarity": "UNCOMMON",
+        "artist": "Richard Thomas",
+        "flavorText": "\"The Lemures had barely taken wing when the sky roared with thunder. The swarm of little beasts wavered, divided, and fell, crashing to the earth.\"\n—General Jarkeld, the Arctic Fox",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4fc5d510-c4f7-4a09-bf86-83c3fa3f8928.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Tor Giant
 {
     "name": "Tor Giant",
@@ -832,6 +3500,43 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Trailblazer
+{
+    "name": "Trailblazer",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature can't be blocked this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "GrantKeyword",
+            "keyword": "CANT_BE_BLOCKED",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "272",
+        "rarity": "RARE",
+        "artist": "Julie Baroh",
+        "flavorText": "\"Our Elvish Hunter Taaveti led us swiftly along hidden paths through the dense forest. We caught the Orcs from behind, and completely by surprise.\"\n—Lucilde Fiksdotter, Leader of the Order of the White Shield",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/9194c69d-c849-4c4a-976c-d1382bd5cf32.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -922,6 +3627,473 @@
     ]
 }
 
+// Wall of Lava
+{
+    "name": "Wall of Lava",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)\n{R}: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "223",
+        "rarity": "UNCOMMON",
+        "artist": "Pete Venters",
+        "flavorText": "\"Now *there's* something you don't see every day.\"\n—Jaya Ballard, Task Mage",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b99d6d11-b3f7-4d73-967c-3049af82a9d8.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Wall of Pine Needles
+{
+    "name": "Wall of Pine Needles",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Plant Wall",
+    "oracleText": "Defender (This creature can't attack.)\n{G}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "274",
+        "rarity": "UNCOMMON",
+        "artist": "Brian Snõddy",
+        "flavorText": "The power of the forest takes a hundred forms. Some are more surprising than others.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d879923-55fc-46ab-9306-5e1f10441c89.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Wall of Shields
+{
+    "name": "Wall of Shields",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)\nBanding (If any creatures with banding you control are blocking a creature, you divide that creature's combat damage, not its controller, among any of the creatures it's being blocked by.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER",
+        "BANDING"
+    ],
+    "metadata": {
+        "collectorNumber": "347",
+        "rarity": "UNCOMMON",
+        "artist": "Randy Gallegos",
+        "flavorText": "\"It's the pokey bits that hurt the most.\"\n—Ib Halfheart, Goblin Tactician",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/6376c7c4-aaca-4625-83d4-a49f01aec535.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// War Chariot
+{
+    "name": "War Chariot",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{3}, {T}: Target creature gains trample until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "348",
+        "rarity": "UNCOMMON",
+        "artist": "Dameon Willich",
+        "flavorText": "\"I wouldn't advise using it with a Woolly Mammoth, but it's quite appropriate for many other beasts.\"\n—Arcum Dagsson, Soldevi Machinist",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0ea0c6c-aa76-4b16-bc99-2ff46dc56d4e.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Warning
+{
+    "name": "Warning",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Prevent all combat damage that would be dealt by target attacking creature this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "PreventDamageShield",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "scope": "CombatOnly",
+            "direction": "FromTarget"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature attacking"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "artist": "Pat Lewis",
+        "flavorText": "\"The folk of the Karplusan Mountains are impossible to ambush.\"\n—Lovisa Coldeyes, Balduvian Chieftain",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cca5b4a7-df11-4635-a147-df12cd13a67c.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Whalebone Glider
+{
+    "name": "Whalebone Glider",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}, {T}: Target creature with power 3 or less gains flying until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow<=3"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "349",
+        "rarity": "UNCOMMON",
+        "artist": "Amy Weber",
+        "flavorText": "\"It's no Ornithopter, but then I'm no Urza.\"\n—Arcum Dagsson, Soldevi Machinist",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b75adf0-9501-4776-a213-456c2b821070.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Wind Spirit
+{
+    "name": "Wind Spirit",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Elemental Spirit",
+    "oracleText": "Flying\nMenace (This creature can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "MENACE"
+    ],
+    "metadata": {
+        "collectorNumber": "106",
+        "rarity": "UNCOMMON",
+        "artist": "Kaja Foglio",
+        "flavorText": "\"To visit the sky requires bravery, and thought, and little else. To master the sky requires the binding of *its* masters, and little else.\"\n—Arnjlot Olasson, Sky Mage",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4d882447-9594-4aab-b1a7-8bb275f250cf.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Wings of Aesthir
+{
+    "name": "Wings of Aesthir",
+    "manaCost": "{W}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +1/+0 and has flying and first strike.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "305",
+        "rarity": "UNCOMMON",
+        "artist": "Edward P. Beard, Jr.",
+        "flavorText": "\"For those of courage, even the sky holds no limit.\"\n—Arnjlot Olasson, Sky Mage",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/eeb0282d-ccec-4556-8b70-b6f665077afe.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Yavimaya Gnats
+{
+    "name": "Yavimaya Gnats",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Flying\n{G}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "280",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Frazier",
+        "flavorText": "\"It is our third day of travel on the Yavimaya River, and still these creatures plague us. Davin Lansson, our naturalist, has facetiously labeled them 'gnats,' and the name has stuck.\"\n—Disa the Restless, journal entry",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d8b7020-ca8f-4867-bc51-13d824daf154.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Zuran Enchanter
+{
+    "name": "Zuran Enchanter",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{2}{B}, {T}: Target player discards a card. Activate only during your turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 1 card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "artist": "Douglas Shuler",
+        "flavorText": "\"We are Kjeldorans no more.\"\n—Zur the Enchanter",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/721edcef-f40a-4d43-9d80-26161dc425cb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "BLUE"
+    ]
+}
+
 // Zuran Orb
 {
     "name": "Zuran Orb",
@@ -957,4 +4129,50 @@
         "imageUri": "https://cards.scryfall.io/normal/front/3/a/3a9d1082-a862-45d4-9e5e-392e879fead6.jpg?1783947454"
     },
     "colorIdentityOverride": []
+}
+
+// Zuran Spellcaster
+{
+    "name": "Zuran Spellcaster",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{T}: This creature deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "artist": "Edward P. Beard, Jr.",
+        "flavorText": "\"A mage must be precise as well as potent; cautious, as well as clever.\"\n—Zur the Enchanter",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/152a72b1-a7b7-4e5c-8558-fab97465f549.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/LEA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LEA.json
@@ -828,6 +828,40 @@
     ]
 }
 
+// Death Ward
+{
+    "name": "Death Ward",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Regenerate target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Regenerate",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "artist": "Mark Poole",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fa5466cc-aa57-4a7f-8b21-d92b2fe02e13.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Deathgrip
 {
     "name": "Deathgrip",


### PR DESCRIPTION
Sweeps Ice Age's Assay-ready backlog to **zero**. Every card was authored to `assay compile`'s JSON rather than to its oracle text, which is why the differential moved 67 comparisons with **no new divergences**.

## The four-way split

| Bucket | Count | Work |
|---|---|---|
| `original` | 67 | canonical `card(...)` authored in ICE |
| `elsewhere` | 1 | Death Ward — canonical authored in **LEA**, `Printing` row in ICE |
| `basic` | 9 | 5 basics × 3 art variants (`basicLand`) + 4 Snow-Covered basics (hand-written `card()`) |
| `unscaffolded` | 0 | — |

**Reprint tail** — the 4 rows the new canonicals made visible in *other* scaffolded sets, landed here rather than left for later: Lhurgoyf in `8ED` and `CMD`, Pit Trap in `USG`, Death Ward in `LEB`.

## Numbers

| | before | after |
|---|---|---|
| `just assay-ready ICE` | **77** | **0** |
| differential compared | 4498 | 4565 |
| differential confirmed | 4449 | 4516 |
| differential **divergent** | **49** | **49** |

Baseline was taken with the freshly-built binary in this checkout, so the A/B is clean. The 49 divergences are pre-existing and untouched by this branch; none of the 67 new comparisons diverged.

`just assay-bake` produced no ledger diff — the baked verdicts were already current, so nothing moved out of `whole`.

## Gates

- `just build` — green (`:mtg-sets:test` included).
- `just rebless-cards` — only `ICE.json` (+67) and `LEA.json` (+1) moved; a name-set diff confirms **nothing was removed**, the `-` lines in the raw diff are alphabetical reflow.
- `just assay-differential` — 4565 / 4516 / 49, above.
- `just check-card-printing` — run for all 68 authored canonicals, **68 ok / 0 drift**.
- `just assay-ready ICE` re-run **on this branch**: 0. Not inferred.

## Capability pre-flight

Every keyword the batch declares was checked against `rules-engine` before authoring, because a `Keyword.X` existing is not the engine reading it. `BANDING` (7 cards), `MENACE`, `SWAMPWALK`, `ISLANDWALK`, `DEFENDER`, `FIRST_STRIKE`, `FLYING`, `TRAMPLE` are all engine-live — banding via `CombatDamageManager` / `CombatDamageUtils`, the landwalks via `BlockEvasionRules`, menace via `BlockPhaseManager`. No display-only keyword shipped, and no new SDK vocabulary was needed for any of the 68 cards.

## Bug fixed on the way

**Snow-Covered Island was missing `inBooster = false`.** `CardDiscovery.findBasicLandsIn` splits on `typeLine.isBasicLand`, which a Basic *Snow* Land satisfies, so `BoosterGenerator.getBasicLands` — which filters on `metadata.inBooster` — was offering Snow-Covered Island as a freely-addable basic during limited deck building. The card's own ruling forbids exactly that ("you can't add basic snow lands to your card pool as you would other basic lands"). The flag is now set, and the four new snow basics carry it from the start.

## Findings the sweep surfaced but did not fix

- **`scripts/generate-reprints.py` is set-wide, not batch-scoped.** Running it for `CMD` emitted 7 rows, only 1 of which (Lhurgoyf) belongs to this sweep; the other 6 — Artisan of Kozilek, Baloth Woodcrasher, Furnace Whelp, Hour of Reckoning, Lightning Greaves, Vampire Nighthawk — are unrelated pre-existing gaps and were dropped to keep this PR scoped and avoid colliding with anyone working CMD. They are real missing rows and worth a separate pass.
- **Cruel Somnophage probably diverges from Assay on its CDA amount.** Authoring Lhurgoyf turned up that `DynamicAmounts.zone(...).count()` builds `DynamicAmount.AggregateZone`, while Assay's grammar emits `DynamicAmount.Count` for the same sentence. Lhurgoyf was authored with `DynamicAmount.Count` (matching Soulless One); Cruel Somnophage — the same "creature cards in all graveyards" reading — uses the `AggregateZone` spelling and was not touched here.
- **There is no `Effects.Regenerate` facade.** 85 corpus files reach past `Effects` to the raw `RegenerateEffect`, which is also what the Assay grammar emits. `FacadeBoundaryTest` has no rule covering it, so nothing is broken — but it is a genuine facade gap.
- **Scryfall rate-limited this machine hard** partway through (HTTP 429 on every request for several minutes, including single lookups). `scripts/missing-reprints.py`'s backoff handles it; ad-hoc fetches need the same retry loop.

## Remaining ICE tail

266 cards, all `LINE_DECLINED` (265) or `LINES_DO_NOT_FOLD` (1). That tail is grammar work in `:oracle-assay`, not authoring work — cumulative upkeep and the snow-mana vocabulary dominate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)