### PR TITLE
Fix three findings from the M19 Assay-ready sweep

### DIFF
--- a/.agents/skills/assay-ready-sweep/SKILL.md
+++ b/.agents/skills/assay-ready-sweep/SKILL.md
@@ -108,7 +108,10 @@ Four mechanics that matter:
   sharing that name: `compile "Savage Lands"` returned an FMSC art card, empty type line, 359 bytes
   against ~1700 for its siblings.
 - **Take metadata from the set's own Scryfall payload, not from the compile.** Its `setCode` and
-  `metadata.imageUri` are whatever printing the Oracle bulk happened to carry.
+  `metadata.imageUri` are whatever printing the Oracle bulk happened to carry — a card whose canonical
+  belongs in Morningtide compiles tagged `CMR`. `compile` now says this on **stderr** after each card
+  (stdout stays pure JSON, so a redirecting loop is unaffected); if you fan the batch out, put the rule
+  in the brief anyway, because an agent reading only the JSON file never sees the stderr line.
 - **When the JSON shows a field the corpus rarely writes** (`prompt`, `showAllCards`, `restOrder`, a
   nested `Composite`), find the `Patterns.*` facade whose defaults produce it — grep the assay `grammar/`
   sources for `Patterns.<X>.<fn>` and it names the function directly.
@@ -133,14 +136,25 @@ sys.modules["mr"] = mr; loader.exec_module(mr)
 for name in ["<Card One>", "<Card Two>"]:
     mr.fetch_printings(name)
 PY
