### PR TITLE
Add 89 Assay-ready cards to Core Set 2019

### DIFF
--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/InfectiousHorrorReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/InfectiousHorrorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Infectious Horror reprint in ARC. Canonical CardDefinition lives in its earliest set.
+ */
+val InfectiousHorrorReprint = Printing(
+    oracleId = "0931206b-eed2-40d0-9496-5ecefc7f8f90",
+    name = "Infectious Horror",
+    setCode = "ARC",
+    collectorNumber = "18",
+    scryfallId = "0cf8dc63-98d4-487a-96f8-d1a125cc87e3",
+    artist = "Pete Venters",
+    imageUri = "https://cards.scryfall.io/normal/front/0/c/0cf8dc63-98d4-487a-96f8-d1a125cc87e3.jpg",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/Ghostform.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/Ghostform.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Ghostform
+ * {1}{U}
+ * Sorcery
+ * Up to two target creatures can't be blocked this turn.
+ *
+ * "Can't be blocked" is an evasion [AbilityFlag] rather than a [com.wingedsheep.sdk.core.Keyword] —
+ * there is no keyword for it to abbreviate — and the blocking rules read the flag directly when
+ * legal blocks are enumerated. "Up to two" is one target requirement with `count = 2, optional = true`,
+ * and [ForEachTargetEffect] runs the grant once per target that was actually chosen.
+ */
+val Ghostform = card("Ghostform") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Up to two target creatures can't be blocked this turn."
+
+    spell {
+        target = TargetCreature(count = 2, optional = true)
+        effect = ForEachTargetEffect(
+            effects = listOf(
+                Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, EffectTarget.ContextTarget(0))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56"
+        artist = "Scott Chou"
+        flavorText = "\"There's no such thing as 'impenetrable.'\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f6a20ba-6691-4844-9685-dfcd4184224e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/InfectiousHorror.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/InfectiousHorror.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Infectious Horror
+ * {3}{B}
+ * Creature — Zombie Horror
+ * 2/2
+ * Whenever this creature attacks, each opponent loses 2 life.
+ */
+val InfectiousHorror = card("Infectious Horror") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Horror"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature attacks, each opponent loses 2 life."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.LoseLife(2, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "47"
+        artist = "Pete Venters"
+        flavorText = "Not once in the history of Grixis has anyone died of old age."
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bb460855-f09d-4460-9d3f-1bfcc7f3e626.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/DaggerbackBasiliskReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddp/cards/DaggerbackBasiliskReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Daggerback Basilisk reprint in DDP. Canonical CardDefinition lives in its earliest set.
+ */
+val DaggerbackBasiliskReprint = Printing(
+    oracleId = "ea4d30c7-7c39-46d5-9b71-a7ebc3e219a1",
+    name = "Daggerback Basilisk",
+    setCode = "DDP",
+    collectorNumber = "11",
+    scryfallId = "0b45e122-85fa-4c11-b5b4-5d3fedb1680e",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/0/b/0b45e122-85fa-4c11-b5b4-5d3fedb1680e.jpg",
+    releaseDate = "2015-08-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/TotallyLost.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/TotallyLost.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.gtc.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+
+/**
+ * Totally Lost
+ * {4}{U}
+ * Instant
+ * Put target nonland permanent on top of its owner's library.
+ *
+ * A plain move to the top of the library — "its owner's" is not a knob, since a card always leaves
+ * the battlefield for its owner's zone (CR 400.3).
+ */
+val TotallyLost = card("Totally Lost") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Put target nonland permanent on top of its owner's library."
+
+    spell {
+        val victim = target("target", Targets.NonlandPermanent)
+        effect = Effects.Move(victim, Zone.LIBRARY, ZonePlacement.Top)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "David Palumbo"
+        flavorText = "Fblthp had always hated crowds."
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec8e4142-7c46-4d2f-aaa6-6410f323d9f0.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/StoneQuarryReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/StoneQuarryReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stone Quarry reprint in KLD. Canonical CardDefinition lives in its earliest set.
+ */
+val StoneQuarryReprint = Printing(
+    oracleId = "90bccf66-58ec-445d-ac96-c6013054a1b4",
+    name = "Stone Quarry",
+    setCode = "KLD",
+    collectorNumber = "269",
+    scryfallId = "8214a439-b388-4f41-a897-725e56d23fe8",
+    artist = "Enora Mercier",
+    imageUri = "https://cards.scryfall.io/normal/front/8/2/8214a439-b388-4f41-a897-725e56d23fe8.jpg",
+    releaseDate = "2016-09-30",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/WoodlandStreamReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/WoodlandStreamReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Woodland Stream reprint in KLD. Canonical CardDefinition lives in its earliest set.
+ */
+val WoodlandStreamReprint = Printing(
+    oracleId = "e887fb3f-d4c9-4022-8f75-1de6ec94af96",
+    name = "Woodland Stream",
+    setCode = "KLD",
+    collectorNumber = "274",
+    scryfallId = "a333bbdc-5af7-4679-b263-3aaa056452a0",
+    artist = "Enora Mercier",
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a333bbdc-5af7-4679-b263-3aaa056452a0.jpg",
+    releaseDate = "2016-09-30",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/Oakenform.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/Oakenform.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Oakenform
+ * {2}{G}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +3/+3.
+ */
+val Oakenform = card("Oakenform") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +3/+3."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(3, 3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "197"
+        artist = "Wayne Reynolds"
+        flavorText = "\"When the beast cloaks itself in the mighty oak, what good is a bow? When the oak wraps itself around the snarling beast, what good is a hatchet?\"\n" +
+            "—Dionus, elvish archdruid"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42df372a-af2b-464a-b54c-039132f70d00.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/MightyLeap.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/MightyLeap.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mighty Leap
+ * {1}{W}
+ * Instant
+ * Target creature gets +2/+2 and gains flying until end of turn.
+ *
+ * The ordinary pump-and-grant pair over one named target — both halves default to
+ * `Duration.EndOfTurn`, which is what the printed "until end of turn" says once for both.
+ */
+val MightyLeap = card("Mighty Leap") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+2 and gains flying until end of turn."
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(2, 2, creature) then
+            Effects.GrantKeyword(Keyword.FLYING, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "22"
+        artist = "rk post"
+        flavorText = "\"The southern fortress taken by invaders? Heh, sure . . . when elephants fly.\"\n" +
+            "—Brezard Skeinbow, captain of the guard"
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bf8e0f93-a450-4188-a735-d601a59ab108.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/Manalith.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/Manalith.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Manalith
+ * {3}
+ * Artifact
+ * {T}: Add one mana of any color.
+ *
+ * A plain mana rock. [Effects.AddAnyColorMana] with its default amount of one is the whole
+ * ability; `manaAbility = true` is CR 605.1a, and the builder derives the `ManaAbility` timing
+ * from it.
+ *
+ * M12 is Manalith's earliest printing, so the canonical definition lives here; later sets
+ * (M19 among them) carry `Printing` rows.
+ */
+val Manalith = card("Manalith") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Add one mana of any color."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        description = "{T}: Add one mana of any color."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "212"
+        artist = "Charles Urbach"
+        flavorText = "Planeswalkers seek out great monuments throughout the Multiverse, knowing that their builders were unknowingly drawn by the convergence of mana in the area."
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/17bf5f25-82b4-460c-94da-b84daa8a53d9.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/MightyLeapReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/MightyLeapReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mighty Leap reprint in M12. Canonical CardDefinition lives in its earliest set.
+ */
+val MightyLeapReprint = Printing(
+    oracleId = "593caa15-e1d1-477f-bbb4-124d7a7b81f3",
+    name = "Mighty Leap",
+    setCode = "M12",
+    collectorNumber = "26",
+    scryfallId = "446e1676-ae7d-46ee-af91-bb54e4d18a78",
+    artist = "rk post",
+    imageUri = "https://cards.scryfall.io/normal/front/4/4/446e1676-ae7d-46ee-af91-bb54e4d18a78.jpg",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/DisperseReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/DisperseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Disperse reprint in M14. Canonical CardDefinition lives in its earliest set.
+ */
+val DisperseReprint = Printing(
+    oracleId = "9d8fe3f8-5027-4f9e-999e-e277caa96478",
+    name = "Disperse",
+    setCode = "M14",
+    collectorNumber = "51",
+    scryfallId = "e6b415d2-53fe-4540-aea6-9cd2c498134c",
+    artist = "Steve Ellis",
+    imageUri = "https://cards.scryfall.io/normal/front/e/6/e6b415d2-53fe-4540-aea6-9cd2c498134c.jpg",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/Disperse.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/Disperse.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.mor.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Disperse
+ * {1}{U}
+ * Instant
+ * Return target nonland permanent to its owner's hand.
+ *
+ * A one-line bounce: [Targets.NonlandPermanent] (`IsNonland` + `IsPermanent`) into
+ * [Effects.ReturnToHand], which is a move to the owner's hand — never the controller's.
+ *
+ * Morningtide is Disperse's earliest printing, so the canonical definition lives here; later
+ * sets (M19 among them) carry `Printing` rows.
+ */
+val Disperse = card("Disperse") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target nonland permanent to its owner's hand."
+
+    spell {
+        val permanent = target("target", Targets.NonlandPermanent)
+        effect = Effects.ReturnToHand(permanent)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "31"
+        artist = "Steve Ellis"
+        flavorText = "Gryffid scowled at the sky. A perfect day for the hunt tainted by clouds. He wished them gone. High above, the clouds looked down, scowled, and made a wish of their own."
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0ae239b2-1596-4906-9711-1d180a246d35.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/CinderBarrens.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/CinderBarrens.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Cinder Barrens
+ * Land
+ * This land enters tapped.
+ * {T}: Add {B} or {R}.
+ */
+val CinderBarrens = card("Cinder Barrens") {
+    colorIdentity = "BR"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {B} or {R}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "168"
+        artist = "Cliff Childs"
+        flavorText = "A mudflow swallowed the lowlands years ago. All that remains are a bottomless mire and an endless rain of ash."
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/949f41a0-9082-4682-88b8-a29fbcb48d5d.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/MeanderingRiver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/MeanderingRiver.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Meandering River
+ * Land
+ * This land enters tapped.
+ * {T}: Add {W} or {U}.
+ *
+ * "Add {W} or {U}" is two separate mana abilities, not one ability with a choice — that is how the
+ * dual lands are modelled throughout the corpus, so the player picks by activating the one they
+ * want and each carries `manaAbility = true` (no stack, CR 605.3).
+ */
+val MeanderingRiver = card("Meandering River") {
+    colorIdentity = "UW"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {W} or {U}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "173"
+        artist = "Cliff Childs"
+        flavorText = "The river split into many channels as it flowed to the Halimar Sea. Few travelers could follow the same one twice."
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6a5bedf1-92b6-465c-afc2-ce8e150a5e57.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/MightyLeapReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/MightyLeapReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mighty Leap reprint in OGW. Canonical CardDefinition lives in its earliest set.
+ */
+val MightyLeapReprint = Printing(
+    oracleId = "593caa15-e1d1-477f-bbb4-124d7a7b81f3",
+    name = "Mighty Leap",
+    setCode = "OGW",
+    collectorNumber = "28",
+    scryfallId = "4e25089b-5a5f-4cb5-9261-be6cb6b45b22",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4e25089b-5a5f-4cb5-9261-be6cb6b45b22.jpg",
+    releaseDate = "2016-01-22",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/SubmergedBoneyard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/SubmergedBoneyard.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Submerged Boneyard
+ * Land
+ * This land enters tapped.
+ * {T}: Add {U} or {B}.
+ */
+val SubmergedBoneyard = card("Submerged Boneyard") {
+    colorIdentity = "BU"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {U} or {B}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "178"
+        artist = "Cliff Childs"
+        flavorText = "\"Long after the land has given up the last of its secrets, there will still be mysteries in the depths of the sea.\"\n" +
+            "—Kiora"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/6479a246-21ac-490a-aefb-6ed72aabdb88.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/TimberGorge.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/TimberGorge.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Timber Gorge
+ * Land
+ * This land enters tapped.
+ * {T}: Add {R} or {G}.
+ *
+ * "Add {R} or {G}" is two separate mana abilities, not one ability with a choice — that is how the
+ * dual lands are modelled throughout the corpus, so the player picks by activating the one they
+ * want and each carries `manaAbility = true` (no stack, CR 605.3).
+ */
+val TimberGorge = card("Timber Gorge") {
+    colorIdentity = "GR"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {R} or {G}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "179"
+        artist = "Cliff Childs"
+        flavorText = "Tazeem's embrace is harsh, but for those that call it home, nothing else will do."
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55d05ff7-f071-4eb3-b10a-203741abdf10.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/TranquilExpanse.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/TranquilExpanse.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Tranquil Expanse
+ * Land
+ * This land enters tapped.
+ * {T}: Add {G} or {W}.
+ */
+val TranquilExpanse = card("Tranquil Expanse") {
+    colorIdentity = "GW"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {G} or {W}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "180"
+        artist = "Cliff Childs"
+        flavorText = "Despite the chaos of the Roil and the devastation of the Eldrazi, Zendikar is a world of breathtaking beauty."
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42787d2b-3f9d-4c29-9ece-e65544eb1340.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/DisperseReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/DisperseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Disperse reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val DisperseReprint = Printing(
+    oracleId = "9d8fe3f8-5027-4f9e-999e-e277caa96478",
+    name = "Disperse",
+    setCode = "ORI",
+    collectorNumber = "54",
+    scryfallId = "f790b0b5-ed67-40f8-b23b-10cf0a71f285",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/f/7/f790b0b5-ed67-40f8-b23b-10cf0a71f285.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MightyLeapReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MightyLeapReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mighty Leap reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val MightyLeapReprint = Printing(
+    oracleId = "593caa15-e1d1-477f-bbb4-124d7a7b81f3",
+    name = "Mighty Leap",
+    setCode = "ORI",
+    collectorNumber = "26",
+    scryfallId = "06dad608-5f8d-49a8-a1f1-c80aae207945",
+    artist = "rk post",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/06dad608-5f8d-49a8-a1f1-c80aae207945.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/MeanderingRiverReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/MeanderingRiverReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meandering River reprint in PZ2. Canonical CardDefinition lives in its earliest set.
+ */
+val MeanderingRiverReprint = Printing(
+    oracleId = "2d9663be-c466-4191-85e2-a69ce0965432",
+    name = "Meandering River",
+    setCode = "PZ2",
+    collectorNumber = "70799",
+    scryfallId = "b4f2d2c8-7fea-4012-9f15-fbf37cd89a3c",
+    artist = "Gaga Zeng",
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b4f2d2c8-7fea-4012-9f15-fbf37cd89a3c.jpg",
+    releaseDate = "2018-12-06",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/TimberGorgeReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/TimberGorgeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Timber Gorge reprint in PZ2. Canonical CardDefinition lives in its earliest set.
+ */
+val TimberGorgeReprint = Printing(
+    oracleId = "00b34fab-5a80-4a4d-b6cf-72479197677a",
+    name = "Timber Gorge",
+    setCode = "PZ2",
+    collectorNumber = "70797",
+    scryfallId = "c5ac9935-ffe7-4280-8b0b-d5913dbf9e6b",
+    artist = "Babyson Chen & Uzhen Lin",
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c5ac9935-ffe7-4280-8b0b-d5913dbf9e6b.jpg",
+    releaseDate = "2018-12-06",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/DaggerbackBasilisk.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/DaggerbackBasilisk.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Daggerback Basilisk
+ * {2}{G}
+ * Creature — Basilisk
+ * 2/2
+ * Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)
+ */
+val DaggerbackBasilisk = card("Daggerback Basilisk") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Basilisk"
+    power = 2
+    toughness = 2
+    oracleText = "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)"
+
+    keywords(Keyword.DEATHTOUCH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "182"
+        artist = "Jesper Ejsing"
+        flavorText = "\"Petrifying gaze, deadly fangs, knifelike dorsal spines, venomous saliva . . . Am I missing anything? . . . Toxic bones? Seriously?\"\n" +
+            "—Samila, Murasa Expeditionary House"
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d4343cb0-6490-496c-9d58-ac1f7d3a91c6.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ExplosiveApparatus.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ExplosiveApparatus.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Explosive Apparatus
+ * {1}
+ * Artifact
+ * {3}, {T}, Sacrifice this artifact: It deals 2 damage to any target.
+ */
+val ExplosiveApparatus = card("Explosive Apparatus") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{3}, {T}, Sacrifice this artifact: It deals 2 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap, Costs.SacrificeSelf)
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "255"
+        artist = "Lindsey Look"
+        flavorText = "\"Souls are volatile things. When compressed and loaded into a handheld device, their destructive potential is quite impressive.\"\n" +
+            "—Dierk, geistmage"
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e7329a19-2f68-4d2c-a725-e0d862cd234e.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ForsakenSanctuary.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ForsakenSanctuary.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Forsaken Sanctuary
+ * Land
+ * This land enters tapped.
+ * {T}: Add {W} or {B}.
+ */
+val ForsakenSanctuary = card("Forsaken Sanctuary") {
+    colorIdentity = "BW"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {W} or {B}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "273"
+        artist = "Vincent Proce"
+        flavorText = "\"Prayers will curdle on the tongue and be heard by rotting ears.\"\n" +
+            "—Minaldra, the Vizag Atum"
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0bd86cac-08c1-4db0-ab54-4bb65a771efe.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/FoulOrchard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/FoulOrchard.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Foul Orchard
+ * Land
+ * This land enters tapped.
+ * {T}: Add {B} or {G}.
+ */
+val FoulOrchard = card("Foul Orchard") {
+    colorIdentity = "BG"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {B} or {G}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "275"
+        artist = "Jung Park"
+        flavorText = "\"Such a beautiful place for a stroll.\"\n" +
+            "—Liliana Vess"
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/2378ac21-9912-40d7-972d-b1b71a8e4984.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/HighlandLake.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/HighlandLake.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Highland Lake
+ * Land
+ * This land enters tapped.
+ * {T}: Add {U} or {R}.
+ *
+ * Highland Lake has no basic land types, so the dual mana ability is spelled out as two
+ * independent [TimingRule.ManaAbility] activations rather than being intrinsic to the type line.
+ */
+val HighlandLake = card("Highland Lake") {
+    colorIdentity = "RU"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {U} or {R}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "277"
+        artist = "Florian de Gesincourt"
+        flavorText = "With the fate of Innistrad uncertain, some seek solace in remote areas."
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48b97a23-c4cf-47c9-9dbf-34215ea0e908.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/StoneQuarry.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/StoneQuarry.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Stone Quarry
+ * Land
+ * This land enters tapped.
+ * {T}: Add {R} or {W}.
+ */
+val StoneQuarry = card("Stone Quarry") {
+    colorIdentity = "RW"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {R} or {W}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "279"
+        artist = "Cliff Childs"
+        flavorText = "In Gavony, headstones come only from quarries that have been blessed by chaplains."
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e636cdc3-4b83-4f15-ad4a-6c8fa3533408.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/WoodlandStream.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/WoodlandStream.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Woodland Stream
+ * Land
+ * This land enters tapped.
+ * {T}: Add {G} or {U}.
+ *
+ * "Add {G} or {U}" is two separate mana abilities, not one ability with a choice — the player picks
+ * which to activate, so each colour gets its own `{T}` ability.
+ */
+val WoodlandStream = card("Woodland Stream") {
+    colorIdentity = "GU"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {G} or {U}."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "282"
+        artist = "James Paick"
+        flavorText = "Two creaking waterwheels herald the approach to Briarbridge through the Ulvenwald."
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/18a0c745-dee6-4cb2-acaa-3d2b8e0cce5b.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/DisperseReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/DisperseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Disperse reprint in SOM. Canonical CardDefinition lives in its earliest set.
+ */
+val DisperseReprint = Printing(
+    oracleId = "9d8fe3f8-5027-4f9e-999e-e277caa96478",
+    name = "Disperse",
+    setCode = "SOM",
+    collectorNumber = "31",
+    scryfallId = "1572457f-90e0-4ffc-a403-6f877c6a8186",
+    artist = "Adrian Smith",
+    imageUri = "https://cards.scryfall.io/normal/front/1/5/1572457f-90e0-4ffc-a403-6f877c6a8186.jpg",
+    releaseDate = "2010-10-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/Omenspeaker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/Omenspeaker.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Omenspeaker
+ * {1}{U}
+ * Creature — Human Wizard
+ * 1/3
+ * When this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+ */
+val Omenspeaker = card("Omenspeaker") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 3
+    oracleText = "When this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.scry(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "57"
+        artist = "Dallas Williams"
+        flavorText = "Her prophecies amaze her even as she speaks them."
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f347eb88-7d1d-4ed5-b841-2bf81f00d5f0.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/PendulumOfPatterns.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/PendulumOfPatterns.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.aer.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pendulum of Patterns
+ * {2}
+ * Artifact
+ * When this artifact enters, you gain 3 life.
+ * {5}, {T}, Sacrifice this artifact: Draw a card.
+ *
+ * An ETB life gain plus a three-atom activated cost — {5}, [Costs.Tap] and
+ * [Costs.SacrificeSelf] — for a card.
+ *
+ * Aether Revolt is the earliest printing, so the canonical definition lives here; later sets
+ * (M19 among them) carry `Printing` rows.
+ */
+val PendulumOfPatterns = card("Pendulum of Patterns") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, you gain 3 life.\n" +
+        "{5}, {T}, Sacrifice this artifact: Draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(3)
+        description = "When this artifact enters, you gain 3 life."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+        description = "{5}, {T}, Sacrifice this artifact: Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "192"
+        artist = "Raoul Vitale"
+        flavorText = "Its elaborate designs reveal secrets of aether's flow."
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d19751aa-823e-4a0f-a004-dee333b34327.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/SubmergedBoneyardReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/SubmergedBoneyardReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.aer.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Submerged Boneyard reprint in AER. Canonical CardDefinition lives in its earliest set.
+ */
+val SubmergedBoneyardReprint = Printing(
+    oracleId = "f27d52e6-aab9-4f95-ae46-33d1173bf4fe",
+    name = "Submerged Boneyard",
+    setCode = "AER",
+    collectorNumber = "194",
+    scryfallId = "09dd7aab-c0ac-4566-bf99-c49931eeea2a",
+    artist = "Christine Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/0/9/09dd7aab-c0ac-4566-bf99-c49931eeea2a.jpg",
+    releaseDate = "2017-01-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/TranquilExpanseReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/TranquilExpanseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.aer.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tranquil Expanse reprint in AER. Canonical CardDefinition lives in its earliest set.
+ */
+val TranquilExpanseReprint = Printing(
+    oracleId = "a5478263-47c9-447f-9c7a-c77ce0752947",
+    name = "Tranquil Expanse",
+    setCode = "AER",
+    collectorNumber = "189",
+    scryfallId = "2ea97c40-310e-4774-ae56-d4c0500a6189",
+    artist = "Sam Burley",
+    imageUri = "https://cards.scryfall.io/normal/front/2/e/2ea97c40-310e-4774-ae56-d4c0500a6189.jpg",
+    releaseDate = "2017-01-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CinderBarrensReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/CinderBarrensReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cinder Barrens reprint in AKH. Canonical CardDefinition lives in its earliest set.
+ */
+val CinderBarrensReprint = Printing(
+    oracleId = "f155a05f-9f5e-4875-a407-103b85ce30ee",
+    name = "Cinder Barrens",
+    setCode = "AKH",
+    collectorNumber = "280",
+    scryfallId = "e12fa835-c13d-4d73-9d26-97bc2268e971",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e12fa835-c13d-4d73-9d26-97bc2268e971.jpg",
+    releaseDate = "2017-04-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ForsakenSanctuaryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ForsakenSanctuaryReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Forsaken Sanctuary reprint in AKH. Canonical CardDefinition lives in its earliest set.
+ */
+val ForsakenSanctuaryReprint = Printing(
+    oracleId = "941b0dd1-0df2-48ee-8829-615e9c3177a7",
+    name = "Forsaken Sanctuary",
+    setCode = "AKH",
+    collectorNumber = "281",
+    scryfallId = "7b7795db-c96a-4f94-bcc8-6977e38d0fe2",
+    artist = "Vincent Proce",
+    imageUri = "https://cards.scryfall.io/normal/front/7/b/7b7795db-c96a-4f94-bcc8-6977e38d0fe2.jpg",
+    releaseDate = "2017-04-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/FoulOrchardReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/FoulOrchardReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Foul Orchard reprint in AKH. Canonical CardDefinition lives in its earliest set.
+ */
+val FoulOrchardReprint = Printing(
+    oracleId = "ad6a2776-801f-4743-8268-6d654122171e",
+    name = "Foul Orchard",
+    setCode = "AKH",
+    collectorNumber = "279",
+    scryfallId = "81435771-2f13-4e53-9a5f-4a4e4ad735ac",
+    artist = "Mark Poole",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/81435771-2f13-4e53-9a5f-4a4e4ad735ac.jpg",
+    releaseDate = "2017-04-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/HighlandLakeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/HighlandLakeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Highland Lake reprint in AKH. Canonical CardDefinition lives in its earliest set.
+ */
+val HighlandLakeReprint = Printing(
+    oracleId = "c643365a-4255-4d23-adb9-0f8b456f0838",
+    name = "Highland Lake",
+    setCode = "AKH",
+    collectorNumber = "282",
+    scryfallId = "7b64bd5c-d014-4a5e-bb71-7cee8756ae8c",
+    artist = "Florian de Gesincourt",
+    imageUri = "https://cards.scryfall.io/normal/front/7/b/7b64bd5c-d014-4a5e-bb71-7cee8756ae8c.jpg",
+    releaseDate = "2017-04-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/MeanderingRiverReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/MeanderingRiverReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meandering River reprint in AKH. Canonical CardDefinition lives in its earliest set.
+ */
+val MeanderingRiverReprint = Printing(
+    oracleId = "2d9663be-c466-4191-85e2-a69ce0965432",
+    name = "Meandering River",
+    setCode = "AKH",
+    collectorNumber = "283",
+    scryfallId = "745525ff-4afe-4a81-8c9d-5e6b9cca1eba",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/7/4/745525ff-4afe-4a81-8c9d-5e6b9cca1eba.jpg",
+    releaseDate = "2017-04-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/MightyLeapReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/MightyLeapReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mighty Leap reprint in AKH. Canonical CardDefinition lives in its earliest set.
+ */
+val MightyLeapReprint = Printing(
+    oracleId = "593caa15-e1d1-477f-bbb4-124d7a7b81f3",
+    name = "Mighty Leap",
+    setCode = "AKH",
+    collectorNumber = "20",
+    scryfallId = "13692658-051b-44ea-bc23-aa33ce6385d3",
+    artist = "Sidharth Chaturvedi",
+    imageUri = "https://cards.scryfall.io/normal/front/1/3/13692658-051b-44ea-bc23-aa33ce6385d3.jpg",
+    releaseDate = "2017-04-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/StoneQuarryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/StoneQuarryReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stone Quarry reprint in AKH. Canonical CardDefinition lives in its earliest set.
+ */
+val StoneQuarryReprint = Printing(
+    oracleId = "90bccf66-58ec-445d-ac96-c6013054a1b4",
+    name = "Stone Quarry",
+    setCode = "AKH",
+    collectorNumber = "274",
+    scryfallId = "2280a5db-72be-4c13-8e15-8d40b7d9f9e7",
+    artist = "Florian de Gesincourt",
+    imageUri = "https://cards.scryfall.io/normal/front/2/2/2280a5db-72be-4c13-8e15-8d40b7d9f9e7.jpg",
+    releaseDate = "2017-04-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SubmergedBoneyardReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/SubmergedBoneyardReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Submerged Boneyard reprint in AKH. Canonical CardDefinition lives in its earliest set.
+ */
+val SubmergedBoneyardReprint = Printing(
+    oracleId = "f27d52e6-aab9-4f95-ae46-33d1173bf4fe",
+    name = "Submerged Boneyard",
+    setCode = "AKH",
+    collectorNumber = "284",
+    scryfallId = "ad4e966e-cb51-461a-9089-25054dec57fb",
+    artist = "Christine Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/a/d/ad4e966e-cb51-461a-9089-25054dec57fb.jpg",
+    releaseDate = "2017-04-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/TatteredMummy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/TatteredMummy.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tattered Mummy
+ * {1}{B}
+ * Creature — Zombie Jackal
+ * 1/2
+ * When this creature dies, each opponent loses 2 life.
+ */
+val TatteredMummy = card("Tattered Mummy") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Jackal"
+    power = 1
+    toughness = 2
+    oracleText = "When this creature dies, each opponent loses 2 life."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.LoseLife(2, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "278"
+        artist = "Slawomir Maniak"
+        flavorText = "The dead who wander beyond the safety of the city crave only to spread their curse."
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f9a5267-eb90-43bc-bf92-fcfb06821bae.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/TimberGorgeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/TimberGorgeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Timber Gorge reprint in AKH. Canonical CardDefinition lives in its earliest set.
+ */
+val TimberGorgeReprint = Printing(
+    oracleId = "00b34fab-5a80-4a4d-b6cf-72479197677a",
+    name = "Timber Gorge",
+    setCode = "AKH",
+    collectorNumber = "285",
+    scryfallId = "c81ae262-fe8d-4c78-8604-711fb8d366d8",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c81ae262-fe8d-4c78-8604-711fb8d366d8.jpg",
+    releaseDate = "2017-04-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/TranquilExpanseReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/TranquilExpanseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tranquil Expanse reprint in AKH. Canonical CardDefinition lives in its earliest set.
+ */
+val TranquilExpanseReprint = Printing(
+    oracleId = "a5478263-47c9-447f-9c7a-c77ce0752947",
+    name = "Tranquil Expanse",
+    setCode = "AKH",
+    collectorNumber = "286",
+    scryfallId = "f6054534-a926-460e-8d3c-db8b576b1352",
+    artist = "Sam Burley",
+    imageUri = "https://cards.scryfall.io/normal/front/f/6/f6054534-a926-460e-8d3c-db8b576b1352.jpg",
+    releaseDate = "2017-04-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/WoodlandStreamReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/WoodlandStreamReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Woodland Stream reprint in AKH. Canonical CardDefinition lives in its earliest set.
+ */
+val WoodlandStreamReprint = Printing(
+    oracleId = "e887fb3f-d4c9-4022-8f75-1de6ec94af96",
+    name = "Woodland Stream",
+    setCode = "AKH",
+    collectorNumber = "287",
+    scryfallId = "f8ff0f82-1326-479c-ba88-8cc85c56d883",
+    artist = "Enora Mercier",
+    imageUri = "https://cards.scryfall.io/normal/front/f/8/f8ff0f82-1326-479c-ba88-8cc85c56d883.jpg",
+    releaseDate = "2017-04-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/FrilledSeaSerpentReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/FrilledSeaSerpentReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Frilled Sea Serpent reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val FrilledSeaSerpentReprint = Printing(
+    oracleId = "6dc534e8-e22b-4e3c-aa30-c6e4c84f698c",
+    name = "Frilled Sea Serpent",
+    setCode = "ANB",
+    collectorNumber = "27",
+    scryfallId = "0e82bd0d-647f-42bd-b6d2-9a5d2a7bcd2f",
+    artist = "Steven Belledin",
+    imageUri = "https://cards.scryfall.io/normal/front/0/e/0e82bd0d-647f-42bd-b6d2-9a5d2a7bcd2f.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/GoblinTrashmasterReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/GoblinTrashmasterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Trashmaster reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val GoblinTrashmasterReprint = Printing(
+    oracleId = "0283bf5e-ddf2-4a4a-a7cf-d3e27eed7e7d",
+    name = "Goblin Trashmaster",
+    setCode = "ANB",
+    collectorNumber = "72",
+    scryfallId = "3f95fec8-99f6-4ce5-bfc3-426a568ee053",
+    artist = "Jakub Kasper",
+    imageUri = "https://cards.scryfall.io/normal/front/3/f/3f95fec8-99f6-4ce5-bfc3-426a568ee053.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/GreenwoodSentinelReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/GreenwoodSentinelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Greenwood Sentinel reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val GreenwoodSentinelReprint = Printing(
+    oracleId = "8178c546-84f8-4563-a804-6489ec016660",
+    name = "Greenwood Sentinel",
+    setCode = "ANB",
+    collectorNumber = "97",
+    scryfallId = "54a50513-8570-47f0-9c57-6a775f0d2cf2",
+    artist = "Johann Bodin",
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/54a50513-8570-47f0-9c57-6a775f0d2cf2.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/KnightSPledgeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/KnightSPledgeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Knight's Pledge reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val KnightSPledgeReprint = Printing(
+    oracleId = "63604320-68de-415e-b1f9-dd0f85c5d8a3",
+    name = "Knight's Pledge",
+    setCode = "ANB",
+    collectorNumber = "12",
+    scryfallId = "e73b3432-fa06-43d2-9112-b5ad23e02ccc",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/e/7/e73b3432-fa06-43d2-9112-b5ad23e02ccc.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/RiddlemasterSphinxReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/RiddlemasterSphinxReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Riddlemaster Sphinx reprint in ANB. Canonical CardDefinition lives in its earliest set.
+ */
+val RiddlemasterSphinxReprint = Printing(
+    oracleId = "29f61caf-1aba-40cd-aff6-c3685a0997d7",
+    name = "Riddlemaster Sphinx",
+    setCode = "ANB",
+    collectorNumber = "31",
+    scryfallId = "2e480ab2-d862-4620-8369-18af0577278b",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/2/e/2e480ab2-d862-4620-8369-18af0577278b.jpg",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/CinderBarrensReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/CinderBarrensReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cinder Barrens reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val CinderBarrensReprint = Printing(
+    oracleId = "f155a05f-9f5e-4875-a407-103b85ce30ee",
+    name = "Cinder Barrens",
+    setCode = "C17",
+    collectorNumber = "241",
+    scryfallId = "a91dd6b5-03e1-46fa-8c7a-2c780e641550",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/a/9/a91dd6b5-03e1-46fa-8c7a-2c780e641550.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/ForsakenSanctuaryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/ForsakenSanctuaryReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Forsaken Sanctuary reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val ForsakenSanctuaryReprint = Printing(
+    oracleId = "941b0dd1-0df2-48ee-8829-615e9c3177a7",
+    name = "Forsaken Sanctuary",
+    setCode = "C17",
+    collectorNumber = "250",
+    scryfallId = "381097a1-aac8-449b-bed5-ec0d9879a2c8",
+    artist = "Vincent Proce",
+    imageUri = "https://cards.scryfall.io/normal/front/3/8/381097a1-aac8-449b-bed5-ec0d9879a2c8.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/StoneQuarryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/StoneQuarryReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stone Quarry reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val StoneQuarryReprint = Printing(
+    oracleId = "90bccf66-58ec-445d-ac96-c6013054a1b4",
+    name = "Stone Quarry",
+    setCode = "C17",
+    collectorNumber = "282",
+    scryfallId = "b2a226c2-da8a-4255-967f-d9561f4206b3",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/b/2/b2a226c2-da8a-4255-967f-d9561f4206b3.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/TranquilExpanseReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/TranquilExpanseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tranquil Expanse reprint in C17. Canonical CardDefinition lives in its earliest set.
+ */
+val TranquilExpanseReprint = Printing(
+    oracleId = "a5478263-47c9-447f-9c7a-c77ce0752947",
+    name = "Tranquil Expanse",
+    setCode = "C17",
+    collectorNumber = "286",
+    scryfallId = "34ae81d1-7858-4790-aca8-d5cd7735d67a",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/34ae81d1-7858-4790-aca8-d5cd7735d67a.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/OmenspeakerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/OmenspeakerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Omenspeaker reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val OmenspeakerReprint = Printing(
+    oracleId = "43d7fcf3-acc2-4e9b-a466-c73b1b6c58af",
+    name = "Omenspeaker",
+    setCode = "CMR",
+    collectorNumber = "83",
+    scryfallId = "1b635abe-ad7e-44b8-b3fe-6e365db87c29",
+    artist = "Dallas Williams",
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1b635abe-ad7e-44b8-b3fe-6e365db87c29.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/ScholarOfStarsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/ScholarOfStarsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scholar of Stars reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val ScholarOfStarsReprint = Printing(
+    oracleId = "0753aee4-33db-48c5-9854-16a9d91535b2",
+    name = "Scholar of Stars",
+    setCode = "CMR",
+    collectorNumber = "92",
+    scryfallId = "5fc4498e-24e6-40e9-8cd5-f42220366664",
+    artist = "Tommy Arnold",
+    imageUri = "https://cards.scryfall.io/normal/front/5/f/5fc4498e-24e6-40e9-8cd5-f42220366664.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/StoneQuarryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/StoneQuarryReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stone Quarry reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val StoneQuarryReprint = Printing(
+    oracleId = "90bccf66-58ec-445d-ac96-c6013054a1b4",
+    name = "Stone Quarry",
+    setCode = "CMR",
+    collectorNumber = "495",
+    scryfallId = "aa3575e1-7d2c-4777-b469-16f7483bb8e7",
+    artist = "Noah Bradley",
+    imageUri = "https://cards.scryfall.io/normal/front/a/a/aa3575e1-7d2c-4777-b469-16f7483bb8e7.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/WoodlandStreamReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/WoodlandStreamReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Woodland Stream reprint in CMR. Canonical CardDefinition lives in its earliest set.
+ */
+val WoodlandStreamReprint = Printing(
+    oracleId = "e887fb3f-d4c9-4022-8f75-1de6ec94af96",
+    name = "Woodland Stream",
+    setCode = "CMR",
+    collectorNumber = "503",
+    scryfallId = "77619840-963f-4ff7-9a42-b36e3d53646d",
+    artist = "Enora Mercier",
+    imageUri = "https://cards.scryfall.io/normal/front/7/7/77619840-963f-4ff7-9a42-b36e3d53646d.jpg",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/MeanderingRiverReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/MeanderingRiverReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.dom.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meandering River reprint in DOM. Canonical CardDefinition lives in its earliest set.
+ */
+val MeanderingRiverReprint = Printing(
+    oracleId = "2d9663be-c466-4191-85e2-a69ce0965432",
+    name = "Meandering River",
+    setCode = "DOM",
+    collectorNumber = "274",
+    scryfallId = "d4585bcf-288b-4251-b57f-9d7e50dffc7e",
+    artist = "James Paick",
+    imageUri = "https://cards.scryfall.io/normal/front/d/4/d4585bcf-288b-4251-b57f-9d7e50dffc7e.jpg",
+    releaseDate = "2018-04-27",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/TimberGorgeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/TimberGorgeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.dom.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Timber Gorge reprint in DOM. Canonical CardDefinition lives in its earliest set.
+ */
+val TimberGorgeReprint = Printing(
+    oracleId = "00b34fab-5a80-4a4d-b6cf-72479197677a",
+    name = "Timber Gorge",
+    setCode = "DOM",
+    collectorNumber = "279",
+    scryfallId = "7a10f979-63e0-4999-9047-fdbd914cedf4",
+    artist = "YW Tang",
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7a10f979-63e0-4999-9047-fdbd914cedf4.jpg",
+    releaseDate = "2018-04-27",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/cards/MeanderingRiverReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/cards/MeanderingRiverReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.gs1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meandering River reprint in GS1. Canonical CardDefinition lives in its earliest set.
+ */
+val MeanderingRiverReprint = Printing(
+    oracleId = "2d9663be-c466-4191-85e2-a69ce0965432",
+    name = "Meandering River",
+    setCode = "GS1",
+    collectorNumber = "19",
+    scryfallId = "88fd9890-131e-47dd-8d57-23ff12776336",
+    artist = "Gaga Zeng",
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/88fd9890-131e-47dd-8d57-23ff12776336.jpg",
+    releaseDate = "2018-06-22",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/cards/TimberGorgeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/cards/TimberGorgeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.gs1.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Timber Gorge reprint in GS1. Canonical CardDefinition lives in its earliest set.
+ */
+val TimberGorgeReprint = Printing(
+    oracleId = "00b34fab-5a80-4a4d-b6cf-72479197677a",
+    name = "Timber Gorge",
+    setCode = "GS1",
+    collectorNumber = "38",
+    scryfallId = "c6bb439c-e682-4c26-ac3a-4a810b12b509",
+    artist = "Babyson Chen & Uzhen Lin",
+    imageUri = "https://cards.scryfall.io/normal/front/c/6/c6bb439c-e682-4c26-ac3a-4a810b12b509.jpg",
+    releaseDate = "2018-06-22",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/CinderBarrensReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/CinderBarrensReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.hou.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cinder Barrens reprint in HOU. Canonical CardDefinition lives in its earliest set.
+ */
+val CinderBarrensReprint = Printing(
+    oracleId = "f155a05f-9f5e-4875-a407-103b85ce30ee",
+    name = "Cinder Barrens",
+    setCode = "HOU",
+    collectorNumber = "209",
+    scryfallId = "caedf353-35f8-4b58-8ed9-183d29302be9",
+    artist = "Titus Lunter",
+    imageUri = "https://cards.scryfall.io/normal/front/c/a/caedf353-35f8-4b58-8ed9-183d29302be9.jpg",
+    releaseDate = "2017-07-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/ManalithReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/ManalithReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.hou.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Manalith reprint in HOU. Canonical CardDefinition lives in its earliest set.
+ */
+val ManalithReprint = Printing(
+    oracleId = "bd9e416a-89b3-4912-be9b-49fce6a93dc9",
+    name = "Manalith",
+    setCode = "HOU",
+    collectorNumber = "164",
+    scryfallId = "d4b420ed-75b8-4779-aaa2-e245e84202d1",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/d/4/d4b420ed-75b8-4779-aaa2-e245e84202d1.jpg",
+    releaseDate = "2017-07-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/WoodlandStreamReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/WoodlandStreamReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.hou.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Woodland Stream reprint in HOU. Canonical CardDefinition lives in its earliest set.
+ */
+val WoodlandStreamReprint = Printing(
+    oracleId = "e887fb3f-d4c9-4022-8f75-1de6ec94af96",
+    name = "Woodland Stream",
+    setCode = "HOU",
+    collectorNumber = "204",
+    scryfallId = "0d757641-a6e8-4584-b35e-be043c228134",
+    artist = "Florian de Gesincourt",
+    imageUri = "https://cards.scryfall.io/normal/front/0/d/0d757641-a6e8-4584-b35e-be043c228134.jpg",
+    releaseDate = "2017-07-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/EpicureOfBloodReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/EpicureOfBloodReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Epicure of Blood reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val EpicureOfBloodReprint = Printing(
+    oracleId = "bdb319a6-a1cd-44f5-999d-af1bb55b2fc4",
+    name = "Epicure of Blood",
+    setCode = "J22",
+    collectorNumber = "411",
+    scryfallId = "0f71ff90-13ff-4ac6-8bdd-2cf53cc24ec1",
+    artist = "Anna Steinbauer",
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0f71ff90-13ff-4ac6-8bdd-2cf53cc24ec1.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/FoulOrchardReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/FoulOrchardReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Foul Orchard reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val FoulOrchardReprint = Printing(
+    oracleId = "ad6a2776-801f-4743-8268-6d654122171e",
+    name = "Foul Orchard",
+    setCode = "KHC",
+    collectorNumber = "110",
+    scryfallId = "1e1bad7b-e102-4dff-b79a-fd755c2b6d49",
+    artist = "Yeong-Hao Han",
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1e1bad7b-e102-4dff-b79a-fd755c2b6d49.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/MeanderingRiverReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/MeanderingRiverReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meandering River reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val MeanderingRiverReprint = Printing(
+    oracleId = "2d9663be-c466-4191-85e2-a69ce0965432",
+    name = "Meandering River",
+    setCode = "KHC",
+    collectorNumber = "114",
+    scryfallId = "e283db9e-6a51-4b28-9f6c-0c040a9d6d8c",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/e/2/e283db9e-6a51-4b28-9f6c-0c040a9d6d8c.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/AerialEngineer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/AerialEngineer.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Aerial Engineer
+ * {2}{W}{U}
+ * Creature — Human Artificer
+ * 2/4
+ * As long as you control an artifact, this creature gets +2/+0 and has flying.
+ *
+ * One printed sentence, two statics: the layer-7c [ModifyStats] and the layer-6 [GrantKeyword]
+ * live in different layers (CR 613.1), so they are two [ConditionalStaticAbility] entries over the
+ * same condition rather than one composite. Both target `GroupFilter.source()` — the permanent
+ * itself — and the shared gate is an existence check on the battlefield, recomputed at projection
+ * so the bonus comes and goes with the artifact.
+ */
+val AerialEngineer = card("Aerial Engineer") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Creature — Human Artificer"
+    power = 2
+    toughness = 4
+    oracleText = "As long as you control an artifact, this creature gets +2/+0 and has flying."
+
+    val controlAnArtifact = Conditions.YouControl(GameObjectFilter.Artifact)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 2, toughnessBonus = 0, filter = GroupFilter.source()),
+            condition = controlAnArtifact,
+        )
+    }
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FLYING, GroupFilter.source()),
+            condition = controlAnArtifact,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "211"
+        artist = "Zoltan Boros"
+        flavorText = "The best of their trade know every bolt of their rigs, stem to stern."
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/5314bae2-4930-4f8a-8a52-853bc3feb88f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/AjanisWelcome.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/AjanisWelcome.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Ajani's Welcome
+ * {W}
+ * Enchantment
+ * Whenever a creature you control enters, you gain 1 life.
+ *
+ * The trigger watches *any* creature entering under your control, not the enchantment itself, so
+ * the binding is [TriggerBinding.ANY] rather than the `entersBattlefield` default of `SELF`.
+ */
+val AjanisWelcome = card("Ajani's Welcome") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a creature you control enters, you gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "6"
+        artist = "Eric Deschamps"
+        flavorText = "\"You cannot defend others if your own well-being is neglected.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c9045fcb-b633-4c35-8058-6234311551ae.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ArisenGorgon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ArisenGorgon.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Arisen Gorgon
+ * {1}{B}{B}
+ * Creature — Zombie Gorgon
+ * 3/3
+ * This creature has deathtouch as long as you control a Liliana planeswalker. (Any amount of damage this deals to a creature is enough to destroy it.)
+ *
+ * The keyword is not printed on the card, so it is a [ConditionalStaticAbility] over
+ * `GroupFilter.source()` rather than a `keywords(...)` line: the grant appears and disappears with
+ * the Liliana, recomputed at projection instead of latched at any point in time.
+ *
+ * "A Liliana planeswalker" is the planeswalker filter narrowed by the planeswalker *subtype*
+ * (CR 205.3j) — the same shape Court Cleric and Tezzeret's Strider use for their own walkers.
+ * `Conditions.YouControl` is the battlefield-existence check; the subtype match is case-exact.
+ */
+val ArisenGorgon = card("Arisen Gorgon") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Gorgon"
+    power = 3
+    toughness = 3
+    oracleText = "This creature has deathtouch as long as you control a Liliana planeswalker. (Any amount of damage this deals to a creature is enough to destroy it.)"
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.DEATHTOUCH, GroupFilter.source()),
+            condition = Conditions.YouControl(GameObjectFilter.Planeswalker.withSubtype("Liliana"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "292"
+        artist = "Livia Prima"
+        flavorText = "\"I'm not picky about what comes up, but the less decay, the better.\"\n" +
+            "—Liliana Vess"
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e39502fd-193c-4526-8dd8-0cd8c822552c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/AvenWindMage.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/AvenWindMage.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Aven Wind Mage
+ * {2}{U}
+ * Creature — Bird Wizard
+ * 2/2
+ * Flying
+ * Whenever you cast an instant or sorcery spell, this creature gets +1/+1 until end of turn.
+ */
+val AvenWindMage = card("Aven Wind Mage") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "Whenever you cast an instant or sorcery spell, this creature gets +1/+1 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "45"
+        artist = "Lius Lasahido"
+        flavorText = "\"My skill sharpens with each beat of my wings.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b12dfc1-81f2-44b2-baa2-73cc21363978.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/CinderBarrensReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/CinderBarrensReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cinder Barrens reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val CinderBarrensReprint = Printing(
+    oracleId = "f155a05f-9f5e-4875-a407-103b85ce30ee",
+    name = "Cinder Barrens",
+    setCode = "M19",
+    collectorNumber = "248",
+    scryfallId = "db41b554-2bb1-4f11-be29-233d36cc955a",
+    artist = "Titus Lunter",
+    imageUri = "https://cards.scryfall.io/normal/front/d/b/db41b554-2bb1-4f11-be29-233d36cc955a.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ColossalDreadmawReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ColossalDreadmawReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Colossal Dreadmaw reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val ColossalDreadmawReprint = Printing(
+    oracleId = "08c7db90-c0cf-4482-b7ee-bb033e5996d2",
+    name = "Colossal Dreadmaw",
+    setCode = "M19",
+    collectorNumber = "172",
+    scryfallId = "80d4ce4f-8255-419b-9e7f-544d9798e5c8",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/80d4ce4f-8255-419b-9e7f-544d9798e5c8.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/CoreSet2019BasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/CoreSet2019BasicLands.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Core Set 2019 Basic Lands
+ *
+ * Core Set 2019 contains 4 art variants of each basic land type (cards 261-280).
+ * Plains 261-264, Island 265-268, Swamp 269-272, Mountain 273-276, Forest 277-280.
+ */
+
+// =============================================================================
+// Plains (Cards 261-264)
+// =============================================================================
+
+val M19Plains261 = basicLand("Plains") {
+    collectorNumber = "261"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/0/b/0b1b55c1-d74b-4688-a3b8-8480d99524c7.jpg?1783934501"
+}
+
+val M19Plains262 = basicLand("Plains") {
+    collectorNumber = "262"
+    artist = "Zoltan Boros & Gabor Szikszai"
+    imageUri = "https://cards.scryfall.io/normal/front/b/2/b2715553-ba9c-4753-9a1f-d13d8e2ed24f.jpg?1783934503"
+}
+
+val M19Plains263 = basicLand("Plains") {
+    collectorNumber = "263"
+    artist = "Nils Hamm"
+    imageUri = "https://cards.scryfall.io/normal/front/1/8/1859ba05-06bc-4e80-8c0b-fd2475c6ca55.jpg?1783934500"
+}
+
+val M19Plains264 = basicLand("Plains") {
+    collectorNumber = "264"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/3645e11b-6b46-44c0-9741-f70da15692d1.jpg?1783934499"
+}
+
+// =============================================================================
+// Island (Cards 265-268)
+// =============================================================================
+
+val M19Island265 = basicLand("Island") {
+    collectorNumber = "265"
+    artist = "Cliff Childs"
+    imageUri = "https://cards.scryfall.io/normal/front/9/1/91890c11-b139-474d-b12d-6afd6b7e6aee.jpg?1783934500"
+}
+
+val M19Island266 = basicLand("Island") {
+    collectorNumber = "266"
+    artist = "Chippy"
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/54c33392-c382-4e8b-812e-8b2c64cdbe8e.jpg?1783934498"
+}
+
+val M19Island267 = basicLand("Island") {
+    collectorNumber = "267"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/4/2/42044efb-b6a8-46c3-90dc-b7a745e819e5.jpg?1783934496"
+}
+
+val M19Island268 = basicLand("Island") {
+    collectorNumber = "268"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e3a0c382-23c4-44a5-a689-1f65fed388b7.jpg?1783934496"
+}
+
+// =============================================================================
+// Swamp (Cards 269-272)
+// =============================================================================
+
+val M19Swamp269 = basicLand("Swamp") {
+    collectorNumber = "269"
+    artist = "Mike Bierek"
+    imageUri = "https://cards.scryfall.io/normal/front/2/b/2bfe9801-b683-45d9-924c-6734110816bf.jpg?1783934496"
+}
+
+val M19Swamp270 = basicLand("Swamp") {
+    collectorNumber = "270"
+    artist = "Cliff Childs"
+    imageUri = "https://cards.scryfall.io/normal/front/4/3/430341f3-7dd5-4161-96a2-e76350699b66.jpg?1783934496"
+}
+
+val M19Swamp271 = basicLand("Swamp") {
+    collectorNumber = "271"
+    artist = "Christine Choi"
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/8808d9dd-70c0-46ff-bd9c-dd60240dd121.jpg?1783934496"
+}
+
+val M19Swamp272 = basicLand("Swamp") {
+    collectorNumber = "272"
+    artist = "Mark Poole"
+    imageUri = "https://cards.scryfall.io/normal/front/f/d/fd7f974d-2634-4fc7-aa4e-bfeb6f3169ea.jpg?1783934495"
+}
+
+// =============================================================================
+// Mountain (Cards 273-276)
+// =============================================================================
+
+val M19Mountain273 = basicLand("Mountain") {
+    collectorNumber = "273"
+    artist = "Noah Bradley"
+    imageUri = "https://cards.scryfall.io/normal/front/7/1/71f2030b-f622-4cc3-ac83-258ae3645fd6.jpg?1783934495"
+}
+
+val M19Mountain274 = basicLand("Mountain") {
+    collectorNumber = "274"
+    artist = "Cliff Childs"
+    imageUri = "https://cards.scryfall.io/normal/front/6/4/6457f78b-aca6-4ebf-9e89-bf9321ceb35d.jpg?1783934498"
+}
+
+val M19Mountain275 = basicLand("Mountain") {
+    collectorNumber = "275"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/f/e/fedbe1f9-b29f-4bdd-9718-615b7c2413b4.jpg?1783934499"
+}
+
+val M19Mountain276 = basicLand("Mountain") {
+    collectorNumber = "276"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/b/b/bb4004c8-c3d9-494e-a257-6d8443cbf1b7.jpg?1783934495"
+}
+
+// =============================================================================
+// Forest (Cards 277-280)
+// =============================================================================
+
+val M19Forest277 = basicLand("Forest") {
+    collectorNumber = "277"
+    artist = "Volkan Baǵa"
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b52ff177-bafe-4e0a-a6c3-2cf012b1319f.jpg?1783934492"
+}
+
+val M19Forest278 = basicLand("Forest") {
+    collectorNumber = "278"
+    artist = "Steven Belledin"
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c1e46627-3cf3-4aca-97ba-80f9e919608c.jpg?1783934494"
+}
+
+val M19Forest279 = basicLand("Forest") {
+    collectorNumber = "279"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/3/2/32df22d3-9b65-4b43-80d9-e4c43575ec74.jpg?1783934492"
+}
+
+val M19Forest280 = basicLand("Forest") {
+    collectorNumber = "280"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/e/a/ea3cc8ba-ab54-46d3-9c3a-91678fd8d381.jpg?1783934491"
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/CourtCleric.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/CourtCleric.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Court Cleric
+ * {W}
+ * Creature — Human Cleric
+ * 1/1
+ * Lifelink (Damage dealt by this creature also causes you to gain that much life.)
+ * This creature gets +1/+1 as long as you control an Ajani planeswalker.
+ *
+ * "An Ajani planeswalker" is a planeswalker whose *subtype* is Ajani (CR 205.3j), so the gate is an
+ * [Exists] over `GameObjectFilter.Planeswalker.withSubtype("Ajani")` — it sees every Ajani card, and
+ * any other permanent that has been given the subtype, rather than a fixed list of card names.
+ * The bonus is a layer-7c [ModifyStats] recomputed at projection, so it appears and disappears with
+ * the planeswalker.
+ */
+val CourtCleric = card("Court Cleric") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 1
+    oracleText = "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\n" +
+        "This creature gets +1/+1 as long as you control an Ajani planeswalker."
+
+    keywords(Keyword.LIFELINK)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(1, 1, GroupFilter.source()),
+            condition = Exists(
+                Player.You,
+                Zone.BATTLEFIELD,
+                GameObjectFilter.Planeswalker.withSubtype("Ajani")
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "283"
+        artist = "Mark Behm"
+        flavorText = "\"The healers of Bant are second to none. I owe them a great deal for their tutelage.\"\n" +
+            "—Ajani Goldmane"
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dc2e1a93-4b5c-4f89-9e11-1693dee64b63.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DaggerbackBasiliskReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DaggerbackBasiliskReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Daggerback Basilisk reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val DaggerbackBasiliskReprint = Printing(
+    oracleId = "ea4d30c7-7c39-46d5-9b71-a7ebc3e219a1",
+    name = "Daggerback Basilisk",
+    setCode = "M19",
+    collectorNumber = "174",
+    scryfallId = "7bc8325b-c7a8-49a5-8a54-a419800ffb93",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/7/b/7bc8325b-c7a8-49a5-8a54-a419800ffb93.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DarkDwellerOracle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DarkDwellerOracle.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Dark-Dweller Oracle
+ * {1}{R}
+ * Creature — Goblin Shaman
+ * 2/2
+ * {1}, Sacrifice a creature: Exile the top card of your library. You may play that card this turn. (You still pay its costs. You can play a land this way only if you have an available land play remaining.)
+ *
+ * The effect is the standard impulse draw — [Patterns.Exile.impulse] gathers the top card,
+ * moves the collection to exile and grants may-play over it with the default
+ * `MayPlayExpiry.EndOfTurn` ("this turn"). "Sacrifice a creature" is not "another", so the
+ * Oracle itself is a legal sacrifice: [Costs.Sacrifice] with no `excludeSelf`.
+ */
+val DarkDwellerOracle = card("Dark-Dweller Oracle") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "{1}, Sacrifice a creature: Exile the top card of your library. You may play that card this turn. (You still pay its costs. You can play a land this way only if you have an available land play remaining.)"
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Sacrifice(GameObjectFilter.Creature))
+        effect = Patterns.Exile.impulse(1)
+        description = "{1}, Sacrifice a creature: Exile the top card of your library. You may play that card this turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "134"
+        artist = "Deruchenko Alexander"
+        flavorText = "Eyes are unnecessary for seeing the future."
+        imageUri = "https://cards.scryfall.io/normal/front/6/9/69a57bfc-1de2-4b3a-84bc-19ec41087f0d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DesecratedTomb.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DesecratedTomb.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Desecrated Tomb
+ * {3}
+ * Artifact
+ * Whenever one or more creature cards leave your graveyard, create a 1/1 black Bat creature token with flying.
+ *
+ * "One or more … leave" is CR 603.2c batch wording, so the batching
+ * [Triggers.CardsLeaveYourGraveyard] is the right shape: a mass reanimation or a graveyard-exiling
+ * sweep fires this exactly once, no matter how many creature cards moved or where they went.
+ */
+val DesecratedTomb = card("Desecrated Tomb") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever one or more creature cards leave your graveyard, create a 1/1 black Bat creature token with flying."
+
+    triggeredAbility {
+        trigger = Triggers.CardsLeaveYourGraveyard(GameObjectFilter.Creature)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Bat"),
+            keywords = setOf(Keyword.FLYING)
+        )
+        description = "Whenever one or more creature cards leave your graveyard, create a 1/1 " +
+            "black Bat creature token with flying."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "230"
+        artist = "Dimitar Marinski"
+        flavorText = "The grave robbers were startled, for the door to the mausoleum was already open."
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/458ce930-c100-4ef5-b75a-a18051282f8c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DismissivePyromancer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DismissivePyromancer.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dismissive Pyromancer
+ * {1}{R}
+ * Creature — Human Wizard
+ * 2/2
+ * {R}, {T}, Discard a card: Draw a card.
+ * {2}{R}, {T}, Sacrifice this creature: It deals 4 damage to target creature.
+ *
+ * Two ordinary activated abilities; the whole card is cost vocabulary. The second one sacrifices its
+ * own source as part of the cost, so "it" is already gone when the ability resolves — the damage is
+ * a flat 4, so no last-known-information read is needed.
+ */
+val DismissivePyromancer = card("Dismissive Pyromancer") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "{R}, {T}, Discard a card: Draw a card.\n" +
+        "{2}{R}, {T}, Sacrifice this creature: It deals 4 damage to target creature."
+
+    // {R}, {T}, Discard a card: Draw a card.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Tap, Costs.DiscardCard)
+        effect = Effects.DrawCards(1)
+    }
+
+    // {2}{R}, {T}, Sacrifice this creature: It deals 4 damage to target creature.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}"), Costs.Tap, Costs.SacrificeSelf)
+        val victim = target("target", Targets.Creature)
+        effect = Effects.DealDamage(4, victim)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "136"
+        artist = "Bram Sels"
+        flavorText = "\"Burn. Burn. Keep. Burn.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a0d0a9fa-75c9-4492-accd-bc9f79407453.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DisperseReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DisperseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Disperse reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val DisperseReprint = Printing(
+    oracleId = "9d8fe3f8-5027-4f9e-999e-e277caa96478",
+    name = "Disperse",
+    setCode = "M19",
+    collectorNumber = "50",
+    scryfallId = "2ff7c89c-41dc-4ac3-bbce-38ab86f435ea",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/2/f/2ff7c89c-41dc-4ac3-bbce-38ab86f435ea.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DoomedDissenterReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DoomedDissenterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Doomed Dissenter reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val DoomedDissenterReprint = Printing(
+    oracleId = "11cb509d-21af-48f1-b355-135ebd3e4bd1",
+    name = "Doomed Dissenter",
+    setCode = "M19",
+    collectorNumber = "93",
+    scryfallId = "a1f70ee8-7e59-43d6-a7b2-29cb5cd1d8b3",
+    artist = "Tony Foti",
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a1f70ee8-7e59-43d6-a7b2-29cb5cd1d8b3.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DraconicDisciple.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DraconicDisciple.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Draconic Disciple
+ * {1}{R}{G}
+ * Creature — Human Shaman
+ * 2/2
+ * {T}: Add one mana of any color.
+ * {7}, {T}, Sacrifice this creature: Create a 5/5 red Dragon creature token with flying.
+ */
+val DraconicDisciple = card("Draconic Disciple") {
+    manaCost = "{1}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Human Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "{T}: Add one mana of any color.\n" +
+        "{7}, {T}, Sacrifice this creature: Create a 5/5 red Dragon creature token with flying."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{7}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.CreateToken(
+            power = 5,
+            toughness = 5,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Dragon"),
+            keywords = setOf(Keyword.FLYING)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "215"
+        artist = "Yongjae Choi"
+        flavorText = "\"If I am to die, I will die in the embrace of immeasurable flame.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a353510a-30de-4891-97b9-d7d556531c41.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DruidOfTheCowlReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DruidOfTheCowlReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Druid of the Cowl reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val DruidOfTheCowlReprint = Printing(
+    oracleId = "b1793c3b-25d6-4fae-a99d-cfdd2210ca67",
+    name = "Druid of the Cowl",
+    setCode = "M19",
+    collectorNumber = "177",
+    scryfallId = "76ceff1d-9e83-41cc-b54b-8bf90d985da9",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/76ceff1d-9e83-41cc-b54b-8bf90d985da9.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DwarvenPriest.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DwarvenPriest.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dwarven Priest
+ * {3}{W}
+ * Creature — Dwarf Cleric
+ * 2/4
+ * When this creature enters, you gain 1 life for each creature you control.
+ *
+ * The count is taken on resolution and includes Dwarven Priest itself, so
+ * [DynamicAmounts.creaturesYouControl] (an `AggregateBattlefield` count over creatures you
+ * control) is read against projected state rather than latched at the trigger.
+ */
+val DwarvenPriest = card("Dwarven Priest") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dwarf Cleric"
+    power = 2
+    toughness = 4
+    oracleText = "When this creature enters, you gain 1 life for each creature you control."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(DynamicAmounts.creaturesYouControl())
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Even Amundsen"
+        flavorText = "\"These storied halls are under my protection.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e1e0f13-35a6-4a5e-8666-47bc5c275be7.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ElectrifyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ElectrifyReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Electrify reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val ElectrifyReprint = Printing(
+    oracleId = "da952213-9a3c-4e13-bc5a-55d1e5dbaa5b",
+    name = "Electrify",
+    setCode = "M19",
+    collectorNumber = "139",
+    scryfallId = "60bee89d-d916-4095-830f-6270f8c4f0d8",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/60bee89d-d916-4095-830f-6270f8c4f0d8.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/EpicureOfBlood.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/EpicureOfBlood.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Epicure of Blood
+ * {4}{B}
+ * Creature — Vampire
+ * 4/4
+ * Whenever you gain life, each opponent loses 1 life.
+ */
+val EpicureOfBlood = card("Epicure of Blood") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire"
+    power = 4
+    toughness = 4
+    oracleText = "Whenever you gain life, each opponent loses 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "Anna Steinbauer"
+        flavorText = "\"Fleshy, with just a hint of leather. A fine vintage.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40b03528-f4ec-4825-ba4c-c485cb4eab3a.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ExplosiveApparatusReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ExplosiveApparatusReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Explosive Apparatus reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val ExplosiveApparatusReprint = Printing(
+    oracleId = "ab8301da-f9f7-4d90-afae-bd7e60834c22",
+    name = "Explosive Apparatus",
+    setCode = "M19",
+    collectorNumber = "233",
+    scryfallId = "608f431b-a05c-4610-94f7-928d87b2c056",
+    artist = "Lindsey Look",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/608f431b-a05c-4610-94f7-928d87b2c056.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/FieryFinish.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/FieryFinish.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fiery Finish
+ * {4}{R}{R}
+ * Sorcery
+ * Fiery Finish deals 7 damage to target creature.
+ */
+val FieryFinish = card("Fiery Finish") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Fiery Finish deals 7 damage to target creature."
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(7, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "140"
+        artist = "Joe Slucher"
+        flavorText = "Negotiations reached an abrupt conclusion."
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3e38127d-63af-4d26-9ff5-358c8a61f39c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ForsakenSanctuaryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ForsakenSanctuaryReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Forsaken Sanctuary reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val ForsakenSanctuaryReprint = Printing(
+    oracleId = "941b0dd1-0df2-48ee-8829-615e9c3177a7",
+    name = "Forsaken Sanctuary",
+    setCode = "M19",
+    collectorNumber = "250",
+    scryfallId = "b376c8c9-cd35-4c2b-8b5b-95ea9735b366",
+    artist = "Vincent Proce",
+    imageUri = "https://cards.scryfall.io/normal/front/b/3/b376c8c9-cd35-4c2b-8b5b-95ea9735b366.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/FoulOrchardReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/FoulOrchardReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Foul Orchard reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val FoulOrchardReprint = Printing(
+    oracleId = "ad6a2776-801f-4743-8268-6d654122171e",
+    name = "Foul Orchard",
+    setCode = "M19",
+    collectorNumber = "251",
+    scryfallId = "6b28e1e1-0813-4e4a-a7a7-058b7787272c",
+    artist = "Yeong-Hao Han",
+    imageUri = "https://cards.scryfall.io/normal/front/6/b/6b28e1e1-0813-4e4a-a7a7-058b7787272c.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/FountainOfRenewal.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/FountainOfRenewal.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fountain of Renewal
+ * {1}
+ * Artifact
+ * At the beginning of your upkeep, you gain 1 life.
+ * {3}, Sacrifice this artifact: Draw a card.
+ *
+ * [Triggers.YourUpkeep] is the printed "at the beginning of your upkeep" — a `StepEvent` on
+ * `Step.UPKEEP` for `Player.You`. The second line is a plain activated ability whose cost is
+ * {3} plus [Costs.SacrificeSelf].
+ */
+val FountainOfRenewal = card("Fountain of Renewal") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "At the beginning of your upkeep, you gain 1 life.\n" +
+        "{3}, Sacrifice this artifact: Draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.GainLife(1)
+        description = "At the beginning of your upkeep, you gain 1 life."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+        description = "{3}, Sacrifice this artifact: Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "235"
+        artist = "Adam Paquette"
+        flavorText = "Entrepreneurs have attempted to sell the water, but to no avail. Whatever magic it contains disappears upon bottling."
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/26894980-8961-4479-85dd-5f01c899718b.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/FrilledSeaSerpent.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/FrilledSeaSerpent.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Frilled Sea Serpent
+ * {4}{U}{U}
+ * Creature — Serpent
+ * 4/6
+ * {5}{U}{U}: This creature can't be blocked this turn.
+ */
+val FrilledSeaSerpent = card("Frilled Sea Serpent") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Serpent"
+    power = 4
+    toughness = 6
+    oracleText = "{5}{U}{U}: This creature can't be blocked this turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{U}{U}")
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, EffectTarget.Self)
+        description = "{5}{U}{U}: This creature can't be blocked this turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56"
+        artist = "Steven Belledin"
+        flavorText = "\"Reel it in. No, wait! Throw it back!\"\n" +
+            "—Gertrude, deep-sea angler"
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0aa62c0-d24b-4bce-9f2b-d42402b0830c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GhostformReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GhostformReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ghostform reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val GhostformReprint = Printing(
+    oracleId = "8d813b72-8ead-4a61-88ff-e93c8d843196",
+    name = "Ghostform",
+    setCode = "M19",
+    collectorNumber = "58",
+    scryfallId = "347760a1-03f5-4cc9-87ad-e08986b1ea21",
+    artist = "Scott Chou",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/347760a1-03f5-4cc9-87ad-e08986b1ea21.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GoblinMotivator.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GoblinMotivator.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Motivator
+ * {R}
+ * Creature — Goblin Warrior
+ * 1/1
+ * {T}: Target creature gains haste until end of turn. (It can attack and {T} this turn.)
+ */
+val GoblinMotivator = card("Goblin Motivator") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Target creature gains haste until end of turn. (It can attack and {T} this turn.)"
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.HASTE, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "143"
+        artist = "Johann Bodin"
+        flavorText = "Small words stoke large flames."
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/94b3a4fb-9024-45ef-a54b-cf3a9fa5b9c2.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GoblinTrashmaster.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GoblinTrashmaster.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Goblin Trashmaster
+ * {2}{R}{R}
+ * Creature — Goblin Warrior
+ * 3/3
+ *
+ * Other Goblins you control get +1/+1.
+ * Sacrifice a Goblin: Destroy target artifact.
+ *
+ * The anthem is a layer-7c [ModifyStats] over *Goblin permanents* you control — the printed line
+ * says "Goblins", not "Goblin creatures", so the affected set is every Goblin permanent (a Goblin
+ * noncreature artifact would still be pumped, and would matter the moment one is animated).
+ * `excludeSelf` carries the "Other".
+ *
+ * The activation cost is an unrestricted "Sacrifice a Goblin" — Goblin Trashmaster itself is a
+ * legal sacrifice, so the cost filter is deliberately *not* `SacrificeAnother`.
+ */
+val GoblinTrashmaster = card("Goblin Trashmaster") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "Other Goblins you control get +1/+1.\n" +
+        "Sacrifice a Goblin: Destroy target artifact."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype(Subtype.GOBLIN).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Permanent.withSubtype(Subtype.GOBLIN))
+        val artifact = target("target", Targets.Artifact)
+        effect = Effects.Destroy(artifact)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "144"
+        artist = "Jakub Kasper"
+        flavorText = "\"Folks 'round here are too in love with their contraptions. Does them some good if we smash one every so often.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2bc69988-3c2d-4b76-a8c0-05926b9bbd08.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GreenwoodSentinel.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GreenwoodSentinel.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Greenwood Sentinel
+ * {1}{G}
+ * Creature — Elf Scout
+ * 2/2
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ */
+val GreenwoodSentinel = card("Greenwood Sentinel") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Scout"
+    power = 2
+    toughness = 2
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)"
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "187"
+        artist = "Johann Bodin"
+        flavorText = "Within a mile of the woodland, you will feel her eyes upon you. Within its borders, you will feel her blade."
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2eebdd18-6930-42e0-b589-fe15820db6e1.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GuttersnipeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GuttersnipeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Guttersnipe reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val GuttersnipeReprint = Printing(
+    oracleId = "c6bdaf76-6a03-4695-9c4b-f040e73435af",
+    name = "Guttersnipe",
+    setCode = "M19",
+    collectorNumber = "145",
+    scryfallId = "bbc0f3e7-a287-4624-8266-ca617448fcaa",
+    artist = "Mathias Kollros",
+    imageUri = "https://cards.scryfall.io/normal/front/b/b/bbc0f3e7-a287-4624-8266-ca617448fcaa.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/HavocDevils.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/HavocDevils.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Havoc Devils
+ * {2}{R}{R}
+ * Creature — Devil
+ * 4/3
+ * Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)
+ */
+val HavocDevils = card("Havoc Devils") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Devil"
+    power = 4
+    toughness = 3
+    oracleText = "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)"
+
+    keywords(Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Viktor Titov"
+        flavorText = "For devils, burning things is the highest form of comedy, diversion, and artistic expression."
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2f003678-0f17-4f1d-87d5-83613a82044b.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/HighlandLakeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/HighlandLakeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Highland Lake reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val HighlandLakeReprint = Printing(
+    oracleId = "c643365a-4255-4d23-adb9-0f8b456f0838",
+    name = "Highland Lake",
+    setCode = "M19",
+    collectorNumber = "252",
+    scryfallId = "b538a465-81c6-4282-9ac3-061167ac7dc3",
+    artist = "Noah Bradley",
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b538a465-81c6-4282-9ac3-061167ac7dc3.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/HiredBlade.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/HiredBlade.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hired Blade
+ * {2}{B}
+ * Creature — Human Assassin
+ * 3/2
+ * Flash (You may cast this spell any time you could cast an instant.)
+ */
+val HiredBlade = card("Hired Blade") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Assassin"
+    power = 3
+    toughness = 2
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)"
+
+    keywords(Keyword.FLASH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "100"
+        artist = "Mark Behm"
+        flavorText = "\"If you want them dead, buy some poison. If you want them to have the worst day of their life before dying, then let's talk price.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/7624c9aa-2f47-4fcc-a9fe-cc843e8de053.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/HostileMinotaur.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/HostileMinotaur.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hostile Minotaur
+ * {3}{R}
+ * Creature — Minotaur
+ * 3/3
+ * Haste (This creature can attack and {T} as soon as it comes under your control.)
+ */
+val HostileMinotaur = card("Hostile Minotaur") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur"
+    power = 3
+    toughness = 3
+    oracleText = "Haste (This creature can attack and {T} as soon as it comes under your control.)"
+
+    keywords(Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "147"
+        artist = "Joe Slucher"
+        flavorText = "The bellow of a minotaur always translates to \"charge.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad6d0a11-3a9c-4de0-9a46-06d2b9356eb7.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/InfectiousHorrorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/InfectiousHorrorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Infectious Horror reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val InfectiousHorrorReprint = Printing(
+    oracleId = "0931206b-eed2-40d0-9496-5ecefc7f8f90",
+    name = "Infectious Horror",
+    setCode = "M19",
+    collectorNumber = "101",
+    scryfallId = "d17aaa92-10ca-4f70-b45e-5a51e9192efb",
+    artist = "Pete Venters",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d17aaa92-10ca-4f70-b45e-5a51e9192efb.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/Isolate.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/Isolate.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Isolate
+ * {W}
+ * Instant
+ * Exile target permanent with mana value 1.
+ */
+val Isolate = card("Isolate") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Exile target permanent with mana value 1."
+
+    spell {
+        val t = target("target", TargetPermanent(filter = TargetFilter.Permanent.manaValue(1)))
+        effect = Effects.Move(t, Zone.EXILE)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "17"
+        artist = "Victor Adame Minguez"
+        flavorText = "Threefold were his crimes, doubled were his pleas, singular was his fate."
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d9ce5eb-eaeb-4c93-8d31-4aeb8fcc4cce.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/KnightsPledge.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/KnightsPledge.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Knight's Pledge
+ * {1}{W}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +2/+2.
+ */
+val KnightsPledge = card("Knight's Pledge") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +2/+2."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Magali Villeneuve"
+        flavorText = "\"As long as my faith persists, so shall I.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/734ff6ac-000d-4fc6-b97b-07b9b21f745c.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/LichsCaress.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/LichsCaress.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lich's Caress
+ * {3}{B}{B}
+ * Sorcery
+ * Destroy target creature. You gain 3 life.
+ *
+ * Two ordered clauses over one target: [Effects.Destroy] on the chosen creature, then a flat
+ * [Effects.GainLife] for the controller. The life gain is part of the same resolution, so an
+ * illegal target on resolution fizzles the whole spell and no life is gained.
+ */
+val LichsCaress = card("Lich's Caress") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature. You gain 3 life."
+
+    spell {
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.Destroy(creature),
+            Effects.GainLife(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Josh Hass"
+        flavorText = "A lich must consume mortal souls to feed its eternal life."
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/32bd3acd-aa62-4708-9336-e3430fd0e541.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/LightningMare.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/LightningMare.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lightning Mare
+ * {R}{R}
+ * Creature — Elemental Horse
+ * 3/1
+ * This spell can't be countered.
+ * This creature can't be blocked by blue creatures.
+ * {1}{R}: This creature gets +1/+0 until end of turn.
+ *
+ * - "This spell can't be countered" is a property of the *card*, not a static ability of the
+ *   permanent, so it is the top-level `cantBeCountered` var the stack consults while the spell is
+ *   still on it.
+ * - The evasion is a single [CantBeBlockedBy] over a coloured *creature* filter, evaluated against
+ *   projected state so a blocker's current colour decides, not its printed one.
+ */
+val LightningMare = card("Lightning Mare") {
+    manaCost = "{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental Horse"
+    power = 3
+    toughness = 1
+    oracleText = "This spell can't be countered.\n" +
+        "This creature can't be blocked by blue creatures.\n" +
+        "{1}{R}: This creature gets +1/+0 until end of turn."
+
+    cantBeCountered = true
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.withColor(Color.BLUE))
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "151"
+        artist = "Lucas Graciano"
+        flavorText = "When it passes, storm clouds bolt across the land."
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2ca822a3-4793-4cbc-a2f3-f43985e7ce8f.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ManalithReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ManalithReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Manalith reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val ManalithReprint = Printing(
+    oracleId = "bd9e416a-89b3-4912-be9b-49fce6a93dc9",
+    name = "Manalith",
+    setCode = "M19",
+    collectorNumber = "239",
+    scryfallId = "9dfba61f-9a6d-43e3-ad28-f74f737ef186",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/9/d/9dfba61f-9a6d-43e3-ad28-f74f737ef186.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/MeanderingRiverReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/MeanderingRiverReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meandering River reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val MeanderingRiverReprint = Printing(
+    oracleId = "2d9663be-c466-4191-85e2-a69ce0965432",
+    name = "Meandering River",
+    setCode = "M19",
+    collectorNumber = "253",
+    scryfallId = "f47ee724-da0f-4eb1-b07b-b07e04e9f5b3",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/f/4/f47ee724-da0f-4eb1-b07b-b07e04e9f5b3.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/MentorOfTheMeekReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/MentorOfTheMeekReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mentor of the Meek reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val MentorOfTheMeekReprint = Printing(
+    oracleId = "b9f4f96b-6e54-4fe6-8df7-623e0fc72409",
+    name = "Mentor of the Meek",
+    setCode = "M19",
+    collectorNumber = "27",
+    scryfallId = "5e18bd43-6cee-40a3-88f5-c775fb705172",
+    artist = "Jana Schirmer & Johannes Voss",
+    imageUri = "https://cards.scryfall.io/normal/front/5/e/5e18bd43-6cee-40a3-88f5-c775fb705172.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/MightyLeapReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/MightyLeapReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mighty Leap reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val MightyLeapReprint = Printing(
+    oracleId = "593caa15-e1d1-477f-bbb4-124d7a7b81f3",
+    name = "Mighty Leap",
+    setCode = "M19",
+    collectorNumber = "28",
+    scryfallId = "dc45dcdd-ed92-43f6-b6d2-670b3252ed27",
+    artist = "Sidharth Chaturvedi",
+    imageUri = "https://cards.scryfall.io/normal/front/d/c/dc45dcdd-ed92-43f6-b6d2-670b3252ed27.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/MilitiaBugler.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/MilitiaBugler.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Militia Bugler
+ * {2}{W}
+ * Creature — Human Soldier
+ * 2/3
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ * When this creature enters, look at the top four cards of your library. You may reveal a creature card with power 2 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
+ *
+ * The whole enters trigger is one composition: [Patterns.Library.lookAtTopRevealMatchingToHand]
+ * gathers the top four, offers *up to one* matching card, reveals the kept card into hand, and
+ * bottoms the remainder in a random order — the pattern's own defaults supply the destination and
+ * the shuffle, so only the count, the filter, and the prompt are card-specific.
+ */
+val MilitiaBugler = card("Militia Bugler") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 3
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)\n" +
+        "When this creature enters, look at the top four cards of your library. You may reveal a creature card with power 2 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.lookAtTopRevealMatchingToHand(
+            count = DynamicAmount.Fixed(4),
+            filter = GameObjectFilter.Creature.powerAtMost(2),
+            prompt = "You may reveal a creature card with power 2 or less from among them and put it into your hand"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "29"
+        artist = "David Gaillet"
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/43c5bf25-937c-4e17-9ed4-b4c4579fa9dc.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/MistCloakedHeraldReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/MistCloakedHeraldReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mist-Cloaked Herald reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val MistCloakedHeraldReprint = Printing(
+    oracleId = "74255add-2894-4c31-81c1-d38873fa325f",
+    name = "Mist-Cloaked Herald",
+    setCode = "M19",
+    collectorNumber = "310",
+    scryfallId = "574f73a7-9ff7-4ce3-9f56-002af968d35a",
+    artist = "Anthony Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/5/7/574f73a7-9ff7-4ce3-9f56-002af968d35a.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/OakenformReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/OakenformReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oakenform reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val OakenformReprint = Printing(
+    oracleId = "b254fefb-11d2-4369-ae5c-0c3bd48ae580",
+    name = "Oakenform",
+    setCode = "M19",
+    collectorNumber = "191",
+    scryfallId = "0bf71f42-6e42-46c0-9e8f-394d2c4519ee",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/0/b/0bf71f42-6e42-46c0-9e8f-394d2c4519ee.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/OmenspeakerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/OmenspeakerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Omenspeaker reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val OmenspeakerReprint = Printing(
+    oracleId = "43d7fcf3-acc2-4e9b-a466-c73b1b6c58af",
+    name = "Omenspeaker",
+    setCode = "M19",
+    collectorNumber = "64",
+    scryfallId = "949589c4-97bc-46b4-bc6c-4b2709fd5e3a",
+    artist = "Dallas Williams",
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/949589c4-97bc-46b4-bc6c-4b2709fd5e3a.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/PelakkaWurmReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/PelakkaWurmReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pelakka Wurm reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val PelakkaWurmReprint = Printing(
+    oracleId = "d36075c2-de66-4202-9217-b1102a2bc14b",
+    name = "Pelakka Wurm",
+    setCode = "M19",
+    collectorNumber = "192",
+    scryfallId = "00906b47-6316-4e00-bbf5-b801ab583f4f",
+    artist = "Daniel Ljunggren",
+    imageUri = "https://cards.scryfall.io/normal/front/0/0/00906b47-6316-4e00-bbf5-b801ab583f4f.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/PendulumOfPatternsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/PendulumOfPatternsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pendulum of Patterns reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val PendulumOfPatternsReprint = Printing(
+    oracleId = "992075d5-f413-4896-b75e-7bb2d589c50e",
+    name = "Pendulum of Patterns",
+    setCode = "M19",
+    collectorNumber = "288",
+    scryfallId = "7ad452a4-be42-4d2f-a161-2b327f423b9c",
+    artist = "Raoul Vitale",
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7ad452a4-be42-4d2f-a161-2b327f423b9c.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ProdigiousGrowth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ProdigiousGrowth.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Prodigious Growth
+ * {4}{G}{G}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +7/+7 and has trample.
+ */
+val ProdigiousGrowth = card("Prodigious Growth") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +7/+7 and has trample."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(7, 7)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "194"
+        artist = "Svetlin Velinov"
+        flavorText = "\"Look how cute it is now!\"\n" +
+            "—Vivien Reid"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba2b0966-4e9e-44dc-9145-3c1e644578bc.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/RavenousHarpy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/RavenousHarpy.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ravenous Harpy
+ * {2}{B}
+ * Creature — Harpy
+ * 1/2
+ * Flying
+ * {1}, Sacrifice another creature: Put a +1/+1 counter on this creature.
+ */
+val RavenousHarpy = card("Ravenous Harpy") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Harpy"
+    power = 1
+    toughness = 2
+    oracleText = "Flying\n" +
+        "{1}, Sacrifice another creature: Put a +1/+1 counter on this creature."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.SacrificeAnother(GameObjectFilter.Creature)
+        )
+        effect = Effects.AddCounters("+1/+1", 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "115"
+        artist = "Sam Rowan"
+        flavorText = "A harpy's hoard is a filthy, bloodstained pile of trinkets and corpses."
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/676ec702-75c4-4733-b500-eb15406778bb.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ReassemblingSkeletonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ReassemblingSkeletonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Reassembling Skeleton reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val ReassemblingSkeletonReprint = Printing(
+    oracleId = "9dbc3530-b278-4c8d-b2cc-a09dfac9d5e5",
+    name = "Reassembling Skeleton",
+    setCode = "M19",
+    collectorNumber = "116",
+    scryfallId = "a3d4ac21-2203-45f4-b5f2-dc186ccdbe69",
+    artist = "Austin Hsu",
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a3d4ac21-2203-45f4-b5f2-dc186ccdbe69.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/RegalBloodlord.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/RegalBloodlord.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Regal Bloodlord
+ * {3}{W}{B}
+ * Creature — Vampire Soldier
+ * 2/4
+ * Flying
+ * At the beginning of each end step, if you gained life this turn, create a 1/1 black Bat creature token with flying.
+ *
+ * The Bat trigger is an intervening-"if" ability: it only triggers when you gained life at some
+ * point during the turn before the end step began, and it re-checks that on resolution. Net life
+ * change is irrelevant — losing life afterwards does not undo the gain.
+ */
+val RegalBloodlord = card("Regal Bloodlord") {
+    manaCost = "{3}{W}{B}"
+    colorIdentity = "BW"
+    typeLine = "Creature — Vampire Soldier"
+    power = 2
+    toughness = 4
+    oracleText = "Flying\n" +
+        "At the beginning of each end step, if you gained life this turn, create a 1/1 black Bat creature token with flying."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EachEndStep
+        interveningIf = Conditions.YouGainedLifeThisTurn
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Bat"),
+            keywords = setOf(Keyword.FLYING)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "222"
+        artist = "Winona Nelson"
+        flavorText = "Those of esteemed birth earn a most esteemed death."
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/65a75d3a-58cb-4ee0-88d3-52099cb57ac3.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/RhoxOracle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/RhoxOracle.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rhox Oracle
+ * {4}{G}
+ * Creature — Rhino Monk
+ * 4/2
+ * When this creature enters, draw a card.
+ */
+val RhoxOracle = card("Rhox Oracle") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Rhino Monk"
+    power = 4
+    toughness = 2
+    oracleText = "When this creature enters, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "198"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"The further into the future I look, the less certain my vision. Even now, the middle distance is obscured by fire.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/281f04d5-af45-4494-ac11-a605d3a06643.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/RiddlemasterSphinx.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/RiddlemasterSphinx.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Riddlemaster Sphinx
+ * {4}{U}{U}
+ * Creature — Sphinx
+ * 5/5
+ * Flying (This creature can't be blocked except by creatures with flying or reach.)
+ * When this creature enters, you may return target creature an opponent controls to its owner's hand.
+ *
+ * The target is mandatory at announcement — the trigger carries a `targetRequirement`, so a creature
+ * is chosen when the ability goes on the stack — while the "you may" is only the resolution-time
+ * yes/no. `optional = true` lowers to that consent gate.
+ */
+val RiddlemasterSphinx = card("Riddlemaster Sphinx") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sphinx"
+    power = 5
+    toughness = 5
+    oracleText = "Flying (This creature can't be blocked except by creatures with flying or reach.)\n" +
+        "When this creature enters, you may return target creature an opponent controls to its owner's hand."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val t = target("target", TargetCreature(filter = TargetFilter.CreatureOpponentControls))
+        effect = Effects.Move(t, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "287"
+        artist = "Ryan Yee"
+        flavorText = "\"Safe passage requires only a simple answer to a simple question, traveler.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/037f6792-ab41-4bcd-a0a3-a4af4a801eb7.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/RootSnare.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/RootSnare.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Root Snare
+ * {1}{G}
+ * Instant
+ * Prevent all combat damage that would be dealt this turn.
+ *
+ * A plain Fog. [Effects.PreventAllCombatDamage] is the whole spell — one untargeted
+ * `PreventDamageEffect` with `PreventionScope.CombatOnly` and no recipient narrowing, so it
+ * shields every source and every recipient; its default `Duration.EndOfTurn` is the printed
+ * "this turn". Passing an explicit `target` here would select the *targeted* shield instead
+ * and the card would stop covering the board.
+ */
+val RootSnare = card("Root Snare") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Prevent all combat damage that would be dealt this turn."
+
+    spell {
+        effect = Effects.PreventAllCombatDamage()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "199"
+        artist = "Mitchell Malloy"
+        flavorText = "The only casualties were a snapped spear, a lost helmet, and some bruised egos."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/76b01fd2-139a-47ed-a8e3-021aa9c91b02.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/RustwingFalcon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/RustwingFalcon.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rustwing Falcon
+ * {W}
+ * Creature — Bird
+ * 1/2
+ * Flying
+ */
+val RustwingFalcon = card("Rustwing Falcon") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird"
+    power = 1
+    toughness = 2
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Paul Scott Canavan"
+        flavorText = "Native to wide prairies and scrublands, falcons occasionally roost in dragon skeletons."
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c6691e62-8887-41e8-8e74-76ee2353d45e.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SatyrEnchanter.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SatyrEnchanter.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Satyr Enchanter
+ * {1}{G}{W}
+ * Creature — Satyr Druid
+ * 2/2
+ * Whenever you cast an enchantment spell, draw a card.
+ */
+val SatyrEnchanter = card("Satyr Enchanter") {
+    manaCost = "{1}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Satyr Druid"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever you cast an enchantment spell, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastEnchantment
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "223"
+        artist = "Sidharth Chaturvedi"
+        flavorText = "\"The threads of magic that protect this place were woven by my will.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e31c544f-a748-4180-8366-9bb1622bb99d.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ScholarOfStars.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ScholarOfStars.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scholar of Stars
+ * {3}{U}
+ * Creature — Human Artificer
+ * 3/2
+ * When this creature enters, if you control an artifact, draw a card.
+ *
+ * "If you control an artifact" is an intervening-if clause (CR 603.4): it is checked when the
+ * ability would trigger *and* again on resolution, so losing the artifact in response fizzles it.
+ */
+val ScholarOfStars = card("Scholar of Stars") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Artificer"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, if you control an artifact, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        interveningIf = Conditions.ControlArtifact
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "71"
+        artist = "Tommy Arnold"
+        flavorText = "\"The path of the stars is as reliable as the instruments that measure them.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb4664d4-fb00-4572-a60d-00336117b8a5.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SerrasGuardian.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SerrasGuardian.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Serra's Guardian
+ * {4}{W}{W}
+ * Creature — Angel
+ * 5/5
+ * Flying (This creature can't be blocked except by creatures with flying or reach.)
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ * Other creatures you control have vigilance.
+ */
+val SerrasGuardian = card("Serra's Guardian") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    power = 5
+    toughness = 5
+    oracleText = "Flying (This creature can't be blocked except by creatures with flying or reach.)\n" +
+        "Vigilance (Attacking doesn't cause this creature to tap.)\n" +
+        "Other creatures you control have vigilance."
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.VIGILANCE,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl()).other(),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "284"
+        artist = "Magali Villeneuve"
+        flavorText = "She watches over the city just as Serra watches over all."
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a1d95b9-aa18-41e2-b972-93fda25e0b11.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SiegebreakerGiant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SiegebreakerGiant.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Siegebreaker Giant
+ * {3}{R}{R}
+ * Creature — Giant Warrior
+ * 6/3
+ * Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)
+ * {3}{R}: Target creature can't block this turn.
+ */
+val SiegebreakerGiant = card("Siegebreaker Giant") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant Warrior"
+    power = 6
+    toughness = 3
+    oracleText = "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\n" +
+        "{3}{R}: Target creature can't block this turn."
+
+    keywords(Keyword.TRAMPLE)
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{R}")
+        val creature = target("target", TargetCreature())
+        effect = Effects.CantBlock(creature)
+        description = "{3}{R}: Target creature can't block this turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "157"
+        artist = "Even Amundsen"
+        flavorText = "No rampart can withstand the fury of a giant."
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/ede2b911-8eec-4993-ab1c-59b55dfb11b4.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SiftReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SiftReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sift reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val SiftReprint = Printing(
+    oracleId = "6e060984-2015-4dc4-b53d-ab6bf2abdacc",
+    name = "Sift",
+    setCode = "M19",
+    collectorNumber = "72",
+    scryfallId = "46588683-74c7-4041-a43b-95d51ba51a94",
+    artist = "Jeremy Jarvis",
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/46588683-74c7-4041-a43b-95d51ba51a94.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SilverbeakGriffin.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SilverbeakGriffin.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silverbeak Griffin
+ * {W}{W}
+ * Creature — Griffin
+ * 2/2
+ * Flying (This creature can't be blocked except by creatures with flying or reach.)
+ */
+val SilverbeakGriffin = card("Silverbeak Griffin") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Griffin"
+    power = 2
+    toughness = 2
+    oracleText = "Flying (This creature can't be blocked except by creatures with flying or reach.)"
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "285"
+        artist = "Viktor Titov"
+        flavorText = "A pair of domesticated griffins escaped from captivity a century ago. Now the skies are filled with the songs of their descendants."
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/36b4c374-42a4-4912-8a74-a11c3fa0e065.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/Skyscanner.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/Skyscanner.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skyscanner
+ * {3}
+ * Artifact Creature — Thopter
+ * 1/1
+ * Flying
+ * When this creature enters, draw a card.
+ *
+ * A colourless flier with a cantrip ETB — [Triggers.EntersBattlefield] (SELF binding) into
+ * [Effects.DrawCards]`(1)`.
+ */
+val Skyscanner = card("Skyscanner") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Thopter"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "When this creature enters, draw a card."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+        description = "When this creature enters, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "245"
+        artist = "Adam Paquette"
+        flavorText = "The municipal senate makes extensive use of the thopters, mostly to gather dirt on rival senators."
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd2c1fb7-3c1d-49a9-b2c2-78ba2264df38.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SovereignsBite.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SovereignsBite.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Sovereign's Bite
+ * {1}{B}
+ * Sorcery
+ * Target player loses 3 life and you gain 3 life.
+ */
+val SovereignsBite = card("Sovereign's Bite") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target player loses 3 life and you gain 3 life."
+
+    spell {
+        val t = target("target", TargetPlayer())
+        effect = Effects.Composite(
+            Effects.LoseLife(3, t),
+            Effects.GainLife(3)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "120"
+        artist = "Volkan Baǵa"
+        flavorText = "\"You have given all to your kingdom, dear knight. Serenity shall be your prize.\"\n" +
+            "—Queen Lian"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/5326d251-bb91-4653-b1fa-44f14c4e0b88.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SpitFlame.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SpitFlame.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Spit Flame
+ * {2}{R}
+ * Instant
+ * Spit Flame deals 4 damage to target creature.
+ * Whenever a Dragon you control enters, you may pay {R}. If you do, return this card from your graveyard to your hand.
+ *
+ * The recursion trigger functions only from the graveyard (CR 113.6m — the ability's effect moves
+ * the card out of that zone), so `triggerZones = {GRAVEYARD}`. "A Dragon you control" is not
+ * "another", so the binding is [TriggerBinding.ANY], and the bare tribal noun names the subtype:
+ * a noncreature Dragon permanent counts. The "you may pay {R}. If you do, ..." is a
+ * [Gate.MayPay] over [PayManaCostEffect], and [Effects.ReturnToHandFromGraveyard] carries the
+ * `fromZone` guard the printed line names.
+ */
+val SpitFlame = card("Spit Flame") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Spit Flame deals 4 damage to target creature.\n" +
+        "Whenever a Dragon you control enters, you may pay {R}. If you do, return this card from your graveyard to your hand."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.DealDamage(4, t)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.DRAGON).youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = GatedEffect(
+            gate = Gate.MayPay(PayManaCostEffect(ManaCost.parse("{R}"))),
+            then = Effects.ReturnToHandFromGraveyard(EffectTarget.Self)
+        )
+        triggerZones = setOf(Zone.GRAVEYARD)
+        description = "Whenever a Dragon you control enters, you may pay {R}. " +
+            "If you do, return this card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "160"
+        artist = "Chris Rahn"
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/94df6198-10c0-44e7-8226-dc96d12957c4.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/StoneQuarryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/StoneQuarryReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stone Quarry reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val StoneQuarryReprint = Printing(
+    oracleId = "90bccf66-58ec-445d-ac96-c6013054a1b4",
+    name = "Stone Quarry",
+    setCode = "M19",
+    collectorNumber = "256",
+    scryfallId = "bac2b853-f788-4b29-a76d-880da61ad91a",
+    artist = "Enora Mercier",
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/bac2b853-f788-4b29-a76d-880da61ad91a.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SubmergedBoneyardReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SubmergedBoneyardReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Submerged Boneyard reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val SubmergedBoneyardReprint = Printing(
+    oracleId = "f27d52e6-aab9-4f95-ae46-33d1173bf4fe",
+    name = "Submerged Boneyard",
+    setCode = "M19",
+    collectorNumber = "257",
+    scryfallId = "df8c56fa-fae6-48ba-813d-0d971b640896",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/d/f/df8c56fa-fae6-48ba-813d-0d971b640896.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SunSentinelReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SunSentinelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sun Sentinel reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val SunSentinelReprint = Printing(
+    oracleId = "4db00a5e-7dbe-4387-90e9-c21ec1daa448",
+    name = "Sun Sentinel",
+    setCode = "M19",
+    collectorNumber = "307",
+    scryfallId = "5cd0b4d6-9753-46a3-924c-2adf3dad2819",
+    artist = "James Ryman",
+    imageUri = "https://cards.scryfall.io/normal/front/5/c/5cd0b4d6-9753-46a3-924c-2adf3dad2819.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SupremePhantom.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SupremePhantom.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Supreme Phantom
+ * {1}{U}
+ * Creature — Spirit
+ * 1/3
+ * Flying
+ * Other Spirits you control get +1/+1.
+ *
+ * "Spirits" is a bare tribal noun, so it names the subtype rather than the card type — a
+ * noncreature Spirit permanent you control is one of them. `excludeSelf` is the printed "Other".
+ */
+val SupremePhantom = card("Supreme Phantom") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    power = 1
+    toughness = 3
+    oracleText = "Flying\n" +
+        "Other Spirits you control get +1/+1."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype(Subtype.SPIRIT).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "76"
+        artist = "Robbie Trevino"
+        flavorText = "A king's knowledge does not vanish when the heart stops beating."
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d65c22b-7640-4433-930b-4bc381ac7361.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SureStrikeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/SureStrikeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sure Strike reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val SureStrikeReprint = Printing(
+    oracleId = "fb694e7e-f66e-4958-b6ed-aa74bc9ac43e",
+    name = "Sure Strike",
+    setCode = "M19",
+    collectorNumber = "161",
+    scryfallId = "1e618ab0-b092-499c-b5e9-d374433ff19c",
+    artist = "Jakub Kasper",
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1e618ab0-b092-499c-b5e9-d374433ff19c.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TakeVengeance.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TakeVengeance.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Take Vengeance
+ * {1}{W}
+ * Sorcery
+ * Destroy target tapped creature.
+ */
+val TakeVengeance = card("Take Vengeance") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target tapped creature."
+
+    spell {
+        val creature = target("target", Targets.TappedCreature)
+        effect = Effects.Destroy(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "Randy Vargas"
+        flavorText = "\"Your death will be a balm, your passing a welcome revision, and all will sigh with peace to know of your demise.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/66fbde22-d98d-4f12-b4d8-1bad2a9878b2.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TalonsOfWildwood.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TalonsOfWildwood.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Talons of Wildwood
+ * {1}{G}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +1/+1 and has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)
+ * {2}{G}: Return this card from your graveyard to your hand.
+ *
+ * The recursion ability is activated from the *graveyard*, not the battlefield — `activateFromZone`
+ * is what makes it legal there.
+ */
+val TalonsOfWildwood = card("Talons of Wildwood") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +1/+1 and has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)\n" +
+        "{2}{G}: Return this card from your graveyard to your hand."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}")
+        effect = Effects.ReturnToHandFromGraveyard(EffectTarget.Self)
+        activateFromZone = Zone.GRAVEYARD
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "202"
+        artist = "Uriah Voth"
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9ffa2e83-bc78-4bde-9692-e5165c4ef63b.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TatteredMummyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TatteredMummyReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tattered Mummy reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val TatteredMummyReprint = Printing(
+    oracleId = "066e7379-d439-41cb-a8c9-60964040b110",
+    name = "Tattered Mummy",
+    setCode = "M19",
+    collectorNumber = "295",
+    scryfallId = "6a27ce41-69e7-4b86-9b9c-1a724d0728e9",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/6/a/6a27ce41-69e7-4b86-9b9c-1a724d0728e9.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TezzeretsStrider.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TezzeretsStrider.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Tezzeret's Strider
+ * {3}
+ * Artifact Creature — Golem
+ * 3/1
+ * As long as you control a Tezzeret planeswalker, this creature has menace. (It can't be blocked except by two or more creatures.)
+ *
+ * A [ConditionalStaticAbility] gating [GrantKeyword] over `GroupFilter.source()` — menace appears
+ * and disappears with the Tezzeret, since the condition is re-evaluated at projection rather than
+ * latched. "A Tezzeret planeswalker" is a planeswalker with the *subtype* Tezzeret, so any
+ * Tezzeret card (or a permanent that has become one) satisfies it, not just the M19 planeswalker
+ * deck's own Tezzeret.
+ */
+val TezzeretsStrider = card("Tezzeret's Strider") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    power = 3
+    toughness = 1
+    oracleText = "As long as you control a Tezzeret planeswalker, this creature has menace. (It can't be blocked except by two or more creatures.)"
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.MENACE, GroupFilter.source()),
+            condition = Conditions.YouControl(GameObjectFilter.Planeswalker.withSubtype("Tezzeret"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "290"
+        artist = "Zack Stella"
+        flavorText = "\"More obedient than any dog.\"\n" +
+            "—Tezzeret"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8cf74535-31e3-4d2c-b42a-072580fa4ba0.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TimberGorgeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TimberGorgeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Timber Gorge reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val TimberGorgeReprint = Printing(
+    oracleId = "00b34fab-5a80-4a4d-b6cf-72479197677a",
+    name = "Timber Gorge",
+    setCode = "M19",
+    collectorNumber = "258",
+    scryfallId = "07076412-18fe-4e15-bdb5-17111b4a66db",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/0/7/07076412-18fe-4e15-bdb5-17111b4a66db.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TotallyLostReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TotallyLostReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Totally Lost reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val TotallyLostReprint = Printing(
+    oracleId = "e0462a2c-fb88-495f-813b-6476ee3e62bb",
+    name = "Totally Lost",
+    setCode = "M19",
+    collectorNumber = "81",
+    scryfallId = "05f0b6ce-eb70-4f42-9360-c7d09f48a5c5",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/0/5/05f0b6ce-eb70-4f42-9360-c7d09f48a5c5.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TranquilExpanseReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TranquilExpanseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tranquil Expanse reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val TranquilExpanseReprint = Printing(
+    oracleId = "a5478263-47c9-447f-9c7a-c77ce0752947",
+    name = "Tranquil Expanse",
+    setCode = "M19",
+    collectorNumber = "259",
+    scryfallId = "78b33867-5ccf-49a1-8e9b-9d2ddac78f17",
+    artist = "Sam Burley",
+    imageUri = "https://cards.scryfall.io/normal/front/7/8/78b33867-5ccf-49a1-8e9b-9d2ddac78f17.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TwoHeadedZombie.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/TwoHeadedZombie.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Two-Headed Zombie
+ * {3}{B}
+ * Creature — Zombie
+ * 4/2
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ */
+val TwoHeadedZombie = card("Two-Headed Zombie") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 4
+    toughness = 2
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)"
+
+    keywords(Keyword.MENACE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "123"
+        artist = "Josh Hass"
+        flavorText = "\"Thread the torsos together with angel hair to ensure they will cooperate in battle.\"\n" +
+            "—*The Stitcher's Tome*"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2cc5760e-8b27-4d37-9772-c9eda90b1d95.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ValiantKnight.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ValiantKnight.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Valiant Knight
+ * {3}{W}
+ * Creature — Human Knight
+ * 3/4
+ * Other Knights you control get +1/+1.
+ * {3}{W}{W}: Knights you control gain double strike until end of turn.
+ *
+ * Two separate abilities, not one: the lord is a static [ModifyStats] with `excludeSelf = true`
+ * ("Other"), while the pump is an activated group grant that *does* include this creature.
+ * Both read a bare tribal noun — "Knights", not "Knight creatures" — so the filter is
+ * `Permanent.withSubtype`, not `Creature.withSubtype`.
+ */
+val ValiantKnight = card("Valiant Knight") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 3
+    toughness = 4
+    oracleText = "Other Knights you control get +1/+1.\n" +
+        "{3}{W}{W}: Knights you control gain double strike until end of turn."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype(Subtype.KNIGHT).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{W}{W}")
+        effect = Patterns.Group.grantKeywordToAll(
+            keyword = Keyword.DOUBLE_STRIKE,
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.KNIGHT).youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "42"
+        artist = "Jakub Kasper"
+        flavorText = "\"Defeat is no reason for retreat. It is a sign we must redouble our efforts to win this fight.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6ad750bc-850b-483b-8910-eb6562f925bc.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/VigilantBaloth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/VigilantBaloth.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vigilant Baloth
+ * {3}{G}{G}
+ * Creature — Beast
+ * 5/5
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ */
+val VigilantBaloth = card("Vigilant Baloth") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 5
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)"
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "206"
+        artist = "Uriah Voth"
+        flavorText = "Villagers employ watchdogs as guardians and companions. Druids prefer something a little bigger."
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/34ad8e5d-0c26-4588-8161-b22197715d63.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/VineMare.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/VineMare.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Vine Mare
+ * {2}{G}{G}
+ * Creature — Elemental Horse
+ * 5/3
+ * Hexproof (This creature can't be the target of spells or abilities your opponents control.)
+ * This creature can't be blocked by black creatures.
+ *
+ * The evasion is a single [CantBeBlockedBy] over a coloured *creature* filter, evaluated against
+ * projected state so a blocker's current colour decides, not its printed one.
+ */
+val VineMare = card("Vine Mare") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental Horse"
+    power = 5
+    toughness = 3
+    oracleText = "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\n" +
+        "This creature can't be blocked by black creatures."
+
+    keywords(Keyword.HEXPROOF)
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.withColor(Color.BLACK))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "207"
+        artist = "Alex Konstad"
+        flavorText = "When it passes, the dead are displaced by flourishing life."
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9980835-cd32-4870-88df-c79cd5534968.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ViviensJaguar.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ViviensJaguar.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vivien's Jaguar
+ * {2}{G}
+ * Creature — Cat Spirit
+ * 3/2
+ * Reach (This creature can block creatures with flying.)
+ * {2}{G}: Return this card from your graveyard to your hand. Activate only if you control a Vivien planeswalker.
+ *
+ * The recursion ability functions in the graveyard, so it carries `activateFromZone` — and the move
+ * itself names `fromZone = Zone.GRAVEYARD` so it can only ever pull the card out of that zone.
+ *
+ * "Activate only if you control a Vivien planeswalker" is an ordinary
+ * [ActivationRestriction.OnlyIfCondition]; `GraveyardAbilityEnumerator` runs the same restriction
+ * check the battlefield enumerator does, resolving `Player.You` to the card's owner while it sits
+ * in their graveyard. The planeswalker is matched by its *subtype* (CR 205.3j), case-exact.
+ */
+val ViviensJaguar = card("Vivien's Jaguar") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat Spirit"
+    power = 3
+    toughness = 2
+    oracleText = "Reach (This creature can block creatures with flying.)\n" +
+        "{2}{G}: Return this card from your graveyard to your hand. Activate only if you control a Vivien planeswalker."
+
+    keywords(Keyword.REACH)
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}")
+        effect = Effects.Move(EffectTarget.Self, Zone.HAND, fromZone = Zone.GRAVEYARD)
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.YouControl(GameObjectFilter.Planeswalker.withSubtype("Vivien"))
+            )
+        )
+        activateFromZone = Zone.GRAVEYARD
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "305"
+        artist = "Magali Villeneuve"
+        flavorText = "Each of Vivien's arrows is an invocation of a species."
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d4b406cf-738b-4e65-ac00-b1c36ded5f96.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/WalkingCorpseReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/WalkingCorpseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Walking Corpse reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val WalkingCorpseReprint = Printing(
+    oracleId = "fea95888-e16a-4209-9cd4-623f7f4d2f67",
+    name = "Walking Corpse",
+    setCode = "M19",
+    collectorNumber = "126",
+    scryfallId = "344a26ab-524f-4daa-ae0a-9d94e34c96df",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/344a26ab-524f-4daa-ae0a-9d94e34c96df.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/WoodlandStreamReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/WoodlandStreamReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Woodland Stream reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val WoodlandStreamReprint = Printing(
+    oracleId = "e887fb3f-d4c9-4022-8f75-1de6ec94af96",
+    name = "Woodland Stream",
+    setCode = "M19",
+    collectorNumber = "260",
+    scryfallId = "303224d6-9769-4127-8e33-9129f337e2a8",
+    artist = "Enora Mercier",
+    imageUri = "https://cards.scryfall.io/normal/front/3/0/303224d6-9769-4127-8e33-9129f337e2a8.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/EpicureOfBloodReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/EpicureOfBloodReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Epicure of Blood reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val EpicureOfBloodReprint = Printing(
+    oracleId = "bdb319a6-a1cd-44f5-999d-af1bb55b2fc4",
+    name = "Epicure of Blood",
+    setCode = "M20",
+    collectorNumber = "99",
+    scryfallId = "4b060bc4-2d0c-46f4-b2b4-21583c2428f2",
+    artist = "Anna Steinbauer",
+    imageUri = "https://cards.scryfall.io/normal/front/4/b/4b060bc4-2d0c-46f4-b2b4-21583c2428f2.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/FrilledSeaSerpentReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/FrilledSeaSerpentReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Frilled Sea Serpent reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val FrilledSeaSerpentReprint = Printing(
+    oracleId = "6dc534e8-e22b-4e3c-aa30-c6e4c84f698c",
+    name = "Frilled Sea Serpent",
+    setCode = "M20",
+    collectorNumber = "61",
+    scryfallId = "b59698a5-be76-4ce2-a337-9052821f239f",
+    artist = "Steven Belledin",
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b59698a5-be76-4ce2-a337-9052821f239f.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/GreenwoodSentinelReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/GreenwoodSentinelReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Greenwood Sentinel reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val GreenwoodSentinelReprint = Printing(
+    oracleId = "8178c546-84f8-4563-a804-6489ec016660",
+    name = "Greenwood Sentinel",
+    setCode = "M20",
+    collectorNumber = "174",
+    scryfallId = "e9a1a70d-c146-453e-84c4-71cae4e0afaa",
+    artist = "Johann Bodin",
+    imageUri = "https://cards.scryfall.io/normal/front/e/9/e9a1a70d-c146-453e-84c4-71cae4e0afaa.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/HostileMinotaurReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/HostileMinotaurReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hostile Minotaur reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val HostileMinotaurReprint = Printing(
+    oracleId = "e050a0a3-f48e-4cba-9cd4-692a92261c9f",
+    name = "Hostile Minotaur",
+    setCode = "M20",
+    collectorNumber = "331",
+    scryfallId = "0e1263ea-adc9-442b-b13e-9afb69596372",
+    artist = "Joe Slucher",
+    imageUri = "https://cards.scryfall.io/normal/front/0/e/0e1263ea-adc9-442b-b13e-9afb69596372.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/OakenformReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/OakenformReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oakenform reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val OakenformReprint = Printing(
+    oracleId = "b254fefb-11d2-4369-ae5c-0c3bd48ae580",
+    name = "Oakenform",
+    setCode = "M20",
+    collectorNumber = "341",
+    scryfallId = "d1ca08a0-c58d-4c13-bf63-0401d89839b4",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d1ca08a0-c58d-4c13-bf63-0401d89839b4.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/RiddlemasterSphinxReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/RiddlemasterSphinxReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Riddlemaster Sphinx reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val RiddlemasterSphinxReprint = Printing(
+    oracleId = "29f61caf-1aba-40cd-aff6-c3685a0997d7",
+    name = "Riddlemaster Sphinx",
+    setCode = "M20",
+    collectorNumber = "317",
+    scryfallId = "7980e24c-bcb4-479c-8012-f19f4e87f0bf",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/7/9/7980e24c-bcb4-479c-8012-f19f4e87f0bf.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/SerraSGuardianReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/SerraSGuardianReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Serra's Guardian reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val SerraSGuardianReprint = Printing(
+    oracleId = "c50cd7e7-8d53-44af-ac96-3e104587bdb3",
+    name = "Serra's Guardian",
+    setCode = "M20",
+    collectorNumber = "310",
+    scryfallId = "84784231-2675-4b5b-929f-a796c091a77c",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/8/4/84784231-2675-4b5b-929f-a796c091a77c.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/TakeVengeanceReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/TakeVengeanceReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Take Vengeance reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val TakeVengeanceReprint = Printing(
+    oracleId = "c60b8edd-aa3f-48ea-b202-d10599f91d9d",
+    name = "Take Vengeance",
+    setCode = "M20",
+    collectorNumber = "313",
+    scryfallId = "30fff340-8e2a-4182-9ece-af5749fa0d2e",
+    artist = "Randy Vargas",
+    imageUri = "https://cards.scryfall.io/normal/front/3/0/30fff340-8e2a-4182-9ece-af5749fa0d2e.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/SkyscannerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/SkyscannerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skyscanner reprint in M21. Canonical CardDefinition lives in its earliest set.
+ */
+val SkyscannerReprint = Printing(
+    oracleId = "974f788a-039f-4310-a2fe-16b14a1e2d35",
+    name = "Skyscanner",
+    setCode = "M21",
+    collectorNumber = "238",
+    scryfallId = "cab69fbd-0179-4b02-adba-71d2a0eeea5c",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/c/a/cab69fbd-0179-4b02-adba-71d2a0eeea5c.jpg",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/oana/cards/KnightSPledgeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/oana/cards/KnightSPledgeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.oana.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Knight's Pledge reprint in OANA. Canonical CardDefinition lives in its earliest set.
+ */
+val KnightSPledgeReprint = Printing(
+    oracleId = "63604320-68de-415e-b1f9-dd0f85c5d8a3",
+    name = "Knight's Pledge",
+    setCode = "OANA",
+    collectorNumber = "5",
+    scryfallId = "4e786d0e-d6bf-4c6b-b989-28ca1ed53e2e",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4e786d0e-d6bf-4c6b-b989-28ca1ed53e2e.jpg",
+    releaseDate = "2018-07-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/CinderBarrensReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/CinderBarrensReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cinder Barrens reprint in RIX. Canonical CardDefinition lives in its earliest set.
+ */
+val CinderBarrensReprint = Printing(
+    oracleId = "f155a05f-9f5e-4875-a407-103b85ce30ee",
+    name = "Cinder Barrens",
+    setCode = "RIX",
+    collectorNumber = "205",
+    scryfallId = "93f6bd6b-92fb-4b4f-89c2-762cc2c465f3",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/9/3/93f6bd6b-92fb-4b4f-89c2-762cc2c465f3.jpg",
+    releaseDate = "2018-01-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/ForsakenSanctuaryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/ForsakenSanctuaryReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Forsaken Sanctuary reprint in RIX. Canonical CardDefinition lives in its earliest set.
+ */
+val ForsakenSanctuaryReprint = Printing(
+    oracleId = "941b0dd1-0df2-48ee-8829-615e9c3177a7",
+    name = "Forsaken Sanctuary",
+    setCode = "RIX",
+    collectorNumber = "187",
+    scryfallId = "32e5daf3-6a55-4c2f-92d1-33e0755ee280",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/3/2/32e5daf3-6a55-4c2f-92d1-33e0755ee280.jpg",
+    releaseDate = "2018-01-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/FoulOrchardReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/FoulOrchardReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Foul Orchard reprint in RIX. Canonical CardDefinition lives in its earliest set.
+ */
+val FoulOrchardReprint = Printing(
+    oracleId = "ad6a2776-801f-4743-8268-6d654122171e",
+    name = "Foul Orchard",
+    setCode = "RIX",
+    collectorNumber = "188",
+    scryfallId = "f66f9017-e04b-4f13-aae0-28a903f2fac2",
+    artist = "Yeong-Hao Han",
+    imageUri = "https://cards.scryfall.io/normal/front/f/6/f66f9017-e04b-4f13-aae0-28a903f2fac2.jpg",
+    releaseDate = "2018-01-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/HighlandLakeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/HighlandLakeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Highland Lake reprint in RIX. Canonical CardDefinition lives in its earliest set.
+ */
+val HighlandLakeReprint = Printing(
+    oracleId = "c643365a-4255-4d23-adb9-0f8b456f0838",
+    name = "Highland Lake",
+    setCode = "RIX",
+    collectorNumber = "189",
+    scryfallId = "344f5678-d25b-40af-aa91-b0eed90fd037",
+    artist = "Noah Bradley",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/344f5678-d25b-40af-aa91-b0eed90fd037.jpg",
+    releaseDate = "2018-01-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/MistCloakedHerald.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/MistCloakedHerald.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mist-Cloaked Herald
+ * {U}
+ * Creature — Merfolk Warrior
+ * 1/1
+ * This creature can't be blocked.
+ */
+val MistCloakedHerald = card("Mist-Cloaked Herald") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "This creature can't be blocked."
+
+    flags(AbilityFlag.CANT_BE_BLOCKED)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "43"
+        artist = "Anthony Palumbo"
+        flavorText = "With matchless stealth, the River Heralds fought a running battle against the three enemy forces."
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/18c1368e-114b-4618-922b-1d824ba0d1d5.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/StoneQuarryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/StoneQuarryReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stone Quarry reprint in RIX. Canonical CardDefinition lives in its earliest set.
+ */
+val StoneQuarryReprint = Printing(
+    oracleId = "90bccf66-58ec-445d-ac96-c6013054a1b4",
+    name = "Stone Quarry",
+    setCode = "RIX",
+    collectorNumber = "190",
+    scryfallId = "315e782c-2159-4e8d-b2d7-9f96b7609db4",
+    artist = "Noah Bradley",
+    imageUri = "https://cards.scryfall.io/normal/front/3/1/315e782c-2159-4e8d-b2d7-9f96b7609db4.jpg",
+    releaseDate = "2018-01-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/SunSentinel.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/SunSentinel.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sun Sentinel
+ * {1}{W}
+ * Creature — Human Soldier
+ * 2/2
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ */
+val SunSentinel = card("Sun Sentinel") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)"
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "26"
+        artist = "James Ryman"
+        flavorText = "\"I will not sleep until Orazca is ours once more.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/6867fd5a-3bbe-416d-96a6-1db0b341260e.jpg"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/WoodlandStreamReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/WoodlandStreamReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Woodland Stream reprint in RIX. Canonical CardDefinition lives in its earliest set.
+ */
+val WoodlandStreamReprint = Printing(
+    oracleId = "e887fb3f-d4c9-4022-8f75-1de6ec94af96",
+    name = "Woodland Stream",
+    setCode = "RIX",
+    collectorNumber = "191",
+    scryfallId = "d1f14b4d-b90e-4ce4-aa32-13c9969aa46a",
+    artist = "James Paick",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d1f14b4d-b90e-4ce4-aa32-13c9969aa46a.jpg",
+    releaseDate = "2018-01-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RootSnareReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/RootSnareReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Root Snare reprint in RNA. Canonical CardDefinition lives in its earliest set.
+ */
+val RootSnareReprint = Printing(
+    oracleId = "cbf743a5-123f-4747-826d-7f8bb929a52c",
+    name = "Root Snare",
+    setCode = "RNA",
+    collectorNumber = "137",
+    scryfallId = "5f38b1a2-3f85-4dcd-b90d-bb049651b8b7",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/5/f/5f38b1a2-3f85-4dcd-b90d-bb049651b8b7.jpg",
+    releaseDate = "2019-01-25",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/SupremePhantomReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/SupremePhantomReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Supreme Phantom reprint in VOC. Canonical CardDefinition lives in its earliest set.
+ */
+val SupremePhantomReprint = Printing(
+    oracleId = "9c5f4d02-eedb-4c6c-9f13-1b7a45382483",
+    name = "Supreme Phantom",
+    setCode = "VOC",
+    collectorNumber = "115",
+    scryfallId = "cbf4ca25-73cc-45ba-bed5-dbaa517e8bb8",
+    artist = "Robbie Trevino",
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cbf4ca25-73cc-45ba-bed5-dbaa517e8bb8.jpg",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/TotallyLostReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/TotallyLostReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Totally Lost reprint in WAR. Canonical CardDefinition lives in its earliest set.
+ */
+val TotallyLostReprint = Printing(
+    oracleId = "e0462a2c-fb88-495f-813b-6476ee3e62bb",
+    name = "Totally Lost",
+    setCode = "WAR",
+    collectorNumber = "74",
+    scryfallId = "adffef78-f776-42d3-ab40-3347c8e5c88b",
+    artist = "Aaron Miller",
+    imageUri = "https://cards.scryfall.io/normal/front/a/d/adffef78-f776-42d3-ab40-3347c8e5c88b.jpg",
+    releaseDate = "2019-05-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/StoneQuarryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/StoneQuarryReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stone Quarry reprint in XLN. Canonical CardDefinition lives in its earliest set.
+ */
+val StoneQuarryReprint = Printing(
+    oracleId = "90bccf66-58ec-445d-ac96-c6013054a1b4",
+    name = "Stone Quarry",
+    setCode = "XLN",
+    collectorNumber = "289",
+    scryfallId = "06da82de-fd37-4c8f-a37d-61da66db567e",
+    artist = "Noah Bradley",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/06da82de-fd37-4c8f-a37d-61da66db567e.jpg",
+    releaseDate = "2017-09-29",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/WoodlandStreamReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/WoodlandStreamReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Woodland Stream reprint in XLN. Canonical CardDefinition lives in its earliest set.
+ */
+val WoodlandStreamReprint = Printing(
+    oracleId = "e887fb3f-d4c9-4022-8f75-1de6ec94af96",
+    name = "Woodland Stream",
+    setCode = "XLN",
+    collectorNumber = "284",
+    scryfallId = "740bb19c-0c91-4fc1-9b3c-be84425a3523",
+    artist = "James Paick",
+    imageUri = "https://cards.scryfall.io/normal/front/7/4/740bb19c-0c91-4fc1-9b3c-be84425a3523.jpg",
+    releaseDate = "2017-09-29",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/MistCloakedHeraldReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/MistCloakedHeraldReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mist-Cloaked Herald reprint in MSC. Canonical CardDefinition lives in its earliest set.
+ */
+val MistCloakedHeraldReprint = Printing(
+    oracleId = "74255add-2894-4c31-81c1-d38873fa325f",
+    name = "Mist-Cloaked Herald",
+    setCode = "MSC",
+    collectorNumber = "760",
+    scryfallId = "1e19ed76-26fe-4e39-8d65-959ae5675d5e",
+    artist = "Nino Is",
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1e19ed76-26fe-4e39-8d65-959ae5675d5e.jpg",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/AER.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AER.json
@@ -250,6 +250,67 @@
     "colorIdentityOverride": []
 }
 
+// Pendulum of Patterns
+{
+    "name": "Pendulum of Patterns",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, you gain 3 life.\n{5}, {T}, Sacrifice this artifact: Draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "descriptionOverride": "When this artifact enters, you gain 3 life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "{5}, {T}, Sacrifice this artifact: Draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "artist": "Raoul Vitale",
+        "flavorText": "Its elaborate designs reveal secrets of aether's flow.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d19751aa-823e-4a0f-a004-dee333b34327.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Prizefighter Construct
 {
     "name": "Prizefighter Construct",

--- a/mtg-sets/src/test/resources/snapshots/cards/AKH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AKH.json
@@ -778,6 +778,50 @@
     ]
 }
 
+// Tattered Mummy
+{
+    "name": "Tattered Mummy",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie Jackal",
+    "oracleText": "When this creature dies, each opponent loses 2 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "278",
+        "artist": "Slawomir Maniak",
+        "flavorText": "The dead who wander beyond the safety of the city crave only to spread their curse.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f9a5267-eb90-43bc-bf92-fcfb06821bae.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Those Who Serve
 {
     "name": "Those Who Serve",

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -1221,6 +1221,47 @@
     ]
 }
 
+// Ghostform
+{
+    "name": "Ghostform",
+    "manaCost": "{1}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Up to two target creatures can't be blocked this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "GrantKeyword",
+                "keyword": "CANT_BE_BLOCKED",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                }
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "artist": "Scott Chou",
+        "flavorText": "\"There's no such thing as 'impenetrable.'\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f6a20ba-6691-4844-9685-dfcd4184224e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Goldnight Commander
 {
     "name": "Goldnight Commander",

--- a/mtg-sets/src/test/resources/snapshots/cards/CON_.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CON_.json
@@ -204,6 +204,46 @@
     ]
 }
 
+// Infectious Horror
+{
+    "name": "Infectious Horror",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Zombie Horror",
+    "oracleText": "Whenever this creature attacks, each opponent loses 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "47",
+        "artist": "Pete Venters",
+        "flavorText": "Not once in the history of Grixis has anyone died of old age.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bb460855-f09d-4460-9d3f-1bfcc7f3e626.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Progenitus
 {
     "name": "Progenitus",

--- a/mtg-sets/src/test/resources/snapshots/cards/GTC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GTC.json
@@ -851,3 +851,40 @@
         "GREEN"
     ]
 }
+
+// Totally Lost
+{
+    "name": "Totally Lost",
+    "manaCost": "{4}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Put target nonland permanent on top of its owner's library.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Library",
+            "placement": "Top"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "artist": "David Palumbo",
+        "flavorText": "Fblthp had always hated crowds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec8e4142-7c46-4d2f-aaa6-6410f323d9f0.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/M10.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M10.json
@@ -446,6 +446,38 @@
     ]
 }
 
+// Oakenform
+{
+    "name": "Oakenform",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +3/+3.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 3
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "197",
+        "artist": "Wayne Reynolds",
+        "flavorText": "\"When the beast cloaks itself in the mighty oak, what good is a bow? When the oak wraps itself around the snarling beast, what good is a hatchet?\"\n—Dionus, elvish archdruid",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42df372a-af2b-464a-b54c-039132f70d00.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Rootbound Crag
 {
     "name": "Rootbound Crag",

--- a/mtg-sets/src/test/resources/snapshots/cards/M11.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M11.json
@@ -588,6 +588,62 @@
     ]
 }
 
+// Mighty Leap
+{
+    "name": "Mighty Leap",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 and gains flying until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "artist": "rk post",
+        "flavorText": "\"The southern fortress taken by invaders? Heh, sure . . . when elephants fly.\"\n—Brezard Skeinbow, captain of the guard",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bf8e0f93-a450-4188-a735-d601a59ab108.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Nether Horror
 {
     "name": "Nether Horror",

--- a/mtg-sets/src/test/resources/snapshots/cards/M12.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M12.json
@@ -550,6 +550,33 @@
     ]
 }
 
+// Manalith
+{
+    "name": "Manalith",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add one mana of any color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add one mana of any color."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "212",
+        "artist": "Charles Urbach",
+        "flavorText": "Planeswalkers seek out great monuments throughout the Multiverse, knowing that their builders were unknowingly drawn by the convergence of mana in the area.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/7/17bf5f25-82b4-460c-94da-b84daa8a53d9.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Rune-Scarred Demon
 {
     "name": "Rune-Scarred Demon",

--- a/mtg-sets/src/test/resources/snapshots/cards/M19.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M19.json
@@ -41,6 +41,68 @@
     ]
 }
 
+// Aerial Engineer
+{
+    "name": "Aerial Engineer",
+    "manaCost": "{2}{W}{U}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "As long as you control an artifact, this creature gets +2/+0 and has flying.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "artifact"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "artifact"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros",
+        "flavorText": "The best of their trade know every bolt of their rigs, stem to stern.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/5314bae2-4930-4f8a-8a52-853bc3feb88f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
 // Aethershield Artificer
 {
     "name": "Aethershield Artificer",
@@ -144,6 +206,44 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Ajani's Welcome
+{
+    "name": "Ajani's Welcome",
+    "manaCost": "{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a creature you control enters, you gain 1 life.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Deschamps",
+        "flavorText": "\"You cannot defend others if your own well-being is neglected.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c9045fcb-b633-4c35-8058-6234311551ae.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -255,6 +355,107 @@
         "imageUri": "https://cards.scryfall.io/normal/front/0/c/0ce4702d-f65b-413e-99da-112f632a0a63.jpg?1783934516"
     },
     "colorIdentityOverride": []
+}
+
+// Arisen Gorgon
+{
+    "name": "Arisen Gorgon",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Creature — Zombie Gorgon",
+    "oracleText": "This creature has deathtouch as long as you control a Liliana planeswalker. (Any amount of damage this deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "planeswalker Liliana"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "292",
+        "rarity": "UNCOMMON",
+        "artist": "Livia Prima",
+        "flavorText": "\"I'm not picky about what comes up, but the less decay, the better.\"\n—Liliana Vess",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e39502fd-193c-4526-8dd8-0cd8c822552c.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Aven Wind Mage
+{
+    "name": "Aven Wind Mage",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Bird Wizard",
+    "oracleText": "Flying\nWhenever you cast an instant or sorcery spell, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "artist": "Lius Lasahido",
+        "flavorText": "\"My skill sharpens with each beat of my wings.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b12dfc1-81f2-44b2-baa2-73cc21363978.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // Blood Divination
@@ -515,6 +716,130 @@
     ]
 }
 
+// Court Cleric
+{
+    "name": "Court Cleric",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nThis creature gets +1/+1 as long as you control an Ajani planeswalker.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "planeswalker Ajani"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "283",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Behm",
+        "flavorText": "\"The healers of Bant are second to none. I owe them a great deal for their tutelage.\"\n—Ajani Goldmane",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dc2e1a93-4b5c-4f89-9e11-1693dee64b63.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Dark-Dweller Oracle
+{
+    "name": "Dark-Dweller Oracle",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Shaman",
+    "oracleText": "{1}, Sacrifice a creature: Exile the top card of your library. You may play that card this turn. (You still pay its costs. You can play a land this way only if you have an available land play remaining.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "impulseExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "impulseExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "impulseExiled"
+                        }
+                    ]
+                },
+                "descriptionOverride": "{1}, Sacrifice a creature: Exile the top card of your library. You may play that card this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "rarity": "RARE",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "Eyes are unnecessary for seeing the future.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/9/69a57bfc-1de2-4b3a-84bc-19ec41087f0d.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Daybreak Chaplain
 {
     "name": "Daybreak Chaplain",
@@ -586,6 +911,49 @@
     ]
 }
 
+// Desecrated Tomb
+{
+    "name": "Desecrated Tomb",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever one or more creature cards leave your graveyard, create a 1/1 black Bat creature token with flying.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "CardsLeftYourGraveyardEvent",
+                    "filter": "creature"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Bat"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                },
+                "descriptionOverride": "Whenever one or more creature cards leave your graveyard, create a 1/1 black Bat creature token with flying."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "230",
+        "rarity": "RARE",
+        "artist": "Dimitar Marinski",
+        "flavorText": "The grave robbers were startled, for the door to the mausoleum was already open.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/458ce930-c100-4ef5-b75a-a18051282f8c.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Diamond Mare
 {
     "name": "Diamond Mare",
@@ -633,6 +1001,161 @@
         "flavorText": "When it passes, rainbows follow.",
         "imageUri": "https://cards.scryfall.io/normal/front/c/a/ca600b3f-2c70-489b-b218-6e3245b90114.jpg?1782709481"
     }
+}
+
+// Dismissive Pyromancer
+{
+    "name": "Dismissive Pyromancer",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{R}, {T}, Discard a card: Draw a card.\n{2}{R}, {T}, Sacrifice this creature: It deals 4 damage to target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "RARE",
+        "artist": "Bram Sels",
+        "flavorText": "\"Burn. Burn. Keep. Burn.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a0d0a9fa-75c9-4492-accd-bc9f79407453.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Draconic Disciple
+{
+    "name": "Draconic Disciple",
+    "manaCost": "{1}{R}{G}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "{T}: Add one mana of any color.\n{7}, {T}, Sacrifice this creature: Create a 5/5 red Dragon creature token with flying.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{7}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 5,
+                    "toughness": 5,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Dragon"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "UNCOMMON",
+        "artist": "Yongjae Choi",
+        "flavorText": "\"If I am to die, I will die in the embrace of immeasurable flame.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a353510a-30de-4891-97b9-d7d556531c41.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
 }
 
 // Dragon's Hoard
@@ -705,6 +1228,87 @@
     "colorIdentityOverride": []
 }
 
+// Dwarven Priest
+{
+    "name": "Dwarven Priest",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Dwarf Cleric",
+    "oracleText": "When this creature enters, you gain 1 life for each creature you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "artist": "Even Amundsen",
+        "flavorText": "\"These storied halls are under my protection.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e1e0f13-35a6-4a5e-8666-47bc5c275be7.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Epicure of Blood
+{
+    "name": "Epicure of Blood",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Whenever you gain life, each opponent loses 1 life.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "artist": "Anna Steinbauer",
+        "flavorText": "\"Fleshy, with just a hint of leather. A fine vintage.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/40b03528-f4ec-4825-ba4c-c485cb4eab3a.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Exclusion Mage
 {
     "name": "Exclusion Mage",
@@ -747,6 +1351,149 @@
         "artist": "Chris Seaman",
         "flavorText": "Successful battles start with knowing who's worth fighting.",
         "imageUri": "https://cards.scryfall.io/normal/front/c/c/ccad82f5-5c5c-42ad-b66e-942f0d9631ca.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Fiery Finish
+{
+    "name": "Fiery Finish",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Fiery Finish deals 7 damage to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 7
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "rarity": "UNCOMMON",
+        "artist": "Joe Slucher",
+        "flavorText": "Negotiations reached an abrupt conclusion.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3e38127d-63af-4d26-9ff5-358c8a61f39c.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Fountain of Renewal
+{
+    "name": "Fountain of Renewal",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "At the beginning of your upkeep, you gain 1 life.\n{3}, Sacrifice this artifact: Draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "At the beginning of your upkeep, you gain 1 life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "{3}, Sacrifice this artifact: Draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "235",
+        "rarity": "UNCOMMON",
+        "artist": "Adam Paquette",
+        "flavorText": "Entrepreneurs have attempted to sell the water, but to no avail. Whatever magic it contains disappears upon bottling.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/26894980-8961-4479-85dd-5f01c899718b.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Frilled Sea Serpent
+{
+    "name": "Frilled Sea Serpent",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Serpent",
+    "oracleText": "{5}{U}{U}: This creature can't be blocked this turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 6
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{U}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": "Self"
+                },
+                "descriptionOverride": "{5}{U}{U}: This creature can't be blocked this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "artist": "Steven Belledin",
+        "flavorText": "\"Reel it in. No, wait! Throw it back!\"\n—Gertrude, deep-sea angler",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0aa62c0-d24b-4bce-9f2b-d42402b0830c.jpg"
     },
     "colorIdentityOverride": [
         "BLUE"
@@ -951,6 +1698,165 @@
     ]
 }
 
+// Goblin Motivator
+{
+    "name": "Goblin Motivator",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "{T}: Target creature gains haste until end of turn. (It can attack and {T} this turn.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "artist": "Johann Bodin",
+        "flavorText": "Small words stoke large flames.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/94b3a4fb-9024-45ef-a54b-cf3a9fa5b9c2.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Goblin Trashmaster
+{
+    "name": "Goblin Trashmaster",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Other Goblins you control get +1/+1.\nSacrifice a Goblin: Destroy target artifact.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "permanent Goblin"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "permanent Goblin ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "rarity": "RARE",
+        "artist": "Jakub Kasper",
+        "flavorText": "\"Folks 'round here are too in love with their contraptions. Does them some good if we smash one every so often.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2bc69988-3c2d-4b76-a8c0-05926b9bbd08.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Greenwood Sentinel
+{
+    "name": "Greenwood Sentinel",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Scout",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "187",
+        "artist": "Johann Bodin",
+        "flavorText": "Within a mile of the woodland, you will feel her eyes upon you. Within its borders, you will feel her blade.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2eebdd18-6930-42e0-b589-fe15820db6e1.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Havoc Devils
+{
+    "name": "Havoc Devils",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Devil",
+    "oracleText": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "146",
+        "artist": "Viktor Titov",
+        "flavorText": "For devils, burning things is the highest form of comedy, diversion, and artistic expression.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2f003678-0f17-4f1d-87d5-83613a82044b.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Herald of Faith
 {
     "name": "Herald of Faith",
@@ -1063,6 +1969,91 @@
     ]
 }
 
+// Hired Blade
+{
+    "name": "Hired Blade",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Assassin",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "metadata": {
+        "collectorNumber": "100",
+        "artist": "Mark Behm",
+        "flavorText": "\"If you want them dead, buy some poison. If you want them to have the worst day of their life before dying, then let's talk price.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/7624c9aa-2f47-4fcc-a9fe-cc843e8de053.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Hostile Minotaur
+{
+    "name": "Hostile Minotaur",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Minotaur",
+    "oracleText": "Haste (This creature can attack and {T} as soon as it comes under your control.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "147",
+        "artist": "Joe Slucher",
+        "flavorText": "The bellow of a minotaur always translates to \"charge.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad6d0a11-3a9c-4de0-9a46-06d2b9356eb7.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Isolate
+{
+    "name": "Isolate",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target permanent with mana value 1.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "permanent mv=1"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "RARE",
+        "artist": "Victor Adame Minguez",
+        "flavorText": "Threefold were his crimes, doubled were his pleas, singular was his fate.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d9ce5eb-eaeb-4c93-8d31-4aeb8fcc4cce.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Kargan Dragonrider
 {
     "name": "Kargan Dragonrider",
@@ -1123,6 +2114,38 @@
         "artist": "Jesper Ejsing",
         "flavorText": "\"Horse? Who needs a horse?\"",
         "imageUri": "https://cards.scryfall.io/normal/front/2/1/213b4584-420a-48c2-9709-7b07458e914b.jpg?1783934605"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Knight's Pledge
+{
+    "name": "Knight's Pledge",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +2/+2.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Magali Villeneuve",
+        "flavorText": "\"As long as my faith persists, so shall I.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/734ff6ac-000d-4fc6-b97b-07b9b21f745c.jpg"
     },
     "colorIdentityOverride": [
         "WHITE"
@@ -1284,6 +2307,118 @@
     ]
 }
 
+// Lich's Caress
+{
+    "name": "Lich's Caress",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature. You gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Josh Hass",
+        "flavorText": "A lich must consume mortal souls to feed its eternal life.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/32bd3acd-aa62-4708-9336-e3430fd0e541.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Lightning Mare
+{
+    "name": "Lightning Mare",
+    "manaCost": "{R}{R}",
+    "typeLine": "Creature — Elemental Horse",
+    "oracleText": "This spell can't be countered.\nThis creature can't be blocked by blue creatures.\n{1}{R}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasColor",
+                            "color": "BLUE"
+                        }
+                    ]
+                }
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "UNCOMMON",
+        "artist": "Lucas Graciano",
+        "flavorText": "When it passes, storm clouds bolt across the land.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2ca822a3-4793-4cbc-a2f3-f43985e7ce8f.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Loxodon Line Breaker
 {
     "name": "Loxodon Line Breaker",
@@ -1406,6 +2541,92 @@
     "colorIdentityOverride": []
 }
 
+// Militia Bugler
+{
+    "name": "Militia Bugler",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen this creature enters, look at the top four cards of your library. You may reveal a creature card with power 2 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "creature pow<=2",
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "prompt": "You may reveal a creature card with power 2 or less from among them and put it into your hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "rarity": "UNCOMMON",
+        "artist": "David Gaillet",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/43c5bf25-937c-4e17-9ed4-b4c4579fa9dc.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Mystic Archaeologist
 {
     "name": "Mystic Archaeologist",
@@ -1466,6 +2687,167 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Prodigious Growth
+{
+    "name": "Prodigious Growth",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +7/+7 and has trample.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 7,
+                "toughnessBonus": 7
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "rarity": "RARE",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"Look how cute it is now!\"\n—Vivien Reid",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba2b0966-4e9e-44dc-9145-3c1e644578bc.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Ravenous Harpy
+{
+    "name": "Ravenous Harpy",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Harpy",
+    "oracleText": "Flying\n{1}, Sacrifice another creature: Put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "rarity": "UNCOMMON",
+        "artist": "Sam Rowan",
+        "flavorText": "A harpy's hoard is a filthy, bloodstained pile of trinkets and corpses.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/676ec702-75c4-4733-b500-eb15406778bb.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Regal Bloodlord
+{
+    "name": "Regal Bloodlord",
+    "manaCost": "{3}{W}{B}",
+    "typeLine": "Creature — Vampire Soldier",
+    "oracleText": "Flying\nAt the beginning of each end step, if you gained life this turn, create a 1/1 black Bat creature token with flying.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Bat"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                },
+                "interveningIf": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "LIFE_GAINED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "rarity": "UNCOMMON",
+        "artist": "Winona Nelson",
+        "flavorText": "Those of esteemed birth earn a most esteemed death.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/65a75d3a-58cb-4ee0-88d3-52099cb57ac3.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
     ]
 }
 
@@ -1587,6 +2969,356 @@
     ]
 }
 
+// Rhox Oracle
+{
+    "name": "Rhox Oracle",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Rhino Monk",
+    "oracleText": "When this creature enters, draw a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"The further into the future I look, the less certain my vision. Even now, the middle distance is obscured by fire.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/281f04d5-af45-4494-ac11-a605d3a06643.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Riddlemaster Sphinx
+{
+    "name": "Riddlemaster Sphinx",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Sphinx",
+    "oracleText": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nWhen this creature enters, you may return target creature an opponent controls to its owner's hand.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "287",
+        "rarity": "RARE",
+        "artist": "Ryan Yee",
+        "flavorText": "\"Safe passage requires only a simple answer to a simple question, traveler.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/037f6792-ab41-4bcd-a0a3-a4af4a801eb7.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Root Snare
+{
+    "name": "Root Snare",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Prevent all combat damage that would be dealt this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "PreventDamageShield",
+            "scope": "CombatOnly"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "199",
+        "artist": "Mitchell Malloy",
+        "flavorText": "The only casualties were a snapped spear, a lost helmet, and some bruised egos.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/76b01fd2-139a-47ed-a8e3-021aa9c91b02.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Rustwing Falcon
+{
+    "name": "Rustwing Falcon",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Paul Scott Canavan",
+        "flavorText": "Native to wide prairies and scrublands, falcons occasionally roost in dragon skeletons.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c6691e62-8887-41e8-8e74-76ee2353d45e.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Satyr Enchanter
+{
+    "name": "Satyr Enchanter",
+    "manaCost": "{1}{G}{W}",
+    "typeLine": "Creature — Satyr Druid",
+    "oracleText": "Whenever you cast an enchantment spell, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsEnchantment"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "223",
+        "rarity": "UNCOMMON",
+        "artist": "Sidharth Chaturvedi",
+        "flavorText": "\"The threads of magic that protect this place were woven by my will.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e31c544f-a748-4180-8366-9bb1622bb99d.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
+// Scholar of Stars
+{
+    "name": "Scholar of Stars",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "When this creature enters, if you control an artifact, draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "interveningIf": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "artifact"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "artist": "Tommy Arnold",
+        "flavorText": "\"The path of the stars is as reliable as the instruments that measure them.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cb4664d4-fb00-4572-a60d-00336117b8a5.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Serra's Guardian
+{
+    "name": "Serra's Guardian",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "Flying (This creature can't be blocked except by creatures with flying or reach.)\nVigilance (Attacking doesn't cause this creature to tap.)\nOther creatures you control have vigilance.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE",
+                "filter": {
+                    "baseFilter": "creature ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "284",
+        "rarity": "RARE",
+        "artist": "Magali Villeneuve",
+        "flavorText": "She watches over the city just as Serra watches over all.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a1d95b9-aa18-41e2-b972-93fda25e0b11.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Siegebreaker Giant
+{
+    "name": "Siegebreaker Giant",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Giant Warrior",
+    "oracleText": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\n{3}{R}: Target creature can't block this turn.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "CantBlockTargetCreatures",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{3}{R}: Target creature can't block this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "rarity": "UNCOMMON",
+        "artist": "Even Amundsen",
+        "flavorText": "No rampart can withstand the fury of a giant.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/ede2b911-8eec-4993-ab1c-59b55dfb11b4.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Silverbeak Griffin
+{
+    "name": "Silverbeak Griffin",
+    "manaCost": "{W}{W}",
+    "typeLine": "Creature — Griffin",
+    "oracleText": "Flying (This creature can't be blocked except by creatures with flying or reach.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "285",
+        "artist": "Viktor Titov",
+        "flavorText": "A pair of domesticated griffins escaped from captivity a century ago. Now the skies are filled with the songs of their descendants.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/36b4c374-42a4-4912-8a74-a11c3fa0e065.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Skeleton Archer
 {
     "name": "Skeleton Archer",
@@ -1634,6 +3366,165 @@
     ]
 }
 
+// Skyscanner
+{
+    "name": "Skyscanner",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Thopter",
+    "oracleText": "Flying\nWhen this creature enters, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "When this creature enters, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "245",
+        "artist": "Adam Paquette",
+        "flavorText": "The municipal senate makes extensive use of the thopters, mostly to gather dirt on rival senators.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd2c1fb7-3c1d-49a9-b2c2-78ba2264df38.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Sovereign's Bite
+{
+    "name": "Sovereign's Bite",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target player loses 3 life and you gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "artist": "Volkan Baǵa",
+        "flavorText": "\"You have given all to your kingdom, dear knight. Serenity shall be your prize.\"\n—Queen Lian",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/5326d251-bb91-4653-b1fa-44f14c4e0b88.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Spit Flame
+{
+    "name": "Spit Flame",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Spit Flame deals 4 damage to target creature.\nWhenever a Dragon you control enters, you may pay {R}. If you do, return this card from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ],
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Dragon ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{R}"
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Hand",
+                        "fromZone": "Graveyard"
+                    }
+                },
+                "activeZones": [
+                    "Graveyard"
+                ],
+                "descriptionOverride": "Whenever a Dragon you control enters, you may pay {R}. If you do, return this card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "rarity": "RARE",
+        "artist": "Chris Rahn",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/94df6198-10c0-44e7-8226-dc96d12957c4.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Strangling Spores
 {
     "name": "Strangling Spores",
@@ -1674,6 +3565,44 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Supreme Phantom
+{
+    "name": "Supreme Phantom",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nOther Spirits you control get +1/+1.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "permanent Spirit ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "rarity": "RARE",
+        "artist": "Robbie Trevino",
+        "flavorText": "A king's knowledge does not vanish when the heart stops beating.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d65c22b-7640-4433-930b-4bc381ac7361.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -1736,6 +3665,138 @@
     }
 }
 
+// Take Vengeance
+{
+    "name": "Take Vengeance",
+    "manaCost": "{1}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target tapped creature.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature tapped"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "artist": "Randy Vargas",
+        "flavorText": "\"Your death will be a balm, your passing a welcome revision, and all will sigh with peace to know of your demise.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/66fbde22-d98d-4f12-b4d8-1bad2a9878b2.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Talons of Wildwood
+{
+    "name": "Talons of Wildwood",
+    "manaCost": "{1}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +1/+1 and has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)\n{2}{G}: Return this card from your graveyard to your hand.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand",
+                    "fromZone": "Graveyard"
+                },
+                "activateFromZone": "Graveyard"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "202",
+        "artist": "Uriah Voth",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9ffa2e83-bc78-4bde-9692-e5165c4ef63b.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Tezzeret's Strider
+{
+    "name": "Tezzeret's Strider",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "As long as you control a Tezzeret planeswalker, this creature has menace. (It can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "MENACE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "planeswalker Tezzeret"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "290",
+        "rarity": "UNCOMMON",
+        "artist": "Zack Stella",
+        "flavorText": "\"More obedient than any dog.\"\n—Tezzeret",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8cf74535-31e3-4d2c-b42a-072580fa4ba0.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Trusty Packbeast
 {
     "name": "Trusty Packbeast",
@@ -1778,6 +3839,91 @@
         "artist": "John Stanko",
         "flavorText": "\"Margaret has traveled with me to the end of the world and back.\"\n—Hewen Frit, merchant",
         "imageUri": "https://cards.scryfall.io/normal/front/8/3/8320e35b-15b9-4f98-b9b8-9c951696408b.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Two-Headed Zombie
+{
+    "name": "Two-Headed Zombie",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "metadata": {
+        "collectorNumber": "123",
+        "artist": "Josh Hass",
+        "flavorText": "\"Thread the torsos together with angel hair to ensure they will cooperate in battle.\"\n—*The Stitcher's Tome*",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2cc5760e-8b27-4d37-9772-c9eda90b1d95.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Valiant Knight
+{
+    "name": "Valiant Knight",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Other Knights you control get +1/+1.\n{3}{W}{W}: Knights you control gain double strike until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "permanent Knight ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "DOUBLE_STRIKE",
+                        "target": "Self"
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "permanent Knight ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "rarity": "RARE",
+        "artist": "Jakub Kasper",
+        "flavorText": "\"Defeat is no reason for retreat. It is a sign we must redouble our efforts to win this fight.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6ad750bc-850b-483b-8910-eb6562f925bc.jpg"
     },
     "colorIdentityOverride": [
         "WHITE"
@@ -1892,6 +4038,72 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Vigilant Baloth
+{
+    "name": "Vigilant Baloth",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "206",
+        "rarity": "UNCOMMON",
+        "artist": "Uriah Voth",
+        "flavorText": "Villagers employ watchdogs as guardians and companions. Druids prefer something a little bigger.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/4/34ad8e5d-0c26-4588-8161-b22197715d63.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Vine Mare
+{
+    "name": "Vine Mare",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Elemental Horse",
+    "oracleText": "Hexproof (This creature can't be the target of spells or abilities your opponents control.)\nThis creature can't be blocked by black creatures.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "keywords": [
+        "HEXPROOF"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasColor",
+                            "color": "BLACK"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "207",
+        "rarity": "UNCOMMON",
+        "artist": "Alex Konstad",
+        "flavorText": "When it passes, the dead are displaced by flourishing life.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9980835-cd32-4870-88df-c79cd5534968.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -2047,6 +4259,63 @@
         "imageUri": "https://cards.scryfall.io/normal/front/6/8/681fbd66-b622-4f20-a860-f101aff21109.jpg?1562302655"
     },
     "startingLoyalty": 5,
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Vivien's Jaguar
+{
+    "name": "Vivien's Jaguar",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Cat Spirit",
+    "oracleText": "Reach (This creature can block creatures with flying.)\n{2}{G}: Return this card from your graveyard to your hand. Activate only if you control a Vivien planeswalker.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand",
+                    "fromZone": "Graveyard"
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "planeswalker Vivien"
+                        }
+                    }
+                ],
+                "activateFromZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "305",
+        "rarity": "UNCOMMON",
+        "artist": "Magali Villeneuve",
+        "flavorText": "Each of Vivien's arrows is an invocation of a species.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d4b406cf-738b-4e65-ac00-b1c36ded5f96.jpg"
+    },
     "colorIdentityOverride": [
         "GREEN"
     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/MOR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MOR.json
@@ -34,6 +34,42 @@
     ]
 }
 
+// Disperse
+{
+    "name": "Disperse",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target nonland permanent to its owner's hand.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "31",
+        "artist": "Steve Ellis",
+        "flavorText": "Gryffid scowled at the sky. A perfect day for the hunt tainted by clouds. He wished them gone. High above, the clouds looked down, scowled, and made a wish of their own.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0ae239b2-1596-4906-9711-1d180a246d35.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Indomitable Ancients
 {
     "name": "Indomitable Ancients",

--- a/mtg-sets/src/test/resources/snapshots/cards/OGW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OGW.json
@@ -164,6 +164,52 @@
     ]
 }
 
+// Cinder Barrens
+{
+    "name": "Cinder Barrens",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {B} or {R}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "rarity": "UNCOMMON",
+        "artist": "Cliff Childs",
+        "flavorText": "A mudflow swallowed the lowlands years ago. All that remains are a bottomless mire and an endless rain of ash.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/949f41a0-9082-4682-88b8-a29fbcb48d5d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Expedite
 {
     "name": "Expedite",
@@ -263,6 +309,52 @@
     ]
 }
 
+// Meandering River
+{
+    "name": "Meandering River",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {W} or {U}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "rarity": "UNCOMMON",
+        "artist": "Cliff Childs",
+        "flavorText": "The river split into many channels as it flowed to the Halimar Sea. Few travelers could follow the same one twice.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6a5bedf1-92b6-465c-afc2-ce8e150a5e57.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
 // Sphinx of the Final Word
 {
     "name": "Sphinx of the Final Word",
@@ -294,6 +386,52 @@
         "imageUri": "https://cards.scryfall.io/normal/front/8/6/866f92a3-2738-4e0f-adda-3ff9227dc17a.jpg?1783937917"
     },
     "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Submerged Boneyard
+{
+    "name": "Submerged Boneyard",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {U} or {B}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "rarity": "UNCOMMON",
+        "artist": "Cliff Childs",
+        "flavorText": "\"Long after the land has given up the last of its secrets, there will still be mysteries in the depths of the sea.\"\n—Kiora",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/6479a246-21ac-490a-aefb-6ed72aabdb88.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
         "BLUE"
     ]
 }
@@ -429,6 +567,98 @@
         "imageUri": "https://cards.scryfall.io/normal/front/b/f/bffc360e-db41-48f3-9365-680d55046e04.jpg?1783937929"
     },
     "colorIdentityOverride": []
+}
+
+// Timber Gorge
+{
+    "name": "Timber Gorge",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {R} or {G}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "rarity": "UNCOMMON",
+        "artist": "Cliff Childs",
+        "flavorText": "Tazeem's embrace is harsh, but for those that call it home, nothing else will do.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/55d05ff7-f071-4eb3-b10a-203741abdf10.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Tranquil Expanse
+{
+    "name": "Tranquil Expanse",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {G} or {W}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "180",
+        "rarity": "UNCOMMON",
+        "artist": "Cliff Childs",
+        "flavorText": "Despite the chaos of the Roil and the devastation of the Eldrazi, Zendikar is a world of breathtaking beauty.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42787d2b-3f9d-4c29-9ece-e65544eb1340.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
 }
 
 // Untamed Hunger

--- a/mtg-sets/src/test/resources/snapshots/cards/RIX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RIX.json
@@ -323,6 +323,30 @@
     ]
 }
 
+// Mist-Cloaked Herald
+{
+    "name": "Mist-Cloaked Herald",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Merfolk Warrior",
+    "oracleText": "This creature can't be blocked.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "flags": [
+        "CANT_BE_BLOCKED"
+    ],
+    "metadata": {
+        "collectorNumber": "43",
+        "artist": "Anthony Palumbo",
+        "flavorText": "With matchless stealth, the River Heralds fought a running battle against the three enemy forces.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/18c1368e-114b-4618-922b-1d824ba0d1d5.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Moment of Craving
 {
     "name": "Moment of Craving",
@@ -720,6 +744,30 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Sun Sentinel
+{
+    "name": "Sun Sentinel",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "26",
+        "artist": "James Ryman",
+        "flavorText": "\"I will not sleep until Orazca is ours once more.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/6867fd5a-3bbe-416d-96a6-1db0b341260e.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/ROE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ROE.json
@@ -246,6 +246,30 @@
     ]
 }
 
+// Daggerback Basilisk
+{
+    "name": "Daggerback Basilisk",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Basilisk",
+    "oracleText": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "metadata": {
+        "collectorNumber": "182",
+        "artist": "Jesper Ejsing",
+        "flavorText": "\"Petrifying gaze, deadly fangs, knifelike dorsal spines, venomous saliva . . . Am I missing anything? . . . Toxic bones? Seriously?\"\n—Samila, Murasa Expeditionary House",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d4343cb0-6490-496c-9d58-ac1f7d3a91c6.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Dreamstone Hedron
 {
     "name": "Dreamstone Hedron",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -1567,6 +1567,59 @@
     ]
 }
 
+// Explosive Apparatus
+{
+    "name": "Explosive Apparatus",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{3}, {T}, Sacrifice this artifact: It deals 2 damage to any target.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "255",
+        "artist": "Lindsey Look",
+        "flavorText": "\"Souls are volatile things. When compressed and loaded into a handheld device, their destructive potential is quite impressive.\"\n—Dierk, geistmage",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e7329a19-2f68-4d2c-a725-e0d862cd234e.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Falkenrath Gorger
 {
     "name": "Falkenrath Gorger",
@@ -1607,6 +1660,98 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Forsaken Sanctuary
+{
+    "name": "Forsaken Sanctuary",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {W} or {B}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "273",
+        "rarity": "UNCOMMON",
+        "artist": "Vincent Proce",
+        "flavorText": "\"Prayers will curdle on the tongue and be heard by rotting ears.\"\n—Minaldra, the Vizag Atum",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0bd86cac-08c1-4db0-ab54-4bb65a771efe.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "WHITE"
+    ]
+}
+
+// Foul Orchard
+{
+    "name": "Foul Orchard",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {B} or {G}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "275",
+        "rarity": "UNCOMMON",
+        "artist": "Jung Park",
+        "flavorText": "\"Such a beautiful place for a stroll.\"\n—Liliana Vess",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/2378ac21-9912-40d7-972d-b1b71a8e4984.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 
@@ -2065,6 +2210,52 @@
         "imageUri": "https://cards.scryfall.io/normal/front/0/d/0d200f98-3377-46a3-9197-3cbd95d03dbf.jpg?1783937712"
     },
     "colorIdentityOverride": []
+}
+
+// Highland Lake
+{
+    "name": "Highland Lake",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {U} or {R}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "277",
+        "rarity": "UNCOMMON",
+        "artist": "Florian de Gesincourt",
+        "flavorText": "With the fate of Innistrad uncertain, some seek solace in remote areas.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48b97a23-c4cf-47c9-9dbf-34215ea0e908.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "BLUE"
+    ]
 }
 
 // Hinterland Logger
@@ -3709,6 +3900,52 @@
     ]
 }
 
+// Stone Quarry
+{
+    "name": "Stone Quarry",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {R} or {W}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "279",
+        "rarity": "UNCOMMON",
+        "artist": "Cliff Childs",
+        "flavorText": "In Gavony, headstones come only from quarries that have been blessed by chaplains.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e636cdc3-4b83-4f15-ad4a-6c8fa3533408.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Strength of Arms
 {
     "name": "Strength of Arms",
@@ -5192,4 +5429,50 @@
         "imageUri": "https://cards.scryfall.io/normal/front/1/2/1285b444-1668-4a3d-9fcd-8ce4e95c6d2f.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Woodland Stream
+{
+    "name": "Woodland Stream",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {G} or {U}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "282",
+        "rarity": "UNCOMMON",
+        "artist": "James Paick",
+        "flavorText": "Two creaking waterwheels herald the approach to Briarbridge through the Ulvenwald.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/18a0c745-dee6-4cb2-acaa-3d2b8e0cce5b.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/THS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THS.json
@@ -375,6 +375,42 @@
     ]
 }
 
+// Omenspeaker
+{
+    "name": "Omenspeaker",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "When this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "artist": "Dallas Williams",
+        "flavorText": "Her prophecies amaze her even as she speaks them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f347eb88-7d1d-4ed5-b841-2bf81f00d5f0.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Pheres-Band Centaurs
 {
     "name": "Pheres-Band Centaurs",


### PR DESCRIPTION
Implements every card Argentum Assay reads whole that M19 had not authored yet.

**M19 Assay-ready: 89 → 0.**

## The four-way split

| Bucket | Count | Work |
|---|---:|---|
| `original` | 49 | canonical authored in M19 — the set is their earliest real printing |
| `elsewhere` | 24 | canonical authored in the earlier set, plus a `Printing` row in M19 |
| `row-only` | 11 | canonical already in the corpus — a `Printing` row only |
| `basic` | 5 | `basicLand(...)` vals + the `basicLands` override — never `Printing` rows |

The 24 `elsewhere` canonicals landed in **14 other sets**: OGW (4), SOI (6), RIX (2), and one each in AKH, ROE, MOR, AVR, CON, M12, M11, M10, THS, AER, GTC.

**Reprint tail: 70 further `Printing` rows across 28 other scaffolded sets** — invisible to `check-card-printing` until the canonicals existed, so they belong in this PR. Biggest: AKH 11, M20 8, RIX 6, ANB 5, C17 4, CMR 4.

Basic lands are the 20 art variants, cards 261-280 (4 per type).

**179 new files** = 73 canonicals + 105 `Printing` rows + 1 basic-lands file.

## Differential

Taken with a freshly built binary in this checkout, before and after:

| | compared | confirmed | divergent |
|---|---:|---:|---:|
| before | 4705 | 4656 | 49 |
| after | 4777 | 4728 | 49 |

**+72 compared, +72 confirmed, divergences unchanged at 49** — every one of the 49 is a pre-existing card in an untouched set. Per-set differential reads **0 divergent** for all 15 sets this PR touches (M19: 85 compared, 0 divergent).

The 73rd canonical is not compared: it sits in one of M19's three `script slot not modelled yet` rows, which is Assay not modelling a slot, not a defect in the card.

Every card was authored to `assay compile`'s `CardDefinition` JSON rather than to the oracle text, which is why the divergence delta is zero.

## Capability pre-flight

All 16 non-obvious constructs the batch touches were traced to a live `rules-engine` consumer before any card was written — **nothing inert**. The keyword set is entirely evergreen (flying, vigilance, trample, menace, reach, haste, flash, hexproof, lifelink, deathtouch), so none of the display-only-keyword trap applies. Three hazards were passed into the authoring brief:

- **Root Snare** — `PreventDamageExecutor`'s Fog branch is match-exact on five fields; passing an explicit `target` silently falls through to the *targeted* shield and the card stops working. Written with the bare `Effects.PreventAllCombatDamage()` facade.
- **Spit Flame** — `triggerZones = setOf(Zone.GRAVEYARD)` combined with `Gate.MayPay` is the **first such combination in the corpus**. The code path exists and reads correctly, but nothing else exercises it; worth a behavioural check that the may-pay prompt reaches the controller while the source sits in the graveyard.
- **Court Cleric / Arisen Gorgon / Tezzeret's Strider / Vivien's Jaguar** — "you control a `<Name>` planeswalker" as a static gate had no precedent. `GameObjectFilter.Planeswalker.withSubtype("Ajani")` composed with no new vocabulary.

Confirmed along the way: `flags(CANT_BE_BLOCKED)` is **live** on a creature's own definition (`baseFlags` → `StateProjector` → `BlockEvasionRules.UnblockableRule`). The known inertness is attachment-specific — the three broken cards put the flag on an Aura/Equipment entity that never attacks — so Mist-Cloaked Herald is safe.

## Gates

- `just build` — green (snapshot re-bless was needed for the 15 touched sets; **+73 cards, 0 removed**, verified name-set before/after per file)
- `just assay-differential` — above
- `just check-card-printing` — **73/73 pass**
- `just assay-ready M19` — re-run on the branch: **0 Assay-ready**, not inferred
- `just assay-bake` — ledger already current, no diff, no `whole` regressions

## Findings this sweep surfaced but did not fix

- **`scripts/generate-reprints.py` is set-wide, not change-scoped.** A bare run wanted to write **333 rows across 53 sets**; only 94 belong to this batch. The other 239 are pre-existing reprint gaps for 141 unrelated cards. They were filtered out by card name; the script has no flag for "only rows owed by these canonicals", and its cache-freshness filter does not scope it either.
- **`DropkickBomber` (FDN) reads its lord as `Creature.withSubtype`** where the printed line is "Other **Goblins** you control get +1/+1" — a bare tribal noun, which is permanents. Goblin Trashmaster in this PR has the identical printed line and is written as `Permanent.withSubtype`. `DropkickBomber` will read as a divergence once Assay covers that family. Not touched.
- **`EpicProportions` (LRW) and `MythicProportions` (ONS) disagree on shape** for the same printed wording — one uses `CompositeStaticAbility`, the other two flat `staticAbilities`. Assay's model is the flat one, which is what Prodigious Growth here follows. `EpicProportions`' own KDoc argues CR 613.6 wants the composite identity; the corpus should pick one.
- **`assay compile`'s `setCode` and `metadata.imageUri` are not a placement signal** — they reflect whichever printing the Oracle bulk carried. Every one of the 9 authoring agents flagged this independently (compiles came back tagged CMM, MOC, GN2, C19, ZNC, TDC, VOC, KHC, 2X2, RVR…). Metadata was taken from each set's own Scryfall payload instead, per the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)