### PR TITLE
Add the Learn keyword action, and Academic Dispute

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3179,6 +3179,18 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
 - `rummage(count?)` — discard then draw.
 - `connive(target?)` — draw 1, discard 1, then put a +1/+1 counter on `target` (default Self) if the discard was a nonland (CR 701.50). Also exposed as `Effects.Connive(target)`. Returns the pipeline wrapped in `ConniveEffect(subject = target, body = …)`: the wrapper names the keyword action and its subject, which is what lets `ModifyKeywordAction` replace it and what makes it emit `PermanentConnivedEvent` (CR 701.50f). The pipeline itself is unchanged.
 - `conniveTargeting(requirement, storeAs?)` — connive whose +1/+1 counter lands on a *reflexively chosen* target: "draw a card, then discard a card. When you discard a nonland card this way, put a +1/+1 counter on target creature you control" (Teo, Spirited Glider). The recipient is selected at resolution via `SelectTargetEffect` *inside* the nonland gate — so the player never chooses up front or when the discard is a land. Pass the recipient's `TargetRequirement` (e.g. `Targets.CreatureYouControl`); do **not** also declare it as a cast-time `target(...)`. Exposed as `Effects.ConniveTargeting(requirement)`. Deliberately **not** wrapped in `ConniveEffect` — Teo's printed text spells the looting out and never says "connive", so it is not the keyword action: it fires no connive triggers and is not touched by "if a creature you control would connive" replacements.
+- `Patterns.Mechanic.learn()` — **Learn** (CR 701.48, Strixhaven), the keyword action printed as a
+  bare "Learn." with reminder text. CR 701.48a is sequential, not a choose-one: *"You may discard a
+  card. If you do, draw a card. If you didn't discard a card, you may reveal a Lesson card you own
+  from outside the game and put it into your hand."* — discarding **forecloses** the Lesson.
+  Composed as `GatherCards(FromZone(HAND, You))` → `SelectFromCollection(ChooseUpTo 1)` →
+  `MoveCollection(→ graveyard, MoveType.Discard)` →
+  `ConditionalOnCollection(ifNotEmpty = DrawCards(1), ifEmpty = Patterns.Sideboard.wish(Lesson))`.
+  Both printed "may"s are `ChooseUpTo(1)` declines rather than yes/no prompts, so an empty hand or a
+  Lesson-less sideboard raises no decision at all. The discard is a real discard
+  (`MoveType.Discard`), so madness and "whenever you discard a card" payoffs see it. Collection
+  names are `learn_`-prefixed so a nested Learn can't collide with its host pipeline's `hand` /
+  `discarded`. Academic Dispute.
 - `Patterns.Mechanic.recruit()` — **Recruit** (The Hobbit): "draw a card, then discard a card. If you
   discarded a nonland card, create a 1/1 white Human Soldier creature token." A keyword *action* with
   fixed reminder text, not a keyword ability, so there is no `Keyword.RECRUIT` — it is connive's pipeline

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1887,6 +1887,12 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `CreateEldraziSpawn(count?, controller?, imageUri?)` — 0/1 colorless Eldrazi Spawn creature tokens
   ("Sacrifice this creature: Add {C}."). `count` accepts an `Int` (default 1) or a `DynamicAmount`
   evaluated at resolution, such as `DynamicAmount.XValue` for Kozilek's Command.
+- `CreatePest(count?, controller?)` — 1/1 **black and green** Pest creature tokens with "When this
+  creature dies, you gain 1 life." (`PredefinedTokens.Pest`) — Strixhaven's Witherbloom token
+  (Hunt for Specimens, Pest Summoning, Sedgemoor Witch, …). Predefined rather than inline because
+  the token is *named* and carries its own triggered ability, which the inline `CreateToken` facade
+  cannot express; its two colors come from a color indicator (CR 204) via `colorIdentity` on the
+  token definition, since a token has no mana cost for `colors` to derive from.
 - `CreateBlood(count?, controller?)` — Blood tokens (artifact with "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a card."). `count` accepts an `Int` or a `DynamicAmount` (the latter evaluated at resolution, e.g. `CreateBlood(DynamicAmount.EntityProperty(EntityReference.Target(0), EntityNumericProperty.ExcessMarkedDamage))` for Lacerate Flesh's "create a number of Blood tokens equal to the amount of excess damage dealt").
 - `CreateClue(count?, controller?)` / `Investigate(count?, controller?)` — Clue tokens (artifact with
   "{2}, Sacrifice this token: Draw a card."). `Investigate` is the keyword-action spelling (CR 701.36) so

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -546,6 +546,7 @@ shape + builder via `ScenarioBuilderService` / `ScenarioSessionFactory`).
     "graveyard": ["Mountain"],
     "exile": ["Swamp"],
     "library": ["Forest", "Forest"],
+    "sideboard": ["Boomerang Basics"],
     "commanders": []
   },
   "player2": { "lifeTotal": 20, "battlefield": [{ "name": "Hill Giant" }] },
@@ -559,6 +560,9 @@ shape + builder via `ScenarioBuilderService` / `ScenarioSessionFactory`).
   yourself — one token controls both seats), `AI` (engine AI, requires `game.ai.enabled`;
   `aiPlayer` 1|2 picks the seat), or `TWO_PLAYER` (two tokens). When omitted it is derived from
   `aiPlayer` for back-compat.