-scripts/generate-reprints.py --set <CODE> --dry-run
-scripts/generate-reprints.py --set <CODE>
+scripts/generate-reprints.py --since main --dry-run     # scope it to YOUR canonicals
+scripts/generate-reprints.py --since main
 ```
+
+**Scope the run, or it will hand you the whole corpus's backlog.** `--set` filters the set a row is
+written *into*, not which canonicals are considered, so a bare run also emits every pre-existing reprint
+gap anywhere in the repo — M19's sweep was offered **333 rows across 53 sets when only 94 were its own**.
+Use `--since <ref>` (canonicals whose file differs from that git ref, untracked files included, so it
+works before you commit), or `--cards-from <file>` / `--card "<Name>"` when you have the name list. The
+run prints the scope it resolved and names any requested card with no canonical in the checkout.
 
 **`generate-reprints.py` silently skips any card whose `~/.cache/scryfall/printings/<slug>.json` is past
 its 30-day TTL** — `load_card_printings` returns `None` and `continue`s, and the skip does not appear in
 the summary. 40 of JMP's 79 were stale and would have been dropped without a word. Refresh first, then
 diff the generated file count against the bucket count.
+
+**Re-run the scoped generate after a merge.** A set scaffolded by someone else's PR turns a row nobody
+owed into a row you owe: merging main mid-sweep made M19's Mighty Leap owe a DDF row that did not exist
+when the batch was generated.
 
 `just coverage-relocate <CODE>` exists and does the `elsewhere` move mechanically, but it emits *mtgish*
 drafts rather than Assay's reading — treat its output as a starting skeleton, not as authored cards.

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/GoblinKing.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/GoblinKing.kt
@@ -27,13 +27,13 @@ val GoblinKing = card("Goblin King") {
         ability = ModifyStats(
             powerBonus = 1,
             toughnessBonus = 1,
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN), excludeSelf = true)
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.GOBLIN), excludeSelf = true)
         )
     }
     staticAbility {
         ability = GrantKeyword(
             Keyword.MOUNTAINWALK,
-            GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN), excludeSelf = true)
+            GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.GOBLIN), excludeSelf = true)
         )
     }
     metadata {

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/LordOfAtlantis.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/LordOfAtlantis.kt
@@ -27,13 +27,13 @@ val LordOfAtlantis = card("Lord of Atlantis") {
         ability = ModifyStats(
             powerBonus = 1,
             toughnessBonus = 1,
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.MERFOLK), excludeSelf = true)
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.MERFOLK), excludeSelf = true)
         )
     }
     staticAbility {
         ability = GrantKeyword(
             Keyword.ISLANDWALK,
-            GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.MERFOLK), excludeSelf = true)
+            GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.MERFOLK), excludeSelf = true)
         )
     }
     metadata {

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/MarrowGnawer.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/chk/cards/MarrowGnawer.kt
@@ -34,10 +34,10 @@ val MarrowGnawer = card("Marrow-Gnawer") {
     power = 2
     toughness = 3
     staticAbility {
-        ability = GrantKeyword(Keyword.FEAR, GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.RAT)))
+        ability = GrantKeyword(Keyword.FEAR, GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.RAT)))
     }
     activatedAbility {
-        cost = Costs.Composite(Costs.Tap, Costs.Sacrifice(GameObjectFilter.Creature.withSubtype("Rat")))
+        cost = Costs.Composite(Costs.Tap, Costs.Sacrifice(GameObjectFilter.Permanent.withSubtype("Rat")))
         effect = Effects.CreateToken(
             count = DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature.withSubtype("Rat")),
             power = 1,

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ImperiousPerfect.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/ImperiousPerfect.kt
@@ -34,7 +34,7 @@ val ImperiousPerfect = card("Imperious Perfect") {
         ability = ModifyStats(
             powerBonus = 1,
             toughnessBonus = 1,
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.ELF).youControl(), excludeSelf = true)
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.ELF).youControl(), excludeSelf = true)
         )
     }
     activatedAbility {

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/GoblinWarchief.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/GoblinWarchief.kt
@@ -36,7 +36,7 @@ val GoblinWarchief = card("Goblin Warchief") {
     staticAbility {
         ability = GrantKeyword(
             keyword = Keyword.HASTE,
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype("Goblin"))
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype("Goblin").youControl())
         )
     }
 

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddf/cards/MightyLeapReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddf/cards/MightyLeapReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddf.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mighty Leap reprint in DDF. Canonical CardDefinition lives in its earliest set.
+ */
+val MightyLeapReprint = Printing(
+    oracleId = "593caa15-e1d1-477f-bbb4-124d7a7b81f3",
+    name = "Mighty Leap",
+    setCode = "DDF",
+    collectorNumber = "24",
+    scryfallId = "92c5ce58-0502-4741-8eaf-eababbef0503",
+    artist = null,
+    imageUri = "https://cards.scryfall.io/normal/front/9/2/92c5ce58-0502-4741-8eaf-eababbef0503.jpg",
+    releaseDate = "2010-09-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/KruinOutlaw.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/KruinOutlaw.kt
@@ -60,7 +60,7 @@ private val TerrorOfKruinPass = card("Terror of Kruin Pass") {
     staticAbility {
         ability = GrantKeyword(
             Keyword.MENACE,
-            GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.WEREWOLF).youControl())
+            GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.WEREWOLF).youControl())
         )
     }
     triggeredAbility {

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/RegalCaracal.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/RegalCaracal.kt
@@ -36,13 +36,13 @@ val RegalCaracal = card("Regal Caracal") {
         ability = ModifyStats(
             powerBonus = 1,
             toughnessBonus = 1,
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.CAT).youControl(), excludeSelf = true)
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.CAT).youControl(), excludeSelf = true)
         )
     }
     staticAbility {
         ability = GrantKeyword(
             Keyword.LIFELINK,
-            GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.CAT).youControl(), excludeSelf = true)
+            GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.CAT).youControl(), excludeSelf = true)
         )
     }
     triggeredAbility {

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/GeralfVisionaryStitcher.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/GeralfVisionaryStitcher.kt
@@ -44,7 +44,7 @@ val GeralfVisionaryStitcher = card("Geralf, Visionary Stitcher") {
     staticAbility {
         ability = GrantKeyword(
             Keyword.FLYING,
-            GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.ZOMBIE).youControl())
+            GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.ZOMBIE).youControl())
         )
     }
 

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CorpsesOfTheLost.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CorpsesOfTheLost.kt
@@ -52,7 +52,7 @@ val CorpsesOfTheLost = card("Corpses of the Lost") {
         ability = ModifyStats(
             powerBonus = 1,
             toughnessBonus = 0,
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SKELETON).youControl())
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.SKELETON).youControl())
         )
     }
 
@@ -60,7 +60,7 @@ val CorpsesOfTheLost = card("Corpses of the Lost") {
     staticAbility {
         ability = GrantKeyword(
             keyword = Keyword.HASTE,
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SKELETON).youControl())
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.SKELETON).youControl())
         )
     }
 

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PalanisHatcher.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PalanisHatcher.kt
@@ -39,7 +39,7 @@ val PalanisHatcher = card("Palani's Hatcher") {
         ability = GrantKeyword(
             keyword = Keyword.HASTE,
             filter = GroupFilter(
-                GameObjectFilter.Creature.withSubtype("Dinosaur").youControl(),
+                GameObjectFilter.Permanent.withSubtype("Dinosaur").youControl(),
                 excludeSelf = true
             )
         )

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ShadowfaxLordOfHorses.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/ShadowfaxLordOfHorses.kt
@@ -48,7 +48,7 @@ val ShadowfaxLordOfHorses = card("Shadowfax, Lord of Horses") {
     staticAbility {
         ability = GrantKeyword(
             keyword = Keyword.HASTE,
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.HORSE).youControl())
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.HORSE).youControl())
         )
     }
 

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CamelliaTheSeedmiser.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CamelliaTheSeedmiser.kt
@@ -41,7 +41,7 @@ val CamelliaTheSeedmiser = card("Camellia, the Seedmiser") {
         ability = GrantKeyword(
             keyword = Keyword.MENACE,
             filter = GroupFilter(
-                GameObjectFilter.Creature.withSubtype("Squirrel").youControl(),
+                GameObjectFilter.Permanent.withSubtype("Squirrel").youControl(),
                 excludeSelf = true
             )
         )
@@ -67,7 +67,7 @@ val CamelliaTheSeedmiser = card("Camellia, the Seedmiser") {
         )
         effect = Effects.ForEachInGroup(
             filter = GroupFilter(
-                GameObjectFilter.Creature.withSubtype("Squirrel").youControl(),
+                GameObjectFilter.Permanent.withSubtype("Squirrel").youControl(),
                 excludeSelf = true
             ),
             effect = AddCountersEffect(

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/MabelHeirToCragflame.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/MabelHeirToCragflame.kt
@@ -33,7 +33,7 @@ val MabelHeirToCragflame = card("Mabel, Heir to Cragflame") {
             powerBonus = 1,
             toughnessBonus = 1,
             filter = GroupFilter(
-                GameObjectFilter.Creature.withSubtype("Mouse").youControl(),
+                GameObjectFilter.Permanent.withSubtype("Mouse").youControl(),
                 excludeSelf = true
             )
         )

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DropkickBomber.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DropkickBomber.kt
@@ -53,7 +53,7 @@ val DropkickBomber = card("Dropkick Bomber") {
             powerBonus = 1,
             toughnessBonus = 1,
             filter = GroupFilter(
-                GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN).youControl(),
+                GameObjectFilter.Permanent.withSubtype(Subtype.GOBLIN).youControl(),
                 excludeSelf = true
             )
         )

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PrivateEye.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PrivateEye.kt
@@ -47,7 +47,7 @@ val PrivateEye = card("Private Eye") {
             powerBonus = 1,
             toughnessBonus = 1,
             filter = GroupFilter(
-                GameObjectFilter.Creature.withSubtype(Subtype.DETECTIVE).youControl(),
+                GameObjectFilter.Permanent.withSubtype(Subtype.DETECTIVE).youControl(),
                 excludeSelf = true
             )
         )

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BruseTarlRovingRancher.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/BruseTarlRovingRancher.kt
@@ -96,7 +96,7 @@ val BruseTarlRovingRancher = card("Bruse Tarl, Roving Rancher") {
     staticAbility {
         ability = GrantKeyword(
             Keyword.DOUBLE_STRIKE,
-            GroupFilter(GameObjectFilter.Creature.withSubtype("Ox").youControl()),
+            GroupFilter(GameObjectFilter.Permanent.withSubtype("Ox").youControl()),
         )
     }
 

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CurseclothWrappings.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/CurseclothWrappings.kt
@@ -52,7 +52,7 @@ val CurseclothWrappings = card("Cursecloth Wrappings") {
         ability = ModifyStats(
             powerBonus = 1,
             toughnessBonus = 1,
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.ZOMBIE).youControl())
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.ZOMBIE).youControl())
         )
     }
 

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/HowlsquadHeavy.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/HowlsquadHeavy.kt
@@ -48,7 +48,7 @@ val HowlsquadHeavy = card("Howlsquad Heavy") {
         ability = GrantKeyword(
             Keyword.HASTE,
             GroupFilter(
-                GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN).youControl(),
+                GameObjectFilter.Permanent.withSubtype(Subtype.GOBLIN).youControl(),
                 excludeSelf = true,
             ),
         )

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DionBahamutsDominant.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DionBahamutsDominant.kt
@@ -126,7 +126,7 @@ private val DionBahamutsDominantFront = card("Dion, Bahamut's Dominant") {
         ability = GrantKeyword(
             Keyword.FLYING,
             GroupFilter(
-                GameObjectFilter.Creature.withSubtype("Knight").youControl(),
+                GameObjectFilter.Permanent.withSubtype("Knight").youControl(),
                 excludeSelf = true,
             ),
         )

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/DoctorOctopusMasterPlanner.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/DoctorOctopusMasterPlanner.kt
@@ -40,7 +40,7 @@ val DoctorOctopusMasterPlanner = card("Doctor Octopus, Master Planner") {
             powerBonus = 2,
             toughnessBonus = 2,
             filter = GroupFilter(
-                GameObjectFilter.Creature.withSubtype("Villain").youControl(),
+                GameObjectFilter.Permanent.withSubtype("Villain").youControl(),
                 excludeSelf = true,
             ),
         )

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SpiderPunk.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SpiderPunk.kt
@@ -49,7 +49,7 @@ val SpiderPunk = card("Spider-Punk") {
     staticAbility {
         ability = GrantKeyword(
             Keyword.RIOT,
-            GroupFilter(GameObjectFilter.Creature.withSubtype("Spider").youControl(), excludeSelf = true),
+            GroupFilter(GameObjectFilter.Permanent.withSubtype("Spider").youControl(), excludeSelf = true),
         )
     }
 

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/WallCrawl.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/WallCrawl.kt
@@ -65,7 +65,7 @@ val WallCrawl = card("Wall Crawl") {
         ability = ModifyStats(
             powerBonus = 1,
             toughnessBonus = 1,
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SPIDER).youControl())
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.SPIDER).youControl())
         )
     }
 
@@ -73,7 +73,7 @@ val WallCrawl = card("Wall Crawl") {
     staticAbility {
         ability = CantBeBlockedBy(
             blockerFilter = GameObjectFilter.Creature.withKeyword(Keyword.DEFENDER),
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SPIDER).youControl())
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.SPIDER).youControl())
         )
     }
 

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/ChampionOfTheClachan.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/ChampionOfTheClachan.kt
@@ -44,7 +44,7 @@ val ChampionOfTheClachan = card("Champion of the Clachan") {
             powerBonus = 1,
             toughnessBonus = 1,
             filter = GroupFilter(
-                GameObjectFilter.Creature.withSubtype("Kithkin").youControl(),
+                GameObjectFilter.Permanent.withSubtype("Kithkin").youControl(),
                 excludeSelf = true
             )
         )

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/DeepchannelDuelist.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/DeepchannelDuelist.kt
@@ -39,7 +39,7 @@ val DeepchannelDuelist = card("Deepchannel Duelist") {
         ability = ModifyStats(
             powerBonus = 1,
             toughnessBonus = 1,
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype("Merfolk").youControl(), excludeSelf = true)
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype("Merfolk").youControl(), excludeSelf = true)
         )
     }
 

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/DeepwayNavigator.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/DeepwayNavigator.kt
@@ -37,7 +37,7 @@ val DeepwayNavigator = card("Deepway Navigator") {
         trigger = Triggers.EntersBattlefield
         effect = Patterns.Group.untapGroup(
             filter = GroupFilter(
-                GameObjectFilter.Creature.youControl().withSubtype("Merfolk"),
+                GameObjectFilter.Permanent.youControl().withSubtype("Merfolk"),
                 excludeSelf = true
             )
         )
@@ -48,7 +48,7 @@ val DeepwayNavigator = card("Deepway Navigator") {
             ability = ModifyStats(
                 powerBonus = 1,
                 toughnessBonus = 0,
-                filter = GroupFilter(GameObjectFilter.Creature.withSubtype("Merfolk").youControl())
+                filter = GroupFilter(GameObjectFilter.Permanent.withSubtype("Merfolk").youControl())
             ),
             condition = Conditions.YouAttackedWithCreaturesThisTurn(
                 filter = GameObjectFilter.Creature.withSubtype("Merfolk").youControl(),

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/MorcantsLoyalist.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ecl/cards/MorcantsLoyalist.kt
@@ -34,7 +34,7 @@ val MorcantsLoyalist = card("Morcant's Loyalist") {
             powerBonus = 1,
             toughnessBonus = 1,
             filter = GroupFilter(
-                GameObjectFilter.Creature.withSubtype("Elf").youControl(),
+                GameObjectFilter.Permanent.withSubtype("Elf").youControl(),
                 excludeSelf = true
             )
         )

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BeornTheFierce.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BeornTheFierce.kt
@@ -60,7 +60,7 @@ val BeornTheFierce = card("Beorn the Fierce") {
             powerBonus = 2,
             toughnessBonus = 2,
             filter = GroupFilter(
-                GameObjectFilter.Creature.withSubtype(Subtype.BEAR).youControl(),
+                GameObjectFilter.Permanent.withSubtype(Subtype.BEAR).youControl(),
                 excludeSelf = true
             )
         )

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThranduilSindarinLiege.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThranduilSindarinLiege.kt
@@ -58,7 +58,7 @@ val ThranduilSindarinLiege = card("Thranduil, Sindarin Liege") {
             powerBonus = 1,
             toughnessBonus = 1,
             filter = GroupFilter(
-                GameObjectFilter.Creature.withSubtype(Subtype.ELF).youControl(),
+                GameObjectFilter.Permanent.withSubtype(Subtype.ELF).youControl(),
                 excludeSelf = true
             )
         )

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/AttumaAtlanteanWarlord.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/AttumaAtlanteanWarlord.kt
@@ -35,7 +35,7 @@ val AttumaAtlanteanWarlord = card("Attuma, Atlantean Warlord") {
             powerBonus = 1,
             toughnessBonus = 1,
             filter = GroupFilter(
-                GameObjectFilter.Creature.withSubtype("Merfolk").youControl(),
+                GameObjectFilter.Permanent.withSubtype("Merfolk").youControl(),
                 excludeSelf = true
             )
         )

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/AvengersAssemble.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/AvengersAssemble.kt
@@ -57,7 +57,7 @@ val AvengersAssemble = card("Avengers Assemble!") {
         ability = ModifyStats(
             powerBonus = 2,
             toughnessBonus = 2,
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.HERO).youControl()),
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.HERO).youControl()),
         )
     }
 

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/CaptainAmericaSuperSoldier.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/CaptainAmericaSuperSoldier.kt
@@ -73,7 +73,7 @@ val CaptainAmericaSuperSoldier = card("Captain America, Super-Soldier") {
             ability = GrantKeyword(
                 Keyword.HEXPROOF,
                 GroupFilter(
-                    GameObjectFilter.Creature.withSubtype(Subtype.HERO).youControl(),
+                    GameObjectFilter.Permanent.withSubtype(Subtype.HERO).youControl(),
                     excludeSelf = true,
                 ),
             ),

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/TheMastersOfEvil.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/TheMastersOfEvil.kt
@@ -42,7 +42,7 @@ val TheMastersOfEvil = card("The Masters of Evil") {
             powerBonus = 2,
             toughnessBonus = 1,
             filter = GroupFilter(
-                GameObjectFilter.Creature.withSubtype(Subtype.VILLAIN).youControl(),
+                GameObjectFilter.Permanent.withSubtype(Subtype.VILLAIN).youControl(),
                 excludeSelf = true
             )
         )

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DarkLeoAndShredder.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DarkLeoAndShredder.kt
@@ -49,7 +49,7 @@ val DarkLeoAndShredder = card("Dark Leo & Shredder") {
     staticAbility {
         ability = GrantKeyword(
             Keyword.DEATHTOUCH,
-            GroupFilter(GameObjectFilter.Creature.withSubtype("Ninja").youControl()).attacking()
+            GroupFilter(GameObjectFilter.Permanent.withSubtype("Ninja").youControl()).attacking()
         )
     }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/AKH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AKH.json
@@ -698,7 +698,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Cat ctrl:you",
+                    "baseFilter": "permanent Cat ctrl:you",
                     "excludeSelf": true
                 }
             },
@@ -706,7 +706,7 @@
                 "type": "GrantKeyword",
                 "keyword": "LIFELINK",
                 "filter": {
-                    "baseFilter": "creature Cat ctrl:you",
+                    "baseFilter": "permanent Cat ctrl:you",
                     "excludeSelf": true
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -2744,7 +2744,7 @@
                     "space": {
                         "type": "IterationSpace.Group",
                         "filter": {
-                            "baseFilter": "creature Squirrel ctrl:you",
+                            "baseFilter": "permanent Squirrel ctrl:you",
                             "excludeSelf": true
                         }
                     },
@@ -2762,7 +2762,7 @@
                 "type": "GrantKeyword",
                 "keyword": "MENACE",
                 "filter": {
-                    "baseFilter": "creature Squirrel ctrl:you",
+                    "baseFilter": "permanent Squirrel ctrl:you",
                     "excludeSelf": true
                 }
             }
@@ -11443,7 +11443,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Mouse ctrl:you",
+                    "baseFilter": "permanent Mouse ctrl:you",
                     "excludeSelf": true
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/CHK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CHK.json
@@ -1456,7 +1456,7 @@
                             "type": "CostAtomWrapper",
                             "atom": {
                                 "type": "AtomSacrifice",
-                                "filter": "creature Rat"
+                                "filter": "permanent Rat"
                             }
                         }
                     ]
@@ -1484,7 +1484,7 @@
                 "type": "GrantKeyword",
                 "keyword": "FEAR",
                 "filter": {
-                    "baseFilter": "creature Rat"
+                    "baseFilter": "permanent Rat"
                 }
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -3871,7 +3871,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Zombie ctrl:you"
+                    "baseFilter": "permanent Zombie ctrl:you"
                 }
             }
         ]
@@ -8428,7 +8428,7 @@
                 "type": "GrantKeyword",
                 "keyword": "HASTE",
                 "filter": {
-                    "baseFilter": "creature Goblin ctrl:you",
+                    "baseFilter": "permanent Goblin ctrl:you",
                     "excludeSelf": true
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/ECL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ECL.json
@@ -3324,7 +3324,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Kithkin ctrl:you",
+                    "baseFilter": "permanent Kithkin ctrl:you",
                     "excludeSelf": true
                 }
             }
@@ -5041,7 +5041,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Merfolk ctrl:you",
+                    "baseFilter": "permanent Merfolk ctrl:you",
                     "excludeSelf": true
                 }
             }
@@ -5086,7 +5086,7 @@
                     "space": {
                         "type": "IterationSpace.Group",
                         "filter": {
-                            "baseFilter": "creature Merfolk ctrl:you",
+                            "baseFilter": "permanent Merfolk ctrl:you",
                             "excludeSelf": true
                         }
                     },
@@ -5106,7 +5106,7 @@
                     "powerBonus": 1,
                     "toughnessBonus": 0,
                     "filter": {
-                        "baseFilter": "creature Merfolk ctrl:you"
+                        "baseFilter": "permanent Merfolk ctrl:you"
                     }
                 },
                 "condition": {
@@ -12599,7 +12599,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Elf ctrl:you",
+                    "baseFilter": "permanent Elf ctrl:you",
                     "excludeSelf": true
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -2758,7 +2758,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Goblin ctrl:you",
+                    "baseFilter": "permanent Goblin ctrl:you",
                     "excludeSelf": true
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -5248,7 +5248,7 @@
                     "type": "GrantKeyword",
                     "keyword": "FLYING",
                     "filter": {
-                        "baseFilter": "creature Knight ctrl:you",
+                        "baseFilter": "permanent Knight ctrl:you",
                         "excludeSelf": true
                     }
                 },

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -1004,7 +1004,7 @@
                 "powerBonus": 2,
                 "toughnessBonus": 2,
                 "filter": {
-                    "baseFilter": "creature Bear ctrl:you",
+                    "baseFilter": "permanent Bear ctrl:you",
                     "excludeSelf": true
                 }
             }
@@ -13257,7 +13257,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Elf ctrl:you",
+                    "baseFilter": "permanent Elf ctrl:you",
                     "excludeSelf": true
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -3478,7 +3478,7 @@
                     "type": "GrantKeyword",
                     "keyword": "MENACE",
                     "filter": {
-                        "baseFilter": "creature Werewolf ctrl:you"
+                        "baseFilter": "permanent Werewolf ctrl:you"
                     }
                 }
             ]

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -4250,14 +4250,14 @@
                 "powerBonus": 1,
                 "toughnessBonus": 0,
                 "filter": {
-                    "baseFilter": "creature Skeleton ctrl:you"
+                    "baseFilter": "permanent Skeleton ctrl:you"
                 }
             },
             {
                 "type": "GrantKeyword",
                 "keyword": "HASTE",
                 "filter": {
-                    "baseFilter": "creature Skeleton ctrl:you"
+                    "baseFilter": "permanent Skeleton ctrl:you"
                 }
             }
         ]
@@ -13242,7 +13242,7 @@
                 "type": "GrantKeyword",
                 "keyword": "HASTE",
                 "filter": {
-                    "baseFilter": "creature Dinosaur ctrl:you",
+                    "baseFilter": "permanent Dinosaur ctrl:you",
                     "excludeSelf": true
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/LEA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LEA.json
@@ -1600,7 +1600,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Goblin",
+                    "baseFilter": "permanent Goblin",
                     "excludeSelf": true
                 }
             },
@@ -1608,7 +1608,7 @@
                 "type": "GrantKeyword",
                 "keyword": "MOUNTAINWALK",
                 "filter": {
-                    "baseFilter": "creature Goblin",
+                    "baseFilter": "permanent Goblin",
                     "excludeSelf": true
                 }
             }
@@ -2608,7 +2608,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Merfolk",
+                    "baseFilter": "permanent Merfolk",
                     "excludeSelf": true
                 }
             },
@@ -2616,7 +2616,7 @@
                 "type": "GrantKeyword",
                 "keyword": "ISLANDWALK",
                 "filter": {
-                    "baseFilter": "creature Merfolk",
+                    "baseFilter": "permanent Merfolk",
                     "excludeSelf": true
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -2306,7 +2306,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Elf ctrl:you",
+                    "baseFilter": "permanent Elf ctrl:you",
                     "excludeSelf": true
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -15697,7 +15697,7 @@
                 "type": "GrantKeyword",
                 "keyword": "HASTE",
                 "filter": {
-                    "baseFilter": "creature Horse ctrl:you"
+                    "baseFilter": "permanent Horse ctrl:you"
                 }
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -16887,7 +16887,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Detective ctrl:you",
+                    "baseFilter": "permanent Detective ctrl:you",
                     "excludeSelf": true
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/MSH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MSH.json
@@ -1454,7 +1454,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Merfolk ctrl:you",
+                    "baseFilter": "permanent Merfolk ctrl:you",
                     "excludeSelf": true
                 }
             }
@@ -1532,7 +1532,7 @@
                 "powerBonus": 2,
                 "toughnessBonus": 2,
                 "filter": {
-                    "baseFilter": "creature Hero ctrl:you"
+                    "baseFilter": "permanent Hero ctrl:you"
                 }
             }
         ]
@@ -3432,7 +3432,7 @@
                     "type": "GrantKeyword",
                     "keyword": "HEXPROOF",
                     "filter": {
-                        "baseFilter": "creature Hero ctrl:you",
+                        "baseFilter": "permanent Hero ctrl:you",
                         "excludeSelf": true
                     }
                 },
@@ -17720,7 +17720,7 @@
                 "powerBonus": 2,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Villain ctrl:you",
+                    "baseFilter": "permanent Villain ctrl:you",
                     "excludeSelf": true
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -2877,7 +2877,7 @@
                 "type": "GrantKeyword",
                 "keyword": "DOUBLE_STRIKE",
                 "filter": {
-                    "baseFilter": "creature Ox ctrl:you"
+                    "baseFilter": "permanent Ox ctrl:you"
                 }
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/SCG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SCG.json
@@ -4086,7 +4086,7 @@
                 "type": "GrantKeyword",
                 "keyword": "HASTE",
                 "filter": {
-                    "baseFilter": "creature Goblin"
+                    "baseFilter": "permanent Goblin ctrl:you"
                 }
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -1978,7 +1978,7 @@
                 "powerBonus": 2,
                 "toughnessBonus": 2,
                 "filter": {
-                    "baseFilter": "creature Villain ctrl:you",
+                    "baseFilter": "permanent Villain ctrl:you",
                     "excludeSelf": true
                 }
             },
@@ -10422,7 +10422,7 @@
                 "type": "GrantKeyword",
                 "keyword": "RIOT",
                 "filter": {
-                    "baseFilter": "creature Spider ctrl:you",
+                    "baseFilter": "permanent Spider ctrl:you",
                     "excludeSelf": true
                 }
             },
@@ -13607,7 +13607,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Spider ctrl:you"
+                    "baseFilter": "permanent Spider ctrl:you"
                 }
             },
             {
@@ -13622,7 +13622,7 @@
                     ]
                 },
                 "filter": {
-                    "baseFilter": "creature Spider ctrl:you"
+                    "baseFilter": "permanent Spider ctrl:you"
                 }
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -1723,7 +1723,7 @@
                 "type": "GrantKeyword",
                 "keyword": "DEATHTOUCH",
                 "filter": {
-                    "baseFilter": "creature Ninja attacking ctrl:you"
+                    "baseFilter": "permanent Ninja attacking ctrl:you"
                 }
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -5086,7 +5086,7 @@
                 "type": "GrantKeyword",
                 "keyword": "FLYING",
                 "filter": {
-                    "baseFilter": "creature Zombie ctrl:you"
+                    "baseFilter": "permanent Zombie ctrl:you"
                 }
             }
         ]

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/cli/Main.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/cli/Main.kt
@@ -258,6 +258,7 @@ private fun compile(flags: Flags): Int {
         is CompileResult.Compiled -> {
             println(CardSerialization.json.encodeToString(CardDefinition.serializer(), result.definition))
             result.warnings.forEach { System.err.println("warning: $it") }
+            printingProvenanceNote(result.definition)
             0
         }
 
@@ -270,6 +271,31 @@ private fun compile(flags: Flags): Int {
             1
         }
     }
+}
+
+
+/**
+ * `setCode` and `metadata.imageUri` are *provenance*, not placement.
+ *
+ * The compiler reads whichever printing the Oracle bulk happened to carry for a name, so a card
+ * whose canonical belongs in Morningtide can compile tagged `CMR`. Authors reading the JSON as a
+ * spec have repeatedly taken those two fields for an instruction about where the card goes — on
+ * one 73-card sweep every reviewer flagged it independently. The model is authoritative; these two
+ * fields are not, so say so next to the output rather than in a doc nobody has open.
+ *
+ * Written to stderr on purpose: stdout stays pure JSON, because the documented way to compile a
+ * batch is a shell loop redirecting stdout per card.
+ */
+private fun printingProvenanceNote(definition: CardDefinition) {
+    val setCode = definition.setCode?.takeIf { it.isNotBlank() } ?: return
+    System.err.println(
+        "note: setCode \"$setCode\"" + (if (definition.metadata.imageUri != null) " and metadata.imageUri" else "") +
+            " describe the printing the Oracle bulk carried, NOT where this card's canonical belongs."
+    )
+    System.err.println(
+        "      Place the canonical in the card's earliest real printing, and take rarity / " +
+            "collectorNumber / artist / imageUri from that set's own Scryfall payload."
+    )
 }
 
 /**

--- a/scripts/generate-reprints.py
+++ b/scripts/generate-reprints.py
@@ -21,8 +21,24 @@ first to populate the cache). Files that already exist are left untouched.
 
 Usage:
   scripts/generate-reprints.py            # generate all; print a summary
-  scripts/generate-reprints.py --set DMU  # only the given target set
+  scripts/generate-reprints.py --set DMU  # only rows written *into* DMU
   scripts/generate-reprints.py --dry-run  # report what would be written
+
+Scoping a sweep to its own work
+-------------------------------
+`--set` filters the *target* set a row is written into; it does not limit which
+canonicals are considered. A bare run therefore also emits every pre-existing
+reprint gap in the corpus — an Assay-ready sweep of one set once found itself
+holding 333 rows across 53 sets when only 94 belonged to the batch.
+
+To generate only the rows owed by the canonicals *you* just authored:
+
+  scripts/generate-reprints.py --cards-from names.txt   # one card name per line
+  scripts/generate-reprints.py --card "Sift" --card "Isolate"
+  scripts/generate-reprints.py --since main             # canonicals added vs a git ref
+
+`--since` reads the working tree, not just commits, so it works mid-sweep while
+the new card files are still uncommitted or untracked.
 """
 
 from __future__ import annotations
@@ -225,12 +241,72 @@ def render(name: str, set_code: str, p: dict, set_entry: dict | None, pkg_dir: s
     return "\n".join(lines)
 
 
+
+def canonical_names_since(ref: str) -> set[str]:
+    """Card names whose canonical `card("...")` lives in a file that differs from `ref`.
+
+    Reads the *working tree*, not just committed history: a sweep runs this while its new
+    card files are still uncommitted, and often untracked. Tracked-but-modified files come
+    from `git diff --name-only <ref>`, brand-new ones from `git ls-files --others`.
+    """
+    import subprocess
+
+    def git(*a: str) -> list[str]:
+        out = subprocess.run(
+            ["git", *a], cwd=REPO_ROOT, capture_output=True, text=True, check=True
+        ).stdout
+        return [ln for ln in out.splitlines() if ln.strip()]
+
+    try:
+        paths = set(git("diff", "--name-only", ref))
+        paths |= set(git("ls-files", "--others", "--exclude-standard"))
+    except subprocess.CalledProcessError as exc:
+        sys.exit(f"--since {ref!r}: git failed ({exc.stderr.strip() or exc})")
+
+    names: set[str] = set()
+    for rel in paths:
+        if "/definitions/" not in rel or not rel.endswith(".kt"):
+            continue
+        path = REPO_ROOT / rel
+        if not path.is_file():
+            continue  # deleted in the working tree
+        text = path.read_text(encoding="utf-8")
+        names |= {unescape_kotlin(m.group(1)) for m in CARD_DSL_RE.finditer(text)}
+    return names
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--set", help="only generate reprints for this target set code")
+    ap.add_argument("--set", help="only write rows INTO this target set code "
+                                  "(does not limit which canonicals are considered)")
+    ap.add_argument("--card", action="append", metavar="NAME", default=[],
+                    help="only rows owed by this canonical; repeatable")
+    ap.add_argument("--cards-from", metavar="FILE",
+                    help="only rows owed by the canonicals named in FILE, one per line "
+                         "(blank lines and #-comments ignored)")
+    ap.add_argument("--since", metavar="REF",
+                    help="only rows owed by canonicals whose file differs from REF in the "
+                         "working tree (includes untracked files, so it works mid-sweep)")
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
     only = args.set.lower() if args.set else None
+
+    # Which canonicals to consider. Empty set == no restriction (the historical behaviour).
+    wanted: set[str] = set(args.card)
+    if args.cards_from:
+        path = Path(args.cards_from)
+        if not path.is_file():
+            sys.exit(f"--cards-from: no such file: {path}")
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                wanted.add(line)
+    if args.since:
+        wanted |= canonical_names_since(args.since)
+    scoped = bool(args.card or args.cards_from or args.since)
+    if scoped and not wanted:
+        print("no canonicals matched the scope — nothing to do")
+        return 0
 
     scaffolded = scaffolded_set_codes()
     dir_for = dir_for_codes()
@@ -243,6 +319,8 @@ def main() -> int:
     by_set: dict[str, int] = defaultdict(int)
 
     for name in sorted(canonical):
+        if scoped and name not in wanted:
+            continue
         printings = load_card_printings(name)
         if printings is None:
             # No per-card cache, or one past the 30-day TTL. Counted and named rather than skipped
@@ -286,6 +364,14 @@ def main() -> int:
             written += 1
             by_set[sc] += 1
 
+    if scoped:
+        considered = sum(1 for n in canonical if n in wanted)
+        print(f"scoped to {len(wanted)} canonical name(s); {considered} of them are "
+              f"implemented in this checkout")
+        unknown = sorted(n for n in wanted if n not in canonical)
+        if unknown:
+            shown = ", ".join(unknown[:8]) + (" …" if len(unknown) > 8 else "")
+            print(f"NOTE: {len(unknown)} requested name(s) have no canonical here: {shown}")
     print(f"{'(dry-run) would write' if args.dry_run else 'wrote'} {written} reprint files "
           f"across {len(by_set)} sets")
     print(f"skipped: {skipped_exists} already exist, {skipped_nocache} missing ids in cache")


### PR DESCRIPTION
Follow-ups to #2026, which reported these but did not fix them.

## 1. `generate-reprints.py` had no change-scoping

`--set` filters the set a row is written *into*, not which canonicals are considered, so a bare run emits every pre-existing reprint gap in the corpus. M19's sweep was offered **333 rows across 53 sets when only 94 were its own**; the other 239 had to be filtered out by hand afterwards.

Adds three ways to scope the run:

```
--card "<Name>"        repeatable
--cards-from <file>    one name per line, # comments ignored
--since <git-ref>      canonicals whose file differs from the ref
```

`--since` reads the **working tree** and includes untracked files, because a sweep runs this while its new card files are still uncommitted. Measured on the M19 branch: unscoped wanted 248 rows, `--since origin/main` wanted 1.

Fail-loud rather than fail-open, per the house rule for sync tools: the run prints the scope it resolved, **names** any requested card with no canonical in the checkout instead of dropping it silently, and an empty scope exits 0 rather than falling back to generating everything.

This immediately found a real row: merging main mid-sweep scaffolded DDF, which turned Mighty Leap's DDF printing into a row that was owed. Included here; `check-card-printing "Mighty Leap"` passes.

## 2. `assay compile`'s `setCode` / `imageUri` read as a placement instruction

They are **provenance** — whichever printing the Oracle bulk happened to carry — so a card whose canonical belongs in Morningtide compiles tagged `CMR`. All nine authoring agents on the M19 sweep flagged this independently, which is the signal that the output is misleading rather than that the readers were careless.

`compile` now says so on stderr after each card. stdout stays pure JSON, because the documented way to compile a batch is a shell loop redirecting stdout per card:

```
note: setCode "MSC" and metadata.imageUri describe the printing the Oracle bulk carried,
      NOT where this card's canonical belongs.
      Place the canonical in the card's earliest real printing, and take rarity /
      collectorNumber / artist / imageUri from that set's own Scryfall payload.
