### PR TITLE
Replace damage with counters on the damaged permanent, and add Soul-Scar Mage

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -11460,6 +11460,28 @@ The priority groups are (CR 616.1a–f):
   Martyrs of Korlis uses `Conditions.SourceIsUntapped` for "As long as this creature is untapped, all
   damage that would be dealt to you by artifacts is dealt to this creature instead" (`redirectTo =
   EffectTarget.Self`, `source = SourceFilter.Matching(GameObjectFilter.Artifact)`).
+- `ReplaceDamageWithCounters(counterType, sacrificeThreshold = null, appliesTo = DamageEvent(recipient =
+  You), counterRecipient = DamageCounterRecipient.ReplacementHost)` — replace matching damage
+  (CR 614.1a, an "instead" effect: the damage is never dealt, so nothing that keys on damage being
+  dealt sees it) with `counterType` counters. Not a prevention effect, so it still applies to damage
+  that can't be prevented. `appliesTo` filters recipient, source, damage type and amount;
+  `counterRecipient` says where the counters land:
+  - `ReplacementHost` (default) — on the permanent that has the ability. **Force Bubble**: "If damage
+    would be dealt to you, put that many depletion counters on this enchantment instead"
+    (`DamageEvent(recipient = You)`, `sacrificeThreshold = 4` for the paired "sacrifice it when it has
+    four or more"). **Anti-Venom, Horrifying Healer** is the self-damage case where host and damaged
+    permanent coincide (`recipient = RecipientFilter.Self`).
+  - `DamagedPermanent` — on the permanent that would have been dealt the damage. **Soul-Scar Mage**:
+    "If a source you control would deal noncombat damage to a creature an opponent controls, put that
+    many -1/-1 counters on that creature instead" — `DamageEvent(recipient =
+    RecipientFilter.CreatureOpponentControls, source = SourceFilter.YouControl, damageType =
+    DamageType.NonCombat)`. A player recipient has nowhere to put counters, so the replacement
+    declines rather than eating the damage.
+
+  Wired in both damage paths (`DamageUtils.applyReplaceDamageWithCounters` for the general path,
+  `CombatDamageManager` for combat); combat callers pass `isCombatDamage = true` so a noncombat-only
+  pattern isn't applied to combat damage. Supported source filters are `Any`, `Self` and `YouControl`
+  — any other `SourceFilter` declines rather than guessing.
 - `ReplaceDamageWithMill(appliesTo = DamageEvent(recipient = Opponent))` — replace matching damage
   (CR 615, neither dealt nor prevented): each opponent of the replacement's controller mills that many
   cards instead. The Mindskinner: `DamageEvent(recipient = RecipientFilter.Opponent, source =

--- a/manual-scenarios/cards/s/soul-scar-mage.json
+++ b/manual-scenarios/cards/s/soul-scar-mage.json
@@ -11,6 +11,7 @@
       {"name": "Mountain"},
       {"name": "Mountain"},
       {"name": "Mountain"},
+      {"name": "Prodigal Sorcerer"},
       {"name": "Fanatical Firebrand"}
     ],
     "graveyard": [],