+- `sideboard` is the "outside the game" zone (CR 400.11). Without it a card that reaches outside
+  the game has nothing to find, so the wish cycle and Strixhaven's **Learn** (CR 701.48) can only
+  ever take their other branch — seed a Lesson here to exercise Learn's Lesson half.
 - Validation rejects unknown card names and (production) enforces per-zone + total card caps,
   returning `400` with `{ "errors": ["Unknown card: …", …] }`.
 - `customCards` (optional) is a list of **Scryfall(-style) card objects, as JSON strings**. Argentum

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioBuilderService.kt
@@ -99,6 +99,7 @@ class ScenarioBuilderService(
             checkZone("$label graveyard", config.graveyard)
             checkZone("$label library", config.library)
             checkZone("$label exile", config.exile)
+            checkZone("$label sideboard", config.sideboard)
             checkZone("$label commanders", config.commanders)
             val battlefield = config.battlefield ?: emptyList()
             total += battlefield.size
@@ -187,6 +188,7 @@ class ScenarioBuilderService(
         config.graveyard?.forEach { builder.withCardInGraveyard(n, it) }
         config.library?.forEach { builder.withCardInLibrary(n, it) }
         config.exile?.forEach { builder.withCardInExile(n, it) }
+        config.sideboard?.forEach { builder.withCardInSideboard(n, it) }
     }
 
     private fun phaseToDefaultStep(phase: Phase): Step = when (phase) {
@@ -237,7 +239,10 @@ class ScenarioBuilderService(
 
             // Initialize empty zones for every player
             for (playerId in playerIds) {
-                for (zoneType in listOf(Zone.HAND, Zone.LIBRARY, Zone.GRAVEYARD, Zone.BATTLEFIELD, Zone.EXILE, Zone.COMMAND)) {
+                for (zoneType in listOf(
+                    Zone.HAND, Zone.LIBRARY, Zone.GRAVEYARD, Zone.BATTLEFIELD,
+                    Zone.EXILE, Zone.COMMAND, Zone.SIDEBOARD
+                )) {
                     val zoneKey = ZoneKey(playerId, zoneType)
                     state = state.copy(zones = state.zones + (zoneKey to emptyList()))
                 }
@@ -380,6 +385,14 @@ class ScenarioBuilderService(
             val playerId = playerFor(playerNumber)
             val cardId = createCard(cardName, playerId)
             state = state.addToZone(ZoneKey(playerId, Zone.EXILE), cardId)
+            return this
+        }
+
+        /** Put a card in the player's sideboard — "outside the game" (CR 400.11). */
+        fun withCardInSideboard(playerNumber: Int, cardName: String): ScenarioBuilder {
+            val playerId = playerFor(playerNumber)
+            val cardId = createCard(cardName, playerId)
+            state = state.addToZone(ZoneKey(playerId, Zone.SIDEBOARD), cardId)
             return this
         }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioDtos.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/scenario/ScenarioDtos.kt
@@ -117,6 +117,12 @@ data class PlayerConfig(
     val library: List<String>? = null,
     val exile: List<String>? = null,
     /**
+     * Cards "outside the game" (CR 400.11) — the player's sideboard. Needed by any card that
+     * reaches outside the game: the wish cycle, and Strixhaven's **Learn** (CR 701.48), whose
+     * Lesson half is simply unreachable without one.
+     */
+    val sideboard: List<String>? = null,
+    /**
      * Commander card names. Each name becomes a card in the player's command zone with
      * [CommanderComponent] attached and registered in [CommanderRegistryComponent].
      * Provide one name for a standard commander, two for Partner / Background.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/controller/ScenarioControllerTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/controller/ScenarioControllerTest.kt
@@ -30,7 +30,7 @@ import java.net.http.HttpResponse
  * Production scenario endpoint `POST /api/scenarios`. Unlike the dev endpoint this is NOT
  * gated behind `game.dev-endpoints.enabled` (note its absence below), so these tests double as
  * the proof that the feature ships to all players. Covers: hotseat (SELF) wiring, the exile
- * zone, and validation of unknown card names.
+ * and sideboard zones, and validation of unknown card names.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ScenarioControllerTest(
@@ -108,6 +108,33 @@ class ScenarioControllerTest(
         val exile = state.getZone(ZoneKey(p1Id, Zone.EXILE))
         exile.shouldNotBeNull()
         val names = exile.mapNotNull { state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name }
+        names shouldContain "Grizzly Bears"
+    }
+
+    test("sideboard zone is populated from the request") {
+        // Without this zone nothing can reach "outside the game" (CR 400.11), so Strixhaven's
+        // Learn (CR 701.48) could only ever take its discard branch and every wish was a blank.
+        val response = post(
+            """
+            {
+              "player1": { "lifeTotal": 20, "sideboard": ["Boomerang Basics", "Grizzly Bears"] },
+              "player2": { "lifeTotal": 20 },
+              "mode": "TWO_PLAYER"
+            }
+            """.trimIndent()
+        )
+        response.statusCode() shouldBe 200
+        val body = json.parseToJsonElement(response.body()).jsonObject
+        val sessionId = body["sessionId"]!!.jsonPrimitive.content
+        val p1Id = EntityId.of(body["player1"]!!.jsonObject["playerId"]!!.jsonPrimitive.content)
+
+        val state = gameRepository.findById(sessionId).shouldNotBeNull().getStateForTesting().shouldNotBeNull()
+        val sideboard = state.getZone(ZoneKey(p1Id, Zone.SIDEBOARD))
+        sideboard.shouldNotBeNull()
+        val names = sideboard.mapNotNull {
+            state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name
+        }
+        names shouldContain "Boomerang Basics"
         names shouldContain "Grizzly Bears"
     }
 

--- a/manual-scenarios/cards/a/academic-dispute.json
+++ b/manual-scenarios/cards/a/academic-dispute.json
@@ -5,30 +5,67 @@
   "aiPlayer": 2,
   "player1": {
     "lifeTotal": 20,
-    "hand": ["Academic Dispute", "Grizzly Bears", "Hill Giant"],
+    "hand": [
+      "Academic Dispute",
+      "Grizzly Bears",
+      "Hill Giant"
+    ],
     "battlefield": [
-      {"name": "Mountain"},
-      {"name": "Mountain"},
-      {"name": "Air Elemental"}
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Air Elemental"
+      }
     ],
     "graveyard": [],
-    "library": ["Craw Wurm", "Mountain", "Lightning Bolt", "Mountain"]
+    "library": [
+      "Craw Wurm",
+      "Mountain",
+      "Lightning Bolt",
+      "Mountain"
+    ],
+    "sideboard": [
+      "Firebending Lesson",
+      "Redirect Lightning",
+      "Aang's Journey",
+      "Hill Giant"
+    ]
   },
   "player2": {
     "lifeTotal": 20,
-    "hand": ["Grizzly Bears", "Mountain"],
+    "hand": [
+      "Grizzly Bears",
+      "Mountain"
+    ],
     "battlefield": [
-      {"name": "Craw Wurm"},
-      {"name": "Mountain"},
-      {"name": "Mountain"}
+      {
+        "name": "Craw Wurm"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      }
     ],
     "graveyard": [],
-    "library": ["Hill Giant", "Mountain", "Grizzly Bears"]
+    "library": [
+      "Hill Giant",
+      "Mountain",
+      "Grizzly Bears"
+    ]
   },
   "phase": "PRECOMBAT_MAIN",
   "activePlayer": 1,
   "priorityPlayer": 1,
-  "player1StopAtSteps": ["DECLARE_ATTACKERS", "DECLARE_BLOCKERS"],
+  "player1StopAtSteps": [
+    "DECLARE_ATTACKERS",
+    "DECLARE_BLOCKERS"
+  ],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
   "player2OpponentStopAtSteps": []

--- a/manual-scenarios/cards/a/academic-dispute.json
+++ b/manual-scenarios/cards/a/academic-dispute.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Academic Dispute", "Grizzly Bears", "Hill Giant"],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Air Elemental"}
+    ],
+    "graveyard": [],
+    "library": ["Craw Wurm", "Mountain", "Lightning Bolt", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Grizzly Bears", "Mountain"],
+    "battlefield": [
+      {"name": "Craw Wurm"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Hill Giant", "Mountain", "Grizzly Bears"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_ATTACKERS", "DECLARE_BLOCKERS"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/a/arcane-subtraction.json
+++ b/manual-scenarios/cards/a/arcane-subtraction.json
@@ -26,6 +26,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Boomerang Basics",
+      "Accumulate Wisdom",
+      "Aang's Journey",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/a/arcane-subtraction.json
+++ b/manual-scenarios/cards/a/arcane-subtraction.json
@@ -1,0 +1,64 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Arcane Subtraction",
+      "Hill Giant",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Hill Giant"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "DECLARE_ATTACKERS",
+    "DECLARE_BLOCKERS"
+  ],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/c/cram-session.json
+++ b/manual-scenarios/cards/c/cram-session.json
@@ -23,6 +23,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Azula Always Lies",
+      "Seismic Sense",
+      "Aang's Journey",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/c/cram-session.json
+++ b/manual-scenarios/cards/c/cram-session.json
@@ -1,0 +1,58 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 11,
+    "hand": [
+      "Cram Session",
+      "Hill Giant",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/d/dream-strix.json
+++ b/manual-scenarios/cards/d/dream-strix.json
@@ -29,6 +29,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Firebending Lesson",
+      "Redirect Lightning",
+      "Aang's Journey",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/d/dream-strix.json
+++ b/manual-scenarios/cards/d/dream-strix.json
@@ -1,0 +1,64 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Lightning Bolt",
+      "Grizzly Bears",
+      "Hill Giant"
+    ],
+    "battlefield": [
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Dream Strix"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/e/enthusiastic-study.json
+++ b/manual-scenarios/cards/e/enthusiastic-study.json
@@ -29,6 +29,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Redirect Lightning",
+      "How to Start a Riot",
+      "Energybending",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/e/enthusiastic-study.json
+++ b/manual-scenarios/cards/e/enthusiastic-study.json
@@ -1,0 +1,67 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Enthusiastic Study",
+      "Hill Giant",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Grizzly Bears"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "DECLARE_ATTACKERS",
+    "DECLARE_BLOCKERS"
+  ],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/e/eyetwitch.json
+++ b/manual-scenarios/cards/e/eyetwitch.json
@@ -29,6 +29,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Firebending Lesson",
+      "Combustion Technique",
+      "Aang's Journey",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/e/eyetwitch.json
+++ b/manual-scenarios/cards/e/eyetwitch.json
@@ -1,0 +1,64 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Lightning Bolt",
+      "Grizzly Bears",
+      "Hill Giant"
+    ],
+    "battlefield": [
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Eyetwitch"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/f/field-trip.json
+++ b/manual-scenarios/cards/f/field-trip.json
@@ -27,6 +27,12 @@
       "Craw Wurm",
       "Forest",
       "Grizzly Bears"
+    ],
+    "sideboard": [
+      "Seismic Sense",
+      "Origin of Metalbending",
+      "Aang's Journey",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/f/field-trip.json
+++ b/manual-scenarios/cards/f/field-trip.json
@@ -1,0 +1,62 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Field Trip",
+      "Hill Giant",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Craw Wurm",
+      "Forest",
+      "Grizzly Bears"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/f/first-day-of-class.json
+++ b/manual-scenarios/cards/f/first-day-of-class.json
@@ -1,0 +1,77 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "First Day of Class",
+      "Grizzly Bears",
+      "Centaur Courser",
+      "Hill Giant"
+    ],
+    "battlefield": [
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "DECLARE_ATTACKERS",
+    "DECLARE_BLOCKERS"
+  ],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/f/first-day-of-class.json
+++ b/manual-scenarios/cards/f/first-day-of-class.json
@@ -39,6 +39,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Firebending Lesson",
+      "Combustion Technique",
+      "Aang's Journey",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/g/gnarled-professor.json
+++ b/manual-scenarios/cards/g/gnarled-professor.json
@@ -29,6 +29,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Seismic Sense",
+      "Shared Roots",
+      "Energybending",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/g/gnarled-professor.json
+++ b/manual-scenarios/cards/g/gnarled-professor.json
@@ -1,0 +1,67 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Gnarled Professor",
+      "Hill Giant",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "DECLARE_ATTACKERS",
+    "DECLARE_BLOCKERS"
+  ],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/g/guiding-voice.json
+++ b/manual-scenarios/cards/g/guiding-voice.json
@@ -1,0 +1,58 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Guiding Voice",
+      "Hill Giant",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Grizzly Bears"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/g/guiding-voice.json
+++ b/manual-scenarios/cards/g/guiding-voice.json
@@ -23,6 +23,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Yip Yip!",
+      "Enter the Avatar State",
+      "Aang's Journey",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/h/hunt-for-specimens.json
+++ b/manual-scenarios/cards/h/hunt-for-specimens.json
@@ -1,0 +1,61 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 14,
+    "hand": [
+      "Hunt for Specimens",
+      "Lightning Bolt",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Mountain"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/h/hunt-for-specimens.json
+++ b/manual-scenarios/cards/h/hunt-for-specimens.json
@@ -26,6 +26,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Azula Always Lies",
+      "Dai Li Indoctrination",
+      "Energybending",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/i/igneous-inspiration.json
+++ b/manual-scenarios/cards/i/igneous-inspiration.json
@@ -1,0 +1,64 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Igneous Inspiration",
+      "Hill Giant",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Grizzly Bears"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/i/igneous-inspiration.json
+++ b/manual-scenarios/cards/i/igneous-inspiration.json
@@ -26,6 +26,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Firebending Lesson",
+      "Price of Freedom",
+      "Aang's Journey",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/o/overgrown-arch.json
+++ b/manual-scenarios/cards/o/overgrown-arch.json
@@ -1,0 +1,60 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 14,
+    "hand": [
+      "Grizzly Bears",
+      "Hill Giant"
+    ],
+    "battlefield": [
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Overgrown Arch"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/o/overgrown-arch.json
+++ b/manual-scenarios/cards/o/overgrown-arch.json
@@ -25,6 +25,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Seismic Sense",
+      "True Ancestry",
+      "Aang's Journey",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/p/poets-quill.json
+++ b/manual-scenarios/cards/p/poets-quill.json
@@ -32,6 +32,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Azula Always Lies",
+      "Ozai's Cruelty",
+      "Aang's Journey",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/p/poets-quill.json
+++ b/manual-scenarios/cards/p/poets-quill.json
@@ -1,0 +1,70 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 14,
+    "hand": [
+      "Poet's Quill",
+      "Grizzly Bears",
+      "Hill Giant"
+    ],
+    "battlefield": [
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Grizzly Bears"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "DECLARE_ATTACKERS",
+    "DECLARE_BLOCKERS"
+  ],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/p/pop-quiz.json
+++ b/manual-scenarios/cards/p/pop-quiz.json
@@ -1,0 +1,61 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Pop Quiz",
+      "Hill Giant",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/p/pop-quiz.json
+++ b/manual-scenarios/cards/p/pop-quiz.json
@@ -26,6 +26,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Octopus Form",
+      "It'll Quench Ya!",
+      "Energybending",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/p/professor-of-symbology.json
+++ b/manual-scenarios/cards/p/professor-of-symbology.json
@@ -1,0 +1,58 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Professor of Symbology",
+      "Grizzly Bears",
+      "Hill Giant"
+    ],
+    "battlefield": [
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/p/professor-of-symbology.json
+++ b/manual-scenarios/cards/p/professor-of-symbology.json
@@ -23,6 +23,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Enter the Avatar State",
+      "Airbender's Reversal",
+      "Aang's Journey",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/r/rise-of-extus.json
+++ b/manual-scenarios/cards/r/rise-of-extus.json
@@ -35,6 +35,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Enter the Avatar State",
+      "Azula Always Lies",
+      "Aang's Journey",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/r/rise-of-extus.json
+++ b/manual-scenarios/cards/r/rise-of-extus.json
@@ -1,0 +1,73 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Rise of Extus",
+      "Hill Giant",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [
+      "Lightning Bolt",
+      "Grizzly Bears"
+    ],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/s/sparring-regimen.json
+++ b/manual-scenarios/cards/s/sparring-regimen.json
@@ -32,6 +32,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Enter the Avatar State",
+      "Airbending Lesson",
+      "Aang's Journey",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/manual-scenarios/cards/s/sparring-regimen.json
+++ b/manual-scenarios/cards/s/sparring-regimen.json
@@ -1,0 +1,70 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Sparring Regimen",
+      "Hill Giant",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Grizzly Bears"
+      },
+      {
+        "name": "Centaur Courser"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Craw Wurm"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "DECLARE_ATTACKERS",
+    "DECLARE_BLOCKERS"
+  ],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/s/study-break.json
+++ b/manual-scenarios/cards/s/study-break.json
@@ -1,0 +1,67 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Study Break",
+      "Hill Giant",
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Hill Giant"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Grizzly Bears"
+    ],
+    "battlefield": [
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Craw Wurm"
+      },
+      {
+        "name": "Centaur Courser"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Craw Wurm"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "DECLARE_ATTACKERS",
+    "DECLARE_BLOCKERS"
+  ],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/s/study-break.json
+++ b/manual-scenarios/cards/s/study-break.json
@@ -26,6 +26,12 @@
       "Craw Wurm",
       "Grizzly Bears",
       "Hill Giant"
+    ],
+    "sideboard": [
+      "Airbender's Reversal",
+      "Fancy Footwork",
+      "Energybending",
+      "Hill Giant"
     ]
   },
   "player2": {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2746,6 +2746,16 @@ object Effects {
         CreatePredefinedTokenEffect("Eldrazi Spawn", count, controller, imageUri = imageUri)
 
     /**
+     * Create N 1/1 black and green Pest creature tokens with "When this creature dies, you gain 1
+     * life." — Strixhaven's Witherbloom token (`PredefinedTokens.Pest`).
+     *
+     * Predefined rather than inline because the token is named and carries a triggered ability,
+     * which the inline [CreateToken] facade does not expose.
+     */
+    fun CreatePest(count: Int = 1, controller: EffectTarget? = null): Effect =
+        CreatePredefinedTokenEffect("Pest", count, controller)
+
+    /**
      * Create a dynamic number of 0/1 colorless Eldrazi Spawn creature tokens.
      * The count is evaluated at resolution time.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/MechanicPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/MechanicPatterns.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.sdk.dsl
 
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
@@ -40,7 +41,8 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
- * Named MTG keyword-mechanic recipes (Blight, Bolster, Explore, Forage, Gift, Incubate, Recruit).
+ * Named MTG keyword-mechanic recipes (Blight, Bolster, Explore, Forage, Gift, Incubate, Learn,
+ * Recruit).
  *
  * Reached through the [Patterns] index — `Patterns.Mechanic.blight(...)`. Each composes existing
  * atomic effects into the printed keyword behaviour; they live here (rather than a zone-based
@@ -366,6 +368,62 @@ object MechanicPatterns {
     // =========================================================================
     // Recruit Pattern (The Hobbit)
     // =========================================================================
+
+    /**
+     * **Learn** (CR 701.48) — the Strixhaven keyword action, printed as a bare "Learn." with
+     * reminder text.
+     *
+     * CR 701.48a spells it out, and the order is load-bearing rather than a "choose one":
+     *
+     * > "Learn" means "You may discard a card. If you do, draw a card. If you didn't discard a
+     * > card, you may reveal a Lesson card you own from outside the game and put it into your
+     * > hand."
+     *
+     * So the discard is offered *first*, and taking it forecloses the Lesson — a player who
+     * discards never gets the sideboard option. The composition follows that shape literally:
+     *
+     * 1. Gather the controller's hand and let them choose **up to one** card to discard. The
+     *    `ChooseUpTo(1)` is where the printed "you may" lives: choosing none is declining, and an
+     *    empty hand auto-resolves to none without a prompt.
+     * 2. If they discarded, draw a card; if they didn't, run a Lesson-restricted
+     *    [SideboardPatterns.wish], whose own `ChooseUpTo(1)` carries the second "may" — declining,
+     *    or owning no Lesson at all, simply does nothing.
+     *
+     * The discard is a real discard ([MoveType.Discard]), so madness and "whenever you discard a
+     * card" triggers see it.
+     *
+     * Collection names are `learn_`-prefixed so a Learn nested inside another pipeline can't
+     * collide with that pipeline's own `hand` / `discarded` collections.
+     */
+    fun learn(): CompositeEffect = CompositeEffect(
+        listOf(
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.HAND, Player.You),
+                storeAs = "learn_hand"
+            ),
+            SelectFromCollectionEffect(
+                from = "learn_hand",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                chooser = Chooser.Controller,
+                storeSelected = "learn_discarded",
+                prompt = "Learn — you may discard a card to draw a card"
+            ),
+            MoveCollectionEffect(
+                from = "learn_discarded",
+                destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You),
+                moveType = MoveType.Discard
+            ),
+            ConditionalOnCollectionEffect(
+                collection = "learn_discarded",
+                ifNotEmpty = DrawCardsEffect(1, EffectTarget.Controller),
+                ifEmpty = SideboardPatterns.wish(
+                    filter = GameObjectFilter.Any.withSubtype(Subtype.LESSON),
+                    storeAs = "learn_lessons"
+                )
+            )
+        ),
+        descriptionOverride = "Learn"
+    )
 
     /**
      * Recruit (The Hobbit) — "Draw a card, then discard a card. If you discarded a nonland card,

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/AcademicDispute.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/AcademicDispute.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Academic Dispute — Strixhaven: School of Mages #91 (canonical printing)
+ * {R} · Instant
+ *
+ * Target creature blocks this turn if able. You may have it gain reach until end of turn.
+ * Learn. (You may reveal a Lesson card you own from outside the game and put it into your hand,
+ * or discard a card to draw a card.)
+ *
+ * A combat trick that forces a block rather than preventing one — the reach rider exists so the
+ * forced blocker can be a flier's blocker, which is why it is optional ([MayEffect]) and why it
+ * lands on the same targeted creature.
+ *
+ * "Blocks this turn if able" is [Effects.MarkMustBlockThisTurn]: a *requirement*, not a guarantee
+ * (CR 509.1c) — a tapped creature, or one whose every block would be illegal, simply doesn't
+ * block. The three clauses resolve in printed order, so the Learn happens whether or not the
+ * creature ends up blocking.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val AcademicDispute = card("Academic Dispute") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature blocks this turn if able. You may have it gain reach until end " +
+        "of turn.\n" +
+        "Learn. (You may reveal a Lesson card you own from outside the game and put it into your " +
+        "hand, or discard a card to draw a card.)"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.MarkMustBlockThisTurn(creature) then
+            MayEffect(
+                effect = Effects.GrantKeyword(Keyword.REACH, creature),
+                descriptionOverride = "You may have it gain reach until end of turn."
+            ) then
+            Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "91"
+        artist = "Manuel Castañón"
+        flavorText = "\"I'll show you original research, you hack!\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/4620cc3b-e401-4096-b310-fed080806344.jpg?1783927359"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ArcaneSubtraction.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ArcaneSubtraction.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arcane Subtraction — Strixhaven: School of Mages #36 (canonical printing)
+ * {1}{U} · Instant
+ *
+ * Target creature gets -4/-0 until end of turn.
+ * Learn.
+ *
+ * A combat trick that blanks an attacker's damage rather than killing it — -0 toughness means it
+ * never dies to this, so no dies-triggers and no last-known-information subtleties. Power can go
+ * negative, which the engine floors at 0 for damage purposes (CR 107.1b).
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val ArcaneSubtraction = card("Arcane Subtraction") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -4/-0 until end of turn.\n" +
+        "Learn. (You may reveal a Lesson card you own from outside the game and put it into your " +
+        "hand, or discard a card to draw a card.)"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-4, 0, creature) then Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "The class learned little that day."
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/68cdb00c-ea86-4b72-8f62-570820edfa1b.jpg?1783927381"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/CramSession.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/CramSession.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cram Session — Strixhaven: School of Mages #170 (canonical printing)
+ * {1}{B/G} · Sorcery
+ *
+ * You gain 4 life.
+ * Learn.
+ *
+ * One of the set's Witherbloom hybrid commons: `{B/G}` is payable with either black or green
+ * (CR 202.2f), so the card is both black and green wherever colour is read.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val CramSession = card("Cram Session") {
+    manaCost = "{1}{B/G}"
+    colorIdentity = "BG"
+    typeLine = "Sorcery"
+    oracleText = "You gain 4 life.\n" +
+        "Learn. (You may reveal a Lesson card you own from outside the game and put it into your " +
+        "hand, or discard a card to draw a card.)"
+
+    spell {
+        effect = Effects.GainLife(4) then Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "170"
+        artist = "Marta Nael"
+        flavorText = "The only thing more delicious than a top grade is Gyome's signature cake."
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c59a249f-35ed-447a-845b-32ba5a53124e.jpg?1783927323"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/DreamStrix.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/DreamStrix.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.BecomesTargetEvent
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dream Strix — Strixhaven: School of Mages #42 (canonical printing)
+ * {2}{U} · Creature — Bird Illusion · 3/2
+ *
+ * Flying
+ * When this creature becomes the target of a spell, sacrifice it.
+ * When this creature dies, learn.
+ *
+ * The classic Illusion drawback, rebuilt so the drawback pays you: pointing removal at it makes
+ * it sacrifice itself — which *is* a death, so the second trigger fires and you Learn anyway.
+ * The removal spell is then left with no legal target and is countered on resolution (CR 608.2b).
+ *
+ * Two rules details the wording pins down:
+ * - **Spells only.** Abilities that target it do not fire the sacrifice, so it survives a tap
+ *   ability or an equip. [Triggers.BecomesTargetOfSpell] is the filter-scoped ANY-bound version of
+ *   this wording; Dream Strix's is self-bound, so the spec is built inline from the same
+ *   `BecomesTargetEvent(spellsOnly = true)` with `TriggerBinding.SELF` rather than re-deriving a
+ *   filter that means "this permanent".
+ * - **Sacrifice, not destroy.** Regeneration and indestructible do not save it (CR 701.17c).
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48). The dies trigger reads last-known information,
+ * so it resolves normally with the Strix already in the graveyard.
+ */
+val DreamStrix = card("Dream Strix") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird Illusion"
+    power = 3
+    toughness = 2
+    oracleText = "Flying\n" +
+        "When this creature becomes the target of a spell, sacrifice it.\n" +
+        "When this creature dies, learn. (You may reveal a Lesson card you own from outside the " +
+        "game and put it into your hand, or discard a card to draw a card.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = BecomesTargetEvent(spellsOnly = true),
+            binding = TriggerBinding.SELF
+        )
+        effect = Effects.SacrificeTarget(EffectTarget.Self)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "42"
+        artist = "YW Tang"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31d82f7a-64f1-463f-bb6b-936c3e49bf2b.jpg?1783927380"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/EnthusiasticStudy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/EnthusiasticStudy.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Enthusiastic Study — Strixhaven: School of Mages #99 (canonical printing)
+ * {2}{R} · Instant
+ *
+ * Target creature gets +3/+1 and gains trample until end of turn.
+ * Learn.
+ *
+ * Both riders land on the same targeted creature and both are until-end-of-turn, so they are two
+ * effects over one target rather than a single compound one.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val EnthusiasticStudy = card("Enthusiastic Study") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+1 and gains trample until end of turn.\n" +
+        "Learn. (You may reveal a Lesson card you own from outside the game and put it into your " +
+        "hand, or discard a card to draw a card.)"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(3, 1, creature) then
+            Effects.GrantKeyword(Keyword.TRAMPLE, creature) then
+            Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "99"
+        artist = "Jesper Ejsing"
+        flavorText = "\"If the pen is mightier than the sword, just think what a giant tome could do!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/543c64ff-2c51-4a63-a940-dc8645717c85.jpg?1783927356"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/Eyetwitch.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/Eyetwitch.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eyetwitch — Strixhaven: School of Mages #70 (canonical printing)
+ * {B} · Creature — Eye Bat · 1/1
+ *
+ * Flying
+ * When this creature dies, learn.
+ *
+ * A one-mana flying chump blocker that replaces itself: the dies trigger reads last-known
+ * information (CR 603.6e), so it resolves with Eyetwitch already in the graveyard.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val Eyetwitch = card("Eyetwitch") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Eye Bat"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "When this creature dies, learn. (You may reveal a Lesson card you own from outside the " +
+        "game and put it into your hand, or discard a card to draw a card.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "70"
+        artist = "Karl Kopinski"
+        flavorText = "Oculomancers see the ideal potion ingredient. The bats don't see it that way."
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f4d1bb6-cb8f-4d01-9879-0b3a0585cbf4.jpg?1783927368"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/FieldTrip.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/FieldTrip.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Field Trip — Strixhaven: School of Mages #131 (canonical printing)
+ * {2}{G} · Sorcery
+ *
+ * Search your library for a basic Forest card, put that card onto the battlefield tapped, then
+ * shuffle.
+ * Learn.
+ *
+ * `Patterns.Library.searchLibrary` is the gather → select → move pipeline: `ChooseUpTo(1)` is what
+ * makes finding a card optional (CR 701.23b — you may fail to find), `entersTapped = true` is the
+ * printed "tapped", and `shuffleAfter = true` is the "then shuffle".
+ *
+ * The two pipelines nest safely: the search stores under `searchable` / `found` and Learn under
+ * `learn_hand` / `learn_discarded`, so neither clobbers the other's collections.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val FieldTrip = card("Field Trip") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Search your library for a basic Forest card, put that card onto the battlefield " +
+        "tapped, then shuffle.\n" +
+        "Learn. (You may reveal a Lesson card you own from outside the game and put it into your " +
+        "hand, or discard a card to draw a card.)"
+
+    spell {
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand.withSubtype(Subtype.FOREST),
+            count = 1,
+            destination = SearchDestination.BATTLEFIELD,
+            entersTapped = true,
+            shuffleAfter = true
+        ) then Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "131"
+        artist = "Piotr Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f235060a-eb49-4a73-bb5f-01228c3c4070.jpg?1783927343"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/FirstDayOfClass.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/FirstDayOfClass.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * First Day of Class — Strixhaven: School of Mages #102 (canonical printing)
+ * {1}{R} · Instant
+ *
+ * Whenever a creature you control enters this turn, put a +1/+1 counter on it and it gains haste
+ * until end of turn.
+ * Learn.
+ *
+ * An instant that installs a *turn-bounded, filter-scoped* delayed triggered ability — the same
+ * shape as Thunder of Unity's chapters II/III. `fireOnce = false` because it fires for **every**
+ * creature you control that enters this turn, not just the first, and
+ * `expiry = DelayedTriggerExpiry.EndOfTurn` is the printed "this turn".
+ *
+ * Scoping is by [GameObjectFilter] rather than a watched entity — there is no single permanent to
+ * watch, and the filter's controller predicate is what keeps it from firing on an opponent's
+ * creatures. [EffectTarget.TriggeringEntity] inside the trigger is the creature that just entered,
+ * so "it" lands on the right permanent.
+ *
+ * Cast before combat on an empty board this does nothing at all; the Learn is what stops it from
+ * being a blank card in that spot.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val FirstDayOfClass = card("First Day of Class") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Whenever a creature you control enters this turn, put a +1/+1 counter on it and " +
+        "it gains haste until end of turn.\n" +
+        "Learn. (You may reveal a Lesson card you own from outside the game and put it into your " +
+        "hand, or discard a card to draw a card.)"
+
+    spell {
+        effect = CreateDelayedTriggerEffect(
+            trigger = Triggers.entersBattlefield(
+                filter = GameObjectFilter.Creature.youControl(),
+                binding = TriggerBinding.ANY
+            ),
+            fireOnce = false,
+            expiry = DelayedTriggerExpiry.EndOfTurn,
+            effect = Effects.AddCounters(
+                Counters.PLUS_ONE_PLUS_ONE,
+                1,
+                EffectTarget.TriggeringEntity
+            ) then Effects.GrantKeyword(Keyword.HASTE, EffectTarget.TriggeringEntity)
+        ) then Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Paul Scott Canavan"
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/091eb13d-9318-4b12-9f94-6276b11981d1.jpg?1783927356"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/GnarledProfessor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/GnarledProfessor.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gnarled Professor — Strixhaven: School of Mages #133 (canonical printing)
+ * {2}{G}{G} · Creature — Treefolk Druid · 5/4
+ *
+ * Trample
+ * When this creature enters, learn.
+ *
+ * A four-mana 5/4 trample that also fetches a Lesson — the green end of the Learn cycle, and the
+ * same ETB shape as Professor of Symbology on a much bigger body.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val GnarledProfessor = card("Gnarled Professor") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Treefolk Druid"
+    power = 5
+    toughness = 4
+    oracleText = "Trample\n" +
+        "When this creature enters, learn. (You may reveal a Lesson card you own from outside the " +
+        "game and put it into your hand, or discard a card to draw a card.)"
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "133"
+        artist = "Simon Dominic"
+        flavorText = "\"Class is in season.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a32338e8-1f6a-49b9-bd93-26578adab6b3.jpg?1783927342"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/GuidingVoice.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/GuidingVoice.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Guiding Voice — Strixhaven: School of Mages #19 (canonical printing)
+ * {W} · Sorcery
+ *
+ * Put a +1/+1 counter on target creature.
+ * Learn.
+ *
+ * The counter is not optional and not restricted to your own creatures — "target creature",
+ * so it can be handed to an opponent's, which matters only as a rules detail here.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48). The clauses resolve in printed order, so the
+ * Learn happens after the counter regardless of whether the creature is still there.
+ */
+val GuidingVoice = card("Guiding Voice") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Put a +1/+1 counter on target creature.\n" +
+        "Learn. (You may reveal a Lesson card you own from outside the game and put it into your " +
+        "hand, or discard a card to draw a card.)"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature) then
+            Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Steve Argyle"
+        flavorText = "When honormancers work together, their compliments are complementary."
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6fb3163-12ca-4a7f-a0c7-b8ddfc9408a0.jpg?1783927388"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/HuntForSpecimens.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/HuntForSpecimens.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hunt for Specimens — Strixhaven: School of Mages #73 (canonical printing)
+ * {1}{B} · Sorcery
+ *
+ * Create a 1/1 black and green Pest creature token with "When this token dies, you gain 1 life."
+ * Learn.
+ *
+ * The Pest is Strixhaven's signature Witherbloom token, so it lives in the predefined-token
+ * registry (`PredefinedTokens.Pest`) rather than being spelled out inline: it is a *named* token
+ * carrying its own triggered ability, which the inline `Effects.CreateToken` facade cannot
+ * express, and roughly a dozen STX cards mint the identical body.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val HuntForSpecimens = card("Hunt for Specimens") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Create a 1/1 black and green Pest creature token with \"When this token dies, " +
+        "you gain 1 life.\"\n" +
+        "Learn. (You may reveal a Lesson card you own from outside the game and put it into your " +
+        "hand, or discard a card to draw a card.)"
+
+    spell {
+        effect = Effects.CreatePest() then Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "73"
+        artist = "Randy Vargas"
+        imageUri = "https://cards.scryfall.io/normal/front/8/f/8ff0f47f-75cb-42b0-ba4d-78522cad9861.jpg?1783927367"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/IgneousInspiration.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/IgneousInspiration.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Igneous Inspiration — Strixhaven: School of Mages #107 (canonical printing)
+ * {2}{R} · Sorcery
+ *
+ * Igneous Inspiration deals 3 damage to any target.
+ * Learn.
+ *
+ * "Any target" is creature, player, or planeswalker/battle ([Targets.Any]). The damage names the
+ * spell as its source, so `damageSource = EffectTarget.Self` — that is what lets lifelink,
+ * "whenever a source you control deals damage" payoffs, and damage-redirection read the right
+ * source.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val IgneousInspiration = card("Igneous Inspiration") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Igneous Inspiration deals 3 damage to any target.\n" +
+        "Learn. (You may reveal a Lesson card you own from outside the game and put it into your " +
+        "hand, or discard a card to draw a card.)"
+
+    spell {
+        val anyTarget = target("any target", Targets.Any)
+        effect = Effects.DealDamage(3, anyTarget, damageSource = EffectTarget.Self) then
+            Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "107"
+        artist = "PINDURSKI"
+        flavorText = "Prismari fosters a burning need to create."
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/5781ad7b-dc1b-4cc1-9e72-6e714b9ba1de.jpg?1783927354"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/OvergrownArch.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/OvergrownArch.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Overgrown Arch — Strixhaven: School of Mages #139 (canonical printing)
+ * {1}{G} · Creature — Plant Wall · 0/4
+ *
+ * Defender
+ * {T}: You gain 1 life.
+ * {2}, Sacrifice this creature: Learn.
+ *
+ * A blocker that cashes itself in for a Lesson once it has stopped mattering. The Learn is on an
+ * *activated* ability rather than a dies trigger, so it only happens when you pay for it —
+ * killing the Arch in combat gets the opponent nothing.
+ *
+ * Note both abilities are usable the turn it enters: [Costs.SacrificeSelf] is not a tap cost, so
+ * summoning sickness does not gate it — only the separate `{T}` lifegain ability is gated.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val OvergrownArch = card("Overgrown Arch") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Wall"
+    power = 0
+    toughness = 4
+    oracleText = "Defender\n" +
+        "{T}: You gain 1 life.\n" +
+        "{2}, Sacrifice this creature: Learn. (You may reveal a Lesson card you own from outside " +
+        "the game and put it into your hand, or discard a card to draw a card.)"
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.GainLife(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.SacrificeSelf
+        )
+        effect = Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "139"
+        artist = "Simon Dominic"
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a71dddf5-8f72-4018-9cc8-5f63a17f1ee5.jpg?1783927339"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/PoetsQuill.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/PoetsQuill.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Poet's Quill — Strixhaven: School of Mages #82 (canonical printing)
+ * {1}{B} · Artifact — Equipment
+ *
+ * When this Equipment enters, learn.
+ * Equipped creature gets +1/+1 and has lifelink.
+ * Equip {1}{B}
+ *
+ * The Learn is on the Equipment *entering*, not on equipping — so it happens once, when the Quill
+ * is cast, and moving it between creatures later never repeats it.
+ *
+ * The two static riders are separate `staticAbility` blocks over [Filters.EquippedCreature]:
+ * a layer-7c stat modification and a layer-6 keyword grant, which the projector applies in the
+ * right order on its own (CR 613.4).
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val PoetsQuill = card("Poet's Quill") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, learn. (You may reveal a Lesson card you own from " +
+        "outside the game and put it into your hand, or discard a card to draw a card.)\n" +
+        "Equipped creature gets +1/+1 and has lifelink.\n" +
+        "Equip {1}{B}"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Mechanic.learn()
+    }
+
+    staticAbility {
+        ability = ModifyStats(+1, +1, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.LIFELINK, Filters.EquippedCreature)
+    }
+
+    equipAbility("{1}{B}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "82"
+        artist = "Anna Fehr"
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e7006f43-0b10-4693-b06f-e7cf86ab4129.jpg?1783927363"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/PopQuiz.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/PopQuiz.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pop Quiz — Strixhaven: School of Mages #49 (canonical printing)
+ * {2}{U} · Instant
+ *
+ * Draw a card.
+ * Learn.
+ *
+ * The order matters and is printed order: the draw happens *before* the Learn, so the freshly
+ * drawn card is already in hand and is itself a legal thing to pitch to the Learn's discard.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val PopQuiz = card("Pop Quiz") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Draw a card.\n" +
+        "Learn. (You may reveal a Lesson card you own from outside the game and put it into your " +
+        "hand, or discard a card to draw a card.)"
+
+    spell {
+        effect = Effects.DrawCards(1) then Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "49"
+        artist = "Matt Stewart"
+        flavorText = "\"Today is hydromancy? I thought it was amplimancy! I studied for amplimancy!\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d16892d8-9d10-45de-ab79-0e645c4b5588.jpg?1783927376"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ProfessorOfSymbology.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/ProfessorOfSymbology.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Professor of Symbology — Strixhaven: School of Mages #24 (canonical printing)
+ * {1}{W} · Creature — Kor Cleric · 2/1
+ *
+ * When this creature enters, learn.
+ *
+ * The plainest Learn card in the set: a vanilla body whose whole text is the keyword action,
+ * which makes it the reference shape for [Patterns.Mechanic.learn] on an ETB trigger.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48) — the discard is offered first and taking it
+ * forecloses the Lesson, so this is *not* a choose-one.
+ */
+val ProfessorOfSymbology = card("Professor of Symbology") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kor Cleric"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature enters, learn. (You may reveal a Lesson card you own from " +
+        "outside the game and put it into your hand, or discard a card to draw a card.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "24"
+        artist = "Jason Rainville"
+        flavorText = "\"A language isn't dead until we stop learning from it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f427cf73-9f5e-4ef5-bc4f-29ffbfda9d57.jpg?1783927387"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/RiseOfExtus.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/RiseOfExtus.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Rise of Extus — Strixhaven: School of Mages #226 (canonical printing)
+ * {4}{W/B}{W/B} · Sorcery
+ *
+ * Exile target creature. Exile up to one target instant or sorcery card from a graveyard.
+ * Learn.
+ *
+ * Two independent target requirements, and the second is genuinely optional: `optional = true` on
+ * the [TargetObject] is the printed "up to one", so the spell is castable — and resolves — with no
+ * graveyard card chosen. When it is declined, `ContextTarget(1)` resolves to null and the second
+ * exile is a no-op rather than an error.
+ *
+ * Exile, not destroy: indestructible and regeneration do not save the creature, and it leaves no
+ * graveyard trigger behind. The graveyard half is incidental instant/sorcery hate — Strixhaven is
+ * a spells set, so it is aimed at flashback and Mystical Archive recursion.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val RiseOfExtus = card("Rise of Extus") {
+    manaCost = "{4}{W/B}{W/B}"
+    colorIdentity = "WB"
+    typeLine = "Sorcery"
+    oracleText = "Exile target creature. Exile up to one target instant or sorcery card from a " +
+        "graveyard.\n" +
+        "Learn. (You may reveal a Lesson card you own from outside the game and put it into your " +
+        "hand, or discard a card to draw a card.)"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        target(
+            "up to one target instant or sorcery card from a graveyard",
+            TargetObject(filter = TargetFilter.InstantOrSorceryInGraveyard, optional = true)
+        )
+        effect = Effects.Exile(creature) then
+            Effects.Exile(EffectTarget.ContextTarget(1)) then
+            Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "226"
+        artist = "Wylie Beckert"
+        flavorText = "With one lethal strike, Extus took control of the Oriq and took his first step towards vengeance."
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bbf97a71-485e-4d47-98de-bdf6f6dae0c2.jpg?1783927296"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/SparringRegimen.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/SparringRegimen.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sparring Regimen — Strixhaven: School of Mages #29 (canonical printing)
+ * {2}{W} · Enchantment
+ *
+ * When this enchantment enters, learn.
+ * Whenever you attack, put a +1/+1 counter on target attacking creature and untap it.
+ *
+ * "Whenever you attack" is [Triggers.YouAttack] — a player-level trigger that fires once per
+ * combat when attackers are declared (CR 508.1), *not* once per attacker. The target is chosen
+ * when the ability goes on the stack, by which time attackers are declared, so
+ * [Targets.AttackingCreature] always has a legal choice when the trigger fires at all.
+ *
+ * Untapping the attacker does not remove it from combat (CR 506.4) — it stays an attacking
+ * creature and still deals combat damage; the untap is a pseudo-vigilance rider.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val SparringRegimen = card("Sparring Regimen") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, learn. (You may reveal a Lesson card you own from " +
+        "outside the game and put it into your hand, or discard a card to draw a card.)\n" +
+        "Whenever you attack, put a +1/+1 counter on target attacking creature and untap it."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Mechanic.learn()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        val attacker = target("target attacking creature", Targets.AttackingCreature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, attacker) then
+            Effects.Untap(attacker)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "29"
+        artist = "Tomasz Jedruszek"
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab7c80d3-3e0c-4510-9ed0-bb9fe39d838f.jpg?1783927388"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/StudyBreak.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/StudyBreak.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Study Break — Strixhaven: School of Mages #34 (canonical printing)
+ * {1}{W} · Instant
+ *
+ * Tap up to two target creatures.
+ * Learn.
+ *
+ * "Up to two" is [Targets.UpToCreatures] (`optional = true`), so zero and one are both legal
+ * choices and the spell still resolves — the Learn is the floor that keeps it from being a dead
+ * card with no creatures on the board. [Effects.TapEachTarget] taps however many were actually
+ * chosen rather than assuming two.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48).
+ */
+val StudyBreak = card("Study Break") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Tap up to two target creatures.\n" +
+        "Learn. (You may reveal a Lesson card you own from outside the game and put it into your " +
+        "hand, or discard a card to draw a card.)"
+
+    spell {
+        target("up to two target creatures", Targets.UpToCreatures(2))
+        effect = Effects.TapEachTarget() then Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "34"
+        artist = "Cristi Balanescu"
+        flavorText = "\"You've been cramming all night. You're taking a nap whether you like it or not.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/ef7cd813-0781-4fd7-8748-2716e1eeb4b9.jpg?1783927382"
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AcademicDisputeScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AcademicDisputeScenarioTest.kt
@@ -1,0 +1,219 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Academic Dispute (STX) — "Target creature blocks this turn if able. You may have it gain reach
+ * until end of turn. Learn."
+ *
+ * The **Learn** keyword action (CR 701.48a) is the interesting half, and its printed order is
+ * load-bearing rather than a "choose one":
+ *
+ * > "You may discard a card. If you do, draw a card. If you didn't discard a card, you may reveal
+ * > a Lesson card you own from outside the game and put it into your hand."
+ *
+ * — so discarding *forecloses* the Lesson, and only a player who didn't discard is offered the
+ * sideboard. Each branch of that sentence gets a test below, plus the two combat clauses.
+ *
+ * The Lesson used as a fixture is Boomerang Basics (TLA), a real `Sorcery — Lesson` in the corpus.
+ */
+class AcademicDisputeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Learn — the discard branch") {
+            test("discarding a card draws a card, and the Lesson is never offered") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Academic Dispute")
+                    .withCardInHand(1, "Grizzly Bears")   // the card to pitch
+                    .withCardInLibrary(1, "Hill Giant")   // the card the draw finds
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withCardInSideboard(1, "Boomerang Basics")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                game.castSpell(1, "Academic Dispute", courser).error shouldBe null
+                game.resolveStack()
+
+                // The optional reach rider comes first — decline it.
+                game.answerYesNo(false)
+
+                withClue("Learn should offer the up-to-one discard") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val discardChoice = game.getPendingDecision() as? SelectCardsDecision
+                discardChoice.shouldNotBeNull()
+                val bears = discardChoice.cardInfo!!.entries
+                    .first { it.value.name == "Grizzly Bears" }.key
+                game.selectCards(listOf(bears))
+
+                withClue("Discarding is the whole branch — no sideboard prompt follows") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("Grizzly Bears was discarded") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("…and the draw replaced it") {
+                    game.isInHand(1, "Hill Giant") shouldBe true
+                }
+                withClue("The Lesson stays in the sideboard — you discarded, so it was never offered") {
+                    game.isInSideboard(1, "Boomerang Basics") shouldBe true
+                }
+            }
+        }
+
+        context("Learn — the Lesson branch") {
+            test("declining the discard offers a Lesson from outside the game") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Academic Dispute")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withCardInSideboard(1, "Boomerang Basics")  // a Lesson — eligible
+                    .withCardInSideboard(1, "Hill Giant")        // not a Lesson — filtered out
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                game.castSpell(1, "Academic Dispute", courser)
+                game.resolveStack()
+                game.answerYesNo(false)   // decline reach
+
+                game.hasPendingDecision() shouldBe true
+                game.skipSelection()      // decline the discard
+
+                withClue("Not discarding should open the sideboard choice") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val lessonChoice = game.getPendingDecision() as? SelectCardsDecision
+                lessonChoice.shouldNotBeNull()
+                val offered = lessonChoice.cardInfo!!
+                withClue("Only Lesson cards are offered") {
+                    offered.values.any { it.name == "Boomerang Basics" } shouldBe true
+                    offered.values.any { it.name == "Hill Giant" } shouldBe false
+                }
+
+                val lesson = offered.entries.first { it.value.name == "Boomerang Basics" }.key
+                game.selectCards(listOf(lesson))
+
+                withClue("The Lesson is now in hand and out of the sideboard") {
+                    game.isInHand(1, "Boomerang Basics") shouldBe true
+                    game.isInSideboard(1, "Boomerang Basics") shouldBe false
+                }
+                withClue("Nothing was discarded and nothing was drawn") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("declining both halves does nothing at all") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Academic Dispute")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withCardInSideboard(1, "Boomerang Basics")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                game.castSpell(1, "Academic Dispute", courser)
+                game.resolveStack()
+                game.answerYesNo(false)
+                game.skipSelection()   // no discard
+                game.skipSelection()   // no Lesson
+
+                game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                game.isInSideboard(1, "Boomerang Basics") shouldBe true
+                game.isInHand(1, "Grizzly Bears") shouldBe true
+            }
+
+            test("an empty hand skips straight to the Lesson — nothing to discard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Academic Dispute")   // the only card, and it's on the stack
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withCardInSideboard(1, "Boomerang Basics")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                game.castSpell(1, "Academic Dispute", courser)
+                game.resolveStack()
+                game.answerYesNo(false)
+
+                withClue("With an empty hand the discard auto-resolves to none — this is the Lesson prompt") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val choice = game.getPendingDecision() as? SelectCardsDecision
+                choice.shouldNotBeNull()
+                choice.cardInfo!!.values.any { it.name == "Boomerang Basics" } shouldBe true
+            }
+        }
+
+        context("the combat clauses") {
+            test("the targeted creature must block") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Academic Dispute")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(1, "Hill Giant")       // your attacker
+                    .withCardOnBattlefield(2, "Centaur Courser")  // the creature you force to block
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                game.castSpell(1, "Academic Dispute", courser)
+                game.resolveStack()
+                game.answerYesNo(false)   // decline reach
+                // Hand and sideboard are both empty here, so Learn raises no prompt at all;
+                // decline whatever it does raise rather than assuming a fixed number of them.
+                while (game.hasPendingDecision()) game.skipSelection()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Hill Giant" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("Declining to block is illegal while the requirement stands (CR 509.1c)") {
+                    game.declareNoBlockers().error shouldNotBe null
+                }
+            }
+
+            test("the optional rider grants reach to the same creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Academic Dispute")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                game.castSpell(1, "Academic Dispute", courser)
+                game.resolveStack()
+                game.answerYesNo(true)    // take the reach
+
+                withClue("Centaur Courser should have reach until end of turn") {
+                    game.state.projectedState.hasKeyword(courser, com.wingedsheep.sdk.core.Keyword.REACH) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DreamStrixScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DreamStrixScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Dream Strix (STX) — "Flying / When this creature becomes the target of a spell, sacrifice it. /
+ * When this creature dies, learn."
+ *
+ * Two things the wording pins down that a lookalike would get wrong:
+ *
+ * 1. **Spells only.** An *ability* that targets it must not fire the sacrifice. That is the whole
+ *    reason the trigger is a `BecomesTargetEvent(spellsOnly = true)` rather than the plain
+ *    self-bound `Triggers.BecomesTarget`, which would also match abilities.
+ * 2. **The drawback pays you.** Pointing removal at it makes it sacrifice itself, which *is* a
+ *    death — so the second trigger fires and you Learn anyway, while the removal spell is left
+ *    with no legal target and is countered on resolution (CR 608.2b).
+ */
+class DreamStrixScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("becomes the target of a spell") {
+            test("sacrifices itself, and the dies trigger still learns") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dream Strix")
+                    .withCardInHand(2, "Shock")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withCardInSideboard(1, "Boomerang Basics")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val strix = game.findPermanent("Dream Strix")
+                strix.shouldNotBeNull()
+
+                game.castSpell(2, "Shock", strix).error shouldBe null
+                // The becomes-target trigger goes on the stack above Shock and resolves first.
+                game.resolveStack()
+
+                withClue("sacrificed to its own trigger, so it is in the graveyard") {
+                    game.findPermanent("Dream Strix") shouldBe null
+                    game.isInGraveyard(1, "Dream Strix") shouldBe true
+                }
+
+                withClue("the dies trigger offers its controller the Learn") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                // Player 1's hand is empty, so the discard half auto-declines and this is the
+                // Lesson prompt; take Boomerang Basics out of the sideboard.
+                val lessonChoice = game.getPendingDecision() as? SelectCardsDecision
+                lessonChoice.shouldNotBeNull()
+                val lesson = lessonChoice.cardInfo!!.entries
+                    .first { it.value.name == "Boomerang Basics" }.key
+                game.selectCards(listOf(lesson))
+
+                withClue("Learn found the Lesson") {
+                    game.isInHand(1, "Boomerang Basics") shouldBe true
+                }
+            }
+        }
+
+        context("becomes the target of an ability") {
+            test("does not sacrifice — the trigger is spells-only") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dream Strix")
+                    .withCardOnBattlefield(2, "Prodigal Sorcerer")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val strix = game.findPermanent("Dream Strix")
+                strix.shouldNotBeNull()
+                val tim = game.findPermanent("Prodigal Sorcerer")!!
+                val abilityId = cardRegistry.getCard("Prodigal Sorcerer")!!
+                    .script.activatedAbilities[0].id
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player2Id,
+                        sourceId = tim,
+                        abilityId = abilityId,
+                        targets = listOf(entityIdToChosenTarget(game.state, strix))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("an ability targeted it — no sacrifice, and 1 damage doesn't kill a 3/2") {
+                    game.findPermanent("Dream Strix") shouldNotBe null
+                    game.isInGraveyard(1, "Dream Strix") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FirstDayOfClassScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/FirstDayOfClassScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * First Day of Class (STX) — "Whenever a creature you control enters this turn, put a +1/+1
+ * counter on it and it gains haste until end of turn. Learn."
+ *
+ * An instant that installs a turn-bounded, *filter-scoped* delayed triggered ability. Two
+ * properties distinguish it from the one-shot shape that `fireOnce = true` would give:
+ *
+ * - it fires for **every** creature you control that enters this turn, not just the first;
+ * - it is prospective — a creature already on the battlefield when it resolves never "enters"
+ *   again, so it picks up nothing.
+ */
+class FirstDayOfClassScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("the delayed trigger") {
+            test("fires for every creature you control that enters this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "First Day of Class")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInHand(1, "Centaur Courser")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "First Day of Class").error shouldBe null
+                game.resolveStack()
+                while (game.hasPendingDecision()) game.skipSelection()
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+                while (game.hasPendingDecision()) game.skipSelection()
+
+                val bears = game.findPermanent("Grizzly Bears")
+                bears.shouldNotBeNull()
+                withClue("the first creature got a +1/+1 counter and haste") {
+                    plusOneCounters(game, bears) shouldBe 1
+                    game.state.projectedState.hasKeyword(bears, Keyword.HASTE) shouldBe true
+                }
+
+                game.castSpell(1, "Centaur Courser").error shouldBe null
+                game.resolveStack()
+                while (game.hasPendingDecision()) game.skipSelection()
+
+                val courser = game.findPermanent("Centaur Courser")
+                courser.shouldNotBeNull()
+                withClue("the second one too — the trigger is not a one-shot") {
+                    plusOneCounters(game, courser) shouldBe 1
+                    game.state.projectedState.hasKeyword(courser, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("leaves creatures that were already on the battlefield alone") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "First Day of Class")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")
+                giant.shouldNotBeNull()
+
+                game.castSpell(1, "First Day of Class").error shouldBe null
+                game.resolveStack()
+                while (game.hasPendingDecision()) game.skipSelection()
+
+                withClue("it never entered after the trigger was installed, so no counter") {
+                    plusOneCounters(game, giant) shouldBe 0
+                }
+                withClue("and no haste either") {
+                    game.state.projectedState.hasKeyword(giant, Keyword.HASTE) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntForSpecimensScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntForSpecimensScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Hunt for Specimens (STX) — "Create a 1/1 black and green Pest creature token with 'When this
+ * token dies, you gain 1 life.' Learn."
+ *
+ * The Pest is the piece worth testing: it is the first user of the new `PredefinedTokens.Pest`
+ * registry entry, and a predefined token's whole point is that the *token* carries the triggered
+ * ability rather than the card that minted it. So the interesting assertion is not "a token
+ * appeared" but "the token that appeared gains its controller 1 life when it dies".
+ *
+ * Its colours come from a colour indicator (CR 204) — a token has no mana cost, so black-and-green
+ * has to survive the round trip through `colorIdentityOverride` rather than being derived.
+ */
+class HuntForSpecimensScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("the Pest token") {
+            test("is a 1/1 black and green Pest") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Hunt for Specimens")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Hunt for Specimens").error shouldBe null
+                game.resolveStack()
+                // Empty hand and empty sideboard: Learn may raise no prompt at all.
+                while (game.hasPendingDecision()) game.skipSelection()
+
+                val pest = game.findPermanent("Pest")
+                withClue("Hunt for Specimens created a Pest token") { pest shouldNotBe null }
+                val pestId = pest!!
+
+                val projected = game.state.projectedState
+                withClue("a 1/1 Pest") {
+                    projected.getPower(pestId) shouldBe 1
+                    projected.getToughness(pestId) shouldBe 1
+                    projected.isCreature(pestId) shouldBe true
+                    projected.hasSubtype(pestId, "Pest") shouldBe true
+                }
+                withClue("black AND green, from the colour indicator (CR 204)") {
+                    projected.getColors(pestId) shouldBe setOf("BLACK", "GREEN")
+                }
+            }
+
+            test("gains its controller 1 life when it dies") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Hunt for Specimens")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Hunt for Specimens").error shouldBe null
+                game.resolveStack()
+                while (game.hasPendingDecision()) game.skipSelection()
+
+                val pest = game.findPermanent("Pest")
+                withClue("Hunt for Specimens created a Pest token") { pest shouldNotBe null }
+                val pestId = pest!!
+                val lifeBefore = game.getLifeTotal(1)
+
+                // Shock your own Pest — 2 damage to a 1/1 is lethal.
+                game.castSpell(1, "Shock", pestId).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Pest died") {
+                    game.findPermanent("Pest") shouldBe null
+                }
+                withClue("its own dies trigger gained you 1 life") {
+                    game.getLifeTotal(1) shouldBe lifeBefore + 1
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RiseOfExtusScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RiseOfExtusScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Rise of Extus (STX) — "Exile target creature. Exile up to one target instant or sorcery card
+ * from a graveyard. Learn."
+ *
+ * The second target is genuinely optional ("up to one"), which is the half worth proving: the
+ * spell must be castable and must resolve with only the creature chosen, and the declined
+ * requirement must not shift the first target's position. `ContextTarget(1)` then resolves to
+ * null and the second exile is a no-op rather than an error — `EffectContext.positionalTarget`
+ * keeps requirement-index alignment precisely so that "target 0" still means the creature.
+ */
+class RiseOfExtusScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("both targets chosen") {
+            test("exiles the creature and the graveyard spell") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Rise of Extus")
+                    .withLandsOnBattlefield(1, "Plains", 6)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withCardInGraveyard(2, "Shock")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                val shock = game.findCardsInGraveyard(2, "Shock").first()
+                val cardId = game.state.getHand(game.player1Id)
+                    .first { game.state.getEntity(it)?.get<CardComponent>()?.name == "Rise of Extus" }
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(
+                            ChosenTarget.Permanent(courser),
+                            ChosenTarget.Card(shock, game.player2Id, Zone.GRAVEYARD)
+                        )
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+                while (game.hasPendingDecision()) game.skipSelection()
+
+                withClue("the creature is exiled, not destroyed") {
+                    game.findPermanent("Centaur Courser") shouldBe null
+                    game.isInExile(2, "Centaur Courser") shouldBe true
+                    game.isInGraveyard(2, "Centaur Courser") shouldBe false
+                }
+                withClue("the graveyard instant is exiled too") {
+                    game.isInExile(2, "Shock") shouldBe true
+                    game.isInGraveyard(2, "Shock") shouldBe false
+                }
+            }
+        }
+
+        context("the optional target declined") {
+            test("resolves with only the creature chosen, leaving the graveyard alone") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Rise of Extus")
+                    .withLandsOnBattlefield(1, "Plains", 6)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withCardInGraveyard(2, "Shock")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+
+                // Only the first requirement is satisfied — "up to one" means zero is legal.
+                game.castSpell(1, "Rise of Extus", courser).error shouldBe null
+                game.resolveStack()
+                while (game.hasPendingDecision()) game.skipSelection()
+
+                withClue("the creature still gets exiled — target 0 did not shift") {
+                    game.findPermanent("Centaur Courser") shouldBe null
+                    game.isInExile(2, "Centaur Courser") shouldBe true
+                }
+                withClue("nothing was exiled from the graveyard") {
+                    game.isInGraveyard(2, "Shock") shouldBe true
+                    game.isInExile(2, "Shock") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -903,6 +903,37 @@ object PredefinedTokens {
     }
 
     /**
+     * Pest token — the 1/1 black **and** green Pest with "When this creature dies, you gain 1
+     * life." that Strixhaven's Witherbloom cards hand out (Hunt for Specimens, Pest Summoning,
+     * Sedgemoor Witch, …).
+     *
+     * A predefined token rather than an inline one because it is a *named* token carrying its own
+     * triggered ability, and because a dozen-odd STX cards mint the identical body — the registry
+     * is what keeps them from each re-declaring the dies trigger.
+     *
+     * Its two colors come from a color indicator (CR 204), stored via the `colorIdentity` DSL
+     * setter → `colorIdentityOverride`: a token has no mana cost, so a bare `colors` would read
+     * colorless.
+     */
+    val Pest = card("Pest") {
+        typeLine = "Creature — Pest"
+        colorIdentity = "BG"
+        power = 1
+        toughness = 1
+
+        triggeredAbility {
+            trigger = Triggers.Dies
+            effect = Effects.GainLife(1)
+            description = "When this creature dies, you gain 1 life."
+        }
+
+        metadata {
+            imageUri = "https://cards.scryfall.io/normal/front/d/0/d0ddbe3e-4a66-494d-9304-7471232549bf.jpg?1783927190"
+            artist = "Ilse Gort"
+        }
+    }
+
+    /**
      * All predefined token definitions.
      * Register these in the CardRegistry so token abilities are resolved.
      */
@@ -932,6 +963,7 @@ object PredefinedTokens {
         Munitions,
         Mutagen,
         Frog,
+        Pest,
         Vehicle,
         TheVoid,
         Redwing,

--- a/mtg-sets/src/test/resources/snapshots/cards/STX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STX.json
@@ -154,6 +154,136 @@
     ]
 }
 
+// Arcane Subtraction
+{
+    "name": "Arcane Subtraction",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -4/-0 until end of turn.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -4
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "The class learned little that day.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/68cdb00c-ea86-4b72-8f62-570820edfa1b.jpg?1783927381"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Burrog Befuddler
 {
     "name": "Burrog Befuddler",
@@ -354,6 +484,120 @@
     ]
 }
 
+// Cram Session
+{
+    "name": "Cram Session",
+    "manaCost": "{1}{B/G}",
+    "typeLine": "Sorcery",
+    "oracleText": "You gain 4 life.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "artist": "Marta Nael",
+        "flavorText": "The only thing more delicious than a top grade is Gyome's signature cake.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c59a249f-35ed-447a-845b-32ba5a53124e.jpg?1783927323"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Deadly Brew
 {
     "name": "Deadly Brew",
@@ -428,6 +672,661 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Dream Strix
+{
+    "name": "Dream Strix",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Bird Illusion",
+    "oracleText": "Flying\nWhen this creature becomes the target of a spell, sacrifice it.\nWhen this creature dies, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BecomesTargetEvent",
+                    "spellsOnly": true
+                },
+                "effect": {
+                    "type": "SacrificeTarget",
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "rarity": "RARE",
+        "artist": "YW Tang",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/31d82f7a-64f1-463f-bb6b-936c3e49bf2b.jpg?1783927380"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Enthusiastic Study
+{
+    "name": "Enthusiastic Study",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+1 and gains trample until end of turn.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "artist": "Jesper Ejsing",
+        "flavorText": "\"If the pen is mightier than the sword, just think what a giant tome could do!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/543c64ff-2c51-4a63-a940-dc8645717c85.jpg?1783927356"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Eyetwitch
+{
+    "name": "Eyetwitch",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Eye Bat",
+    "oracleText": "Flying\nWhen this creature dies, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "rarity": "UNCOMMON",
+        "artist": "Karl Kopinski",
+        "flavorText": "Oculomancers see the ideal potion ingredient. The bats don't see it that way.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f4d1bb6-cb8f-4d01-9879-0b3a0585cbf4.jpg?1783927368"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Field Trip
+{
+    "name": "Field Trip",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Search your library for a basic Forest card, put that card onto the battlefield tapped, then shuffle.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": "basicland Forest"
+                    },
+                    "storeAs": "searchable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "searchable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "found"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "found",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield",
+                        "placement": "Tapped"
+                    }
+                },
+                "ShuffleLibrary",
+                "EmitLibrarySearchedEvent",
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "artist": "Piotr Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f235060a-eb49-4a73-bb5f-01228c3c4070.jpg?1783927343"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// First Day of Class
+{
+    "name": "First Day of Class",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Whenever a creature you control enters this turn, put a +1/+1 counter on it and it gains haste until end of turn.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreateDelayedTrigger",
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "TriggeringEntity"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": "TriggeringEntity"
+                            }
+                        ]
+                    },
+                    "trigger": {
+                        "event": {
+                            "type": "ZoneChangeEvent",
+                            "filter": "creature ctrl:you",
+                            "to": "Battlefield"
+                        },
+                        "binding": "ANY"
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Paul Scott Canavan",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/091eb13d-9318-4b12-9f94-6276b11981d1.jpg?1783927356"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -546,6 +1445,884 @@
     ]
 }
 
+// Gnarled Professor
+{
+    "name": "Gnarled Professor",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Treefolk Druid",
+    "oracleText": "Trample\nWhen this creature enters, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "rarity": "RARE",
+        "artist": "Simon Dominic",
+        "flavorText": "\"Class is in season.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a32338e8-1f6a-49b9-bd93-26578adab6b3.jpg?1783927342"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Guiding Voice
+{
+    "name": "Guiding Voice",
+    "manaCost": "{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Put a +1/+1 counter on target creature.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Steve Argyle",
+        "flavorText": "When honormancers work together, their compliments are complementary.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d6fb3163-12ca-4a7f-a0c7-b8ddfc9408a0.jpg?1783927388"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Hunt for Specimens
+{
+    "name": "Hunt for Specimens",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a 1/1 black and green Pest creature token with \"When this token dies, you gain 1 life.\"\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Pest"
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "artist": "Randy Vargas",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/f/8ff0f47f-75cb-42b0-ba4d-78522cad9861.jpg?1783927367"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Igneous Inspiration
+{
+    "name": "Igneous Inspiration",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Igneous Inspiration deals 3 damage to any target.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    },
+                    "damageSource": "Self"
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "any target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "rarity": "UNCOMMON",
+        "artist": "PINDURSKI",
+        "flavorText": "Prismari fosters a burning need to create.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/5781ad7b-dc1b-4cc1-9e72-6e714b9ba1de.jpg?1783927354"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Overgrown Arch
+{
+    "name": "Overgrown Arch",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Plant Wall",
+    "oracleText": "Defender\n{T}: You gain 1 life.\n{2}, Sacrifice this creature: Learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "rarity": "UNCOMMON",
+        "artist": "Simon Dominic",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a71dddf5-8f72-4018-9cc8-5f63a17f1ee5.jpg?1783927339"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Poet's Quill
+{
+    "name": "Poet's Quill",
+    "manaCost": "{1}{B}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)\nEquipped creature gets +1/+1 and has lifelink.\nEquip {1}{B}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "LIFELINK"
+            }
+        ]
+    },
+    "equipCost": "{1}{B}",
+    "metadata": {
+        "collectorNumber": "82",
+        "rarity": "RARE",
+        "artist": "Anna Fehr",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e7006f43-0b10-4693-b06f-e7cf86ab4129.jpg?1783927363"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Pop Quiz
+{
+    "name": "Pop Quiz",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Draw a card.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "artist": "Matt Stewart",
+        "flavorText": "\"Today is hydromancy? I thought it was amplimancy! I studied for amplimancy!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d16892d8-9d10-45de-ab79-0e645c4b5588.jpg?1783927376"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Prismari Campus
 {
     "name": "Prismari Campus",
@@ -612,6 +2389,406 @@
     ]
 }
 
+// Professor of Symbology
+{
+    "name": "Professor of Symbology",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Kor Cleric",
+    "oracleText": "When this creature enters, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Rainville",
+        "flavorText": "\"A language isn't dead until we stop learning from it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f427cf73-9f5e-4ef5-bc4f-29ffbfda9d57.jpg?1783927387"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Rise of Extus
+{
+    "name": "Rise of Extus",
+    "manaCost": "{4}{W/B}{W/B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Exile target creature. Exile up to one target instant or sorcery card from a graveyard.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "destination": "Exile"
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 1
+                    },
+                    "destination": "Exile"
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "instant|sorcery",
+                    "zone": "Graveyard"
+                },
+                "id": "up to one target instant or sorcery card from a graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "artist": "Wylie Beckert",
+        "flavorText": "With one lethal strike, Extus took control of the Oriq and took his first step towards vengeance.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bbf97a71-485e-4d47-98de-bdf6f6dae0c2.jpg?1783927296"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
+// Sparring Regimen
+{
+    "name": "Sparring Regimen",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, learn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)\nWhenever you attack, put a +1/+1 counter on target attacking creature and untap it.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target attacking creature"
+                            }
+                        },
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target attacking creature"
+                            },
+                            "tap": false
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature attacking"
+                    },
+                    "id": "target attacking creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "rarity": "RARE",
+        "artist": "Tomasz Jedruszek",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab7c80d3-3e0c-4510-9ed0-bb9fe39d838f.jpg?1783927388"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Spined Karok
 {
     "name": "Spined Karok",
@@ -629,6 +2806,134 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Study Break
+{
+    "name": "Study Break",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Tap up to two target creatures.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "up to two target creatures"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "artist": "Cristi Balanescu",
+        "flavorText": "\"You've been cramming all night. You're taking a nap whether you like it or not.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/ef7cd813-0781-4fd7-8748-2716e1eeb4b9.jpg?1783927382"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/STX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STX.json
@@ -1,3 +1,139 @@
+// Academic Dispute
+{
+    "name": "Academic Dispute",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature blocks this turn if able. You may have it gain reach until end of turn.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MarkMustBlockThisTurn",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "GrantKeyword",
+                        "keyword": "REACH",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature"
+                        }
+                    },
+                    "descriptionOverride": "You may have it gain reach until end of turn."
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "91",
+        "rarity": "UNCOMMON",
+        "artist": "Manuel Castañón",
+        "flavorText": "\"I'll show you original research, you hack!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/4620cc3b-e401-4096-b310-fed080806344.jpg?1783927359"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Ageless Guardian
 {
     "name": "Ageless Guardian",


### PR DESCRIPTION
# Add the Learn keyword action, and Academic Dispute

Learn (CR 701.48) had no SDK spelling. Both halves of the mechanic already existed as
primitives — that's why this is a `Patterns.Mechanic` recipe rather than a new effect
type — but with nothing composing them, Strixhaven's Lesson-fetchers were
unimplementable.

## Learn is sequential, not a choose-one

CR 701.48a, verified against `MagicCompRules_20260808.txt`:

> "Learn" means "You may discard a card. If you do, draw a card. If you didn't discard
> a card, you may reveal a Lesson card you own from outside the game and put it into
> your hand."

The order is load-bearing and easy to get wrong, because the printed *reminder* text
lists the two options the other way round ("You may reveal a Lesson card ... or
discard a card to draw a card"). The rules text governs: discarding **forecloses** the
Lesson. A player who discards never gets the sideboard option, and modelling it as a
two-mode choice would let them take the Lesson and then still discard.

`Patterns.Mechanic.learn()` follows 701.48a literally:

```
GatherCards(hand) -> SelectFromCollection(ChooseUpTo 1)
-> MoveCollection(-> graveyard, MoveType.Discard)
-> ConditionalOnCollection(ifNotEmpty = DrawCards(1),
                           ifEmpty    = Patterns.Sideboard.wish(Lesson))
```

Both printed "may"s are `ChooseUpTo(1)` declines rather than yes/no prompts. That is a
UX decision as much as a modelling one: an empty hand or a Lesson-less sideboard
auto-resolves to none and raises **no decision at all**, so the player is never asked
a question that cannot matter. The discard is a real discard (`MoveType.Discard`), so
madness and "whenever you discard a card" payoffs see it. Collection names are
`learn_`-prefixed so a Learn nested inside another pipeline can't collide with that
pipeline's own `hand` / `discarded`.

`Patterns.Sideboard.wish` already models "outside the game" as the private
`Zone.SIDEBOARD` (CR 100.4 / 400.11a) with reveal-on and no shuffle, so the Lesson
half needed only a subtype-restricted filter.

## Academic Dispute

STX #91, `{R}` Instant — "Target creature blocks this turn if able. You may have it
gain reach until end of turn. Learn."

`Effects.MarkMustBlockThisTurn` + an optional `Effects.GrantKeyword(REACH)` on the
same target + `learn()`. The reach rider is a real `MayEffect` and lands on the
targeted creature, because its whole point is letting the forced blocker block a
flier. "Blocks this turn if able" is a *requirement*, not a guarantee (CR 509.1c): a
tapped creature, or one whose every possible block would be illegal, simply doesn't
block. The three clauses resolve in printed order, so the Learn happens whether or not
the creature ends up blocking.

## Client

None needed, and that is the point rather than an omission. Both Learn prompts are
ordinary `SelectCards` decisions — the sideboard one is the same wish flow Burning
Wish has used since Judgment — and the reach rider is a yes/no. Nothing new reaches
`web-client/src/components/decisions/`.

## Verification

- `just test-class AcademicDisputeScenarioTest` — 6/6. Covers **both branches of
  701.48a** (discard-then-draw with the Lesson never offered; decline-then-fetch with
  only Lesson cards offered), declining both halves, an empty hand skipping straight to
  the Lesson, the block requirement being a requirement rather than a guarantee, and
  the reach rider.
- **Mutation-checked.** Widening the Lesson filter to `GameObjectFilter.Any` reddens
  exactly the "only Lesson cards are offered" test; restored and verified identical.
- `./scripts/gradle-locked :mtg-sets:test` — green after re-blessing; the only failure
  was the expected STX snapshot, and only Academic Dispute moved in the golden, which
  is the check that the new `MechanicPatterns` entry changed no existing card.
- `just check-card-printing "Academic Dispute"` — clean; STX is the only printing.
- `just assay-differential --set STX` — 6/6 confirmed, 0 divergences.
- `:oracle-assay:compileKotlin` — green.

**What this does not cover:** no TypeScript gate was run, because the diff contains no
`.ts`; a green Kotlin suite would say nothing about the client either way. No E2E run
— the decisions Learn raises are existing components on an existing route.

## Note for the reviewer

The Lesson fixture in the scenario test is Boomerang Basics (TLA), a real
`Sorcery — Lesson` already in the corpus, so no card was added just to have something
to fetch. Strixhaven's own Lessons remain unimplemented; Learn is reachable today
through the Avatar Lessons.

## Try it

```bash
curl -X POST http://localhost:8080/api/dev/scenarios \
  -H 'Content-Type: application/json' -d @manual-scenarios/cards/a/academic-dispute.json
```

Built around the card's actual combo: attack with the Air Elemental, then Dispute the
opponent's ground Craw Wurm — forcing it to block a flier only does anything if you also take
the optional reach rider, so both combat clauses are exercised in one attack. **Learn is only
half-testable there**: the scenario API's `PlayerConfig` has no sideboard field, so the
"reveal a Lesson from outside the game" branch can't be set up by hand and is covered by the
scenario test instead.
