### PR TITLE
Add 76 Assay-ready cards to Scars of Mirrodin

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/RevokeExistenceReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/RevokeExistenceReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.bng.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Revoke Existence reprint in BNG. Canonical CardDefinition lives in its earliest set.
+ */
+val RevokeExistenceReprint = Printing(
+    oracleId = "289e1a7c-b301-4395-baf8-e9a1c6d38aab",
+    name = "Revoke Existence",
+    setCode = "BNG",
+    collectorNumber = "25",
+    scryfallId = "597916e4-0294-4911-98e0-6ac5993533ae",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/5/9/597916e4-0294-4911-98e0-6ac5993533ae.jpg",
+    releaseDate = "2014-02-07",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/PalladiumMyrReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/PalladiumMyrReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Palladium Myr reprint in C14. Canonical CardDefinition lives in its earliest set.
+ */
+val PalladiumMyrReprint = Printing(
+    oracleId = "7b0767b8-b504-456e-93bd-218502f73b3d",
+    name = "Palladium Myr",
+    setCode = "C14",
+    collectorNumber = "258",
+    scryfallId = "91272ec6-376c-4db7-b4e3-8e5edf67c072",
+    artist = "Alan Pollack",
+    imageUri = "https://cards.scryfall.io/normal/front/9/1/91272ec6-376c-4db7-b4e3-8e5edf67c072.jpg",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SunblastAngelReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/SunblastAngelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sunblast Angel reprint in C14. Canonical CardDefinition lives in its earliest set.
+ */
+val SunblastAngelReprint = Printing(
+    oracleId = "8b34d1df-4024-497d-bd28-a7caa8c3fa24",
+    name = "Sunblast Angel",
+    setCode = "C14",
+    collectorNumber = "92",
+    scryfallId = "f6dea195-3da3-47b4-9a33-5b859881bc01",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/f/6/f6dea195-3da3-47b4-9a33-5b859881bc01.jpg",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddf/DuelDecksElspethVsTezzeretSet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddf/DuelDecksElspethVsTezzeretSet.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.ddf
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Duel Decks: Elspeth vs. Tezzeret (2010)
+ *
+ * Scaffolded so that Kemba's Skyguard — printed here on 2010-09-03, a month before Scars of
+ * Mirrodin — can hold its canonical [CardDefinition] in its earliest real printing, with a
+ * [Printing] row in SOM. The rest of the product is still unauthored.
+ *
+ * [sealedSupported] stays false: a duel deck is two fixed 60-card decks, not a draftable product.
+ *
+ * Set Code: DDF
+ * Release Date: 2010-09-03
+ */
+object DuelDecksElspethVsTezzeretSet : MtgSet {
+
+    override val code = "DDF"
+    override val displayName = "Duel Decks: Elspeth vs. Tezzeret"
+    override val releaseDate = "2010-09-03"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.ddf.cards"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddf/cards/KembasSkyguard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddf/cards/KembasSkyguard.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ddf.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kemba's Skyguard
+ * {1}{W}{W}
+ * Creature — Cat Knight
+ * 2 / 2
+ *
+ * Flying
+ * When this creature enters, you gain 2 life.
+ */
+val KembasSkyguard = card("Kemba's Skyguard") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Knight"
+    oracleText = "Flying\n" +
+        "When this creature enters, you gain 2 life."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(2)
+        description = "When this creature enters, you gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "13"
+        artist = "Whit Brachna"
+        flavorText = "\"We're now to dispense aid to any Mirran we see battling anything . . . 'strange.' " +
+            "Regent's orders.\"\n—Ranya, skyhunter captain"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/66ce7c11-09bf-4884-893c-fc8bdbe776d4.jpg?1783941769"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/AccorderSShieldReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/AccorderSShieldReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Accorder's Shield reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val AccorderSShieldReprint = Printing(
+    oracleId = "dd70d439-bd60-43d1-ac26-13b744cc4a37",
+    name = "Accorder's Shield",
+    setCode = "M14",
+    collectorNumber = "204",
+    scryfallId = "c5a4c2ab-c5bc-4e07-8671-a688ebd5471c",
+    artist = "Alan Pollack",
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c5a4c2ab-c5bc-4e07-8671-a688ebd5471c.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/DisperseReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/DisperseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Disperse reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val DisperseReprint = Printing(
+    oracleId = "9d8fe3f8-5027-4f9e-999e-e277caa96478",
+    name = "Disperse",
+    setCode = "M14",
+    collectorNumber = "51",
+    scryfallId = "e6b415d2-53fe-4540-aea6-9cd2c498134c",
+    artist = "Steve Ellis",
+    imageUri = "https://cards.scryfall.io/normal/front/e/6/e6b415d2-53fe-4540-aea6-9cd2c498134c.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/Disperse.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/Disperse.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.mor.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Disperse
+ * {1}{U}
+ * Instant
+ *
+ * Return target nonland permanent to its owner's hand.
+ */
+val Disperse = card("Disperse") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target nonland permanent to its owner's hand."
+
+    spell {
+        val t = target("target nonland permanent", Targets.NonlandPermanent)
+        effect = Effects.ReturnToHand(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "31"
+        artist = "Steve Ellis"
+        flavorText = "Gryffid scowled at the sky. A perfect day for the hunt tainted by clouds. He wished them gone. High above, the clouds looked down, scowled, and made a wish of their own."
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0ae239b2-1596-4906-9711-1d180a246d35.jpg?1783942800"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/GraspOfDarknessReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/GraspOfDarknessReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grasp of Darkness reprint in OGW. Canonical CardDefinition lives in its earliest set.
+ */
+val GraspOfDarknessReprint = Printing(
+    oracleId = "494c819d-7d73-432b-8c96-4cb9dcd31094",
+    name = "Grasp of Darkness",
+    setCode = "OGW",
+    collectorNumber = "85",
+    scryfallId = "7d692236-92e5-460f-a8fc-8f6c73eba30c",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/7/d/7d692236-92e5-460f-a8fc-8f6c73eba30c.jpg",
+    releaseDate = "2016-01-22",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/StriderHarnessReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/StriderHarnessReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Strider Harness reprint in OGW. Canonical CardDefinition lives in its earliest set.
+ */
+val StriderHarnessReprint = Printing(
+    oracleId = "bd4ad383-8c40-4dda-bc9c-ba8a001d6882",
+    name = "Strider Harness",
+    setCode = "OGW",
+    collectorNumber = "167",
+    scryfallId = "47c90f49-d1eb-420e-bfb6-b834a496860d",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/4/7/47c90f49-d1eb-420e-bfb6-b834a496860d.jpg",
+    releaseDate = "2016-01-22",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/DisperseReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/DisperseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Disperse reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val DisperseReprint = Printing(
+    oracleId = "9d8fe3f8-5027-4f9e-999e-e277caa96478",
+    name = "Disperse",
+    setCode = "ORI",
+    collectorNumber = "54",
+    scryfallId = "f790b0b5-ed67-40f8-b23b-10cf0a71f285",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/f/7/f790b0b5-ed67-40f8-b23b-10cf0a71f285.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/ScarsOfMirrodinSet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/ScarsOfMirrodinSet.kt
@@ -23,6 +23,10 @@ object ScarsOfMirrodinSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/AbunaAcolyte.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/AbunaAcolyte.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Abuna Acolyte
+ * {1}{W}
+ * Creature — Cat Cleric
+ * 1/1
+ *
+ * {T}: Prevent the next 1 damage that would be dealt to any target this turn.
+ * {T}: Prevent the next 2 damage that would be dealt to target artifact creature this turn.
+ *
+ * Two independent tap abilities, each a plain [Effects.PreventNextDamage] shield — the same
+ * primitive Samite Healer and Argivian Blacksmith use, differing only in the shield size and in
+ * which target requirement declares the recipient.
+ */
+val AbunaAcolyte = card("Abuna Acolyte") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Cleric"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Prevent the next 1 damage that would be dealt to any target this turn.\n" +
+        "{T}: Prevent the next 2 damage that would be dealt to target artifact creature this turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", Targets.Any)
+        effect = Effects.PreventNextDamage(1, t)
+        description = "{T}: Prevent the next 1 damage that would be dealt to any target this turn."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target(
+            "target",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.ArtifactCreature))
+        )
+        effect = Effects.PreventNextDamage(2, t)
+        description = "{T}: Prevent the next 2 damage that would be dealt to target artifact creature this turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "1"
+        artist = "Igor Kieryluk"
+        flavorText = "\"You can break nothing I cannot mend.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e17bbf7-00c0-46f2-9718-2762fd7388d3.jpg?1783941748"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/AccordersShield.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/AccordersShield.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Accorder's Shield — Scars of Mirrodin #136
+ * {0} · Artifact — Equipment
+ *
+ * Equipped creature gets +0/+3 and has vigilance. (Attacking doesn't cause it to tap.)
+ * Equip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)
+ *
+ * Two statics over [GroupFilter.attachedCreature] — the affected set of every "equipped creature
+ * …" line — plus the printed equip ability, which `equipAbility` lowers into the sorcery-speed
+ * attach that CR 702.6 describes.
+ */
+val AccordersShield = card("Accorder's Shield") {
+    manaCost = "{0}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +0/+3 and has vigilance. (Attacking doesn't cause it to tap.)\n" +
+        "Equip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(0, 3, GroupFilter.attachedCreature())
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter.attachedCreature())
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "136"
+        artist = "Alan Pollack"
+        flavorText = "An Auriok shield is polished to a mirror finish even on the inside, enabling its bearer to watch foes ahead and behind."
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a7305c18-5058-42dd-b62a-7f6a42624036.jpg?1783941713"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Asceticism.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Asceticism.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+
+/**
+ * Asceticism
+ * {3}{G}{G}
+ * Enchantment
+ *
+ * Creatures you control have hexproof.
+ * {1}{G}: Regenerate target creature. (The next time it would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)
+ */
+val Asceticism = card("Asceticism") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Creatures you control have hexproof.\n" +
+        "{1}{G}: Regenerate target creature. (The next time it would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.HEXPROOF, Filters.Group.creaturesYouControl)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{G}")
+        val creature = target("target creature", Targets.Creature)
+        effect = RegenerateEffect(creature)
+        description = "{1}{G}: Regenerate target creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "110"
+        artist = "Daarken"
+        flavorText = "\"Let my ignominy build walls thicker than iron and stronger than darksteel.\"\n—Thrun, the last troll"
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec2b56b0-126c-411b-8c43-b690fc8c194b.jpg?1783941722"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/AssaultStrobe.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/AssaultStrobe.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Assault Strobe
+ * {R}
+ * Sorcery
+ *
+ * Target creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)
+ */
+val AssaultStrobe = card("Assault Strobe") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Target creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)"
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "82"
+        artist = "Kev Walker"
+        flavorText = "When breaking someone's face once just isn't enough."
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b505c78-5dbd-483d-92bb-5144060e962f.jpg?1783941727"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/AuriokEdgewright.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/AuriokEdgewright.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Auriok Edgewright — Scars of Mirrodin #3
+ * {W}{W} · Creature — Human Soldier · 2 / 2
+ *
+ * Metalcraft — This creature has double strike as long as you control three or more artifacts.
+ *
+ * "Metalcraft" is an ability word (CR 207.2c): pure flavour with no rules meaning of its own, so
+ * there is no `Keyword.METALCRAFT` and nothing but the oracle line records it. What it introduces
+ * is an ordinary conditional static ability — a layer-6 [GrantKeyword] over `GroupFilter.source()`
+ * gated by [Conditions.YouControlAtLeast], recomputed at projection so double strike appears and
+ * disappears with the third artifact rather than being latched at any point in time.
+ */
+val AuriokEdgewright = card("Auriok Edgewright") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Metalcraft — This creature has double strike as long as you control three or more artifacts."
+
+    staticAbility {
+        condition = Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact)
+        ability = GrantKeyword(Keyword.DOUBLE_STRIKE, GroupFilter.source())
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "3"
+        artist = "Mike Bierek"
+        flavorText = "Auriok soldiers craft their own weapons, forging a connection to the steel with each blow of the hammer."
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f76b18a-396b-41f5-b34b-ac232b7f316b.jpg?1783941747"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/AuriokSunchaser.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/AuriokSunchaser.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Auriok Sunchaser — Scars of Mirrodin #4
+ * {1}{W} · Creature — Human Soldier · 1 / 1
+ *
+ * Metalcraft — As long as you control three or more artifacts, this creature gets +2/+2 and has flying.
+ *
+ * "Metalcraft" is an ability word (CR 207.2c) with no rules meaning of its own — there is no
+ * `Keyword.METALCRAFT`, only the oracle line records it. What the clause introduces is a pair of
+ * ordinary [ConditionalStaticAbility]s over `GroupFilter.source()`: the P/T bonus in layer 7c and
+ * the keyword grant in layer 6, each gated by the same artifact count. They stay two abilities
+ * rather than one because the layers they apply in are different, and both are recomputed at
+ * projection so the bonus and the flying appear and vanish with the third artifact.
+ */
+val AuriokSunchaser = card("Auriok Sunchaser") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "Metalcraft — As long as you control three or more artifacts, this creature gets +2/+2 and has flying."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 2, toughnessBonus = 2, filter = GroupFilter.source()),
+            condition = Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact),
+        )
+    }
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FLYING, GroupFilter.source()),
+            condition = Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "4"
+        artist = "James Ryman"
+        flavorText = "\"Grant me loft. Grant me light. Grant me the accuracy I need to kill all who threaten Bladehold.\"\n—Prayer to the Whitesun"
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e274a8b3-2d92-43d9-a436-d3f6f619ca95.jpg?1783941746"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/BarbedBattlegear.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/BarbedBattlegear.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Barbed Battlegear — Scars of Mirrodin #139
+ * {3} · Artifact — Equipment
+ *
+ * Equipped creature gets +4/-1.
+ * Equip {2}
+ *
+ * A layer-7c [ModifyStats] over [Filters.EquippedCreature] — the filter is spelled even though it
+ * is the default, because the neighbouring keyword-granting family defaults the other way and an
+ * omitted filter on an attachment is silently inert. The negative toughness half is not damage:
+ * it lowers toughness in the same layer the +4 raises power, so a 1/1 wearing it is a 5/0 and dies
+ * to state-based actions rather than being destroyed.
+ */
+val BarbedBattlegear = card("Barbed Battlegear") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +4/-1.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        ability = ModifyStats(4, -1, Filters.EquippedCreature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "139"
+        artist = "Steve Argyle"
+        flavorText = "\"One need only look at the inhabitants of this world to see that they are forged halfway to perfection. All they need is a whisper of the Glorious Word.\"\n—Urabrask the Hidden"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/03b80b2f-8d07-4ad3-9b20-4ba0fe9f37a2.jpg?1783941713"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/BellowingTanglewurm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/BellowingTanglewurm.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Bellowing Tanglewurm
+ * {3}{G}{G}
+ * Creature — Wurm
+ * 4/4
+ *
+ * Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)
+ * Other green creatures you control have intimidate.
+ *
+ * The lord half is a plain [GrantKeyword] over green creatures you control with `excludeSelf` set:
+ * the Tanglewurm has intimidate printed on it, so "other" only has to keep the grant from doubling
+ * up on the source. Green is read off *projected* colour, so a creature turned green by a colour
+ * changer picks the keyword up and one turned off it loses it.
+ */
+val BellowingTanglewurm = card("Bellowing Tanglewurm") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    power = 4
+    toughness = 4
+    oracleText = "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\n" +
+        "Other green creatures you control have intimidate."
+
+    keywords(Keyword.INTIMIDATE)
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.INTIMIDATE,
+            GroupFilter(
+                GameObjectFilter.Creature.withColor(Color.GREEN).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "111"
+        artist = "jD"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/44eb3e3a-60ee-4293-a321-daa452d4c70d.jpg?1783941720"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/BladeTribeBerserkers.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/BladeTribeBerserkers.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blade-Tribe Berserkers
+ * {3}{R}
+ * Creature — Human Berserker
+ * 3/3
+ *
+ * Metalcraft — When this creature enters, if you control three or more artifacts, this creature gets +3/+3 and gains haste until end of turn.
+ *
+ * "Metalcraft" is an ability word (CR 207.2c) with no rules meaning of its own — there is no
+ * `Keyword.METALCRAFT`, and nothing but the oracle line records it. What the line actually is:
+ * an ETB trigger whose printed "if …" clause is an intervening-if condition
+ * ([Conditions.YouControlAtLeast]), checked both when the trigger would go on the stack and again
+ * as it resolves (CR 603.4).
+ */
+val BladeTribeBerserkers = card("Blade-Tribe Berserkers") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Berserker"
+    power = 3
+    toughness = 3
+    oracleText = "Metalcraft — When this creature enters, if you control three or more artifacts, this creature gets +3/+3 and gains haste until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        interveningIf = Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact)
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 3, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self)
+        )
+        description = "Metalcraft — When this creature enters, if you control three or more artifacts, " +
+            "this creature gets +3/+3 and gains haste until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/acd124bb-1ed1-469c-8527-d7261ea720b9.jpg?1783941726"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/BladedPinions.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/BladedPinions.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Bladed Pinions — Scars of Mirrodin #140
+ * {2} · Artifact — Equipment
+ *
+ * Equipped creature has flying and first strike.
+ * Equip {2}
+ *
+ * One [GrantKeyword] per printed keyword, each over [GroupFilter.attachedCreature] so the grant
+ * lands on the creature this Equipment is attached to rather than on the Equipment itself.
+ */
+val BladedPinions = card("Bladed Pinions") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature has flying and first strike.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING, GroupFilter.attachedCreature())
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FIRST_STRIKE, GroupFilter.attachedCreature())
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "140"
+        artist = "Steve Argyle"
+        flavorText = "Lacking trained pterons, the Auriok had to rely on other measures to gain the upper hand in the skies."
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bf479c90-c791-4152-a8e6-fd3123f698df.jpg?1783941713"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/BleakCovenVampires.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/BleakCovenVampires.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Bleak Coven Vampires
+ * {3}{B}{B}
+ * Creature — Vampire Warrior
+ * 4/3
+ *
+ * Metalcraft — When this creature enters, if you control three or more artifacts, target player loses 4 life and you gain 4 life.
+ *
+ * Metalcraft is an ability word, not a keyword: the artifact count is an ordinary intervening-"if"
+ * (CR 603.4), rechecked on resolution, and the word itself survives only in the Oracle text.
+ */
+val BleakCovenVampires = card("Bleak Coven Vampires") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Warrior"
+    power = 4
+    toughness = 3
+    oracleText = "Metalcraft — When this creature enters, if you control three or more artifacts, target player loses 4 life and you gain 4 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        interveningIf = Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact)
+        val victim = target("target player", Targets.Player)
+        effect = Effects.Composite(
+            Effects.LoseLife(4, victim),
+            Effects.GainLife(4),
+        )
+        description = "Metalcraft — When this creature enters, if you control three or more " +
+            "artifacts, target player loses 4 life and you gain 4 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "55"
+        artist = "Randis Albion"
+        flavorText = "As the shadow of the Mephidross spread over the Tangle, the vampires' territory expanded."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d3386e4-bbd6-4756-b29d-f55619e98d0d.jpg?1783941734"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Blistergrub.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Blistergrub.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blistergrub
+ * {2}{B}
+ * Creature — Phyrexian Horror
+ * 2/2
+ *
+ * Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)
+ * When this creature dies, each opponent loses 2 life.
+ */
+val Blistergrub = card("Blistergrub") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Horror"
+    power = 2
+    toughness = 2
+    oracleText = "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\n" +
+        "When this creature dies, each opponent loses 2 life."
+
+    keywords(Keyword.SWAMPWALK)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.LoseLife(2, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56"
+        artist = "Daarken"
+        flavorText = "\"The sooner you join Phyrexia, the sooner you'll forget your painful rebirth.\"\n—Sheoldred, Whispering One"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/5431debc-0037-49ff-a38f-3fa2f9f5ee33.jpg?1783941734"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/BluntTheAssault.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/BluntTheAssault.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Blunt the Assault — Scars of Mirrodin #113
+ * {3}{G} · Instant
+ *
+ * You gain 1 life for each creature on the battlefield. Prevent all combat damage that would be
+ * dealt this turn.
+ *
+ * "Each creature on the battlefield" is `AggregateBattlefield(Player.Each)` — every creature, no
+ * matter who controls it — counted on resolution (CR 608.2). The prevention half is the plain
+ * turn-wide combat shield, so it also blanks damage from creatures that entered after this
+ * resolved.
+ */
+val BluntTheAssault = card("Blunt the Assault") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "You gain 1 life for each creature on the battlefield. Prevent all combat damage that would be dealt this turn."
+
+    spell {
+        effect = Effects.Composite(
+            Effects.GainLife(DynamicAmount.AggregateBattlefield(Player.Each, GameObjectFilter.Creature)),
+            Effects.PreventAllCombatDamage(),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "113"
+        artist = "Matt Stewart"
+        flavorText = "\"Much can be gained from the appearance of vulnerability.\"\n—Ezuri, renegade leader"
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6ecff12a-37d5-4a7b-b615-4c5e3bd950bb.jpg?1783941719"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/CarapaceForger.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/CarapaceForger.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Carapace Forger — Scars of Mirrodin #114
+ * {1}{G} · Creature — Elf Artificer · 2 / 2
+ *
+ * Metalcraft — This creature gets +2/+2 as long as you control three or more artifacts.
+ *
+ * "Metalcraft" is an ability word (CR 207.2c) — flavour, not rules — so nothing but the oracle
+ * line records it. The clause itself is an ordinary layer-7c [ConditionalStaticAbility] over
+ * `GroupFilter.source()`, recomputed at projection so the bonus tracks the artifact count instead
+ * of latching when the creature entered.
+ */
+val CarapaceForger = card("Carapace Forger") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Artificer"
+    power = 2
+    toughness = 2
+    oracleText = "Metalcraft — This creature gets +2/+2 as long as you control three or more artifacts."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 2, toughnessBonus = 2, filter = GroupFilter.source()),
+            condition = Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "114"
+        artist = "Matt Cavotta"
+        flavorText = "\"Bows and whips cannot save us from these new horrors of the Mephidross.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/9/e9948e4c-d583-4fde-a305-df926cf00199.jpg?1783941719"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/ChromeSteed.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/ChromeSteed.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Chrome Steed — Scars of Mirrodin #142
+ * {4} · Artifact Creature — Horse · 2 / 2
+ *
+ * Metalcraft — This creature gets +2/+2 as long as you control three or more artifacts.
+ *
+ * "Metalcraft" is an ability word (CR 207.2c): pure flavour with no rules meaning, so there is no
+ * `Keyword.METALCRAFT` and only the oracle line records it. What it introduces is an ordinary
+ * [ConditionalStaticAbility] — a layer-7c [ModifyStats] over [GroupFilter.source] gated by
+ * [Conditions.YouControlAtLeast], recomputed at projection so the bonus appears and disappears
+ * with the third artifact. The Steed counts itself, so it needs only two other artifacts.
+ */
+val ChromeSteed = card("Chrome Steed") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Horse"
+    power = 2
+    toughness = 2
+    oracleText = "Metalcraft — This creature gets +2/+2 as long as you control three or more artifacts."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 2, toughnessBonus = 2, filter = GroupFilter.source()),
+            condition = Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "Jana Schirmer & Johannes Voss"
+        flavorText = "According to Auriok myth, it collects scrap in order to reassemble its lost rider."
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ce881675-690f-4d4c-a951-ab8302e904ab.jpg?1783941712"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/CopperMyrReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/CopperMyrReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Copper Myr reprint in SOM. Canonical CardDefinition lives in its earliest set.
+ */
+val CopperMyrReprint = Printing(
+    oracleId = "8b52f30c-5e38-4333-88ab-901b37105b36",
+    name = "Copper Myr",
+    setCode = "SOM",
+    collectorNumber = "146",
+    scryfallId = "323efe27-da58-4207-9c0c-dba5031bfa04",
+    artist = "Alan Pollack",
+    imageUri = "https://cards.scryfall.io/normal/front/3/2/323efe27-da58-4207-9c0c-dba5031bfa04.jpg",
+    releaseDate = "2010-10-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/CorruptedHarvester.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/CorruptedHarvester.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Corrupted Harvester
+ * {4}{B}{B}
+ * Creature — Phyrexian Horror
+ * 6/3
+ *
+ * {B}, Sacrifice a creature: Regenerate this creature.
+ *
+ * The sacrifice is unrestricted beyond "a creature", so the Harvester can eat itself — a legal but
+ * pointless activation, since the shield it buys has nothing left to protect.
+ */
+val CorruptedHarvester = card("Corrupted Harvester") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Horror"
+    power = 6
+    toughness = 3
+    oracleText = "{B}, Sacrifice a creature: Regenerate this creature."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{B}"),
+            Costs.Sacrifice(GameObjectFilter.Creature)
+        )
+        effect = RegenerateEffect(EffectTarget.Self)
+        description = "{B}, Sacrifice a creature: Regenerate this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "59"
+        artist = "Nils Hamm"
+        flavorText = "\"Before the blessed assault begins, we must seek specimens that are well-adapted to our way of . . . life.\"\n—Sheoldred, Whispering One"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b54625ac-484f-4522-8048-38e01c545ac3.jpg?1783941733"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/DarkslickDrake.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/DarkslickDrake.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Darkslick Drake
+ * {2}{U}{U}
+ * Creature — Phyrexian Drake
+ * 2/4
+ *
+ * Flying
+ * When this creature dies, draw a card.
+ */
+val DarkslickDrake = card("Darkslick Drake") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Phyrexian Drake"
+    power = 2
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When this creature dies, draw a card."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.DrawCards(1)
+        description = "When this creature dies, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "30"
+        artist = "Chippy"
+        flavorText = "At the edge of the Mephidross, Phyrexia's influence seeps into life and land."
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/234f4131-1e7f-4220-b46c-bb4a6713876e.jpg?1783941740"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/DarksteelAxe.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/DarksteelAxe.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Darksteel Axe — Scars of Mirrodin #149
+ * {1} · Artifact — Equipment
+ *
+ * Indestructible (Effects that say "destroy" don't destroy this Equipment.)
+ * Equipped creature gets +2/+0.
+ * Equip {2}
+ *
+ * Indestructible is the Equipment's own keyword — it protects the Axe, not its bearer — so it is a
+ * `keywords(...)` entry rather than a grant over [GroupFilter.attachedCreature]. Only the pump
+ * crosses to the equipped creature.
+ */
+val DarksteelAxe = card("Darksteel Axe") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Indestructible (Effects that say \"destroy\" don't destroy this Equipment.)\n" +
+        "Equipped creature gets +2/+0.\n" +
+        "Equip {2}"
+
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    staticAbility {
+        ability = ModifyStats(2, 0, GroupFilter.attachedCreature())
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "149"
+        artist = "Daniel Ljunggren"
+        flavorText = "Heavier than it looks, tricky to wield, guaranteed to last."
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b997c3e6-4b0e-4f4a-9f66-3fc1d8395494.jpg?1783941712"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/DarksteelMyr.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/DarksteelMyr.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Darksteel Myr
+ * {3}
+ * Artifact Creature — Myr
+ * 0/1
+ *
+ * Indestructible (Damage and effects that say "destroy" don't destroy this creature. If its toughness is 0 or less, it still dies.)
+ */
+val DarksteelMyr = card("Darksteel Myr") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Myr"
+    power = 0
+    toughness = 1
+    oracleText = "Indestructible (Damage and effects that say \"destroy\" don't destroy this creature. If its toughness is 0 or less, it still dies.)"
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "151"
+        artist = "Randis Albion"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f5712cf-c6a9-4a2e-90db-8ca17c621724.jpg?1783941710"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/DarksteelSentinel.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/DarksteelSentinel.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Darksteel Sentinel
+ * {6}
+ * Artifact Creature — Golem
+ * 3/3
+ *
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * Vigilance
+ * Indestructible (Damage and effects that say "destroy" don't destroy this creature. If its toughness is 0 or less, it's still put into its owner's graveyard.)
+ */
+val DarksteelSentinel = card("Darksteel Sentinel") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    power = 3
+    toughness = 3
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "Vigilance\n" +
+        "Indestructible (Damage and effects that say \"destroy\" don't destroy this creature. If its toughness is 0 or less, it's still put into its owner's graveyard.)"
+
+    keywords(Keyword.FLASH, Keyword.VIGILANCE, Keyword.INDESTRUCTIBLE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "152"
+        artist = "Erica Yang"
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/768e9dde-59e5-4b50-9b38-b46e2a593107.jpg?1783941710"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/DisperseReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/DisperseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Disperse reprint in SOM. Canonical CardDefinition lives in its earliest set.
+ */
+val DisperseReprint = Printing(
+    oracleId = "9d8fe3f8-5027-4f9e-999e-e277caa96478",
+    name = "Disperse",
+    setCode = "SOM",
+    collectorNumber = "31",
+    scryfallId = "1572457f-90e0-4ffc-a403-6f877c6a8186",
+    artist = "Adrian Smith",
+    imageUri = "https://cards.scryfall.io/normal/front/1/5/1572457f-90e0-4ffc-a403-6f877c6a8186.jpg",
+    releaseDate = "2010-10-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/DrossHopper.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/DrossHopper.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dross Hopper — Scars of Mirrodin #60
+ * {1}{B} · Creature — Phyrexian Insect Horror · 2 / 1
+ *
+ * Sacrifice a creature: This creature gains flying until end of turn.
+ *
+ * The sacrifice filter is unrestricted — the Hopper is itself a legal creature to sacrifice, which
+ * fizzles the ability for want of a source but is a legal activation (CR 601.2h / 602.2a).
+ */
+val DrossHopper = card("Dross Hopper") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Insect Horror"
+    power = 2
+    toughness = 1
+    oracleText = "Sacrifice a creature: This creature gains flying until end of turn."
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Creature)
+        effect = Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Dave Allsop"
+        flavorText = "Bred in the vicious Mephidross, dross hoppers learned to eat quickly and escape faster."
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a0656f6-a016-479a-a003-72e106e986b0.jpg?1783941732"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Embersmith.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Embersmith.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Embersmith — Scars of Mirrodin #87
+ * {1}{R} · Creature — Human Artificer · 2 / 1
+ *
+ * Whenever you cast an artifact spell, you may pay {1}. If you do, this creature deals 1 damage to any target.
+ *
+ * The Lightning Rift shape: an optional mana payment gating the payoff. [MayPayManaEffect] lowers
+ * to a `GatedEffect` over `Gate.MayPay`, which the engine recognizes as the flat optional-mana
+ * form — the controller taps for the {1} at resolution and only then chooses the target.
+ */
+val Embersmith = card("Embersmith") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Artificer"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever you cast an artifact spell, you may pay {1}. If you do, this creature deals 1 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(GameObjectFilter.Artifact)
+        val t = target("target", Targets.Any)
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}"),
+            effect = Effects.DealDamage(1, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "87"
+        artist = "Eric Deschamps"
+        flavorText = "The Vulshok see the artificer as a catalyst, bringing the spark of creation that ignites change."
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/ee86cfc8-9faa-474c-90a9-5405f3f6037c.jpg?1783941726"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/EzurisBrigade.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/EzurisBrigade.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Ezuri's Brigade — Scars of Mirrodin #121
+ * {2}{G}{G} · Creature — Elf Warrior · 4 / 4
+ *
+ * Metalcraft — As long as you control three or more artifacts, this creature gets +4/+4 and has
+ * trample.
+ *
+ * "Metalcraft" is an ability word (CR 207.2c) with no rules meaning of its own — there is no
+ * `Keyword.METALCRAFT`, only the oracle line. The printed sentence hands out two effects in two
+ * different layers — [ModifyStats] in 7c, [GrantKeyword] in 6 — so it is two
+ * [ConditionalStaticAbility]s over the same [Conditions.YouControlAtLeast] gate rather than one.
+ * The Brigade is not itself an artifact, so it needs three others.
+ */
+val EzurisBrigade = card("Ezuri's Brigade") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    power = 4
+    toughness = 4
+    oracleText = "Metalcraft — As long as you control three or more artifacts, this creature gets +4/+4 and has trample."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 4, toughnessBonus = 4, filter = GroupFilter.source()),
+            condition = Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact),
+        )
+    }
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.TRAMPLE, GroupFilter.source()),
+            condition = Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "121"
+        artist = "Nic Klein"
+        flavorText = "Riding ravenous, ever-growing vorracs is almost as dangerous as fitting them with saddles."
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/079a6b44-3492-4484-aed1-5cd2449e702d.jpg?1783941718"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Ferrovore.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Ferrovore.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ferrovore
+ * {2}{R}
+ * Creature — Beast
+ * 2/2
+ *
+ * {R}, Sacrifice an artifact: This creature gets +3/+0 until end of turn.
+ *
+ * The sacrifice is any artifact, not only one you control by some narrower reading — the cost's
+ * filter is the bare artifact type, and the payer can only ever sacrifice permanents they control
+ * anyway (CR 701.17a).
+ */
+val Ferrovore = card("Ferrovore") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Beast"
+    power = 2
+    toughness = 2
+    oracleText = "{R}, Sacrifice an artifact: This creature gets +3/+0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{R}"),
+            Costs.Sacrifice(GameObjectFilter.Artifact)
+        )
+        effect = Effects.ModifyStats(3, 0, EffectTarget.Self)
+        description = "{R}, Sacrifice an artifact: This creature gets +3/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "88"
+        artist = "Austin Hsu"
+        flavorText = "The Vulshok use its digestion to break down the most obstinate artifacts, from darksteel myr to seastrider plates."
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8dcc7170-38d9-4b9e-a5f9-73ac1208c439.jpg?1783941726"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/FumeSpitter.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/FumeSpitter.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fume Spitter
+ * {B}
+ * Creature — Phyrexian Horror
+ * 1/1
+ *
+ * Sacrifice this creature: Put a -1/-1 counter on target creature.
+ */
+val FumeSpitter = card("Fume Spitter") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Horror"
+    power = 1
+    toughness = 1
+    oracleText = "Sacrifice this creature: Put a -1/-1 counter on target creature."
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        val t = target("target", Targets.Creature)
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 1, t)
+        description = "Sacrifice this creature: Put a -1/-1 counter on target creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "63"
+        artist = "Nils Hamm"
+        flavorText = "\"Our archers made sport of it as it fumbled its way up the slag ridge. As it collapsed we thought ourselves safe, but the foul thing carried more than necrogen.\"\n—Adaran, Tangle hunter"
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/58cd149b-ecf4-43ed-b6e5-98870953b4b8.jpg?1783941731"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/GhalmasWarden.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/GhalmasWarden.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Ghalma's Warden — Scars of Mirrodin #8
+ * {3}{W} · Creature — Elephant Soldier · 2 / 4
+ *
+ * Metalcraft — This creature gets +2/+2 as long as you control three or more artifacts.
+ *
+ * "Metalcraft" is an ability word (CR 207.2c) with no rules meaning of its own — there is no
+ * `Keyword.METALCRAFT`, and only the oracle line records the word. What it introduces is an
+ * ordinary [ConditionalStaticAbility]: a layer-7c [ModifyStats] over [GroupFilter.source] gated by
+ * [Conditions.YouControlAtLeast], recomputed at projection so the bonus comes and goes with the
+ * third artifact.
+ */
+val GhalmasWarden = card("Ghalma's Warden") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elephant Soldier"
+    power = 2
+    toughness = 4
+    oracleText = "Metalcraft — This creature gets +2/+2 as long as you control three or more artifacts."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 2, toughnessBonus = 2, filter = GroupFilter.source()),
+            condition = Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "8"
+        artist = "Mike Bierek"
+        flavorText = "A special unit guards the loxodon artificer known as Ghalma the Shaper. They are armed and armored in her finest works of silver and steel."
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/efbf5ff1-6539-4116-ad4f-ce412ae20640.jpg?1783941745"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/GoldMyrReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/GoldMyrReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gold Myr reprint in SOM. Canonical CardDefinition lives in its earliest set.
+ */
+val GoldMyrReprint = Printing(
+    oracleId = "bd6af7b3-b30f-4a65-a18f-8655f778e76a",
+    name = "Gold Myr",
+    setCode = "SOM",
+    collectorNumber = "157",
+    scryfallId = "ac92126c-fb22-4b97-bbc5-b0533a0baad8",
+    artist = "Alan Pollack",
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/ac92126c-fb22-4b97-bbc5-b0533a0baad8.jpg",
+    releaseDate = "2010-10-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/GolemsHeart.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/GolemsHeart.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Golem's Heart
+ * {2}
+ * Artifact
+ *
+ * Whenever a player casts an artifact spell, you may gain 1 life.
+ */
+val GolemsHeart = card("Golem's Heart") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever a player casts an artifact spell, you may gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.anyPlayerCasts(GameObjectFilter.Artifact)
+        optional = true
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "161"
+        artist = "Matt Cavotta"
+        flavorText = "The heart of a golem gives life to more than just the iron husk around it."
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/647ecb81-2d23-40f3-8570-0b86e2ed1c5e.jpg?1783941707"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/GraspOfDarkness.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/GraspOfDarkness.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grasp of Darkness
+ * {B}{B}
+ * Instant
+ *
+ * Target creature gets -4/-4 until end of turn.
+ */
+val GraspOfDarkness = card("Grasp of Darkness") {
+    manaCost = "{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -4/-4 until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(-4, -4, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "65"
+        artist = "Johann Bodin"
+        flavorText = "On a world with five suns, night is compelled to become an aggressive force."
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cda628ba-19f4-4e24-9500-cca295a992bb.jpg?1783941730"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/IronMyrReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/IronMyrReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Iron Myr reprint in SOM. Canonical CardDefinition lives in its earliest set.
+ */
+val IronMyrReprint = Printing(
+    oracleId = "6c5cbab6-ee27-46f5-97a7-df85698d1e9f",
+    name = "Iron Myr",
+    setCode = "SOM",
+    collectorNumber = "168",
+    scryfallId = "5bd0a588-b695-4060-b5d5-c6a74710ff0f",
+    artist = "Alan Pollack",
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5bd0a588-b695-4060-b5d5-c6a74710ff0f.jpg",
+    releaseDate = "2010-10-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/KembaSSkyguardReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/KembaSSkyguardReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kemba's Skyguard reprint in SOM. Canonical CardDefinition lives in its earliest set.
+ */
+val KembaSSkyguardReprint = Printing(
+    oracleId = "4c8167af-2eb0-4f0a-a1b9-b61b65bac261",
+    name = "Kemba's Skyguard",
+    setCode = "SOM",
+    collectorNumber = "13",
+    scryfallId = "b9f20a74-7614-4bd9-ac08-0e098f98df0c",
+    artist = "Whit Brachna",
+    imageUri = "https://cards.scryfall.io/normal/front/b/9/b9f20a74-7614-4bd9-ac08-0e098f98df0c.jpg",
+    releaseDate = "2010-10-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/KuldothaForgemaster.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/KuldothaForgemaster.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Kuldotha Forgemaster — Scars of Mirrodin #169
+ * {5} · Artifact Creature — Construct · 3 / 5
+ *
+ * {T}, Sacrifice three artifacts: Search your library for an artifact card, put it onto the
+ * battlefield, then shuffle.
+ *
+ * The Forgemaster itself is one of the three artifacts it can eat — the sacrifice is paid as a
+ * cost, so the ability is already on the stack and resolves fine without its source.
+ */
+val KuldothaForgemaster = card("Kuldotha Forgemaster") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 3
+    toughness = 5
+    oracleText = "{T}, Sacrifice three artifacts: Search your library for an artifact card, put it onto the battlefield, then shuffle."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.SacrificeMultiple(3, GameObjectFilter.Artifact),
+        )
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Artifact,
+            destination = SearchDestination.BATTLEFIELD,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "169"
+        artist = "jD"
+        flavorText = "The goblins say it used to be larger, before it began to stoke the Great Furnace with pieces of itself."
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad590bea-b872-4af7-a612-c8e8759d59df.jpg?1783941706"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/KuldothaRebirth.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/KuldothaRebirth.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Kuldotha Rebirth — Scars of Mirrodin #96
+ * {R} · Sorcery
+ *
+ * As an additional cost to cast this spell, sacrifice an artifact.
+ * Create three 1/1 red Goblin creature tokens.
+ *
+ * The sacrifice is a cast-time additional cost, not part of the resolution — it is paid when the
+ * spell is announced, so countering it does not give the artifact back. The token needs no
+ * `imageUri`: Scars of Mirrodin prints its own 1/1 red Goblin, so the set's token art sheet
+ * resolves the art by identity.
+ */
+val KuldothaRebirth = card("Kuldotha Rebirth") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, sacrifice an artifact.\n" +
+        "Create three 1/1 red Goblin creature tokens."
+
+    additionalCost(Costs.additional.SacrificePermanent(GameObjectFilter.Artifact))
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Goblin"),
+            count = 3
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "96"
+        artist = "Goran Josic"
+        flavorText = "All goblin rituals serve a dual purpose as fertility rites, even the destructive ones. Especially the destructive ones."
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7ee07266-a95d-4cd8-9863-1664922e9490.jpg?1783941723"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/LeadenMyrReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/LeadenMyrReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Leaden Myr reprint in SOM. Canonical CardDefinition lives in its earliest set.
+ */
+val LeadenMyrReprint = Printing(
+    oracleId = "f62cabf0-df0d-4c4f-a93a-9340967d1775",
+    name = "Leaden Myr",
+    setCode = "SOM",
+    collectorNumber = "170",
+    scryfallId = "3a709559-fec3-44f4-a2bf-3396989b9189",
+    artist = "Alan Pollack",
+    imageUri = "https://cards.scryfall.io/normal/front/3/a/3a709559-fec3-44f4-a2bf-3396989b9189.jpg",
+    releaseDate = "2010-10-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Lifesmith.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Lifesmith.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Lifesmith — Scars of Mirrodin #124
+ * {1}{G} · Creature — Human Artificer · 2 / 1
+ *
+ * Whenever you cast an artifact spell, you may pay {1}. If you do, you gain 3 life.
+ *
+ * A cast trigger ([Triggers.youCastSpell] over [GameObjectFilter.Artifact]), so it goes on the
+ * stack above the artifact and resolves first — the payment is offered whether or not the artifact
+ * ever resolves, and a countered artifact spell still gained you the life. The optional payment is
+ * [MayPayManaEffect], the flat mana [com.wingedsheep.sdk.scripting.effects.Gate.MayPay] shape the
+ * engine recognizes for manual mana-source selection at resolution.
+ */
+val Lifesmith = card("Lifesmith") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Artificer"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever you cast an artifact spell, you may pay {1}. If you do, you gain 3 life."
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Artifact)
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}"),
+            effect = Effects.GainLife(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "124"
+        artist = "Eric Deschamps"
+        flavorText = "The Sylvok see the artificer as a gardener, preparing the world for hardy growth."
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/28e5dcac-0d59-4bcc-8a0e-036cc23065b5.jpg?1783941716"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/LumengridDrake.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/LumengridDrake.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Lumengrid Drake
+ * {3}{U}
+ * Creature — Drake
+ * 2/2
+ *
+ * Flying
+ * Metalcraft — When this creature enters, if you control three or more artifacts, return target creature to its owner's hand.
+ *
+ * Metalcraft is an ability word, not a keyword: it survives only in the printed text, and the rules
+ * text is an ordinary intervening-if clause on the enters trigger. As an intervening if it is
+ * checked twice (CR 603.4) — once when the Drake enters, and again as the ability resolves — so
+ * losing the third artifact in response fizzles the bounce.
+ */
+val LumengridDrake = card("Lumengrid Drake") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drake"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "Metalcraft — When this creature enters, if you control three or more artifacts, return target creature to its owner's hand."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        interveningIf = Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact)
+        val victim = target("target creature", Targets.Creature)
+        effect = Effects.ReturnToHand(victim)
+        description = "Metalcraft — When this creature enters, if you control three or more artifacts, " +
+            "return target creature to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Johann Bodin"
+        flavorText = "Properly outfitted, drakes made perfect sentries for vedalken strongholds."
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f44e9820-2209-40a2-bc4f-46b440c05e9d.jpg?1783941738"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/LuxCannon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/LuxCannon.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lux Cannon
+ * {4}
+ * Artifact
+ *
+ * {T}: Put a charge counter on this artifact.
+ * {T}, Remove three charge counters from this artifact: Destroy target permanent.
+ *
+ * The charge counters are spent straight off the source, so the removal is a self-scoped
+ * [Costs.RemoveCounterFromSelf] atom rather than the distributed "from among permanents you
+ * control" form.
+ */
+val LuxCannon = card("Lux Cannon") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Put a charge counter on this artifact.\n" +
+        "{T}, Remove three charge counters from this artifact: Destroy target permanent."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddCounters(Counters.CHARGE, 1, EffectTarget.Self)
+        description = "{T}: Put a charge counter on this artifact."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.RemoveCounterFromSelf(Counters.CHARGE, 3)
+        )
+        val t = target("target", Targets.Permanent)
+        effect = Effects.Destroy(t)
+        description = "{T}, Remove three charge counters from this artifact: Destroy target permanent."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "173"
+        artist = "Martina Pilcerova"
+        flavorText = "There are few problems that can't be solved by putting a hole in the world."
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/95e274ea-e8f6-48ea-a877-c84b77c96d0c.jpg?1783941704"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/MoxOpal.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/MoxOpal.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Mox Opal — Scars of Mirrodin #179
+ * {0} · Legendary Artifact
+ *
+ * Metalcraft — {T}: Add one mana of any color. Activate only if you control three or more artifacts.
+ *
+ * A mana ability (CR 605.1a) — it adds mana, doesn't target and never touches a library — so it
+ * uses no stack and may be activated while paying a cost. The metalcraft clause is an ordinary
+ * [ActivationRestriction.OnlyIfCondition]: it gates *activation*, so it is checked when the ability
+ * is activated, not on resolution. Colour identity stays colourless: "any color" adds nothing to it
+ * (CR 903.4).
+ */
+val MoxOpal = card("Mox Opal") {
+    manaCost = "{0}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact"
+    oracleText = "Metalcraft — {T}: Add one mana of any color. Activate only if you control three or more artifacts."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "179"
+        artist = "Volkan Baǵa"
+        flavorText = "The suns of Mirrodin have shone upon perfection only once."
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6be9b1d5-9ab8-4adb-ba54-2c0117e842fa.jpg?1783941702"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/NecrogenCenser.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/NecrogenCenser.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Necrogen Censer
+ * {3}
+ * Artifact
+ *
+ * This artifact enters with two charge counters on it.
+ * {T}, Remove a charge counter from this artifact: Target player loses 2 life.
+ */
+val NecrogenCenser = card("Necrogen Censer") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "This artifact enters with two charge counters on it.\n" +
+        "{T}, Remove a charge counter from this artifact: Target player loses 2 life."
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.CHARGE),
+            count = 2,
+            selfOnly = true
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.RemoveCounterFromSelf(Counters.CHARGE)
+        )
+        val victim = target("target player", Targets.Player)
+        effect = Effects.LoseLife(2, victim)
+        description = "{T}, Remove a charge counter from this artifact: Target player loses 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "184"
+        artist = "Pete Venters"
+        flavorText = "Moriok necromancers actively spread necrogen, encouraging the transformation from Mirran to nim."
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f707119-ede9-4697-b723-d6cea96e6f2b.jpg?1783941702"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/NeurokInvisimancer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/NeurokInvisimancer.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Neurok Invisimancer
+ * {1}{U}{U}
+ * Creature — Human Wizard
+ * 2/1
+ *
+ * This creature can't be blocked.
+ * When this creature enters, target creature can't be blocked this turn.
+ *
+ * "Can't be blocked" is an [AbilityFlag], not a CR 702 keyword — so the printed evasion is a
+ * card-level flag and the enters trigger is the ordinary until-end-of-turn grant over that flag.
+ */
+val NeurokInvisimancer = card("Neurok Invisimancer") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "This creature can't be blocked.\n" +
+        "When this creature enters, target creature can't be blocked this turn."
+
+    flags(AbilityFlag.CANT_BE_BLOCKED)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "37"
+        artist = "Izzy"
+        flavorText = "\"They won't see your shadow or hear your breath, but they will feel your blade.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e88f78f4-77d8-4c3e-a5bf-a9dd902aaae1.jpg?1783941738"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/NeurokReplica.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/NeurokReplica.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Neurok Replica — Scars of Mirrodin #186
+ * {3} · Artifact Creature — Wizard · 1 / 4
+ *
+ * {1}{U}, Sacrifice this creature: Return target creature to its owner's hand.
+ *
+ * The Replica can bounce itself: the sacrifice is a cost, so it is already in the graveyard when
+ * the ability resolves and the target must be some other creature (CR 601.2h).
+ */
+val NeurokReplica = card("Neurok Replica") {
+    manaCost = "{3}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Wizard"
+    power = 1
+    toughness = 4
+    oracleText = "{1}{U}, Sacrifice this creature: Return target creature to its owner's hand."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}"), Costs.SacrificeSelf)
+        val t = target("target", Targets.Creature)
+        effect = Effects.ReturnToHand(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "186"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "All the curiosity of the Neurok with only a trace of their duplicity."
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4e32d5a8-0916-4728-9cb2-3903262bf873.jpg?1783941701"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/OxiddaDaredevil.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/OxiddaDaredevil.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Oxidda Daredevil — Scars of Mirrodin #100
+ * {1}{R} · Creature — Goblin Artificer · 2 / 1
+ *
+ * Sacrifice an artifact: This creature gains haste until end of turn.
+ *
+ * A free activated ability whose whole cost is the sacrifice — no mana, no tap — so it can be
+ * activated as often as there are artifacts to feed it. `Costs.Sacrifice` (not `SacrificeAnother`):
+ * the Daredevil is not itself an artifact, so there is nothing to exclude.
+ */
+val OxiddaDaredevil = card("Oxidda Daredevil") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Artificer"
+    power = 2
+    toughness = 1
+    oracleText = "Sacrifice an artifact: This creature gains haste until end of turn."
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Artifact)
+        effect = Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "100"
+        artist = "Pete Venters"
+        flavorText = "His goggles spattered with grime and his mouth full of bugs, he tossed the engines another priceless relic."
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b0bde7b-dc2d-45d2-b124-69b4b51ef3d9.jpg?1783941723"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/OxiddaScrapmelter.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/OxiddaScrapmelter.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oxidda Scrapmelter — Scars of Mirrodin #101
+ * {3}{R} · Creature — Beast · 3 / 3
+ *
+ * When this creature enters, destroy target artifact.
+ *
+ * A plain SELF-bound [Triggers.EntersBattlefield] over [Effects.Destroy]. The trigger is not
+ * optional and its target is not "up to", so it must pick an artifact if one is on the battlefield
+ * — including one of yours when the opponent has none. `Destroy` lowers to a graveyard move flagged
+ * `byDestruction`, which is what lets indestructible and regeneration see it.
+ */
+val OxiddaScrapmelter = card("Oxidda Scrapmelter") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Beast"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, destroy target artifact."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val artifact = target("target artifact", Targets.Artifact)
+        effect = Effects.Destroy(artifact)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "101"
+        artist = "Igor Kieryluk"
+        flavorText = "It subsists on a diet rich in screaming metal and molten blood."
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c64fe85b-e471-489a-8c38-2357da1c7969.jpg?1783941722"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/PalladiumMyr.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/PalladiumMyr.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Palladium Myr
+ * {3}
+ * Artifact Creature — Myr
+ * 2/2
+ *
+ * {T}: Add {C}{C}.
+ */
+val PalladiumMyr = card("Palladium Myr") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Myr"
+    power = 2
+    toughness = 2
+    oracleText = "{T}: Add {C}{C}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(2)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add {C}{C}."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "190"
+        artist = "Alan Pollack"
+        flavorText = "The myr are like the Glimmervoid: blank canvases on which to build grand creations."
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/18c016ad-bb82-4944-8c06-ab180b808041.jpg?1783941700"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/RevokeExistence.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/RevokeExistence.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Revoke Existence
+ * {1}{W}
+ * Sorcery
+ *
+ * Exile target artifact or enchantment.
+ */
+val RevokeExistence = card("Revoke Existence") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Exile target artifact or enchantment."
+
+    spell {
+        val t = target("target", Targets.ArtifactOrEnchantment)
+        effect = Effects.Exile(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Allen Williams"
+        flavorText = "\"No half measures, no regrets. We'll tell no stories of this day. It will be as if it never existed at all.\"\n—Ganedor, loxodon mystic"
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/18ae62f9-361c-4849-b0af-2b08fc0421c8.jpg?1783941744"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SaberclawGolem.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SaberclawGolem.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Saberclaw Golem — Scars of Mirrodin #200
+ * {5} · Artifact Creature — Golem · 4 / 2
+ *
+ * {R}: This creature gains first strike until end of turn.
+ *
+ * A colourless artifact creature with a red activation cost, so its colour identity is red while
+ * the card itself stays colourless.
+ */
+val SaberclawGolem = card("Saberclaw Golem") {
+    manaCost = "{5}"
+    colorIdentity = "R"
+    typeLine = "Artifact Creature — Golem"
+    power = 4
+    toughness = 2
+    oracleText = "{R}: This creature gains first strike until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "200"
+        artist = "Mike Bierek"
+        flavorText = "The warriors of the Blade Tribe charged the golem, twenty strong. They returned numbering ten . . . and a half."
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/6656b6d1-1c92-4da4-8afb-36f11610b0b4.jpg?1783941697"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SalvageScout.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SalvageScout.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Salvage Scout
+ * {W}
+ * Creature — Human Scout
+ * 1/1
+ *
+ * {W}, Sacrifice this creature: Return target artifact card from your graveyard to your hand.
+ */
+val SalvageScout = card("Salvage Scout") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Scout"
+    power = 1
+    toughness = 1
+    oracleText = "{W}, Sacrifice this creature: Return target artifact card from your graveyard to your hand."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.SacrificeSelf)
+        val artifact = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Artifact.ownedByYou(), zone = Zone.GRAVEYARD))
+        )
+        effect = Effects.ReturnToHandFromGraveyard(artifact)
+        description = "{W}, Sacrifice this creature: Return target artifact card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Randis Albion"
+        flavorText = "\"I'm not saying it's dangerous work. I'm just saying don't sign up if you have plans for your seventieth birthday.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/5909e77e-a930-4713-bca4-c6b265238c17.jpg?1783941742"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/ScarsOfMirrodinBasicLands.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/ScarsOfMirrodinBasicLands.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Scars of Mirrodin Basic Lands
+ *
+ * Four art variants of each basic land type, collector numbers 230-249.
+ */
+
+val SomPlains230 = basicLand("Plains") {
+    collectorNumber = "230"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/a/4/a410e95b-afd0-4ac4-beb5-96163b411fe2.jpg?1783941689"
+}
+
+val SomPlains231 = basicLand("Plains") {
+    collectorNumber = "231"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/4/4/440680d3-1eea-442a-b58e-96db09bc279e.jpg?1783941690"
+}
+
+val SomPlains232 = basicLand("Plains") {
+    collectorNumber = "232"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/4/3/4315d5ea-eb76-4378-a3da-5d5cdad809b8.jpg?1783941690"
+}
+
+val SomPlains233 = basicLand("Plains") {
+    collectorNumber = "233"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/e/4/e4f48ac3-f0cb-4e5c-8ea6-e423aa92ce11.jpg?1783941688"
+}
+
+val SomIsland234 = basicLand("Island") {
+    collectorNumber = "234"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/d/2/d2748f53-0d81-4656-8e4b-5f0128215879.jpg?1783941687"
+}
+
+val SomIsland235 = basicLand("Island") {
+    collectorNumber = "235"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/b/6/b6549f83-e3da-4df2-a1e4-f01773607d56.jpg?1783941687"
+}
+
+val SomIsland236 = basicLand("Island") {
+    collectorNumber = "236"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/27e879fe-a79b-427f-9901-c989fa73e234.jpg?1783941687"
+}
+
+val SomIsland237 = basicLand("Island") {
+    collectorNumber = "237"
+    artist = "Jung Park"
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e160cb2a-1d8a-47cb-b136-8347eaab67d7.jpg?1783941687"
+}
+
+val SomSwamp238 = basicLand("Swamp") {
+    collectorNumber = "238"
+    artist = "Lars Grant-West"
+    imageUri = "https://cards.scryfall.io/normal/front/4/2/42a1264f-bda3-45ac-b959-463c6e532fd3.jpg?1783941687"
+}
+
+val SomSwamp239 = basicLand("Swamp") {
+    collectorNumber = "239"
+    artist = "Lars Grant-West"
+    imageUri = "https://cards.scryfall.io/normal/front/f/d/fd8897b2-0ef2-4812-9772-cd99c5ce5586.jpg?1783941686"
+}
+
+val SomSwamp240 = basicLand("Swamp") {
+    collectorNumber = "240"
+    artist = "Lars Grant-West"
+    imageUri = "https://cards.scryfall.io/normal/front/2/3/239511f0-34b7-423c-b53b-1327d6b7da28.jpg?1783941685"
+}
+
+val SomSwamp241 = basicLand("Swamp") {
+    collectorNumber = "241"
+    artist = "Lars Grant-West"
+    imageUri = "https://cards.scryfall.io/normal/front/a/e/aeccfafb-0b3e-4e22-8c5c-6d5a0f5896c5.jpg?1783941685"
+}
+
+val SomMountain242 = basicLand("Mountain") {
+    collectorNumber = "242"
+    artist = "Tomasz Jedruszek"
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6df2f49d-097e-4685-8ddb-69c55f07f60c.jpg?1783941686"
+}
+
+val SomMountain243 = basicLand("Mountain") {
+    collectorNumber = "243"
+    artist = "Tomasz Jedruszek"
+    imageUri = "https://cards.scryfall.io/normal/front/a/6/a68647c2-a343-4314-8abb-00e7de6ecf0d.jpg?1783941685"
+}
+
+val SomMountain244 = basicLand("Mountain") {
+    collectorNumber = "244"
+    artist = "Tomasz Jedruszek"
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/46bad0eb-807f-4391-82c9-edc9d14070f5.jpg?1783941685"
+}
+
+val SomMountain245 = basicLand("Mountain") {
+    collectorNumber = "245"
+    artist = "Tomasz Jedruszek"
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/58dcb5ef-85f8-48ce-be39-d0a4eb8345af.jpg?1783941684"
+}
+
+val SomForest246 = basicLand("Forest") {
+    collectorNumber = "246"
+    artist = "Mark Tedin"
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/34cc6a36-b551-40c7-b081-53beffbca235.jpg?1783941685"
+}
+
+val SomForest247 = basicLand("Forest") {
+    collectorNumber = "247"
+    artist = "Mark Tedin"
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/46c661a6-322a-4460-9d75-a2c95d1a49de.jpg?1783941684"
+}
+
+val SomForest248 = basicLand("Forest") {
+    collectorNumber = "248"
+    artist = "Mark Tedin"
+    imageUri = "https://cards.scryfall.io/normal/front/7/9/798b4f41-1e33-4da6-99c1-de926297c073.jpg?1783941683"
+}
+
+val SomForest249 = basicLand("Forest") {
+    collectorNumber = "249"
+    artist = "Mark Tedin"
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/edb2bf35-efe6-4ad4-bf6e-55848ba71dfe.jpg?1783941681"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SeizeTheInitiative.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SeizeTheInitiative.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seize the Initiative
+ * {W}
+ * Instant
+ *
+ * Target creature gets +1/+1 and gains first strike until end of turn.
+ */
+val SeizeTheInitiative = card("Seize the Initiative") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/+1 and gains first strike until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 1, t),
+            Effects.GrantKeyword(Keyword.FIRST_STRIKE, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "Steve Argyle"
+        flavorText = "The time between spotting a leonin shikari and feeling its claws is just time enough to draw your last breath."
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6d745f35-944a-4157-a351-baa06f67b725.jpg?1783941743"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/ShatterReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/ShatterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shatter reprint in SOM. Canonical CardDefinition lives in its earliest set.
+ */
+val ShatterReprint = Printing(
+    oracleId = "84d32e68-72b9-432d-a023-7bc6a26b8ad0",
+    name = "Shatter",
+    setCode = "SOM",
+    collectorNumber = "103",
+    scryfallId = "04d70f7e-5ae9-455f-8430-123623920a92",
+    artist = "jD",
+    imageUri = "https://cards.scryfall.io/normal/front/0/4/04d70f7e-5ae9-455f-8430-123623920a92.jpg",
+    releaseDate = "2010-10-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SilverMyrReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SilverMyrReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silver Myr reprint in SOM. Canonical CardDefinition lives in its earliest set.
+ */
+val SilverMyrReprint = Printing(
+    oracleId = "66e8f7f8-3a6d-46ba-837c-b9713ddf7f40",
+    name = "Silver Myr",
+    setCode = "SOM",
+    collectorNumber = "202",
+    scryfallId = "fdd60081-3942-4e0e-aacd-a0c121bb08c7",
+    artist = "Alan Pollack",
+    imageUri = "https://cards.scryfall.io/normal/front/f/d/fdd60081-3942-4e0e-aacd-a0c121bb08c7.jpg",
+    releaseDate = "2010-10-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Skinrender.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Skinrender.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skinrender — Scars of Mirrodin #78
+ * {2}{B}{B} · Creature — Phyrexian Zombie · 3 / 3
+ *
+ * When this creature enters, put three -1/-1 counters on target creature.
+ *
+ * The trigger is not optional and the target is not "another creature" — with no other creature on
+ * the battlefield the Skinrender must target itself and shrinks to 0/0.
+ */
+val Skinrender = card("Skinrender") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Zombie"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, put three -1/-1 counters on target creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Creature)
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 3, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "78"
+        artist = "David Rapoza"
+        flavorText = "\"Your creations are effective, Sheoldred, but we must unite the flesh, not merely flay it.\"\n—Elesh Norn, Grand Cenobite"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be358357-2abe-4ead-bb18-76cad8274489.jpg?1783941728"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SkyEelSchool.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SkyEelSchool.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sky-Eel School — Scars of Mirrodin #44
+ * {3}{U}{U} · Creature — Fish · 3 / 3
+ *
+ * Flying
+ * When this creature enters, draw a card, then discard a card.
+ *
+ * "Draw a card, then discard a card" is looting, and `Patterns.Hand.loot()` is the composition:
+ * the draw first, then the Gather → Select → Move spine that makes the discard a real choice from
+ * the post-draw hand rather than a pre-selected card.
+ */
+val SkyEelSchool = card("Sky-Eel School") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Fish"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "When this creature enters, draw a card, then discard a card."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Hand.loot()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "44"
+        artist = "Daniel Ljunggren"
+        flavorText = "They swim on tides few can see, away from a threat few yet understand."
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5cfc4db7-13b5-4c88-91f2-581c9792f1ff.jpg?1783941737"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SnapsailGlider.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SnapsailGlider.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Snapsail Glider — Scars of Mirrodin #203
+ * {3} · Artifact Creature — Construct · 2 / 2
+ *
+ * Metalcraft — This creature has flying as long as you control three or more artifacts.
+ *
+ * "Metalcraft" is an ability word (CR 207.2c) — no keyword, no rules meaning, only the oracle
+ * line. The clause itself is a layer-6 [GrantKeyword] over [GroupFilter.source] wrapped in a
+ * [ConditionalStaticAbility]; because the gate is re-read at projection rather than latched, the
+ * Glider loses flying mid-combat if the third artifact leaves, and a creature already blocking it
+ * stays a legal blocker.
+ */
+val SnapsailGlider = card("Snapsail Glider") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 2
+    toughness = 2
+    oracleText = "Metalcraft — This creature has flying as long as you control three or more artifacts."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FLYING, GroupFilter.source()),
+            condition = Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "203"
+        artist = "Efrem Palacios"
+        flavorText = "Built from a reconfigured thresher, it charges with light reflected off the golden plain, ready to take to the air in case of danger."
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc98e0af-b18e-4172-bc56-19952ebd0303.jpg?1783941697"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Soliton.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Soliton.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Soliton
+ * {5}
+ * Artifact Creature — Construct
+ * 3/4
+ *
+ * {U}: Untap this creature.
+ *
+ * The untap is repeatable and instant-speed, so the Soliton can attack and then untap to block —
+ * or shrug off a tapper for one blue each time.
+ */
+val Soliton = card("Soliton") {
+    manaCost = "{5}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Construct"
+    power = 3
+    toughness = 4
+    oracleText = "{U}: Untap this creature."
+
+    activatedAbility {
+        cost = Costs.Mana("{U}")
+        effect = Effects.Untap(EffectTarget.Self)
+        description = "{U}: Untap this creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "204"
+        artist = "Jason Felix"
+        flavorText = "The gemini engines had lost connection with each other and wandered apart, developing an independent awareness of their surroundings."
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7b608c28-18cc-47d6-861e-2fd783aa3ade.jpg?1783941695"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/StoicRebuttal.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/StoicRebuttal.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Stoic Rebuttal
+ * {1}{U}{U}
+ * Instant
+ *
+ * Metalcraft — This spell costs {1} less to cast if you control three or more artifacts.
+ * Counter target spell.
+ *
+ * "Metalcraft" is an ability word (CR 207.2c) — no keyword, no rules meaning of its own. The
+ * discount is an ordinary self-cast [ModifySpellCost] gated by [CostGating.OnlyIf], evaluated as
+ * the spell is cast (CR 601.2f).
+ */
+val StoicRebuttal = card("Stoic Rebuttal") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Metalcraft — This spell costs {1} less to cast if you control three or more artifacts.\n" +
+        "Counter target spell."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(1),
+            gating = CostGating.OnlyIf(Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact))
+        )
+    }
+
+    spell {
+        target("target", Targets.Spell)
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "46"
+        artist = "Chris Rahn"
+        flavorText = "Obsessed with the pursuit of knowledge above all else, vedalken can appear to be cold and emotionless."
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f2805239-f30a-4eca-a10b-41673daaa287.jpg?1783941736"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/StriderHarness.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/StriderHarness.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Strider Harness — Scars of Mirrodin #207
+ * {3} · Artifact — Equipment
+ *
+ * Equipped creature gets +1/+1 and has haste.
+ * Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)
+ *
+ * The pump and the keyword are two separate statics over [GroupFilter.attachedCreature]; the equip
+ * ability is the sorcery-speed attach of CR 702.6.
+ */
+val StriderHarness = card("Strider Harness") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1 and has haste.\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(1, 1, GroupFilter.attachedCreature())
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.HASTE, GroupFilter.attachedCreature())
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "207"
+        artist = "Matt Stewart"
+        flavorText = "Each journey begins with a single step—and sometimes ends with that single step as well."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d7b9e54-b3ef-44fb-9240-0d67c1c4b7f6.jpg?1783941695"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SunblastAngel.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SunblastAngel.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Sunblast Angel
+ * {4}{W}{W}
+ * Creature — Angel
+ * 4/5
+ *
+ * Flying
+ * When this creature enters, destroy all tapped creatures.
+ */
+val SunblastAngel = card("Sunblast Angel") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    power = 4
+    toughness = 5
+    oracleText = "Flying\n" +
+        "When this creature enters, destroy all tapped creatures."
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DestroyAll(GameObjectFilter.Creature.tapped())
+        description = "When this creature enters, destroy all tapped creatures."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "22"
+        artist = "Jason Chan"
+        flavorText = "There may exist powers even greater than Phyrexia."
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/32217d3b-8a44-40e3-a4fd-c849fdffc1e4.jpg?1783941741"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SylvokReplica.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/SylvokReplica.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sylvok Replica
+ * {3}
+ * Artifact Creature — Shaman
+ * 1/3
+ *
+ * {G}, Sacrifice this creature: Destroy target artifact or enchantment.
+ */
+val SylvokReplica = card("Sylvok Replica") {
+    manaCost = "{3}"
+    colorIdentity = "G"
+    typeLine = "Artifact Creature — Shaman"
+    power = 1
+    toughness = 3
+    oracleText = "{G}, Sacrifice this creature: Destroy target artifact or enchantment."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.SacrificeSelf)
+        val t = target("target", Targets.ArtifactOrEnchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "210"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "All the zeal of the Sylvok with only a trace of their conservancy."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7caa3ce3-15a9-40ca-ad45-baff0f276483.jpg?1783941695"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/TemperedSteel.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/TemperedSteel.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Tempered Steel — Scars of Mirrodin #24
+ * {1}{W}{W} · Enchantment
+ *
+ * Artifact creatures you control get +2/+2.
+ *
+ * A plain layer-7c (CR 613.4c) [ModifyStats] lord over a group filter, recomputed at projection —
+ * so an artifact creature that enters, changes controller, or stops being an artifact picks the
+ * bonus up or drops it immediately, with no trigger and no timestamp of its own.
+ */
+val TemperedSteel = card("Tempered Steel") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Artifact creatures you control get +2/+2."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 2,
+            toughnessBonus = 2,
+            filter = GroupFilter(GameObjectFilter.ArtifactCreature.youControl()),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "24"
+        artist = "Wayne Reynolds"
+        flavorText = "\"Death shall prevail as long as our will falls to rust. May necessity anneal our resolve.\"\n—Ghalma the Shaper"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/6661b39d-505a-48f4-bc06-59084c6a3b0c.jpg?1783941742"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/TowerOfCalamities.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/TowerOfCalamities.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tower of Calamities — Scars of Mirrodin #212
+ * {4} · Artifact
+ *
+ * {8}, {T}: This artifact deals 12 damage to target creature.
+ */
+val TowerOfCalamities = card("Tower of Calamities") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{8}, {T}: This artifact deals 12 damage to target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{8}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.DealDamage(12, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "212"
+        artist = "Aleksi Briclot"
+        flavorText = "The ur-golems concealed one of their towers out of fear that its power would be abused, and in anticipation of a time when its power would be sorely needed."
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8a77391b-5727-4408-bb50-970f7a13a83c.jpg?1783941694"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/TrigonOfCorruption.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/TrigonOfCorruption.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Trigon of Corruption — Scars of Mirrodin #213
+ * {4} · Artifact
+ *
+ * This artifact enters with three charge counters on it.
+ * {B}{B}, {T}: Put a charge counter on this artifact.
+ * {2}, {T}, Remove a charge counter from this artifact: Put a -1/-1 counter on target creature.
+ *
+ * The charge counters are a battery, not a clock: [EntersWithCounters] loads three at entry, the
+ * first ability recharges one at a time, and the second spends one. Both abilities tap, so the
+ * Trigon fires at most once a turn and recharging costs it that turn's shot.
+ *
+ * The removal is [Costs.RemoveCounterFromSelf] — a self-scoped counter atom rather than a
+ * filtered "from among permanents you control" one, so there is nothing for the player to choose
+ * and the ability is simply unactivatable at zero charge counters.
+ */
+val TrigonOfCorruption = card("Trigon of Corruption") {
+    manaCost = "{4}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "This artifact enters with three charge counters on it.\n" +
+        "{B}{B}, {T}: Put a charge counter on this artifact.\n" +
+        "{2}, {T}, Remove a charge counter from this artifact: Put a -1/-1 counter on target creature."
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.CHARGE),
+            count = 3,
+            selfOnly = true
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}{B}"), Costs.Tap)
+        effect = Effects.AddCounters(Counters.CHARGE, 1, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Tap,
+            Costs.RemoveCounterFromSelf(Counters.CHARGE)
+        )
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.AddCounters(Counters.MINUS_ONE_MINUS_ONE, 1, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "213"
+        artist = "Nils Hamm"
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/26e215e0-836c-4b37-8f9a-9093a535bff1.jpg?1783941694"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/TrigonOfMending.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/TrigonOfMending.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Trigon of Mending
+ * {2}
+ * Artifact
+ *
+ * This artifact enters with three charge counters on it.
+ * {W}{W}, {T}: Put a charge counter on this artifact.
+ * {2}, {T}, Remove a charge counter from this artifact: Target player gains 3 life.
+ *
+ * Both halves share the tap symbol, so the Trigon either recharges or fires in a given turn cycle,
+ * never both. The removal is part of the *cost*, so an activation that gets countered on the stack
+ * does not refund the counter.
+ */
+val TrigonOfMending = card("Trigon of Mending") {
+    manaCost = "{2}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "This artifact enters with three charge counters on it.\n" +
+        "{W}{W}, {T}: Put a charge counter on this artifact.\n" +
+        "{2}, {T}, Remove a charge counter from this artifact: Target player gains 3 life."
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.CHARGE),
+            count = 3,
+            selfOnly = true
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{W}{W}"),
+            Costs.Tap
+        )
+        effect = Effects.AddCounters(Counters.CHARGE, 1, EffectTarget.Self)
+        description = "{W}{W}, {T}: Put a charge counter on this artifact."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Tap,
+            Costs.RemoveCounterFromSelf(Counters.CHARGE, 1)
+        )
+        val player = target("target player", Targets.Player)
+        effect = Effects.GainLife(3, player)
+        description = "{2}, {T}, Remove a charge counter from this artifact: Target player gains 3 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "215"
+        artist = "Igor Kieryluk"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/241142e0-3a79-4bce-8535-18ae7e392f5e.jpg?1783941693"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/TrigonOfRage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/TrigonOfRage.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Trigon of Rage
+ * {2}
+ * Artifact
+ *
+ * This artifact enters with three charge counters on it.
+ * {R}{R}, {T}: Put a charge counter on this artifact.
+ * {2}, {T}, Remove a charge counter from this artifact: Target creature gets +3/+0 until end of turn.
+ *
+ * The printed "enters with three charge counters" line is an [EntersWithCounters] replacement
+ * effect (CR 121.6), not a trigger; the counters are there as the artifact arrives. Both
+ * activations spend or feed that same self-scoped pool.
+ */
+val TrigonOfRage = card("Trigon of Rage") {
+    manaCost = "{2}"
+    colorIdentity = "R"
+    typeLine = "Artifact"
+    oracleText = "This artifact enters with three charge counters on it.\n" +
+        "{R}{R}, {T}: Put a charge counter on this artifact.\n" +
+        "{2}, {T}, Remove a charge counter from this artifact: Target creature gets +3/+0 until end of turn."
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.CHARGE),
+            count = 3,
+            selfOnly = true
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}{R}"), Costs.Tap)
+        effect = Effects.AddCounters(Counters.CHARGE, 1, EffectTarget.Self)
+        description = "{R}{R}, {T}: Put a charge counter on this artifact."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Tap,
+            Costs.RemoveCounterFromSelf(Counters.CHARGE)
+        )
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(3, 0, t)
+        description = "{2}, {T}, Remove a charge counter from this artifact: " +
+            "Target creature gets +3/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "216"
+        artist = "Marc Simonetti"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/1135f3b7-8c6b-47ff-b895-b7127836b0bf.jpg?1783941693"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/TrigonOfThought.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/TrigonOfThought.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Trigon of Thought — Scars of Mirrodin #217
+ * {5} · Artifact
+ *
+ * This artifact enters with three charge counters on it.
+ * {U}{U}, {T}: Put a charge counter on this artifact.
+ * {2}, {T}, Remove a charge counter from this artifact: Draw a card.
+ *
+ * The counters it enters with are a replacement effect (CR 614.1c), not a trigger — nothing ever
+ * sees the Trigon on the battlefield without them. Recharging and spending are two activated
+ * abilities that each tap, so a single turn does one or the other.
+ */
+val TrigonOfThought = card("Trigon of Thought") {
+    manaCost = "{5}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "This artifact enters with three charge counters on it.\n" +
+        "{U}{U}, {T}: Put a charge counter on this artifact.\n" +
+        "{2}, {T}, Remove a charge counter from this artifact: Draw a card."
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.CHARGE),
+            count = 3,
+            selfOnly = true,
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}{U}"), Costs.Tap)
+        effect = Effects.AddCounters(Counters.CHARGE, 1, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Tap,
+            Costs.RemoveCounterFromSelf(Counters.CHARGE),
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "217"
+        artist = "Mike Bierek"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f8da37ba-52e3-417e-8d7b-6c3e060552a4.jpg?1783941692"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/VulshokHeartstoker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/VulshokHeartstoker.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vulshok Heartstoker
+ * {2}{R}
+ * Creature — Human Shaman
+ * 2/2
+ *
+ * When this creature enters, target creature gets +2/+0 until end of turn.
+ */
+val VulshokHeartstoker = card("Vulshok Heartstoker") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, target creature gets +2/+0 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(2, 0, creature)
+        description = "When this creature enters, target creature gets +2/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "107"
+        artist = "Shelly Wan"
+        flavorText = "He fashions stirring words with as much passion as a smith fashioning a warhammer."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d3152bc-5c59-4e98-95de-a51de05a3c98.jpg?1783941721"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/VulshokReplica.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/VulshokReplica.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vulshok Replica
+ * {3}
+ * Artifact Creature — Berserker
+ * 3/1
+ *
+ * {1}{R}, Sacrifice this creature: It deals 3 damage to target player or planeswalker.
+ */
+val VulshokReplica = card("Vulshok Replica") {
+    manaCost = "{3}"
+    colorIdentity = "R"
+    typeLine = "Artifact Creature — Berserker"
+    power = 3
+    toughness = 1
+    oracleText = "{1}{R}, Sacrifice this creature: It deals 3 damage to target player or planeswalker."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{R}"), Costs.SacrificeSelf)
+        val t = target("target", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(3, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "221"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "All the fury of the Vulshok with only a trace of their recklessness."
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/32885a6c-b293-405f-9f2e-9e0dd7d1cb8c.jpg?1783941691"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/WallOfTanglecord.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/WallOfTanglecord.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wall of Tanglecord — Scars of Mirrodin #222
+ * {2} · Artifact Creature — Wall · 0 / 6
+ *
+ * Defender
+ * {G}: This creature gains reach until end of turn. (It can block creatures with flying.)
+ *
+ * A colorless artifact with a green activation cost — hence the green color identity on an
+ * otherwise colorless card (CR 903.4).
+ */
+val WallOfTanglecord = card("Wall of Tanglecord") {
+    manaCost = "{2}"
+    colorIdentity = "G"
+    typeLine = "Artifact Creature — Wall"
+    power = 0
+    toughness = 6
+    oracleText = "Defender\n" +
+        "{G}: This creature gains reach until end of turn. (It can block creatures with flying.)"
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        effect = Effects.GrantKeyword(Keyword.REACH, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "222"
+        artist = "Vance Kovacs"
+        flavorText = "Rootlike fibers travel far from Mirrodin's metallic forests, emerging from the crust to drink in the mana-infused sunlight."
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/792e2aed-ce6e-4fa1-a31c-a4574e5cf1f5.jpg?1783941691"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/WhitesunsPassage.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/WhitesunsPassage.kt
@@ -1,0 +1,30 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Whitesun's Passage — Scars of Mirrodin #27
+ * {1}{W} · Instant
+ *
+ * You gain 5 life.
+ */
+val WhitesunsPassage = card("Whitesun's Passage") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "You gain 5 life."
+
+    spell {
+        effect = Effects.GainLife(5)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "27"
+        artist = "John Avon"
+        flavorText = "All over the Razor Fields, Whitesun is celebrated. Even the followers of the rebel Juryan, far from the Cave of Light, bow their heads in reverence."
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a74d1bf3-4630-4be0-af5f-590789d27a0c.jpg?1783941740"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/WithstandDeath.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/WithstandDeath.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Withstand Death — Scars of Mirrodin #134
+ * {G} · Instant
+ *
+ * Target creature gains indestructible until end of turn.
+ *
+ * [Effects.GrantKeyword] with the default [com.wingedsheep.sdk.scripting.Duration.EndOfTurn] — the
+ * grant is a keyword, not a damage-prevention shield, so it survives lethal damage and "destroy"
+ * alike while still letting the creature die to 0 toughness or to sacrifice. The target is any
+ * creature, not only one you control.
+ */
+val WithstandDeath = card("Withstand Death") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it still dies.)"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "134"
+        artist = "Tomasz Jedruszek"
+        flavorText = "On Mirrodin, every conflict ends in either death or darksteel."
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b059cca0-2373-428b-a3a6-c8be5523c96f.jpg?1783941715"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DisperseReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DisperseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Disperse reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val DisperseReprint = Printing(
+    oracleId = "9d8fe3f8-5027-4f9e-999e-e277caa96478",
+    name = "Disperse",
+    setCode = "M19",
+    collectorNumber = "50",
+    scryfallId = "2ff7c89c-41dc-4ac3-bbce-38ab86f435ea",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/2/f/2ff7c89c-41dc-4ac3-bbce-38ab86f435ea.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/GraspOfDarknessReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/GraspOfDarknessReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grasp of Darkness reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val GraspOfDarknessReprint = Printing(
+    oracleId = "494c819d-7d73-432b-8c96-4cb9dcd31094",
+    name = "Grasp of Darkness",
+    setCode = "M21",
+    collectorNumber = "102",
+    scryfallId = "7737b578-8ae3-4846-b508-93ef40f25244",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/7/7/7737b578-8ae3-4846-b508-93ef40f25244.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/PalladiumMyrReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/PalladiumMyrReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Palladium Myr reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val PalladiumMyrReprint = Printing(
+    oracleId = "7b0767b8-b504-456e-93bd-218502f73b3d",
+    name = "Palladium Myr",
+    setCode = "M21",
+    collectorNumber = "234",
+    scryfallId = "27305aad-f1bd-4895-8611-143bc0250bee",
+    artist = "Alan Pollack",
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/27305aad-f1bd-4895-8611-143bc0250bee.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/StriderHarnessReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/StriderHarnessReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Strider Harness reprint in RIX. Canonical CardDefinition lives in its earliest set.
+ */
+val StriderHarnessReprint = Printing(
+    oracleId = "bd4ad383-8c40-4dda-bc9c-ba8a001d6882",
+    name = "Strider Harness",
+    setCode = "RIX",
+    collectorNumber = "183",
+    scryfallId = "5e94daa9-5b9b-4fd2-829e-081eed22c18f",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/5/e/5e94daa9-5b9b-4fd2-829e-081eed22c18f.jpg",
+    releaseDate = "2018-01-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/RevokeExistenceReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/RevokeExistenceReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Revoke Existence reprint in THB. Canonical CardDefinition lives in its earliest set.
+ */
+val RevokeExistenceReprint = Printing(
+    oracleId = "289e1a7c-b301-4395-baf8-e9a1c6d38aab",
+    name = "Revoke Existence",
+    setCode = "THB",
+    collectorNumber = "34",
+    scryfallId = "9dbb9f86-f487-44b1-815f-30d87868b531",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/9/d/9dbb9f86-f487-44b1-815f-30d87868b531.jpg",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/DDF.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DDF.json
@@ -1,0 +1,42 @@
+// Kemba's Skyguard
+{
+    "name": "Kemba's Skyguard",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Creature — Cat Knight",
+    "oracleText": "Flying\nWhen this creature enters, you gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "When this creature enters, you gain 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "artist": "Whit Brachna",
+        "flavorText": "\"We're now to dispense aid to any Mirran we see battling anything . . . 'strange.' Regent's orders.\"\n—Ranya, skyhunter captain",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/66ce7c11-09bf-4884-893c-fc8bdbe776d4.jpg?1783941769"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MOR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MOR.json
@@ -34,6 +34,42 @@
     ]
 }
 
+// Disperse
+{
+    "name": "Disperse",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target nonland permanent to its owner's hand.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target nonland permanent"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target nonland permanent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "31",
+        "artist": "Steve Ellis",
+        "flavorText": "Gryffid scowled at the sky. A perfect day for the hunt tainted by clouds. He wished them gone. High above, the clouds looked down, scowled, and made a wish of their own.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0ae239b2-1596-4906-9711-1d180a246d35.jpg?1783942800"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Indomitable Ancients
 {
     "name": "Indomitable Ancients",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOM.json
@@ -1,3 +1,135 @@
+// Abuna Acolyte
+{
+    "name": "Abuna Acolyte",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Cat Cleric",
+    "oracleText": "{T}: Prevent the next 1 damage that would be dealt to any target this turn.\n{T}: Prevent the next 2 damage that would be dealt to target artifact creature this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{T}: Prevent the next 1 damage that would be dealt to any target this turn."
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{T}: Prevent the next 2 damage that would be dealt to target artifact creature this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "UNCOMMON",
+        "artist": "Igor Kieryluk",
+        "flavorText": "\"You can break nothing I cannot mend.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e17bbf7-00c0-46f2-9718-2762fd7388d3.jpg?1783941748"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Accorder's Shield
+{
+    "name": "Accorder's Shield",
+    "manaCost": "{0}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +0/+3 and has vigilance. (Attacking doesn't cause it to tap.)\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 0,
+                "toughnessBonus": 3
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "136",
+        "artist": "Alan Pollack",
+        "flavorText": "An Auriok shield is polished to a mirror finish even on the inside, enabling its bearer to watch foes ahead and behind.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a7305c18-5058-42dd-b62a-7f6a42624036.jpg?1783941713"
+    },
+    "colorIdentityOverride": []
+}
+
 // Alpha Tyrranax
 {
     "name": "Alpha Tyrranax",
@@ -16,6 +148,280 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Asceticism
+{
+    "name": "Asceticism",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Creatures you control have hexproof.\n{1}{G}: Regenerate target creature. (The next time it would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "{1}{G}: Regenerate target creature."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "HEXPROOF",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "rarity": "RARE",
+        "artist": "Daarken",
+        "flavorText": "\"Let my ignominy build walls thicker than iron and stronger than darksteel.\"\n—Thrun, the last troll",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec2b56b0-126c-411b-8c43-b690fc8c194b.jpg?1783941722"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Assault Strobe
+{
+    "name": "Assault Strobe",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)",
+    "script": {
+        "spellEffect": {
+            "type": "GrantKeyword",
+            "keyword": "DOUBLE_STRIKE",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "artist": "Kev Walker",
+        "flavorText": "When breaking someone's face once just isn't enough.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b505c78-5dbd-483d-92bb-5144060e962f.jpg?1783941727"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Auriok Edgewright
+{
+    "name": "Auriok Edgewright",
+    "manaCost": "{W}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Metalcraft — This creature has double strike as long as you control three or more artifacts.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "UNCOMMON",
+        "artist": "Mike Bierek",
+        "flavorText": "Auriok soldiers craft their own weapons, forging a connection to the steel with each blow of the hammer.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f76b18a-396b-41f5-b34b-ac232b7f316b.jpg?1783941747"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Auriok Sunchaser
+{
+    "name": "Auriok Sunchaser",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Metalcraft — As long as you control three or more artifacts, this creature gets +2/+2 and has flying.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "artist": "James Ryman",
+        "flavorText": "\"Grant me loft. Grant me light. Grant me the accuracy I need to kill all who threaten Bladehold.\"\n—Prayer to the Whitesun",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e274a8b3-2d92-43d9-a436-d3f6f619ca95.jpg?1783941746"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Barbed Battlegear
+{
+    "name": "Barbed Battlegear",
+    "manaCost": "{3}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +4/-1.\nEquip {2}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 4,
+                "toughnessBonus": -1
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "139",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Argyle",
+        "flavorText": "\"One need only look at the inhabitants of this world to see that they are forged halfway to perfection. All they need is a whisper of the Glorious Word.\"\n—Urabrask the Hidden",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/03b80b2f-8d07-4ad3-9b20-4ba0fe9f37a2.jpg?1783941713"
+    },
+    "colorIdentityOverride": []
 }
 
 // Barrage Ogre
@@ -74,6 +480,42 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Bellowing Tanglewurm
+{
+    "name": "Bellowing Tanglewurm",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Wurm",
+    "oracleText": "Intimidate (This creature can't be blocked except by artifact creatures and/or creatures that share a color with it.)\nOther green creatures you control have intimidate.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "INTIMIDATE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "INTIMIDATE",
+                "filter": {
+                    "baseFilter": "creature green ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "rarity": "UNCOMMON",
+        "artist": "jD",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/44eb3e3a-60ee-4293-a321-daa452d4c70d.jpg?1783941720"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -149,6 +591,385 @@
     ]
 }
 
+// Blade-Tribe Berserkers
+{
+    "name": "Blade-Tribe Berserkers",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Berserker",
+    "oracleText": "Metalcraft — When this creature enters, if you control three or more artifacts, this creature gets +3/+3 and gains haste until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "HASTE",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "interveningIf": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "descriptionOverride": "Metalcraft — When this creature enters, if you control three or more artifacts, this creature gets +3/+3 and gains haste until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "artist": "Kev Walker",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/acd124bb-1ed1-469c-8527-d7261ea720b9.jpg?1783941726"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Bladed Pinions
+{
+    "name": "Bladed Pinions",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature has flying and first strike.\nEquip {2}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "140",
+        "artist": "Steve Argyle",
+        "flavorText": "Lacking trained pterons, the Auriok had to rely on other measures to gain the upper hand in the skies.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bf479c90-c791-4152-a8e6-fd3123f698df.jpg?1783941713"
+    },
+    "colorIdentityOverride": []
+}
+
+// Bleak Coven Vampires
+{
+    "name": "Bleak Coven Vampires",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Vampire Warrior",
+    "oracleText": "Metalcraft — When this creature enters, if you control three or more artifacts, target player loses 4 life and you gain 4 life.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 4
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                },
+                "interveningIf": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "descriptionOverride": "Metalcraft — When this creature enters, if you control three or more artifacts, target player loses 4 life and you gain 4 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "artist": "Randis Albion",
+        "flavorText": "As the shadow of the Mephidross spread over the Tangle, the vampires' territory expanded.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d3386e4-bbd6-4756-b29d-f55619e98d0d.jpg?1783941734"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Blistergrub
+{
+    "name": "Blistergrub",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Phyrexian Horror",
+    "oracleText": "Swampwalk (This creature can't be blocked as long as defending player controls a Swamp.)\nWhen this creature dies, each opponent loses 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "SWAMPWALK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "artist": "Daarken",
+        "flavorText": "\"The sooner you join Phyrexia, the sooner you'll forget your painful rebirth.\"\n—Sheoldred, Whispering One",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/5431debc-0037-49ff-a38f-3fa2f9f5ee33.jpg?1783941734"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Blunt the Assault
+{
+    "name": "Blunt the Assault",
+    "manaCost": "{3}{G}",
+    "typeLine": "Instant",
+    "oracleText": "You gain 1 life for each creature on the battlefield. Prevent all combat damage that would be dealt this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "Each",
+                        "filter": "creature"
+                    }
+                },
+                {
+                    "type": "PreventDamageShield",
+                    "scope": "CombatOnly"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "artist": "Matt Stewart",
+        "flavorText": "\"Much can be gained from the appearance of vulnerability.\"\n—Ezuri, renegade leader",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/e/6ecff12a-37d5-4a7b-b615-4c5e3bd950bb.jpg?1783941719"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Carapace Forger
+{
+    "name": "Carapace Forger",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Artificer",
+    "oracleText": "Metalcraft — This creature gets +2/+2 as long as you control three or more artifacts.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "artist": "Matt Cavotta",
+        "flavorText": "\"Bows and whips cannot save us from these new horrors of the Mephidross.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/9/e9948e4c-d583-4fde-a305-df926cf00199.jpg?1783941719"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Chrome Steed
+{
+    "name": "Chrome Steed",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Horse",
+    "oracleText": "Metalcraft — This creature gets +2/+2 as long as you control three or more artifacts.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "artist": "Jana Schirmer & Johannes Voss",
+        "flavorText": "According to Auriok myth, it collects scrap in order to reassemble its lost rider.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce881675-690f-4d4c-a951-ab8302e904ab.jpg?1783941712"
+    },
+    "colorIdentityOverride": []
+}
+
 // Copperline Gorge
 {
     "name": "Copperline Gorge",
@@ -218,6 +1039,104 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Corrupted Harvester
+{
+    "name": "Corrupted Harvester",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Creature — Phyrexian Horror",
+    "oracleText": "{B}, Sacrifice a creature: Regenerate this creature.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                },
+                "descriptionOverride": "{B}, Sacrifice a creature: Regenerate this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "rarity": "UNCOMMON",
+        "artist": "Nils Hamm",
+        "flavorText": "\"Before the blessed assault begins, we must seek specimens that are well-adapted to our way of . . . life.\"\n—Sheoldred, Whispering One",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b54625ac-484f-4522-8048-38e01c545ac3.jpg?1783941733"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Darkslick Drake
+{
+    "name": "Darkslick Drake",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Phyrexian Drake",
+    "oracleText": "Flying\nWhen this creature dies, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "When this creature dies, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "rarity": "UNCOMMON",
+        "artist": "Chippy",
+        "flavorText": "At the edge of the Mephidross, Phyrexia's influence seeps into life and land.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/234f4131-1e7f-4220-b46c-bb4a6713876e.jpg?1783941740"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -293,6 +1212,214 @@
     ]
 }
 
+// Darksteel Axe
+{
+    "name": "Darksteel Axe",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Indestructible (Effects that say \"destroy\" don't destroy this Equipment.)\nEquipped creature gets +2/+0.\nEquip {2}",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 0
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "149",
+        "rarity": "UNCOMMON",
+        "artist": "Daniel Ljunggren",
+        "flavorText": "Heavier than it looks, tricky to wield, guaranteed to last.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b997c3e6-4b0e-4f4a-9f66-3fc1d8395494.jpg?1783941712"
+    },
+    "colorIdentityOverride": []
+}
+
+// Darksteel Myr
+{
+    "name": "Darksteel Myr",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Myr",
+    "oracleText": "Indestructible (Damage and effects that say \"destroy\" don't destroy this creature. If its toughness is 0 or less, it still dies.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "UNCOMMON",
+        "artist": "Randis Albion",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f5712cf-c6a9-4a2e-90db-8ca17c621724.jpg?1783941710"
+    },
+    "colorIdentityOverride": []
+}
+
+// Darksteel Sentinel
+{
+    "name": "Darksteel Sentinel",
+    "manaCost": "{6}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nVigilance\nIndestructible (Damage and effects that say \"destroy\" don't destroy this creature. If its toughness is 0 or less, it's still put into its owner's graveyard.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "VIGILANCE",
+        "INDESTRUCTIBLE"
+    ],
+    "metadata": {
+        "collectorNumber": "152",
+        "rarity": "UNCOMMON",
+        "artist": "Erica Yang",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/768e9dde-59e5-4b50-9b38-b46e2a593107.jpg?1783941710"
+    },
+    "colorIdentityOverride": []
+}
+
+// Dross Hopper
+{
+    "name": "Dross Hopper",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Phyrexian Insect Horror",
+    "oracleText": "Sacrifice a creature: This creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "Dave Allsop",
+        "flavorText": "Bred in the vicious Mephidross, dross hoppers learned to eat quickly and escape faster.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a0656f6-a016-479a-a003-72e106e986b0.jpg?1783941732"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Embersmith
+{
+    "name": "Embersmith",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "Whenever you cast an artifact spell, you may pay {1}. If you do, this creature deals 1 damage to any target.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsArtifact"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Deschamps",
+        "flavorText": "The Vulshok see the artificer as a catalyst, bringing the spark of creation that ignites change.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/ee86cfc8-9faa-474c-90a9-5405f3f6037c.jpg?1783941726"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Exsanguinate
 {
     "name": "Exsanguinate",
@@ -311,6 +1438,189 @@
         "artist": "Carl Critchlow",
         "flavorText": "Vampires don't consider patience a virtue nor gluttony a sin.",
         "imageUri": "https://cards.scryfall.io/normal/front/0/8/0878b541-a730-49db-b062-5a01656e269d.jpg?1782715331"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Ezuri's Brigade
+{
+    "name": "Ezuri's Brigade",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "Metalcraft — As long as you control three or more artifacts, this creature gets +4/+4 and has trample.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 4,
+                    "toughnessBonus": 4,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "RARE",
+        "artist": "Nic Klein",
+        "flavorText": "Riding ravenous, ever-growing vorracs is almost as dangerous as fitting them with saddles.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/079a6b44-3492-4484-aed1-5cd2449e702d.jpg?1783941718"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Ferrovore
+{
+    "name": "Ferrovore",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "{R}, Sacrifice an artifact: This creature gets +3/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{R}, Sacrifice an artifact: This creature gets +3/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "artist": "Austin Hsu",
+        "flavorText": "The Vulshok use its digestion to break down the most obstinate artifacts, from darksteel myr to seastrider plates.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8dcc7170-38d9-4b9e-a5f9-73ac1208c439.jpg?1783941726"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Fume Spitter
+{
+    "name": "Fume Spitter",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Phyrexian Horror",
+    "oracleText": "Sacrifice this creature: Put a -1/-1 counter on target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "-1/-1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "Sacrifice this creature: Put a -1/-1 counter on target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "artist": "Nils Hamm",
+        "flavorText": "\"Our archers made sport of it as it fumbled its way up the slag ridge. As it collapsed we thought ourselves safe, but the foul thing carried more than necrogen.\"\n—Adaran, Tangle hunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/58cd149b-ecf4-43ed-b6e5-98870953b4b8.jpg?1783941731"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -409,6 +1719,318 @@
     ]
 }
 
+// Ghalma's Warden
+{
+    "name": "Ghalma's Warden",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Elephant Soldier",
+    "oracleText": "Metalcraft — This creature gets +2/+2 as long as you control three or more artifacts.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "artist": "Mike Bierek",
+        "flavorText": "A special unit guards the loxodon artificer known as Ghalma the Shaper. They are armed and armored in her finest works of silver and steel.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/efbf5ff1-6539-4116-ad4f-ce412ae20640.jpg?1783941745"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Golem's Heart
+{
+    "name": "Golem's Heart",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever a player casts an artifact spell, you may gain 1 life.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsArtifact"
+                        ]
+                    },
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "161",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Cavotta",
+        "flavorText": "The heart of a golem gives life to more than just the iron husk around it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/647ecb81-2d23-40f3-8570-0b86e2ed1c5e.jpg?1783941707"
+    },
+    "colorIdentityOverride": []
+}
+
+// Grasp of Darkness
+{
+    "name": "Grasp of Darkness",
+    "manaCost": "{B}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -4/-4 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": -4
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "artist": "Johann Bodin",
+        "flavorText": "On a world with five suns, night is compelled to become an aggressive force.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cda628ba-19f4-4e24-9500-cca295a992bb.jpg?1783941730"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Kuldotha Forgemaster
+{
+    "name": "Kuldotha Forgemaster",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "{T}, Sacrifice three artifacts: Search your library for an artifact card, put it onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact",
+                                "count": 3
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "artifact"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "169",
+        "rarity": "RARE",
+        "artist": "jD",
+        "flavorText": "The goblins say it used to be larger, before it began to stoke the Great Furnace with pieces of itself.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad590bea-b872-4af7-a612-c8e8759d59df.jpg?1783941706"
+    },
+    "colorIdentityOverride": []
+}
+
+// Kuldotha Rebirth
+{
+    "name": "Kuldotha Rebirth",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, sacrifice an artifact.\nCreate three 1/1 red Goblin creature tokens.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "RED"
+            ],
+            "creatureTypes": [
+                "Goblin"
+            ]
+        },
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "96",
+        "artist": "Goran Josic",
+        "flavorText": "All goblin rituals serve a dual purpose as fertility rites, even the destructive ones. Especially the destructive ones.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7ee07266-a95d-4cd8-9863-1664922e9490.jpg?1783941723"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Lifesmith
+{
+    "name": "Lifesmith",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "Whenever you cast an artifact spell, you may pay {1}. If you do, you gain 3 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsArtifact"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Deschamps",
+        "flavorText": "The Sylvok see the artificer as a gardener, preparing the world for hardy growth.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/28e5dcac-0d59-4bcc-8a0e-036cc23065b5.jpg?1783941716"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Loxodon Wayfarer
 {
     "name": "Loxodon Wayfarer",
@@ -427,6 +2049,141 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// Lumengrid Drake
+{
+    "name": "Lumengrid Drake",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying\nMetalcraft — When this creature enters, if you control three or more artifacts, return target creature to its owner's hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                },
+                "interveningIf": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "descriptionOverride": "Metalcraft — When this creature enters, if you control three or more artifacts, return target creature to its owner's hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Johann Bodin",
+        "flavorText": "Properly outfitted, drakes made perfect sentries for vedalken strongholds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f44e9820-2209-40a2-bc4f-46b440c05e9d.jpg?1783941738"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Lux Cannon
+{
+    "name": "Lux Cannon",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Put a charge counter on this artifact.\n{T}, Remove three charge counters from this artifact: Destroy target permanent.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "charge",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "{T}: Put a charge counter on this artifact."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{T}, Remove three charge counters from this artifact: Destroy target permanent."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "rarity": "MYTHIC",
+        "artist": "Martina Pilcerova",
+        "flavorText": "There are few problems that can't be solved by putting a hole in the world.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/95e274ea-e8f6-48ea-a877-c84b77c96d0c.jpg?1783941704"
+    },
+    "colorIdentityOverride": []
 }
 
 // Memnite
@@ -466,6 +2223,116 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Mox Opal
+{
+    "name": "Mox Opal",
+    "manaCost": "{0}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "Metalcraft — {T}: Add one mana of any color. Activate only if you control three or more artifacts.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "artifact"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    }
+                ],
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "rarity": "MYTHIC",
+        "artist": "Volkan Baǵa",
+        "flavorText": "The suns of Mirrodin have shone upon perfection only once.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6be9b1d5-9ab8-4adb-ba54-2c0117e842fa.jpg?1783941702"
+    },
+    "colorIdentityOverride": []
+}
+
+// Necrogen Censer
+{
+    "name": "Necrogen Censer",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "This artifact enters with two charge counters on it.\n{T}, Remove a charge counter from this artifact: Target player loses 2 life.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "descriptionOverride": "{T}, Remove a charge counter from this artifact: Target player loses 2 life."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "charge"
+                },
+                "count": 2,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "artist": "Pete Venters",
+        "flavorText": "Moriok necromancers actively spread necrogen, encouraging the transformation from Mirran to nim.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f707119-ede9-4697-b723-d6cea96e6f2b.jpg?1783941702"
+    },
+    "colorIdentityOverride": []
 }
 
 // Necrogen Scudder
@@ -510,6 +2377,203 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Neurok Invisimancer
+{
+    "name": "Neurok Invisimancer",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "This creature can't be blocked.\nWhen this creature enters, target creature can't be blocked this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "flags": [
+        "CANT_BE_BLOCKED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "artist": "Izzy",
+        "flavorText": "\"They won't see your shadow or hear your breath, but they will feel your blade.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/8/e88f78f4-77d8-4c3e-a5bf-a9dd902aaae1.jpg?1783941738"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Neurok Replica
+{
+    "name": "Neurok Replica",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Wizard",
+    "oracleText": "{1}{U}, Sacrifice this creature: Return target creature to its owner's hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "All the curiosity of the Neurok with only a trace of their duplicity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4e32d5a8-0916-4728-9cb2-3903262bf873.jpg?1783941701"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Oxidda Daredevil
+{
+    "name": "Oxidda Daredevil",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Artificer",
+    "oracleText": "Sacrifice an artifact: This creature gains haste until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "artifact"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "artist": "Pete Venters",
+        "flavorText": "His goggles spattered with grime and his mouth full of bugs, he tossed the engines another priceless relic.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b0bde7b-dc2d-45d2-b124-69b4b51ef3d9.jpg?1783941723"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Oxidda Scrapmelter
+{
+    "name": "Oxidda Scrapmelter",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "When this creature enters, destroy target artifact.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact"
+                    },
+                    "id": "target artifact"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "rarity": "UNCOMMON",
+        "artist": "Igor Kieryluk",
+        "flavorText": "It subsists on a diet rich in screaming metal and molten blood.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c64fe85b-e471-489a-8c38-2357da1c7969.jpg?1783941722"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -563,6 +2627,44 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Palladium Myr
+{
+    "name": "Palladium Myr",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Myr",
+    "oracleText": "{T}: Add {C}{C}.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {C}{C}."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "190",
+        "rarity": "UNCOMMON",
+        "artist": "Alan Pollack",
+        "flavorText": "The myr are like the Glimmervoid: blank canvases on which to build grand creations.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/18c016ad-bb82-4944-8c06-ab180b808041.jpg?1783941700"
+    },
+    "colorIdentityOverride": []
 }
 
 // Perilous Myr
@@ -722,6 +2824,143 @@
     ]
 }
 
+// Revoke Existence
+{
+    "name": "Revoke Existence",
+    "manaCost": "{1}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Exile target artifact or enchantment.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Allen Williams",
+        "flavorText": "\"No half measures, no regrets. We'll tell no stories of this day. It will be as if it never existed at all.\"\n—Ganedor, loxodon mystic",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/18ae62f9-361c-4849-b0af-2b08fc0421c8.jpg?1783941744"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Saberclaw Golem
+{
+    "name": "Saberclaw Golem",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "{R}: This creature gains first strike until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "200",
+        "artist": "Mike Bierek",
+        "flavorText": "The warriors of the Blade Tribe charged the golem, twenty strong. They returned numbering ten . . . and a half.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/6656b6d1-1c92-4da4-8afb-36f11610b0b4.jpg?1783941697"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Salvage Scout
+{
+    "name": "Salvage Scout",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "{W}, Sacrifice this creature: Return target artifact card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand",
+                    "fromZone": "Graveyard"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{W}, Sacrifice this creature: Return target artifact card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Randis Albion",
+        "flavorText": "\"I'm not saying it's dangerous work. I'm just saying don't sign up if you have plans for your seventieth birthday.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/5909e77e-a930-4713-bca4-c6b265238c17.jpg?1783941742"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Scoria Elemental
 {
     "name": "Scoria Elemental",
@@ -810,6 +3049,281 @@
     },
     "colorIdentityOverride": [
         "WHITE",
+        "BLUE"
+    ]
+}
+
+// Seize the Initiative
+{
+    "name": "Seize the Initiative",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +1/+1 and gains first strike until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "Steve Argyle",
+        "flavorText": "The time between spotting a leonin shikari and feeling its claws is just time enough to draw your last breath.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6d745f35-944a-4157-a351-baa06f67b725.jpg?1783941743"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Skinrender
+{
+    "name": "Skinrender",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Phyrexian Zombie",
+    "oracleText": "When this creature enters, put three -1/-1 counters on target creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "-1/-1",
+                    "count": 3,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "rarity": "UNCOMMON",
+        "artist": "David Rapoza",
+        "flavorText": "\"Your creations are effective, Sheoldred, but we must unite the flesh, not merely flay it.\"\n—Elesh Norn, Grand Cenobite",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/be358357-2abe-4ead-bb18-76cad8274489.jpg?1783941728"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Sky-Eel School
+{
+    "name": "Sky-Eel School",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Fish",
+    "oracleText": "Flying\nWhen this creature enters, draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "artist": "Daniel Ljunggren",
+        "flavorText": "They swim on tides few can see, away from a threat few yet understand.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5cfc4db7-13b5-4c88-91f2-581c9792f1ff.jpg?1783941737"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Snapsail Glider
+{
+    "name": "Snapsail Glider",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Metalcraft — This creature has flying as long as you control three or more artifacts.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "203",
+        "artist": "Efrem Palacios",
+        "flavorText": "Built from a reconfigured thresher, it charges with light reflected off the golden plain, ready to take to the air in case of danger.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc98e0af-b18e-4172-bc56-19952ebd0303.jpg?1783941697"
+    },
+    "colorIdentityOverride": []
+}
+
+// Soliton
+{
+    "name": "Soliton",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "{U}: Untap this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                },
+                "descriptionOverride": "{U}: Untap this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "artist": "Jason Felix",
+        "flavorText": "The gemini engines had lost connection with each other and wandered apart, developing an independent awareness of their surroundings.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7b608c28-18cc-47d6-861e-2fd783aa3ade.jpg?1783941695"
+    },
+    "colorIdentityOverride": [
         "BLUE"
     ]
 }
@@ -904,4 +3418,923 @@
         "imageUri": "https://cards.scryfall.io/normal/front/b/1/b126ee24-9597-4ee8-9c4d-5caed585424a.jpg?1783941698"
     },
     "colorIdentityOverride": []
+}
+
+// Stoic Rebuttal
+{
+    "name": "Stoic Rebuttal",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Metalcraft — This spell costs {1} less to cast if you control three or more artifacts.\nCounter target spell.",
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                },
+                "id": "target"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "Compare",
+                        "left": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "artifact"
+                        },
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "artist": "Chris Rahn",
+        "flavorText": "Obsessed with the pursuit of knowledge above all else, vedalken can appear to be cold and emotionless.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2805239-f30a-4eca-a10b-41673daaa287.jpg?1783941736"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Strider Harness
+{
+    "name": "Strider Harness",
+    "manaCost": "{3}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+1 and has haste.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE"
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "207",
+        "artist": "Matt Stewart",
+        "flavorText": "Each journey begins with a single step—and sometimes ends with that single step as well.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d7b9e54-b3ef-44fb-9240-0d67c1c4b7f6.jpg?1783941695"
+    },
+    "colorIdentityOverride": []
+}
+
+// Sunblast Angel
+{
+    "name": "Sunblast Angel",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "Flying\nWhen this creature enters, destroy all tapped creatures.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": "creature tapped"
+                            },
+                            "storeAs": "destroyAll_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "destroyAll_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy"
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, destroy all tapped creatures."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "rarity": "RARE",
+        "artist": "Jason Chan",
+        "flavorText": "There may exist powers even greater than Phyrexia.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/32217d3b-8a44-40e3-a4fd-c849fdffc1e4.jpg?1783941741"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Sylvok Replica
+{
+    "name": "Sylvok Replica",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Shaman",
+    "oracleText": "{G}, Sacrifice this creature: Destroy target artifact or enchantment.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact|enchantment"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "All the zeal of the Sylvok with only a trace of their conservancy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7caa3ce3-15a9-40ca-ad45-baff0f276483.jpg?1783941695"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Tempered Steel
+{
+    "name": "Tempered Steel",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Artifact creatures you control get +2/+2.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2,
+                "filter": {
+                    "baseFilter": "artifact creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "RARE",
+        "artist": "Wayne Reynolds",
+        "flavorText": "\"Death shall prevail as long as our will falls to rust. May necessity anneal our resolve.\"\n—Ghalma the Shaper",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/6661b39d-505a-48f4-bc06-59084c6a3b0c.jpg?1783941742"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Tower of Calamities
+{
+    "name": "Tower of Calamities",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "{8}, {T}: This artifact deals 12 damage to target creature.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{8}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 12
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "212",
+        "rarity": "RARE",
+        "artist": "Aleksi Briclot",
+        "flavorText": "The ur-golems concealed one of their towers out of fear that its power would be abused, and in anticipation of a time when its power would be sorely needed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8a77391b-5727-4408-bb50-970f7a13a83c.jpg?1783941694"
+    },
+    "colorIdentityOverride": []
+}
+
+// Trigon of Corruption
+{
+    "name": "Trigon of Corruption",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "This artifact enters with three charge counters on it.\n{B}{B}, {T}: Put a charge counter on this artifact.\n{2}, {T}, Remove a charge counter from this artifact: Put a -1/-1 counter on target creature.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "charge",
+                    "count": 1,
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "-1/-1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "charge"
+                },
+                "count": 3,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "213",
+        "rarity": "UNCOMMON",
+        "artist": "Nils Hamm",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/26e215e0-836c-4b37-8f9a-9093a535bff1.jpg?1783941694"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Trigon of Mending
+{
+    "name": "Trigon of Mending",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "This artifact enters with three charge counters on it.\n{W}{W}, {T}: Put a charge counter on this artifact.\n{2}, {T}, Remove a charge counter from this artifact: Target player gains 3 life.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "charge",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "{W}{W}, {T}: Put a charge counter on this artifact."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "descriptionOverride": "{2}, {T}, Remove a charge counter from this artifact: Target player gains 3 life."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "charge"
+                },
+                "count": 3,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "UNCOMMON",
+        "artist": "Igor Kieryluk",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/241142e0-3a79-4bce-8535-18ae7e392f5e.jpg?1783941693"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Trigon of Rage
+{
+    "name": "Trigon of Rage",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "This artifact enters with three charge counters on it.\n{R}{R}, {T}: Put a charge counter on this artifact.\n{2}, {T}, Remove a charge counter from this artifact: Target creature gets +3/+0 until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "charge",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "{R}{R}, {T}: Put a charge counter on this artifact."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{2}, {T}, Remove a charge counter from this artifact: Target creature gets +3/+0 until end of turn."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "charge"
+                },
+                "count": 3,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "rarity": "UNCOMMON",
+        "artist": "Marc Simonetti",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/1135f3b7-8c6b-47ff-b895-b7127836b0bf.jpg?1783941693"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Trigon of Thought
+{
+    "name": "Trigon of Thought",
+    "manaCost": "{5}",
+    "typeLine": "Artifact",
+    "oracleText": "This artifact enters with three charge counters on it.\n{U}{U}, {T}: Put a charge counter on this artifact.\n{2}, {T}, Remove a charge counter from this artifact: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "charge",
+                    "count": 1,
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "charge"
+                },
+                "count": 3,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "217",
+        "rarity": "UNCOMMON",
+        "artist": "Mike Bierek",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f8da37ba-52e3-417e-8d7b-6c3e060552a4.jpg?1783941692"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Vulshok Heartstoker
+{
+    "name": "Vulshok Heartstoker",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "When this creature enters, target creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                },
+                "descriptionOverride": "When this creature enters, target creature gets +2/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "artist": "Shelly Wan",
+        "flavorText": "He fashions stirring words with as much passion as a smith fashioning a warhammer.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d3152bc-5c59-4e98-95de-a51de05a3c98.jpg?1783941721"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Vulshok Replica
+{
+    "name": "Vulshok Replica",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Berserker",
+    "oracleText": "{1}{R}, Sacrifice this creature: It deals 3 damage to target player or planeswalker.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayerOrPlaneswalker",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "221",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "All the fury of the Vulshok with only a trace of their recklessness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/32885a6c-b293-405f-9f2e-9e0dd7d1cb8c.jpg?1783941691"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Wall of Tanglecord
+{
+    "name": "Wall of Tanglecord",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Wall",
+    "oracleText": "Defender\n{G}: This creature gains reach until end of turn. (It can block creatures with flying.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 6
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "REACH",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "artist": "Vance Kovacs",
+        "flavorText": "Rootlike fibers travel far from Mirrodin's metallic forests, emerging from the crust to drink in the mana-infused sunlight.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/9/792e2aed-ce6e-4fa1-a31c-a4574e5cf1f5.jpg?1783941691"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Whitesun's Passage
+{
+    "name": "Whitesun's Passage",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "You gain 5 life.",
+    "script": {
+        "spellEffect": {
+            "type": "GainLife",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "27",
+        "artist": "John Avon",
+        "flavorText": "All over the Razor Fields, Whitesun is celebrated. Even the followers of the rebel Juryan, far from the Cave of Light, bow their heads in reverence.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a74d1bf3-4630-4be0-af5f-590789d27a0c.jpg?1783941740"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Withstand Death
+{
+    "name": "Withstand Death",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it. If its toughness is 0 or less, it still dies.)",
+    "script": {
+        "spellEffect": {
+            "type": "GrantKeyword",
+            "keyword": "INDESTRUCTIBLE",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "On Mirrodin, every conflict ends in either death or darksteel.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b059cca0-2373-428b-a3a6-c8be5523c96f.jpg?1783941715"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
 }


### PR DESCRIPTION
Every card Argentum Assay reads whole that Scars of Mirrodin had not authored yet. **76 → 0.**

## The four-way split

| Bucket | Count | What was done |
|---|---:|---|
| `original` | 63 | canonical `card(...)` authored in SOM |
| `elsewhere` | 1 | Disperse — canonical in **MOR**, `Printing` row here |
| `row-only` | 6 | Copper/Gold/Iron/Leaden/Silver Myr, Shatter — rows only |
| `basic` | 5 (20 files) | `basicLand(...)` vals for all four art variants each + the `basicLands` override |
| `unscaffolded` | 1 | **unblocked**: DDF scaffolded so Kemba's Skyguard's canonical lands in its earliest real printing |

Plus the **reprint tail**: 13 `Printing` rows the new canonicals owe in 9 other scaffolded sets — C14 (2), M14 (2), M21 (2), OGW (2), BNG, M19, ORI, RIX, THB.

## Kemba's Skyguard unblocked the DDF scaffold

Its earliest real printing is Duel Decks: Elspeth vs. Tezzeret (2010-09-03), a month before SOM, and DDF had no `definitions/ddf/`. Scaffolding it is one `MtgSet` object, so the card is filed correctly rather than dropped: `incomplete = true`, `sealedSupported = false` (a duel deck is two fixed 60-card decks, not a draftable product). The rest of the product is still unauthored.

## Verification

| Gate | Result |
|---|---|
| `just build` | ✅ green |
| `just rebless-cards` | SOM +63 entries, MOR +1, DDF new — **0 existing entries changed, 0 removed** |
| `just assay-differential` | 4705/4656/**49** → 4769/4719/**50** |
| `just check-card-printing` | 65/65 canonicals `ok` |
| `just assay-ready SOM` | **76 → 0**, re-run on the branch (not inferred) |

The differential gained **+64 compared, +63 confirmed, +1 divergent**. The one new divergence is deliberate and named below.

## Findings

**1. Salvage Scout was missing its graveyard guard — the sweep's one divergence (parser gap, card is correct).**
"Return target artifact card **from your graveyard** to your hand." Assay's reading emits `MoveToZone(destination = Hand)` with **no `fromZone`**. Without the guard, an artifact exiled from the graveyard in response still returns — from exile. The card ships `Effects.ReturnToHandFromGraveyard`, so the card is right and Assay is short by one field. This is the same shape as the `fromZone` family in #1986; that band fixed 18 shipped cards, and this sentence still isn't emitting it. Worth a rule in Assay's graveyard-return path.

**2. `assay compile` nests P/T under `creatureStats`, not at the top level.** Briefing agents off a top-level `power` silently dropped P/T for every creature in the batch. All eight agents independently caught it against Scryfall and reported it rather than shipping 0/0 creatures — the "copy metadata verbatim from the brief, and report anything you think is wrong" rule doing exactly its job. Every P/T in this PR is verified mechanically against the SOM Scryfall printing.

**3. `generate-reprints.py --set <CODE>` is set-wide, not change-scoped.** Refreshing the printing caches for this sweep's 71 names made the script emit **56** rows across the 9 tail sets, of which only 13 belong to this change; the other 43 are pre-existing gaps for unrelated canonicals (Colossal Dreadmaw, the Medallion cycle, Auramancer, Mentor of the Meek, …) that were merely invisible while their caches were stale. Those 43 are **left out of scope** here, and are genuinely owed — a follow-up sweep across C14/M14/M19/M21/OGW/ORI/RIX/THB/BNG would land them.

**4. Metalcraft needed no engine work.** It's an ability word (CR 207.2c) with no rules meaning of its own — there is no `Keyword.METALCRAFT`, and the word survives only in `oracleText`. All eight metalcraft cards are ordinary `ConditionalStaticAbility` / `ActivationRestriction.OnlyIfCondition` gates on `YouControlAtLeast(3, Artifact)`. The pre-flight also confirmed intimidate, swampwalk, prevention shields, regenerate and equip all have live `rules-engine` consumers — no display-only keyword shipped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)