--- a/manual-scenarios/cards/s/soul-scar-mage.json
+++ b/manual-scenarios/cards/s/soul-scar-mage.json
@@ -1,0 +1,38 @@
+{
+  "player1Name": "You",
+  "player2Name": "AI",
+  "mode": "AI",
+  "aiPlayer": 2,
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Soul-Scar Mage", "Lightning Bolt", "Shock"],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Fanatical Firebrand"}
+    ],
+    "graveyard": [],
+    "library": ["Hill Giant", "Mountain", "Grizzly Bears", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Grizzly Bears", "Mountain"],
+    "battlefield": [
+      {"name": "Craw Wurm"},
+      {"name": "Serra Angel"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Hill Giant", "Mountain", "Grizzly Bears"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_ATTACKERS", "DECLARE_BLOCKERS"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -1971,13 +1971,50 @@ data class EntersWithDevour(
 // =============================================================================
 
 /**
- * Replace damage dealt to a player with counters on this permanent.
- * Example: Force Bubble — "If damage would be dealt to you, put that many
- * depletion counters on this enchantment instead."
+ * Where the counters land when a [ReplaceDamageWithCounters] applies.
  *
- * @param counterType The type of counter to add (e.g., "depletion")
+ * The recipient of the *damage* is already named by the replacement's `appliesTo` pattern; this
+ * names the recipient of the *counters*, which is a separate question the printed cards answer
+ * two different ways.
+ */
+@Serializable
+enum class DamageCounterRecipient {
+    /**
+     * The permanent that has the replacement effect — "put that many depletion counters on
+     * **this enchantment** instead" (Force Bubble), and the self-damage case where the host and
+     * the damaged permanent happen to be the same object (Anti-Venom).
+     */
+    ReplacementHost,
+
+    /**
+     * The permanent that would have been dealt the damage — "put that many -1/-1 counters on
+     * **that creature** instead" (Soul-Scar Mage). Only meaningful when the pattern's recipient
+     * is a permanent; a player recipient has nowhere to put them, and the replacement declines.
+     */
+    DamagedPermanent
+}
+
+/**
+ * Replace damage with counters (CR 614.1a — an "instead" effect, so the damage is never dealt and
+ * nothing that keys on damage being dealt sees it; notably *not* a prevention effect, so it still
+ * applies to damage that can't be prevented).
+ *
+ * Which damage is replaced comes from [appliesTo] — recipient, source, damage type and amount are
+ * all filterable there. Where the counters go comes from [counterRecipient]:
+ *
+ * - Force Bubble — "If damage would be dealt to you, put that many depletion counters on this
+ *   enchantment instead": `DamageEvent(recipient = You)`, counters on the [ReplacementHost].
+ * - Soul-Scar Mage — "If a source you control would deal noncombat damage to a creature an
+ *   opponent controls, put that many -1/-1 counters on that creature instead":
+ *   `DamageEvent(recipient = CreatureOpponentControls, source = YouControl,
+ *   damageType = NonCombat)`, counters on the [DamagedPermanent].
+ *
+ * @param counterType The type of counter to add (e.g., "depletion", "-1/-1")
  * @param sacrificeThreshold If non-null, sacrifice this permanent when it has
- *        this many or more counters of the specified type (state-triggered ability)
+ *        this many or more counters of the specified type (state-triggered ability).
+ *        Only meaningful together with [DamageCounterRecipient.ReplacementHost].
+ * @param counterRecipient Which permanent receives the counters. Defaults to the replacement's
+ *        own host, which is what every "on this permanent" printing says.
  */
 @SerialName("ReplaceDamageWithCounters")
 @Serializable
@@ -1986,10 +2023,15 @@ data class ReplaceDamageWithCounters(
     val sacrificeThreshold: Int? = null,
     override val appliesTo: EventPattern = EventPattern.DamageEvent(
         recipient = RecipientFilter.You
-    )
+    ),
+    val counterRecipient: DamageCounterRecipient = DamageCounterRecipient.ReplacementHost
 ) : ReplacementEffect {
     override val description: String = buildString {
-        append("If ${appliesTo.description}, put that many $counterType counters on this permanent instead")
+        val where = when (counterRecipient) {
+            DamageCounterRecipient.ReplacementHost -> "this permanent"
+            DamageCounterRecipient.DamagedPermanent -> "that permanent"
+        }
+        append("If ${appliesTo.description}, put that many $counterType counters on $where instead")
         if (sacrificeThreshold != null) {
             append(". When there are $sacrificeThreshold or more $counterType counters on this permanent, sacrifice it")
         }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SoulScarMage.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SoulScarMage.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.DamageCounterRecipient
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.ReplaceDamageWithCounters
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+
+/**
+ * Soul-Scar Mage — Amonkhet #148 (canonical printing)
+ * {R} · Creature — Human Wizard · 1/2
+ *
+ * Prowess
+ * If a source you control would deal noncombat damage to a creature an opponent controls, put
+ * that many -1/-1 counters on that creature instead.
+ *
+ * A one-mana prowess body that turns every burn spell, ping and fight into permanent shrinkage.
+ * The second ability is a **replacement effect** (CR 614.1a — "instead"), not a prevention effect:
+ * the damage is never dealt, so nothing keying on damage being dealt sees it, and — per the card's
+ * own ruling — it still applies to damage that can't be prevented.
+ *
+ * Every part of the clause is carried by the event pattern rather than by bespoke code:
+ * `source = YouControl` for "a source you control" (a permanent, a spell on the stack, or an
+ * ability alike), `damageType = NonCombat` so combat damage is untouched, and
+ * `recipient = CreatureOpponentControls` for the creatures it applies to. The counters land on the
+ * damaged creature rather than on the Mage, which is [DamageCounterRecipient.DamagedPermanent].
+ *
+ * Fight damage is noncombat damage, so a fight an opponent's creature loses leaves -1/-1 counters
+ * behind (2017-04-18 ruling) — that falls out of the pattern without a special case.
+ */
+val SoulScarMage = card("Soul-Scar Mage") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 2
+    oracleText = "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until " +
+        "end of turn.)\n" +
+        "If a source you control would deal noncombat damage to a creature an opponent controls, " +
+        "put that many -1/-1 counters on that creature instead."
+
+    prowess()
+
+    replacementEffect(
+        ReplaceDamageWithCounters(
+            counterType = Counters.MINUS_ONE_MINUS_ONE,
+            appliesTo = EventPattern.DamageEvent(
+                recipient = RecipientFilter.CreatureOpponentControls,
+                source = SourceFilter.YouControl,
+                damageType = DamageType.NonCombat
+            ),
+            counterRecipient = DamageCounterRecipient.DamagedPermanent
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "148"
+        artist = "Steve Argyle"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a8003786-6e2a-4e2d-a915-f23293c7273a.jpg?1783936483"
+        ruling(
+            "2017-04-18",
+            "If an effect causes a creature you control to fight a creature an opponent controls, " +
+                "the damage is dealt simultaneously. For instance, if your 2/2 creature fights an " +
+                "opponent's 4/4 creature, your creature will be dealt 4 damage and your opponent's " +
+                "creature will have two -1/-1 counters put on it."
+        )
+        ruling(
+            "2017-04-18",
+            "Soul-Scar Mage's effect isn't a prevention effect. Damage that can't be prevented " +
+                "will be replaced with -1/-1 counters."
+        )
+        ruling(
+            "2017-04-18",
+            "If multiple prevention and/or replacement effects are trying to apply to the same " +
+                "damage, the controller of the creature that would be dealt damage chooses the " +
+                "order in which to apply them."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SoulScarMage.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SoulScarMage.kt
@@ -31,6 +31,17 @@ import com.wingedsheep.sdk.scripting.events.SourceFilter
  *
  * Fight damage is noncombat damage, so a fight an opponent's creature loses leaves -1/-1 counters
  * behind (2017-04-18 ruling) — that falls out of the pattern without a special case.
+ *
+ * **Known deviation — CR 616.1 ordering is not modelled.** When this replacement competes with
+ * another replacement or prevention effect, CR 616.1 gives the choice of which to apply first to
+ * "the affected object's controller" — the opponent, here — and the card's own 2017-04-18 ruling
+ * spells out both directions they would use it in (converting the damage to counters *before*
+ * Insult could double it, so Insult no longer applies; or taking Djeru's Resolve's prevention over
+ * the counters). The engine has no 616.1 prompt at all: it amplifies before it replaces, and it
+ * places counters ahead of a shield counter — in both cases the order the affected player would
+ * not have chosen. That is engine-wide behaviour rather than anything specific to this card, and
+ * the `ruling(...)` block below ships the ordering ruling verbatim, so this note is here to keep
+ * the two from reading as a contradiction.
  */
 val SoulScarMage = card("Soul-Scar Mage") {
     manaCost = "{R}"

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulScarMageScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulScarMageScenarioTest.kt
@@ -1,0 +1,178 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Soul-Scar Mage (AKH) — "If a source you control would deal noncombat damage to a creature an
+ * opponent controls, put that many -1/-1 counters on that creature instead."
+ *
+ * A `ReplaceDamageWithCounters` whose event pattern carries all three clauses
+ * (`source = YouControl`, `damageType = NonCombat`, `recipient = CreatureOpponentControls`) and
+ * whose counters land on the *damaged* permanent rather than on the Mage
+ * (`DamageCounterRecipient.DamagedPermanent`).
+ *
+ * The tests below pin each clause separately, because each one is a way the replacement could
+ * over-apply: combat damage, damage to your own creatures, damage to players, and damage from a
+ * source your opponent controls all have to stay ordinary damage.
+ */
+class SoulScarMageScenarioTest : FunSpec({
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    /**
+     * Cast a Lightning Bolt from [caster] at [target] and let it resolve. The cast is asserted, not
+     * assumed — a bolt that never got cast would otherwise read as "the replacement did not apply".
+     */
+    fun GameTestDriver.bolt(caster: EntityId, target: ChosenTarget) {
+        giveMana(caster, Color.RED, 1)
+        val bolt = putCardInHand(caster, "Lightning Bolt")
+        // The non-active player only gets to cast an instant once the active player passes.
+        if (priorityPlayer != caster) passPriority(priorityPlayer!!)
+        castSpellWithTargets(caster, bolt, listOf(target)).error shouldBe null
+        bothPass()
+        resolveStack(this)
+    }
+
+    fun GameTestDriver.counters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.MINUS_ONE_MINUS_ONE) ?: 0
+
+    fun GameTestDriver.markedDamage(id: EntityId): Int =
+        state.getEntity(id)?.get<DamageComponent>()?.amount ?: 0
+
+    test("noncombat damage from a spell you control becomes -1/-1 counters on the opponent's creature") {
+        val (driver, you, opponent) = newGame()
+        driver.putCreatureOnBattlefield(you, "Soul-Scar Mage")
+        val wurm = driver.putCreatureOnBattlefield(opponent, "Craw Wurm") // 6/4
+
+        driver.bolt(you, ChosenTarget.Permanent(wurm)) // 3 damage
+
+        // Replaced outright (CR 614.1a): no damage is marked, three -1/-1 counters instead, and the
+        // shrink is permanent — a 6/4 becomes a 3/1 rather than a 6/4 with 3 damage on it.
+        driver.markedDamage(wurm) shouldBe 0
+        driver.counters(wurm) shouldBe 3
+        driver.state.projectedState.getPower(wurm) shouldBe 3
+        driver.state.projectedState.getToughness(wurm) shouldBe 1
+        driver.state.getBattlefield().contains(wurm) shouldBe true
+    }
+
+    test("enough -1/-1 counters kill the creature as a state-based action") {
+        val (driver, you, opponent) = newGame()
+        driver.putCreatureOnBattlefield(you, "Soul-Scar Mage")
+        val courser = driver.putCreatureOnBattlefield(opponent, "Centaur Courser") // 3/3
+
+        driver.bolt(you, ChosenTarget.Permanent(courser)) // 3 damage -> three -1/-1 counters -> 0/0
+
+        driver.state.getBattlefield().contains(courser) shouldBe false
+    }
+
+    test("combat damage is untouched — the clause is noncombat only") {
+        val (driver, you, opponent) = newGame()
+        val mage = driver.putCreatureOnBattlefield(you, "Soul-Scar Mage") // 1/2
+        driver.removeSummoningSickness(mage)
+        val wurm = driver.putCreatureOnBattlefield(opponent, "Craw Wurm") // 6/4
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(mage), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, mapOf(wurm to listOf(mage)))
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        resolveStack(driver)
+
+        // The Mage's own 1 combat damage is marked on the Wurm as normal damage, not converted.
+        driver.counters(wurm) shouldBe 0
+        driver.markedDamage(wurm) shouldBe 1
+    }
+
+    test("damage to a creature you control is untouched") {
+        val (driver, you, _) = newGame()
+        driver.putCreatureOnBattlefield(you, "Soul-Scar Mage")
+        val yourWurm = driver.putCreatureOnBattlefield(you, "Craw Wurm") // 6/4
+
+        driver.bolt(you, ChosenTarget.Permanent(yourWurm))
+
+        driver.counters(yourWurm) shouldBe 0
+        driver.markedDamage(yourWurm) shouldBe 3
+    }
+
+    test("damage to a player is untouched") {
+        val (driver, you, opponent) = newGame()
+        driver.putCreatureOnBattlefield(you, "Soul-Scar Mage")
+
+        driver.bolt(you, ChosenTarget.Player(opponent))
+
+        driver.getLifeTotal(opponent) shouldBe 17
+    }
+
+    test("damage from a source your opponent controls is untouched") {
+        val (driver, you, opponent) = newGame()
+        driver.putCreatureOnBattlefield(you, "Soul-Scar Mage")
+        val theirWurm = driver.putCreatureOnBattlefield(opponent, "Craw Wurm") // 6/4
+
+        // The opponent bolts their own creature. The recipient matches ("a creature an opponent
+        // controls", from the Mage's controller's point of view) but the *source* is not one you
+        // control, so the replacement does not apply.
+        driver.bolt(opponent, ChosenTarget.Permanent(theirWurm))
+
+        driver.counters(theirWurm) shouldBe 0
+        driver.markedDamage(theirWurm) shouldBe 3
+    }
+
+    test("fight damage is noncombat damage — the opponent's creature takes counters, yours takes damage") {
+        val (driver, you, opponent) = newGame()
+        driver.putCreatureOnBattlefield(you, "Soul-Scar Mage")
+        val yourCourser = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+        val theirWurm = driver.putCreatureOnBattlefield(opponent, "Craw Wurm") // 6/4
+
+        driver.giveMana(you, Color.GREEN, 1)
+        driver.giveColorlessMana(you, 1)
+        val punch = driver.putCardInHand(you, "Savage Punch")
+        driver.castSpellWithTargets(
+            you, punch,
+            listOf(ChosenTarget.Permanent(yourCourser), ChosenTarget.Permanent(theirWurm))
+        )
+        driver.bothPass()
+        resolveStack(driver)
+
+        // 2017-04-18 ruling: the damage is simultaneous, and only the half aimed at the opponent's
+        // creature is replaced. Your Courser is dealt 6 and dies; their Wurm gets three -1/-1
+        // counters instead of 3 damage.
+        driver.counters(theirWurm) shouldBe 3
+        driver.markedDamage(theirWurm) shouldBe 0
+        driver.state.getBattlefield().contains(yourCourser) shouldBe false
+    }
+
+    test("prowess still works") {
+        val (driver, you, opponent) = newGame()
+        val mage = driver.putCreatureOnBattlefield(you, "Soul-Scar Mage") // 1/2
+        val wurm = driver.putCreatureOnBattlefield(opponent, "Craw Wurm")
+
+        driver.bolt(you, ChosenTarget.Permanent(wurm))
+
+        driver.state.projectedState.getPower(mage) shouldBe 2
+        driver.state.projectedState.getToughness(mage) shouldBe 3
+    }
+})

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulScarMageScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulScarMageScenarioTest.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.DamageComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
@@ -163,6 +164,57 @@ class SoulScarMageScenarioTest : FunSpec({
         driver.counters(theirWurm) shouldBe 3
         driver.markedDamage(theirWurm) shouldBe 0
         driver.state.getBattlefield().contains(yourCourser) shouldBe false
+    }
+
+    /**
+     * Activate [cardName]'s first activated ability from [controller] at [target] and let it
+     * resolve. Everything the Mage cares about is on the source side, so the two cases below differ
+     * only in whether the source is still on the battlefield when the damage is dealt.
+     */
+    fun GameTestDriver.ping(controller: EntityId, cardName: String, source: EntityId, target: ChosenTarget) {
+        val abilityId = cardRegistry.getCard(cardName)!!.activatedAbilities.first().id
+        submit(
+            ActivateAbility(
+                playerId = controller,
+                sourceId = source,
+                abilityId = abilityId,
+                targets = listOf(target)
+            )
+        ).error shouldBe null
+        bothPass()
+        resolveStack(this)
+    }
+
+    test("noncombat damage from an activated ability you control becomes -1/-1 counters") {
+        val (driver, you, opponent) = newGame()
+        driver.putCreatureOnBattlefield(you, "Soul-Scar Mage")
+        val sorcerer = driver.putCreatureOnBattlefield(you, "Prodigal Sorcerer")
+        driver.removeSummoningSickness(sorcerer)
+        val angel = driver.putCreatureOnBattlefield(opponent, "Serra Angel") // 4/4
+
+        // The clause covers any source you control, not just spells — an ability's source counts.
+        driver.ping(you, "Prodigal Sorcerer", sorcerer, ChosenTarget.Permanent(angel))
+
+        driver.counters(angel) shouldBe 1
+        driver.markedDamage(angel) shouldBe 0
+    }
+
+    test("a source sacrificed to pay its own cost still counts as a source you control") {
+        val (driver, you, opponent) = newGame()
+        driver.putCreatureOnBattlefield(you, "Soul-Scar Mage")
+        // "{T}, Sacrifice this creature: It deals 1 damage to any target" — haste, so no need to
+        // clear summoning sickness for the tap.
+        val firebrand = driver.putCreatureOnBattlefield(you, "Fanatical Firebrand")
+        val angel = driver.putCreatureOnBattlefield(opponent, "Serra Angel") // 4/4
+
+        driver.ping(you, "Fanatical Firebrand", firebrand, ChosenTarget.Permanent(angel))
+
+        // The Firebrand is in the graveyard by the time it deals the damage, so its controller has
+        // to come from last-known information (CR 113.7a / 608.2h). Reading the live state instead
+        // found no controller at all and the replacement silently declined.
+        driver.state.getBattlefield().contains(firebrand) shouldBe false
+        driver.counters(angel) shouldBe 1
+        driver.markedDamage(angel) shouldBe 0
     }
 
     test("prowess still works") {

--- a/mtg-sets/src/test/resources/snapshots/cards/AKH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AKH.json
@@ -778,6 +778,85 @@
     ]
 }
 
+// Soul-Scar Mage
+{
+    "name": "Soul-Scar Mage",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nIf a source you control would deal noncombat damage to a creature an opponent controls, put that many -1/-1 counters on that creature instead.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "PROWESS"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "ReplaceDamageWithCounters",
+                "counterType": "-1/-1",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": "CreatureOpponentControls",
+                    "source": "SourceYouControl",
+                    "damageType": "DamageNonCombat"
+                },
+                "counterRecipient": "DamagedPermanent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "rarity": "RARE",
+        "artist": "Steve Argyle",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a8003786-6e2a-4e2d-a915-f23293c7273a.jpg?1783936483",
+        "rulings": [
+            {
+                "date": "2017-04-18",
+                "text": "If an effect causes a creature you control to fight a creature an opponent controls, the damage is dealt simultaneously. For instance, if your 2/2 creature fights an opponent's 4/4 creature, your creature will be dealt 4 damage and your opponent's creature will have two -1/-1 counters put on it."
+            },
+            {
+                "date": "2017-04-18",
+                "text": "Soul-Scar Mage's effect isn't a prevention effect. Damage that can't be prevented will be replaced with -1/-1 counters."
+            },
+            {
+                "date": "2017-04-18",
+                "text": "If multiple prevention and/or replacement effects are trying to apply to the same damage, the controller of the creature that would be dealt damage chooses the order in which to apply them."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Those Who Serve
 {
     "name": "Those Who Serve",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -24,6 +24,7 @@ import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.battlefield.LastKnownPermanentComponent
 import com.wingedsheep.engine.state.components.battlefield.DealtDamageToThisGameComponent
 import com.wingedsheep.engine.state.components.battlefield.DamageDealtByPlayersThisTurnComponent
 import com.wingedsheep.engine.state.components.battlefield.DamageDealtToCreaturesThisTurnComponent
@@ -142,16 +143,40 @@ object DamageUtils {
      * 609.7), and neither has a projected entry, which is why this falls back to the base
      * [ControllerComponent] the same way [replacementHostController] does.
      */
-    private fun damageSourceController(state: GameState, entityId: EntityId): EntityId? =
-        controllerOfObject(state, entityId)
+    private fun damageSourceController(
+        state: GameState,
+        entityId: EntityId,
+        projected: ProjectedState = state.projectedState
+    ): EntityId? = controllerOfObject(state, entityId, projected)
 
     /**
      * Projected controller of an object, falling back to its base [ControllerComponent] for
-     * objects outside the battlefield (stack, exile) that have no projected entry.
+     * objects outside the battlefield (stack, exile) that have no projected entry, and then to the
+     * *last-known* controller of one that has left the battlefield altogether.
+     *
+     * That last step is load-bearing on the source side. A permanent sacrificed to pay its own
+     * ability's cost (Fanatical Firebrand: "{T}, Sacrifice this creature: It deals 1 damage to any
+     * target") deals its damage from the graveyard, where `stripBattlefieldComponents` has already
+     * taken its [ControllerComponent] away — so the projected and base lookups both come back
+     * empty. CR 113.7a and CR 608.2h say the source's last known information answers "a source you
+     * control" in exactly that case; without this fallback every [SourceFilter.YouControl]
+     * replacement (Soul-Scar Mage, Twinflame Tyrant) silently declined for a self-sacrificing
+     * source, while the same ability from a source that stayed on the battlefield (Prodigal
+     * Sorcerer) worked.
+     *
+     * @param projected the projection to read control off — [GameState.projectedState] for ordinary
+     *   callers, the in-flight one for a mid-projection caller.
      */
-    private fun controllerOfObject(state: GameState, entityId: EntityId): EntityId? =
-        state.projectedState.getController(entityId)
-            ?: state.getEntity(entityId)?.get<ControllerComponent>()?.playerId
+    private fun controllerOfObject(
+        state: GameState,
+        entityId: EntityId,
+        projected: ProjectedState = state.projectedState
+    ): EntityId? {
+        val container = state.getEntity(entityId) ?: return null
+        return projected.getController(entityId)
+            ?: container.get<ControllerComponent>()?.playerId
+            ?: container.get<LastKnownPermanentComponent>()?.snapshot?.controllerId
+    }
 
     /**
      * Deal damage to a target (player or creature).
@@ -1719,16 +1744,11 @@ object DamageUtils {
             sourceId != null && sourceId == attachedTo
         }
         // "A source you control" — any source (permanent, spell, or ability) whose controller is
-        // this replacement's controller. Projected control for battlefield permanents; the base
-        // ControllerComponent for spells and abilities on the stack.
-        is SourceFilter.YouControl -> {
-            if (sourceId == null) false
-            else {
-                val sourceController = projected.getController(sourceId)
-                    ?: state.getEntity(sourceId)?.get<ControllerComponent>()?.playerId
-                sourceController == hostControllerId
-            }
-        }
+        // this replacement's controller. Projected control for battlefield permanents, the base
+        // ControllerComponent for spells and abilities on the stack, and last-known information for
+        // a source that has left the battlefield (see [controllerOfObject]).
+        is SourceFilter.YouControl ->
+            sourceId != null && damageSourceController(state, sourceId, projected) == hostControllerId
         is SourceFilter.Matching -> {
             if (sourceId == null) false
             else {
@@ -2611,16 +2631,17 @@ object DamageUtils {
                 }
                 if (!damageTypeMatches) continue
 
-                // "a source you control" (Soul-Scar Mage) / "this permanent" — anything else is
-                // a source filter this path has never had to answer, and answering it wrong would
-                // silently widen a card's reach, so it declines instead.
-                val sourceMatches = when (damageEvent.source) {
-                    is SourceFilter.Any -> true
-                    is SourceFilter.Self -> sourceId == entityId
-                    is SourceFilter.YouControl ->
-                        sourceId != null && damageSourceController(state, sourceId) == sourceControllerId
-                    else -> false
-                }
+                // "a source you control" (Soul-Scar Mage) / "this permanent" — shared with every
+                // other damage-replacement scan so the supported filters cannot drift apart.
+                val sourceMatches = damageSourceMatches(
+                    state = state,
+                    projected = state.projectedState,
+                    filter = damageEvent.source,
+                    sourceId = sourceId,
+                    hostId = entityId,
+                    hostControllerId = sourceControllerId,
+                    recipientId = targetId,
+                )
                 if (!sourceMatches) continue
 
                 // Check recipient filter

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -71,6 +71,7 @@ import com.wingedsheep.sdk.scripting.PreventDamage
 import com.wingedsheep.sdk.scripting.PreventLifeGain
 import com.wingedsheep.sdk.scripting.RedirectDamage
 import com.wingedsheep.sdk.scripting.effects.RedirectScope
+import com.wingedsheep.sdk.scripting.DamageCounterRecipient
 import com.wingedsheep.sdk.scripting.ReplaceDamageWithCounters
 import com.wingedsheep.sdk.scripting.ReplaceDamageWithMill
 import com.wingedsheep.sdk.scripting.ReplacementEffect
@@ -132,6 +133,23 @@ object DamageUtils {
      * [ControllerComponent] only for entities with no projected entry.
      */
     private fun replacementHostController(state: GameState, entityId: EntityId): EntityId? =
+        controllerOfObject(state, entityId)
+
+    /**
+     * Controller of the object *dealing* damage — the other half of the "a source you control"
+     * question ([SourceFilter.YouControl]). A damage source is not always a battlefield permanent:
+     * a burn spell resolving off the stack and an ability's source are damage sources too (CR
+     * 609.7), and neither has a projected entry, which is why this falls back to the base
+     * [ControllerComponent] the same way [replacementHostController] does.
+     */
+    private fun damageSourceController(state: GameState, entityId: EntityId): EntityId? =
+        controllerOfObject(state, entityId)
+
+    /**
+     * Projected controller of an object, falling back to its base [ControllerComponent] for
+     * objects outside the battlefield (stack, exile) that have no projected entry.
+     */
+    private fun controllerOfObject(state: GameState, entityId: EntityId): EntityId? =
         state.projectedState.getController(entityId)
             ?: state.getEntity(entityId)?.get<ControllerComponent>()?.playerId
 
@@ -259,7 +277,7 @@ object DamageUtils {
         // This replaces the damage entirely — it is neither dealt nor prevented.
         val isPlayer = newState.getEntity(targetId)?.get<LifeTotalComponent>() != null
         if (isPlayer) {
-            val counterResult = applyReplaceDamageWithCounters(newState, targetId, effectiveAmount, sourceId)
+            val counterResult = applyReplaceDamageWithCounters(newState, targetId, effectiveAmount, sourceId, isCombatDamage)
             if (counterResult != null) return counterResult
 
             // Damage-to-an-opponent → prevent + each opponent mills that many (The Mindskinner).
@@ -269,7 +287,7 @@ object DamageUtils {
             // Damage-to-a-creature self-replacement (Anti-Venom): "if damage would be dealt to
             // <this creature>, prevent it and put that many +1/+1 counters on him." Matches only a
             // Self-recipient replacement whose host is the damaged creature.
-            val counterResult = applyReplaceDamageWithCounters(newState, targetId, effectiveAmount, sourceId)
+            val counterResult = applyReplaceDamageWithCounters(newState, targetId, effectiveAmount, sourceId, isCombatDamage)
             if (counterResult != null) return counterResult
         }
 
@@ -2541,23 +2559,35 @@ object DamageUtils {
     }
 
     /**
-     * Check for ReplaceDamageWithCounters replacement effects (Force Bubble).
+     * Check for [ReplaceDamageWithCounters] replacement effects (Force Bubble, Anti-Venom,
+     * Soul-Scar Mage).
      *
-     * Scans the battlefield for permanents with ReplaceDamageWithCounters replacement
-     * effects. If found and the recipient matches, replaces all damage with counters
-     * on the source permanent. If the counter threshold is met, sacrifices the permanent.
+     * Scans the battlefield for permanents carrying a [ReplaceDamageWithCounters] whose
+     * [com.wingedsheep.sdk.scripting.EventPattern.DamageEvent] matches this damage event —
+     * recipient, source and damage type all have to agree — and, on the first match, replaces the
+     * damage outright (CR 614.1a: the damage is never dealt) with counters on the permanent named
+     * by [ReplaceDamageWithCounters.counterRecipient]. The first match wins because a replacement
+     * gets one shot at an event (CR 614.5) and, after this one applies, the event is no longer a
+     * damage event for any other to see.
+     *
+     * This is a *replacement*, not a prevention effect, so it deliberately runs even when the
+     * damage can't be prevented (Soul-Scar Mage's own ruling says exactly that).
      *
      * @param state The current game state
-     * @param targetId The player entity receiving damage
+     * @param targetId The entity receiving damage — a player or a permanent
      * @param amount The damage amount to replace
-     * @param sourceId The entity dealing damage (for source filtering)
+     * @param sourceId The entity dealing damage (matched against the pattern's source filter)
+     * @param isCombatDamage Whether this is combat damage, matched against the pattern's damage
+     *        type. Combat-damage callers must pass `true`, or a noncombat-only replacement
+     *        (Soul-Scar Mage) would swallow combat damage as well.
      * @return ExecutionResult if replacement was applied, null if no replacement found
      */
     fun applyReplaceDamageWithCounters(
         state: GameState,
         targetId: EntityId,
         amount: Int,
-        sourceId: EntityId?
+        sourceId: EntityId?,
+        isCombatDamage: Boolean = false
     ): EffectResult? {
         if (amount <= 0) return null
 
@@ -2572,43 +2602,76 @@ object DamageUtils {
                 val damageEvent = effect.appliesTo
                 if (damageEvent !is com.wingedsheep.sdk.scripting.EventPattern.DamageEvent) continue
 
+                // Combat vs noncombat. Soul-Scar Mage only replaces noncombat damage, so a
+                // replacement that names a type is skipped when this event is the other one.
+                val damageTypeMatches = when (damageEvent.damageType) {
+                    is DamageType.Any -> true
+                    is DamageType.Combat -> isCombatDamage
+                    is DamageType.NonCombat -> !isCombatDamage
+                }
+                if (!damageTypeMatches) continue
+
+                // "a source you control" (Soul-Scar Mage) / "this permanent" — anything else is
+                // a source filter this path has never had to answer, and answering it wrong would
+                // silently widen a card's reach, so it declines instead.
+                val sourceMatches = when (damageEvent.source) {
+                    is SourceFilter.Any -> true
+                    is SourceFilter.Self -> sourceId == entityId
+                    is SourceFilter.YouControl ->
+                        sourceId != null && damageSourceController(state, sourceId) == sourceControllerId
+                    else -> false
+                }
+                if (!sourceMatches) continue
+
                 // Check recipient filter
                 val recipientMatches = when (val recipient = damageEvent.recipient) {
                     is RecipientFilter.You -> targetId == sourceControllerId
                     // "If damage would be dealt to <this creature>…" (Anti-Venom) — the damaged
                     // permanent is the replacement's own host; counters go on it (entityId).
                     is RecipientFilter.Self -> targetId == entityId
+                    // "…to a creature an opponent controls" (Soul-Scar Mage). Reads the projected
+                    // controller and the projected type, so a stolen creature and one that is only
+                    // a creature because of a continuous effect are both judged correctly.
+                    is RecipientFilter.CreatureOpponentControls ->
+                        state.projectedState.isCreature(targetId) &&
+                            state.projectedState.getController(targetId)
+                                ?.let { it != sourceControllerId } == true
                     is RecipientFilter.Any -> true
                     else -> false
                 }
                 if (!recipientMatches) continue
 
-                // Match found — replace damage with counters on this permanent
+                // Which permanent the counters land on. "That creature" (Soul-Scar Mage) is the
+                // damaged permanent; every "this permanent" printing is the replacement's host.
+                // A player has nowhere to put counters, so a DamagedPermanent replacement declines
+                // rather than dropping the damage on the floor.
+                val counterHolderId = when (effect.counterRecipient) {
+                    DamageCounterRecipient.ReplacementHost -> entityId
+                    DamageCounterRecipient.DamagedPermanent -> targetId
+                }
+                val counterHolder = state.getEntity(counterHolderId) ?: continue
+                if (effect.counterRecipient == DamageCounterRecipient.DamagedPermanent &&
+                    counterHolder.get<LifeTotalComponent>() != null
+                ) continue
+
+                // Match found — replace damage with counters
                 val events = mutableListOf<EngineGameEvent>()
                 var newState = state
 
-                // Convert string counter type to CounterType enum
-                val counterType = try {
-                    CounterType.valueOf(
-                        effect.counterType.uppercase()
-                            .replace(' ', '_')
-                            .replace('+', 'P')
-                            .replace('-', 'M')
-                            .replace("/", "_")
-                    )
-                } catch (e: IllegalArgumentException) {
-                    CounterType.PLUS_ONE_PLUS_ONE
-                }
+                // Convert the printed counter name to its CounterType. `fromName` is the shared
+                // parse: it knows the symbolic stat names ("+1/+1", "-1/-1") that `valueOf` alone
+                // cannot reach.
+                val counterType = CounterType.fromName(effect.counterType)
+                    ?: CounterType.PLUS_ONE_PLUS_ONE
 
-                // Add counters to the enchantment
-                val currentCounters = container.get<CountersComponent>() ?: CountersComponent()
+                val currentCounters = counterHolder.get<CountersComponent>() ?: CountersComponent()
                 val updatedCounters = currentCounters.withAdded(counterType, amount)
-                newState = newState.updateEntity(entityId) { c ->
+                newState = newState.updateEntity(counterHolderId) { c ->
                     c.with(updatedCounters)
                 }
 
-                val entityName = container.get<CardComponent>()?.name ?: ""
-                events.add(CountersAddedEvent(entityId, effect.counterType, amount, entityName, placedBy = sourceControllerId))
+                val entityName = counterHolder.get<CardComponent>()?.name ?: ""
+                events.add(CountersAddedEvent(counterHolderId, effect.counterType, amount, entityName, placedBy = sourceControllerId))
 
                 // Check sacrifice threshold (state-triggered ability approximation)
                 val totalCounters = updatedCounters.getCount(counterType)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -968,7 +968,7 @@ internal class CombatDamageManager(
         var newState = state
 
         // Replace with counters (Force Bubble)
-        val counterResult = DamageUtils.applyReplaceDamageWithCounters(newState, targetId, amplifiedAmount, sourceId)
+        val counterResult = DamageUtils.applyReplaceDamageWithCounters(newState, targetId, amplifiedAmount, sourceId, isCombatDamage = true)
         if (counterResult != null) {
             newState = counterResult.state
             events.addAll(counterResult.events)
@@ -1213,7 +1213,7 @@ internal class CombatDamageManager(
         // Damage-to-counters self-replacement (Anti-Venom): "if damage would be dealt to <this
         // creature>, prevent it and put that many +1/+1 counters on him." Replaces the damage
         // entirely (CR 615) — checked before redirection and final marking.
-        val counterResult = DamageUtils.applyReplaceDamageWithCounters(newState, targetId, effectiveAmount, sourceId)
+        val counterResult = DamageUtils.applyReplaceDamageWithCounters(newState, targetId, effectiveAmount, sourceId, isCombatDamage = true)
         if (counterResult != null) {
             newState = counterResult.state
             events.addAll(counterResult.events)


### PR DESCRIPTION
# Replace damage with counters on the damaged permanent, and add Soul-Scar Mage

Soul-Scar Mage (AKH #148) needs one thing the SDK didn't have: a damage replacement
whose counters land on the **damaged** permanent rather than on the permanent
carrying the ability.

## The SDK change: parameterize, don't clone

`ReplaceDamageWithCounters` hardcoded the counter recipient as its own host — "put
that many depletion counters on **this enchantment** instead" (Force Bubble), and the
self-damage case where host and damaged permanent coincide (Anti-Venom). Soul-Scar
Mage says the other thing: "put that many -1/-1 counters on **that creature**
instead".

That is a constant baked into a type, which `sdk-design-principles.md` says to
parameterize rather than clone, so the type gains
`counterRecipient: DamageCounterRecipient` — `ReplacementHost` (the default, so every
existing printing is untouched) or `DamagedPermanent`. A near-duplicate replacement
type would have doubled the engine's damage-replacement surface for one field.

Nothing else was needed at the card layer: every clause of the printed text is
carried by the event pattern the SDK already had —
`DamageEvent(recipient = CreatureOpponentControls, source = YouControl, damageType = NonCombat)`.

## The engine change: honour the pattern that was already there

`DamageUtils.applyReplaceDamageWithCounters` was ignoring most of its own
`appliesTo` pattern. That was invisible while the only users left `source` and
`damageType` at `Any`, and immediately wrong for a noncombat-only, source-scoped
replacement — it would have swallowed combat damage and an opponent's burn spell
alike. It now honours:

- **damage type** (`Any` / `Combat` / `NonCombat`), with the two combat call sites in
  `CombatDamageManager` passing `isCombatDamage = true`;
- **source filter** (`Any` / `Self` / `YouControl`), *declining* any other filter
  rather than guessing at it — answering an unmodelled filter wrong would silently
  widen a card's reach;
- **`RecipientFilter.CreatureOpponentControls`**, read off projected state for both
  the type and the controller, so a stolen creature is judged by its current
  controller and a creature that is only a creature because of a continuous effect is
  judged correctly.

Both are no-ops for Force Bubble and Anti-Venom. The card snapshot golden is the
evidence: re-blessing moved **only** Soul-Scar Mage's tree.

### A latent bug fixed on the way

The helper parsed the printed counter name with a homegrown transform
(`"+1/+1"` → uppercase → `'+'`→`'P'` → `'-'`→`'M'` → `'/'`→`'_'` → `"P1_P1"`), which
`CounterType.valueOf` always threw on, and the `catch` fell back to
`PLUS_ONE_PLUS_ONE`. Anti-Venom therefore worked *by accident*, and a `"-1/-1"`
replacement would have silently placed **+1/+1** counters — i.e. Soul-Scar Mage would
have pumped the creature it was meant to shrink. Replaced with the shared
`CounterType.fromName`, which knows the symbolic stat names. Same answer for both
existing cards, correct answer for the new one.

## The second engine change: answer "a source you control" with last-known information

Playtesting the dev scenario surfaced a bug the first commit's tests could not see. The
Mage replaced Prodigal Sorcerer's ping but *not* Fanatical Firebrand's. Both are
noncombat damage from a source their controller controls; the only difference is that
the Firebrand sacrifices itself to pay its own activation cost, so it deals its damage
from the graveyard.

`controllerOfObject` asked the projection and then the base `ControllerComponent`, and a
permanent that has left the battlefield has neither — `stripBattlefieldComponents` takes
the `ControllerComponent` on the way out. The lookup returned null, `SourceFilter.YouControl`
declined, and the damage stayed ordinary damage. **CR 113.7a** and **CR 608.2h** both say
the source's last known information answers questions about a source that is no longer in
the zone it was expected to be in, so the lookup now falls back to
`LastKnownPermanentComponent`.

**This was never Soul-Scar-Mage-specific.** `damageSourceMatches` — shared by the
prevention, doubling and flat/dynamic-modification scans — carried its own copy of the same
two-step lookup and so had the same hole. Every implemented card with the same source
clause was equally blind to a self-sacrificing source:

| Card | Set | Clause |
|---|---|---|
| Hawkeye, Young Avenger | MSH | "…deals that much damage plus X" |
| Fated Firepower | TLA | source-scoped damage modification |
| Far Fortune, End Boss | DFT | source-scoped damage modification |

Both now route through `damageSourceController`, which takes the projection as a parameter
so a mid-projection caller can pass its in-flight one instead of `state.projectedState`.

`applyReplaceDamageWithCounters` held a *third* copy of the source-filter `when` — which is
how the two drifted apart in the first place — and now calls the shared
`damageSourceMatches`. That also widens it from `Any`/`Self`/`YouControl` to every filter
the other scans already support, rather than declining the rest. The "declines rather than
guesses" property noted in the review is preserved: `damageSourceMatches` has the same
`else -> false` floor.

## Rules

- **CR 614.1a** — effects that use the word "instead" are replacement effects. The
  damage is never dealt, so nothing keying on damage being dealt sees it.
- **CR 614.5** — a replacement gets one opportunity at an event, which is why the
  first matching effect wins and the scan stops.
- The card's own 2017-04-18 rulings, carried into `metadata { ruling(...) }`: fight
  damage is noncombat damage and *is* replaced; the effect is not a prevention effect,
  so it still applies to damage that can't be prevented; and when several
  prevention/replacement effects compete, the damaged creature's controller orders
  them.

Rule numbers checked against `MagicCompRules_20260808.txt`, not from memory.

## Verification

The branch is two units of work with two gates. Everything below was re-run after the
last commit unless marked otherwise.

**The last-known-information fix** (engine-wide damage code, so the gate is scoped to the
modules the diff can reach):

- `scripts/gradle-locked :rules-engine:test` — **BUILD SUCCESSFUL**. This is the gate that
  matters: it covers Force Bubble, Anti-Venom, wither, and the rest of the damage paths the
  shared helper feeds.
- `just test-scenarios` for **2017-2022, 2025, 2026 and 2003-2007** — 786 + 1595 + 1320 +
  670 = **4,371 tests, 0 failures, 0 errors** (counted from the JUnit XML, not from a
  "BUILD SUCCESSFUL" line). Those four eras hold every card that reaches the changed code:
  Soul-Scar Mage, Anti-Venom, Force Bubble, Hawkeye, Fated Firepower, Far Fortune.
- `just test-class SoulScarMageScenarioTest` — **10/10**, up from 8 with two new cases, one
  per side of the difference the bug turned on: Prodigal Sorcerer (source stays on the
  battlefield) as the regression guard, Fanatical Firebrand (source sacrificed to its own
  cost) for the bug.
- **Mutation-checked.** Dropping the `LastKnownPermanentComponent` fallback reddens exactly
  the Firebrand test and leaves the other nine green. Restored and re-run green.

**The SDK + pattern-honouring change** (from the first commit, not re-run since — nothing
after it touched the SDK or the goldens):

- `:mtg-sets:test` — green after re-blessing; only Soul-Scar Mage moved in the golden.
- Both new filters mutation-checked: forcing the damage-type branch to `true` reddens
  exactly "combat damage is untouched"; forcing the source branch to `true` reddens exactly
  "damage from a source your opponent controls is untouched".
- `just check-card-printing "Soul-Scar Mage"` — clean, AKH is the earliest real printing.
- `just assay-differential --set AKH` — 16/16 confirmed, 0 divergences.
- `:oracle-assay:compileKotlin` / `:compileTestKotlin` — green.

Card oracle text re-checked against Scryfall: still "a **creature** an opponent controls",
not "permanent", so `RecipientFilter.CreatureOpponentControls` is right and no errata has
landed. Rule numbers checked against `MagicCompRules_20260808.txt`, not from memory.

**What this does not cover:** nothing here touches the web client or the server, so no
TypeScript or `:game-server` gate was run and neither would say anything about this diff.
No E2E run — the change surfaces no new decision or UI affordance; -1/-1 counters already
render. The scenario eras *not* listed above were not re-run; the grep for
`SourceFilter.YouControl` and `ReplaceDamageWithCounters` across the corpus found no card
outside those four.

## Not done, on purpose

**CR 616.1 ordering is not modelled**, and this card is the first to make the deviation
observable in the affected player's disfavour. When this replacement competes with another
replacement or prevention effect, 616.1 gives the ordering choice to the affected object's
controller — the opponent — and the card's own 2017-04-18 ruling spells out both directions
they would use it in. The engine has no 616.1 prompt at all: it amplifies before it
replaces and places counters ahead of a shield counter, in both cases the order the
affected player would not choose. That is engine-wide behaviour rather than anything this
branch introduced, and building 616.1 ordering is plainly out of scope. Since the card's
`metadata` ships the ordering ruling verbatim, the deviation is now named in the card's
KDoc so the two don't read as a contradiction.

`ReplaceDamageWithCounters` has no entry in the mtgish bridge — the generator can't
predict or draft *any* card using it, before or after this change. Adding one would be
about the pre-existing type rather than about this parameter, so it is left as a
standing gap rather than folded in here (`add-feature` Step 8b gates on introducing a
new IR tag, and this introduces none).

## Try it

```bash
curl -X POST http://localhost:8080/api/dev/scenarios \
  -H 'Content-Type: application/json' -d @manual-scenarios/cards/s/soul-scar-mage.json
```

Burn an opponent's creature to see the counters and the permanent shrink; tap Prodigal
Sorcerer and then the hasty Fanatical Firebrand to confirm the clause covers an *ability*
source, whether or not that source survives paying its own cost — those two side by side
are the bug this branch's second commit fixes; attack with the Mage next turn to confirm
combat damage stays ordinary damage.