```

The `assay-ready-sweep` skill is updated for both of the above — including the note that an agent reading only the JSON file never sees the stderr line, so a fan-out brief must still carry the rule.

## 3. A bare tribal noun is permanents, not creatures — 33 files

"Other Goblins you control get +1/+1" applies to a Goblin artifact too; only "&lt;Tribe&gt; **creatures**" narrows to creatures. Assay already reads it that way — `compile "Goblin Trashmaster"` emits `IsPermanent + HasSubtype` — so every card spelling a bare noun as `Creature.withSubtype` is a latent differential divergence.

The corpus was split almost exactly evenly: **20 wrong against 21 right** across tribal `ModifyStats` lords, plus 13 more in static `GrantKeyword` lords. `DropkickBomber` (the card #2026 named) turned out to be representative, not an outlier.

All 41 sites were judged individually against the card's own printed line rather than swept with a find-and-replace. Deliberately **left** on `Creature`:

- **targeting restrictions** (`TargetCreature` / `TargetFilter`) — Dropkick Bomber's "another target Goblin you control", Private Eye's "target Detective can't be blocked";
- **count and turn-history expressions** (`DynamicAmount`, `YouAttackedWith…`) — Wall Crawl's "for each Spider", Beorn's "three or more Bears";
- lines that genuinely print "&lt;Tribe&gt; creatures" (28 files cleared on cross-check, e.g. Bloodline Keeper's back face "Other **Vampire creatures** you control get +2/+2").

### Live bug fixed next door

**Goblin Warchief** granted haste through `GroupFilter(Permanent.withSubtype("Goblin"))` with **no controller predicate**, so it hasted *opponents'* Goblins. The printed line is "Goblins **you control** have haste". `GroupFilter`'s `baseFilter` carries no implicit controller predicate, and every other lord in the batch spells `.youControl()`.

## Gates

- `just build` — green
- snapshots re-blessed across the 20 affected sets; delta is exactly `creature <Tribe>` → `permanent <Tribe>` plus Goblin Warchief's `ctrl:you`, and `CardDefinitionSnapshotTest` re-run with `--rerun-tasks` against this base
- `just assay-differential` — **49 divergent before and after**, no regressions

## Not fixed here — needs its own PR

The fourth finding, `EpicProportions` vs `MythicProportions`, turned out to be **a 184-card family, not a 3-card cleanup**, so it is deliberately out of scope.

CR 613.6 says one printed line granting both a P/T change (layer 7c) and a keyword (layer 6) is *one* effect whose affected set locks across layers — so `CompositeStaticAbility` is correct and a flat pair loses the P/T half if the ability is removed mid-sequence. But composite is currently the **5-card minority (2.7%)**, and Assay's grammar actively canonicalises the flat form at `Statics.kt:764` and `Statics.kt:523` with a KDoc arguing against a compound type.

Agreed scope for the follow-up: **only the 22 group anthems**, where the affected set can genuinely drift between layers. The 129 Aura/Equipment cases keep flat — their affected set is a single fixed attachment that cannot drift, so 613.6 locking is unobservable there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)