### PR TITLE
Import a pasted decklist's sideboard, and carry it into the game

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/deck/SideboardSanitizer.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/deck/SideboardSanitizer.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.gameserver.deck
+
+import com.wingedsheep.engine.registry.CardRegistry
+
+/**
+ * Drops sideboard entries the card registry doesn't know, at the server boundary.
+ *
+ * A submitted *deck* is validated and rejected outright when it names a card this engine hasn't
+ * implemented. A sideboard isn't: it lives "outside the game" (CR 100.4a) and reaches
+ * `GameInitializer` unchecked, where `cardRegistry.requireCard` throws on the first unknown name —
+ * so a single unimplemented sideboard card would fail game *initialization*, taking down a lobby
+ * whose decks were all perfectly legal.
+ *
+ * Rejecting the submission instead would be worse: real decklists are pasted from Arena or
+ * Moxfield with full 15-card sideboards, and one card the corpus hasn't reached yet would lock the
+ * player out of a game they could otherwise play. So unknown names are dropped and reported to the
+ * caller for logging — a wish simply won't find them, which is the truth of it.
+ *
+ * Non-positive counts are dropped too; they can't produce a card and would otherwise sit in the
+ * lobby state as noise.
+ */
+object SideboardSanitizer {
+
+    /**
+     * @param kept entries the registry can resolve, safe to hand to the engine
+     * @param dropped names that were discarded, for the caller's log line
+     */
+    data class Result(val kept: Map<String, Int>, val dropped: List<String>) {
+        val hasDrops: Boolean get() = dropped.isNotEmpty()
+    }
+
+    fun sanitize(sideboard: Map<String, Int>, registry: CardRegistry): Result {
+        if (sideboard.isEmpty()) return Result(emptyMap(), emptyList())
+        val kept = LinkedHashMap<String, Int>(sideboard.size)
+        val dropped = mutableListOf<String>()
+        for ((name, count) in sideboard) {
+            when {
+                count <= 0 -> Unit
+                registry.hasCard(name) -> kept[name] = count
+                else -> dropped += name
+            }
+        }
+        return Result(kept, dropped)
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/deck/SideboardSanitizer.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/deck/SideboardSanitizer.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.engine.registry.CardRegistry
  * Drops sideboard entries the card registry doesn't know, at the server boundary.
  *
  * A submitted *deck* is validated and rejected outright when it names a card this engine hasn't
- * implemented. A sideboard isn't: it lives "outside the game" (CR 100.4a) and reaches
+ * implemented. A sideboard isn't: it lives "outside the game" (CR 400.11a) and reaches
  * `GameInitializer` unchecked, where `cardRegistry.requireCard` throws on the first unknown name —
  * so a single unimplemented sideboard card would fail game *initialization*, taking down a lobby
  * whose decks were all perfectly legal.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.gameserver.handler
 
 import com.wingedsheep.gameserver.ai.AiGameManager
 import com.wingedsheep.gameserver.ai.AiWebSocketSession
+import com.wingedsheep.gameserver.deck.SideboardSanitizer
 import com.wingedsheep.ai.engine.SealedDeckGenerator
 import com.wingedsheep.gameserver.protocol.ClientMessage
 import com.wingedsheep.gameserver.protocol.ErrorCode
@@ -51,6 +52,21 @@ class GamePlayHandler(
     private val deckProfiler: com.wingedsheep.gameserver.stats.DeckProfiler
 ) {
     private val logger = LoggerFactory.getLogger(GamePlayHandler::class.java)
+
+    /**
+     * Drop sideboard cards this engine hasn't implemented before they reach the engine, which
+     * would throw on the first one and fail the whole game start. See [SideboardSanitizer] for
+     * why unknown names are dropped rather than the submission rejected.
+     */
+    private fun sanitizeSideboard(sideboard: Map<String, Int>?, playerName: String): Map<String, Int> =
+        SideboardSanitizer.sanitize(sideboard.orEmpty(), cardRegistry).also { result ->
+            if (result.hasDrops) {
+                logger.info(
+                    "Dropped ${result.dropped.size} unknown sideboard card(s) from $playerName's " +
+                        "submission: ${result.dropped}",
+                )
+            }
+        }.kept
 
     @Volatile
     var waitingGameSession: GameSession? = null
@@ -138,7 +154,13 @@ class GamePlayHandler(
         )
         gameSession.quickGameSetCode = quickGameSetCode
         // A generated random/quick deck has no sideboard; only a real submitted deck carries one.
-        val sideboard = if (quickGameSetCode != null) emptyMap() else message.sideboard
+        // Sanitize whatever the client sent: an unimplemented name would throw out of
+        // GameInitializer and fail the game creation outright (see SideboardSanitizer).
+        val sideboard = if (quickGameSetCode != null) {
+            emptyMap()
+        } else {
+            sanitizeSideboard(message.sideboard, playerSession.playerName)
+        }
         gameSession.addPlayer(playerSession, deckList, sideboard = sideboard)
 
         // Store player info for persistence
@@ -279,7 +301,11 @@ class GamePlayHandler(
         )
 
         // A generated random deck (empty submission) has no sideboard.
-        val sideboard = if (message.deckList.isEmpty()) emptyMap() else message.sideboard
+        val sideboard = if (message.deckList.isEmpty()) {
+            emptyMap()
+        } else {
+            sanitizeSideboard(message.sideboard, playerSession.playerName)
+        }
         gameSession.addPlayer(playerSession, deckList, sideboard = sideboard)
 
         // Store player info for persistence

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -23,6 +23,7 @@ import com.wingedsheep.gameserver.session.GameSession
 import com.wingedsheep.gameserver.config.GameProperties
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.gameserver.deck.DeckValidator
+import com.wingedsheep.gameserver.deck.SideboardSanitizer
 import com.wingedsheep.gameserver.deck.EasterEggDeckInjector
 import com.wingedsheep.gameserver.cube.CubeCardEntry
 import com.wingedsheep.gameserver.cube.CubeList
@@ -2759,9 +2760,21 @@ class LobbyHandler(
             }
         }
 
+        // Unknown card names are dropped before the sideboard is stored: it reaches the engine
+        // unvalidated (unlike the deck, which is rejected above), and GameInitializer throws on the
+        // first name the registry can't resolve — failing a game start whose decks were all legal.
+        val sanitizedSideboard = SideboardSanitizer.sanitize(sideboard, cardRegistry).also { result ->
+            if (result.hasDrops) {
+                logger.info(
+                    "Lobby $lobbyId: dropped ${result.dropped.size} unknown sideboard card(s) from " +
+                        "${identity.playerName}'s submission: ${result.dropped}",
+                )
+            }
+        }.kept
+
         // For a PREMADE_DECKS (constructed) lobby this explicit sideboard is honored; for Limited
         // lobbies TournamentLobby.submitDeck ignores it and derives pool − maindeck (CR 100.4b).
-        val result = lobby.submitDeck(identity.playerId, deckList, effectiveCommander, sideboard)
+        val result = lobby.submitDeck(identity.playerId, deckList, effectiveCommander, sanitizedSideboard)
         when (result) {
             is TournamentLobby.DeckSubmissionResult.Success -> {
                 val deckSize = deckList.values.sum()

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/QuickGameLobbyHandler.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.gameserver.ai.RandomDeckResolver
 import com.wingedsheep.gameserver.config.GameProperties
 import com.wingedsheep.gameserver.deck.DeckValidator
 import com.wingedsheep.gameserver.deck.EasterEggDeckInjector
+import com.wingedsheep.gameserver.deck.SideboardSanitizer
 import com.wingedsheep.gameserver.lobby.AiDeckSpec
 import com.wingedsheep.gameserver.lobby.AiDeckSpecView
 import com.wingedsheep.gameserver.lobby.MomirBasicSetup
@@ -502,14 +503,38 @@ class QuickGameLobbyHandler(
                 return
             }
         }
+
+        // A sideboard belongs to a submitted deck; for a random pool it is meaningless (a Limited
+        // sideboard is the pool minus the maindeck, derived at game start). Unknown card names are
+        // dropped here rather than at game start, where they would throw out of GameInitializer.
+        val sanitizedSideboard = if (message.deckList.isNotEmpty()) {
+            SideboardSanitizer.sanitize(message.sideboard.orEmpty(), cardRegistry).also { result ->
+                if (result.hasDrops) {
+                    logger.info(
+                        "Lobby ${lobby.lobbyId}: dropped ${result.dropped.size} unknown sideboard " +
+                            "card(s) from ${playerSession.playerName}'s submission: ${result.dropped}",
+                    )
+                }
+            }.kept
+        } else {
+            emptyMap()
+        }
+
         lobbyRepository.withLock(lobby.lobbyId) { current ->
             if (current == null) return@withLock
             val player = current.findPlayer(playerSession.playerId) ?: return@withLock
             // No-op if the same deck is being resubmitted: avoids ping-pong with the picker
             // (which can re-emit its current value on every render) and keeps the ready flag
-            // sticky as long as the player's chosen deck hasn't actually changed.
-            if (player.deckList == message.deckList && player.commander == message.commander) return@withLock
+            // sticky as long as the player's chosen deck hasn't actually changed. The sideboard is
+            // part of "the same deck" — editing only the sideboard still has to resubmit.
+            if (player.deckList == message.deckList &&
+                player.commander == message.commander &&
+                player.sideboard == sanitizedSideboard
+            ) {
+                return@withLock
+            }
             player.deckList = message.deckList
+            player.sideboard = sanitizedSideboard
             // For random-pool submissions the commander field is meaningless; drop it so a stale
             // commander from a prior submission doesn't leak into the game start.
             player.commander = if (message.deckList.isNotEmpty()) message.commander else null
@@ -708,7 +733,15 @@ class QuickGameLobbyHandler(
                 commander != null -> stripCommanderFromCards(deckList, commander)
                 else -> deckList
             }
-            gameSession.addPlayer(playerSession, engineDeckList, commanderCardName = commander)
+            // Momir Basic substitutes a fixed deck and has no sideboard; every other seat brings
+            // whatever it submitted (empty for a random pool).
+            val sideboard = if (lobby.momirBasic) emptyMap() else lobbyPlayer.sideboard
+            gameSession.addPlayer(
+                playerSession,
+                engineDeckList,
+                commanderCardName = commander,
+                sideboard = sideboard,
+            )
             // Persistence info so a mid-game reconnect can find the player by token.
             val token = sessionRegistry.getTokenByWsId(playerSession.webSocketSession.id)
             if (token != null) {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/QuickGameLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/QuickGameLobby.kt
@@ -165,7 +165,7 @@ data class QuickGameLobbyPlayer(
      */
     var commander: String? = null,
     /**
-     * Constructed sideboard ("outside the game", CR 100.4a), card name → count. Submitted
+     * Constructed sideboard ("outside the game", CR 400.11a), card name → count. Submitted
      * alongside the deck list and handed to the engine at game start, so wish effects have
      * something to fetch. Empty for a random pool and for Momir Basic, neither of which has a
      * constructed sideboard.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/QuickGameLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/QuickGameLobby.kt
@@ -164,4 +164,11 @@ data class QuickGameLobbyPlayer(
      * shape. Resubmitted by the client alongside the deck list.
      */
     var commander: String? = null,
+    /**
+     * Constructed sideboard ("outside the game", CR 100.4a), card name → count. Submitted
+     * alongside the deck list and handed to the engine at game start, so wish effects have
+     * something to fetch. Empty for a random pool and for Momir Basic, neither of which has a
+     * constructed sideboard.
+     */
+    var sideboard: Map<String, Int> = emptyMap(),
 )

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -597,7 +597,7 @@ sealed interface ClientMessage {
         /** Optional pinned printing for [commander]. Ignored when [commander] is null. */
         val commanderPrinting: PrintingRef? = null,
         /**
-         * Constructed sideboard ("outside the game", CR 100.4a), card name → count — the cards a
+         * Constructed sideboard ("outside the game", CR 400.11a), card name → count — the cards a
          * wish effect can fetch. Null / empty for a random pool, which has no constructed sideboard
          * (a Limited sideboard is derived from the pool instead; see `SideboardDerivation`).
          *

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -596,6 +596,14 @@ sealed interface ClientMessage {
         val cardEntries: List<DeckEntryDTO>? = null,
         /** Optional pinned printing for [commander]. Ignored when [commander] is null. */
         val commanderPrinting: PrintingRef? = null,
+        /**
+         * Constructed sideboard ("outside the game", CR 100.4a), card name → count — the cards a
+         * wish effect can fetch. Null / empty for a random pool, which has no constructed sideboard
+         * (a Limited sideboard is derived from the pool instead; see `SideboardDerivation`).
+         *
+         * Names the card registry doesn't know are dropped on arrival — see `SideboardSanitizer`.
+         */
+        val sideboard: Map<String, Int>? = null,
     ) : ClientMessage
 
     /** Toggle this player's ready flag. The server starts the game when both players are ready. */

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/deck/SideboardSanitizerTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/deck/SideboardSanitizerTest.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.gameserver.deck
+
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit tests for [SideboardSanitizer] — the guard that keeps an unimplemented sideboard card from
+ * reaching `GameInitializer`, where `CardRegistry.requireCard` would throw and fail the whole game
+ * start. A pasted Arena sideboard routinely names cards the corpus hasn't reached yet.
+ */
+class SideboardSanitizerTest : FunSpec({
+
+    val registry = CardRegistry().apply {
+        register(CardDefinition.sorcery("Lightning Bolt", ManaCost.parse("{R}"), ""))
+        register(CardDefinition.sorcery("Spell Pierce", ManaCost.parse("{U}"), ""))
+    }
+
+    test("keeps the cards the registry knows") {
+        val result = SideboardSanitizer.sanitize(
+            mapOf("Lightning Bolt" to 2, "Spell Pierce" to 1),
+            registry,
+        )
+        result.kept shouldBe mapOf("Lightning Bolt" to 2, "Spell Pierce" to 1)
+        result.dropped shouldBe emptyList()
+        result.hasDrops shouldBe false
+    }
+
+    test("drops unimplemented cards and reports them, keeping the rest") {
+        val result = SideboardSanitizer.sanitize(
+            mapOf("Lightning Bolt" to 2, "Iroh's Demonstration" to 1, "Octopus Form" to 1),
+            registry,
+        )
+        // The playable half survives — one unimplemented card must not cost the player the game.
+        result.kept shouldBe mapOf("Lightning Bolt" to 2)
+        result.dropped shouldBe listOf("Iroh's Demonstration", "Octopus Form")
+        result.hasDrops shouldBe true
+    }
+
+    test("drops non-positive counts, which can never produce a card") {
+        val result = SideboardSanitizer.sanitize(
+            mapOf("Lightning Bolt" to 0, "Spell Pierce" to -1),
+            registry,
+        )
+        result.kept shouldBe emptyMap()
+        // Not "dropped" in the reportable sense — the card exists, the count was empty.
+        result.dropped shouldBe emptyList()
+    }
+
+    test("an empty sideboard stays empty") {
+        val result = SideboardSanitizer.sanitize(emptyMap(), registry)
+        result.kept shouldBe emptyMap()
+        result.hasDrops shouldBe false
+    }
+})

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -328,6 +328,10 @@ export function DeckbuilderPage() {
       setDeckName(existing.name)
       setDeckCards(mergeCommanderIntoCards(existing.cards, existing.commander ?? null))
       setCommander(existing.commander ?? null)
+      // Without this a refresh (or a deep link to /deckbuilder/<id>) rehydrates the deck with an
+      // empty sideboard, and the next Save writes that emptiness back — `saveDeck` replaces the
+      // stored record wholesale rather than merging, so the sideboard is destroyed.
+      setSideboardCards(existing.sideboard ? { ...existing.sideboard } : {})
       setActiveDeckId(existing.id)
       setPinnedPrintings(pinnedPrintingsFromEntries(existing.entries))
       if (existing.format) {
@@ -1031,6 +1035,9 @@ export function DeckbuilderPage() {
     }
     setDeckCards({ ...ex.cards })
     setCommander(ex.commander ?? null)
+    // Examples carry no sideboard; clear rather than leave the previous deck's attached, which
+    // would follow the example into a save and into a game.
+    setSideboardCards({})
     setActiveDeckId(null)
     // Pre-fill pinned printings from the example. The commander's pin is keyed by name
     // alongside the rest — same shape `pinnedPrintingsFromEntries` produces on saved-deck

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -393,6 +393,9 @@ export function DeckbuilderPage() {
         setDeckName(shared.name || 'Shared deck')
         setDeckCards(mergeCommanderIntoCards(shared.cards, shared.commander ?? null))
         setCommander(shared.commander ?? null)
+        // Reset rather than leave in place: a deck loaded without one has no sideboard, and a
+        // stale board from the previously open deck would otherwise follow it.
+        setSideboardCards(shared.sideboard ? { ...shared.sideboard } : {})
         setActiveDeckId(null)
         const pins: Record<string, PrintingRef> = { ...(shared.printings ?? {}) }
         if (shared.commander && shared.commanderPrinting) pins[shared.commander] = shared.commanderPrinting
@@ -892,8 +895,10 @@ export function DeckbuilderPage() {
       ...(activeFormat ? { format: activeFormat } : {}),
       ...(designated ? { commander: designated } : {}),
       ...(commanderPrinting ? { commanderPrinting } : {}),
+      // Carried for the account save; the v2 share code has no field for it and drops it.
+      ...(Object.keys(sideboardCards).length > 0 ? { sideboard: sideboardCards } : {}),
     }
-  }, [isCommanderFormat, commander, deckCards, pinnedPrintings, deckName, activeFormat])
+  }, [isCommanderFormat, commander, deckCards, pinnedPrintings, deckName, activeFormat, sideboardCards])
 
   // Apply a SharedDeck into the builder (account load / deep link). Mirrors the share-URL decode
   // path: schedules format + commander in one transition so the "clear commander" guard never sees
@@ -914,6 +919,9 @@ export function DeckbuilderPage() {
         setDeckName(shared.name || 'Saved deck')
         setDeckCards(mergeCommanderIntoCards(shared.cards, shared.commander ?? null))
         setCommander(shared.commander ?? null)
+        // Reset rather than leave in place: a deck loaded without one has no sideboard, and a
+        // stale board from the previously open deck would otherwise follow it.
+        setSideboardCards(shared.sideboard ? { ...shared.sideboard } : {})
         setActiveDeckId(null)
         const pins: Record<string, PrintingRef> = { ...(shared.printings ?? {}) }
         if (shared.commander && shared.commanderPrinting) pins[shared.commander] = shared.commanderPrinting
@@ -1774,7 +1782,7 @@ function ImportPreview({
         </span>
         {parsed.sideboard.length > 0 && (
           <span className={styles.importMutedBadge}>
-            sideboard ignored ({parsed.sideboard.reduce((a, e) => a + e.count, 0)})
+            sideboard ({parsed.sideboard.reduce((a, e) => a + e.count, 0)})
           </span>
         )}
         {issueCount > 0 && <span className={styles.importBadBadge}>{issueCount} issue{issueCount === 1 ? '' : 's'}</span>}

--- a/web-client/src/components/deckbuilder/parseArenaDeck.ts
+++ b/web-client/src/components/deckbuilder/parseArenaDeck.ts
@@ -40,11 +40,22 @@ export interface ParseResult {
    */
   commander: ParsedEntry[]
   /**
-   * Lines that looked like card entries but couldn't be parsed. `section` records which
-   * board the line sat under, so a caller that rescues unparseable lines (the lobby's paste
-   * box tolerates a bare card name as one copy) can rescue them onto the right board.
+   * Lines that looked like card entries but couldn't be parsed.
+   *
+   * `raw` is the verbatim line, for showing the user what it couldn't read. `cleaned` is the
+   * same line with the `SB:` prefix and the Moxfield decorations (`*F*`, `#tag`) stripped —
+   * a caller that *rescues* an unparseable line (the lobby's paste box tolerates a bare card
+   * name as one copy) must read `cleaned`, or it will manufacture a card named
+   * `"SB: Counterspell"`. `section` records which board the line sat under, so the rescue
+   * lands on the right one.
    */
-  errors: Array<{ line: number; raw: string; reason: string; section: CardSection }>
+  errors: Array<{
+    line: number
+    raw: string
+    cleaned: string
+    reason: string
+    section: CardSection
+  }>
   /**
    * Deck name pulled from an Arena-style `Name <…>` line in the leading
    * `About` block, if present.
@@ -154,6 +165,7 @@ export function parseArenaDeckList(text: string): ParseResult {
       errors.push({
         line: i + 1,
         raw: trimmed,
+        cleaned,
         reason: 'unrecognised line format',
         section: targetSection,
       })
@@ -161,7 +173,13 @@ export function parseArenaDeckList(text: string): ParseResult {
     }
     const count = parseInt(match[1]!, 10)
     if (!Number.isFinite(count) || count <= 0) {
-      errors.push({ line: i + 1, raw: trimmed, reason: 'invalid card count', section: targetSection })
+      errors.push({
+        line: i + 1,
+        raw: trimmed,
+        cleaned,
+        reason: 'invalid card count',
+        section: targetSection,
+      })
       continue
     }
     const entry: ParsedEntry = {

--- a/web-client/src/components/deckbuilder/parseArenaDeck.ts
+++ b/web-client/src/components/deckbuilder/parseArenaDeck.ts
@@ -32,7 +32,7 @@ export interface ParsedEntry {
 export interface ParseResult {
   /** Main-deck entries, in source order. */
   entries: ParsedEntry[]
-  /** Sideboard entries — the constructed "outside the game" board (CR 100.4a). */
+  /** Sideboard entries — the constructed "outside the game" board (CR 400.11a). */
   sideboard: ParsedEntry[]
   /**
    * Commander entries — cards listed under a `Commander` / `Commanders` /

--- a/web-client/src/components/deckbuilder/parseArenaDeck.ts
+++ b/web-client/src/components/deckbuilder/parseArenaDeck.ts
@@ -11,8 +11,10 @@
  *
  * Section headers (case-insensitive) include `Deck` / `Mainboard` / `Main Deck`
  * / `Maindeck`, `Sideboard` / `Side` / `SB`, `Commander` / `Commanders` / `EDH`,
- * `Companion`, and `About` (the latter three are skipped — only the main deck
- * is imported). Blank lines and lines starting with `//` or `#` are ignored.
+ * `Companion`, and `About`. Main deck, sideboard, and commander are returned as
+ * separate lists; `Companion` and `About` are skipped (the latter only donates
+ * its `Name <…>` line). Blank lines and lines starting with `//` or `#` are
+ * ignored.
  */
 import type { CardSummary } from './cardFilter'
 
@@ -30,15 +32,19 @@ export interface ParsedEntry {
 export interface ParseResult {
   /** Main-deck entries, in source order. */
   entries: ParsedEntry[]
-  /** Sideboard entries (recognised but not imported into the working deck). */
+  /** Sideboard entries — the constructed "outside the game" board (CR 100.4a). */
   sideboard: ParsedEntry[]
   /**
    * Commander entries — cards listed under a `Commander` / `Commanders` /
    * `EDH` header. Most decks have exactly one; partner pairs etc. produce two.
    */
   commander: ParsedEntry[]
-  /** Lines that looked like card entries but couldn't be parsed. */
-  errors: Array<{ line: number; raw: string; reason: string }>
+  /**
+   * Lines that looked like card entries but couldn't be parsed. `section` records which
+   * board the line sat under, so a caller that rescues unparseable lines (the lobby's paste
+   * box tolerates a bare card name as one copy) can rescue them onto the right board.
+   */
+  errors: Array<{ line: number; raw: string; reason: string; section: CardSection }>
   /**
    * Deck name pulled from an Arena-style `Name <…>` line in the leading
    * `About` block, if present.
@@ -51,7 +57,10 @@ export interface ParseResult {
 // (`*F*`, `*A*`, `#tag`, trailing `*`) before this regex runs.
 const ENTRY_RE = /^(\d+)x?\s+(.+?)(?:\s+\(([A-Za-z0-9]{2,5})\)(?:\s+(\S+))?)?\s*$/
 
-type Section = 'main' | 'side' | 'commander' | 'ignore'
+/** A board a parsed entry can land on. */
+export type CardSection = 'main' | 'side' | 'commander'
+
+type Section = CardSection | 'ignore'
 
 const SECTION_HEADERS: Record<string, Section> = {
   deck: 'main',
@@ -142,12 +151,17 @@ export function parseArenaDeckList(text: string): ParseResult {
 
     const match = ENTRY_RE.exec(cleaned)
     if (!match) {
-      errors.push({ line: i + 1, raw: trimmed, reason: 'unrecognised line format' })
+      errors.push({
+        line: i + 1,
+        raw: trimmed,
+        reason: 'unrecognised line format',
+        section: targetSection,
+      })
       continue
     }
     const count = parseInt(match[1]!, 10)
     if (!Number.isFinite(count) || count <= 0) {
-      errors.push({ line: i + 1, raw: trimmed, reason: 'invalid card count' })
+      errors.push({ line: i + 1, raw: trimmed, reason: 'invalid card count', section: targetSection })
       continue
     }
     const entry: ParsedEntry = {

--- a/web-client/src/components/deckbuilder/shareDeck.ts
+++ b/web-client/src/components/deckbuilder/shareDeck.ts
@@ -76,6 +76,14 @@ export interface SharedDeck {
   commanderPrinting?: PrintingRef
   /** Optional sparse per-card printing pins, keyed by card name. */
   printings?: Record<string, PrintingRef>
+  /**
+   * Optional constructed sideboard ("outside the game", CR 100.4a), card name → copies.
+   *
+   * Carried by the account (cloud) path only, which stores this object as JSON verbatim. The v2
+   * *share code* below does not encode it — its compact framing has no field for one — so a deck
+   * shared by link arrives without its sideboard.
+   */
+  sideboard?: Record<string, number>
 }
 
 /**

--- a/web-client/src/components/deckbuilder/shareDeck.ts
+++ b/web-client/src/components/deckbuilder/shareDeck.ts
@@ -77,7 +77,7 @@ export interface SharedDeck {
   /** Optional sparse per-card printing pins, keyed by card name. */
   printings?: Record<string, PrintingRef>
   /**
-   * Optional constructed sideboard ("outside the game", CR 100.4a), card name → copies.
+   * Optional constructed sideboard ("outside the game", CR 400.11a), card name → copies.
    *
    * Carried by the account (cloud) path only, which stores this object as JSON verbatim. The v2
    * *share code* below does not encode it — its compact framing has no field for one — so a deck

--- a/web-client/src/components/lobby/LobbyScreen.tsx
+++ b/web-client/src/components/lobby/LobbyScreen.tsx
@@ -746,26 +746,34 @@ function QuickGameDeckPicker({
 
   const pendingDeckRef = useRef<Record<string, number> | null>(null)
   const pendingCommanderRef = useRef<string | null>(null)
+  const pendingSideboardRef = useRef<Record<string, number>>({})
   const lastSubmittedKeyRef = useRef<string | null>(null)
   const debounceRef = useRef<number | null>(null)
 
   const handleDeckChange = useCallback(
-    (deckList: Record<string, number>, commander?: string | null) => {
-      // The commander rides in the dedupe key, so swapping commanders on otherwise-identical deck
-      // contents still resubmits.
-      const key = `${serializeDeck(deckList)}|${commander ?? ''}`
+    (
+      deckList: Record<string, number>,
+      commander?: string | null,
+      sideboard?: Record<string, number>,
+    ) => {
+      // The commander and the sideboard ride in the dedupe key, so swapping either on otherwise-
+      // identical deck contents still resubmits — editing only the sideboard is a real change.
+      const board = sideboard ?? {}
+      const key = `${serializeDeck(deckList)}|${commander ?? ''}|${serializeDeck(board)}`
       if (key === lastSubmittedKeyRef.current) return
       pendingDeckRef.current = deckList
       pendingCommanderRef.current = commander ?? null
+      pendingSideboardRef.current = board
       if (debounceRef.current !== null) window.clearTimeout(debounceRef.current)
       debounceRef.current = window.setTimeout(() => {
         const pending = pendingDeckRef.current
         if (!pending) return
         const pendingCmdr = pendingCommanderRef.current
-        const pendingKey = `${serializeDeck(pending)}|${pendingCmdr ?? ''}`
+        const pendingSide = pendingSideboardRef.current
+        const pendingKey = `${serializeDeck(pending)}|${pendingCmdr ?? ''}|${serializeDeck(pendingSide)}`
         if (pendingKey === lastSubmittedKeyRef.current) return
         lastSubmittedKeyRef.current = pendingKey
-        submitDeck(pending, pendingCmdr)
+        submitDeck(pending, pendingCmdr, pendingSide)
       }, 250)
     },
     [submitDeck],
@@ -777,8 +785,13 @@ function QuickGameDeckPicker({
       if (debounceRef.current !== null) window.clearTimeout(debounceRef.current)
       const pending = pendingDeckRef.current
       const pendingCmdr = pendingCommanderRef.current
-      const pendingKey = pending ? `${serializeDeck(pending)}|${pendingCmdr ?? ''}` : null
-      if (pending && pendingKey !== lastSubmittedKeyRef.current) submitDeck(pending, pendingCmdr)
+      const pendingSide = pendingSideboardRef.current
+      const pendingKey = pending
+        ? `${serializeDeck(pending)}|${pendingCmdr ?? ''}|${serializeDeck(pendingSide)}`
+        : null
+      if (pending && pendingKey !== lastSubmittedKeyRef.current) {
+        submitDeck(pending, pendingCmdr, pendingSide)
+      }
     }
   }, [submitDeck])
 

--- a/web-client/src/components/ui/DeckPicker.tsx
+++ b/web-client/src/components/ui/DeckPicker.tsx
@@ -43,7 +43,7 @@ import {
   deckColors,
   rarestCard,
 } from '@/components/deck/DeckTile'
-import { parseArenaDeckList } from '../deckbuilder/parseArenaDeck'
+import { formatDeckText, parseDeckText } from './deckPasteText'
 import type { CardSummary } from '../deckbuilder/cardFilter'
 import { SetSelector, rollRandomSet } from './SetSelector'
 import styles from './DeckPicker.module.css'
@@ -130,33 +130,6 @@ interface ExampleDeck {
 }
 
 type ValidationResult = DeckValidationResult
-
-function parseDeckText(text: string): { cards: Record<string, number>; deckName?: string } {
-  // Delegate to the shared Arena/Moxfield/plain-text parser so section headers
-  // (`About`, `Deck`, `Sideboard`, …) and Arena's `Name <deck-name>` metadata
-  // line don't end up as bogus card entries.
-  const parsed = parseArenaDeckList(text)
-  const cards: Record<string, number> = {}
-  for (const entry of parsed.entries) {
-    cards[entry.name] = (cards[entry.name] ?? 0) + entry.count
-  }
-  // Tolerate the "bare card name = 1 copy" shorthand the old parser supported,
-  // since the picker's textarea never required a leading count.
-  for (const err of parsed.errors) {
-    if (err.reason !== 'unrecognised line format') continue
-    const name = err.raw.trim()
-    if (!name) continue
-    cards[name] = (cards[name] ?? 0) + 1
-  }
-  return parsed.deckName !== undefined ? { cards, deckName: parsed.deckName } : { cards }
-}
-
-function formatDeckText(cards: Record<string, number>): string {
-  return Object.entries(cards)
-    .filter(([, n]) => n > 0)
-    .map(([name, n]) => `${n} ${name}`)
-    .join('\n')
-}
 
 const ALL_TABS: ReadonlyArray<Tab> = ['saved', 'examples', 'paste', 'random']
 
@@ -411,17 +384,18 @@ export function DeckPicker({
     return null
   }, [tab, decks, selectedSavedId, pasteCommander])
 
-  // The constructed sideboard ("outside the game", CR 100.4a) the wish effects fetch from. Only
-  // saved decks carry one (the deckbuilder persists it); paste/random/examples have none. The
-  // server ignores it for Limited lobbies (those derive pool − maindeck) and uses it for
-  // constructed/premade ones.
+  // The constructed sideboard ("outside the game", CR 100.4a) the wish effects fetch from.
+  // Saved decks carry one (the deckbuilder persists it) and a pasted list carries whatever sat
+  // under its `Sideboard` / `SB:` section; Random and Examples have none. The server ignores it
+  // for Limited lobbies (those derive pool − maindeck) and uses it for constructed/premade ones.
   const currentSideboard: Record<string, number> = useMemo(() => {
     if (tab === 'saved') {
       const saved = decks.find((d) => d.id === selectedSavedId)
       return saved?.sideboard ?? {}
     }
+    if (tab === 'paste') return parsedPaste.sideboard
     return {}
-  }, [tab, decks, selectedSavedId])
+  }, [tab, decks, selectedSavedId, parsedPaste])
 
   // Strip the commander out of `currentDeck` before crossing the network boundary. `currentDeck`
   // keeps the commander baked in so the totalCards display reads "100 cards" for a Commander
@@ -483,6 +457,12 @@ export function DeckPicker({
 
   const stats = useMemo(() => computeDeckStats(currentDeck, cards), [currentDeck, cards])
   const totalCards = Object.values(currentDeck).reduce((a, b) => a + b, 0)
+  // Shown under the paste box so a pasted `Sideboard` section is visibly accounted for rather
+  // than looking dropped — it deliberately isn't part of `totalCards` (CR 100.4a).
+  const pasteSideboardCount = useMemo(
+    () => Object.values(parsedPaste.sideboard).reduce((a, b) => a + b, 0),
+    [parsedPaste],
+  )
 
   const handleLoadExample = (ex: ExampleDeck) => {
     setPasteText(formatDeckText(ex.cards))
@@ -494,7 +474,11 @@ export function DeckPicker({
   const handleSaveCurrent = async () => {
     if (!pendingName.trim() || Object.keys(currentDeck).length === 0) return
     // Routes to the account when signed in (then refresh so the new cloud deck appears), else local.
-    const { id } = await saveDeckRouted({ name: pendingName.trim(), cards: currentDeck })
+    const { id } = await saveDeckRouted({
+      name: pendingName.trim(),
+      cards: currentDeck,
+      ...(Object.keys(currentSideboard).length > 0 ? { sideboard: currentSideboard } : {}),
+    })
     reloadDecks()
     setSelectedSavedId(id)
     setPendingName('')
@@ -562,7 +546,9 @@ export function DeckPicker({
               // Show the full deck in the paste editor — including the commander,
               // which is stored separately on `SavedDeck` but should appear in the
               // text the user can edit.
-              setPasteText(formatDeckText(mergeCommanderIntoCards(d.cards, d.commander ?? null)))
+              setPasteText(
+                formatDeckText(mergeCommanderIntoCards(d.cards, d.commander ?? null), d.sideboard),
+              )
               setPendingName(d.name)
               setTab('paste')
             }}
@@ -593,7 +579,13 @@ export function DeckPicker({
               className={styles.textarea}
               placeholder={'4 Lightning Bolt\n4 Goblin Guide\n12 Mountain\n…'}
             />
-            <p className={styles.helperText}>One card per line. Format: "4 Card Name" or "Card Name x4".</p>
+            <p className={styles.helperText}>
+              One card per line. Format: "4 Card Name" or "Card Name x4". A{' '}
+              <code>Sideboard</code> header (or per-line <code>SB:</code>) starts the sideboard.
+              {pasteSideboardCount > 0
+                ? ` Sideboard: ${pasteSideboardCount} card${pasteSideboardCount === 1 ? '' : 's'}.`
+                : ''}
+            </p>
             <div className={styles.actionsRow}>
               <input
                 value={pendingName}

--- a/web-client/src/components/ui/DeckPicker.tsx
+++ b/web-client/src/components/ui/DeckPicker.tsx
@@ -384,7 +384,7 @@ export function DeckPicker({
     return null
   }, [tab, decks, selectedSavedId, pasteCommander])
 
-  // The constructed sideboard ("outside the game", CR 100.4a) the wish effects fetch from.
+  // The constructed sideboard ("outside the game", CR 400.11a) the wish effects fetch from.
   // Saved decks carry one (the deckbuilder persists it) and a pasted list carries whatever sat
   // under its `Sideboard` / `SB:` section; Random and Examples have none. The server ignores it
   // for Limited lobbies (those derive pool − maindeck) and uses it for constructed/premade ones.
@@ -458,7 +458,7 @@ export function DeckPicker({
   const stats = useMemo(() => computeDeckStats(currentDeck, cards), [currentDeck, cards])
   const totalCards = Object.values(currentDeck).reduce((a, b) => a + b, 0)
   // Shown under the paste box so a pasted `Sideboard` section is visibly accounted for rather
-  // than looking dropped — it deliberately isn't part of `totalCards` (CR 100.4a).
+  // than looking dropped — it deliberately isn't part of `totalCards` (CR 400.11a).
   const pasteSideboardCount = useMemo(
     () => Object.values(parsedPaste.sideboard).reduce((a, b) => a + b, 0),
     [parsedPaste],

--- a/web-client/src/components/ui/__tests__/deckPickerPaste.test.ts
+++ b/web-client/src/components/ui/__tests__/deckPickerPaste.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Pins the lobby deck picker's paste box to the shared decklist parser.
+ *
+ * The picker used to keep only `parsed.entries`, so a pasted Arena export arrived with an empty
+ * sideboard however faithfully the parser had read it. These exercise the two halves of the paste
+ * tab that decide what reaches the server: the text → {main, sideboard} split, and the render back
+ * into the textarea when a saved deck is opened for editing.
+ */
+import { describe, expect, it } from 'vitest'
+import { formatDeckText, parseDeckText } from '../deckPasteText'
+
+const ARENA_EXPORT = `Deck
+4 Monastery Swiftspear
+2 Mountain
+
+Sideboard
+2 Redcap Melee
+1 Ghost Vacuum`
+
+describe('DeckPicker paste parsing', () => {
+  it('keeps the Sideboard section out of the deck and in the sideboard', () => {
+    const parsed = parseDeckText(ARENA_EXPORT)
+    expect(parsed.cards).toEqual({ 'Monastery Swiftspear': 4, Mountain: 2 })
+    expect(parsed.sideboard).toEqual({ 'Redcap Melee': 2, 'Ghost Vacuum': 1 })
+  })
+
+  it('reads the per-line SB: prefix as sideboard too', () => {
+    const parsed = parseDeckText('4 Lightning Bolt\nSB: 2 Counterspell')
+    expect(parsed.cards).toEqual({ 'Lightning Bolt': 4 })
+    expect(parsed.sideboard).toEqual({ Counterspell: 2 })
+  })
+
+  it('rescues the bare-name shorthand onto the board it was written under', () => {
+    const parsed = parseDeckText('Deck\nLightning Bolt\nSideboard\nCounterspell')
+    expect(parsed.cards).toEqual({ 'Lightning Bolt': 1 })
+    expect(parsed.sideboard).toEqual({ Counterspell: 1 })
+  })
+
+  it('leaves the sideboard empty when the list has no sideboard section', () => {
+    expect(parseDeckText('4 Lightning Bolt').sideboard).toEqual({})
+  })
+
+  it('round-trips through the textarea rendering', () => {
+    const parsed = parseDeckText(ARENA_EXPORT)
+    const text = formatDeckText(parsed.cards, parsed.sideboard)
+    expect(text).toContain('Sideboard')
+    const again = parseDeckText(text)
+    expect(again.cards).toEqual(parsed.cards)
+    expect(again.sideboard).toEqual(parsed.sideboard)
+  })
+
+  it('omits the Sideboard header when there is nothing to put under it', () => {
+    expect(formatDeckText({ 'Lightning Bolt': 4 }, {})).toBe('4 Lightning Bolt')
+    expect(formatDeckText({ 'Lightning Bolt': 4 })).toBe('4 Lightning Bolt')
+  })
+})

--- a/web-client/src/components/ui/__tests__/deckPickerPaste.test.ts
+++ b/web-client/src/components/ui/__tests__/deckPickerPaste.test.ts
@@ -36,6 +36,21 @@ describe('DeckPicker paste parsing', () => {
     expect(parsed.sideboard).toEqual({ Counterspell: 1 })
   })
 
+  // The rescue reads the *preprocessed* line. Reading the raw one instead produced a card named
+  // "SB: Counterspell", which then silently vanished: the server drops it as unknown, after the
+  // paste box has already counted it in the sideboard total.
+  it('strips the SB: prefix when rescuing a bare name, rather than baking it into the name', () => {
+    const parsed = parseDeckText('4 Lightning Bolt\nSB: Counterspell')
+    expect(parsed.cards).toEqual({ 'Lightning Bolt': 4 })
+    expect(parsed.sideboard).toEqual({ Counterspell: 1 })
+  })
+
+  it('strips Moxfield decorations when rescuing a bare name', () => {
+    const parsed = parseDeckText('Lightning Bolt *F*\nSideboard\nCounterspell #tag')
+    expect(parsed.cards).toEqual({ 'Lightning Bolt': 1 })
+    expect(parsed.sideboard).toEqual({ Counterspell: 1 })
+  })
+
   it('leaves the sideboard empty when the list has no sideboard section', () => {
     expect(parseDeckText('4 Lightning Bolt').sideboard).toEqual({})
   })

--- a/web-client/src/components/ui/deckPasteText.ts
+++ b/web-client/src/components/ui/deckPasteText.ts
@@ -1,0 +1,67 @@
+/**
+ * The paste box's text ↔ deck conversion, kept out of the component so it can be tested on its own.
+ *
+ * The lobby picker accepts the same Arena / Moxfield / plain-text shapes as the deckbuilder's
+ * import — it delegates the line parsing to {@link parseArenaDeckList} — and adds two things the
+ * textarea has always tolerated: a bare card name meaning one copy, and rendering a deck back out
+ * for editing.
+ */
+import { parseArenaDeckList } from '@/components/deckbuilder/parseArenaDeck'
+
+export interface ParsedPaste {
+  cards: Record<string, number>
+  /**
+   * The `Sideboard` / `SB:` section, card name → copies. The constructed sideboard lives
+   * "outside the game" (CR 100.4a) and is only reachable through wish effects, so it is kept
+   * apart from `cards` rather than merged in — merging it would deal the sideboard into the
+   * library and inflate the deck past its legal size.
+   */
+  sideboard: Record<string, number>
+  deckName?: string
+}
+
+export function parseDeckText(text: string): ParsedPaste {
+  // Delegate to the shared Arena/Moxfield/plain-text parser so section headers
+  // (`About`, `Deck`, `Sideboard`, …) and Arena's `Name <deck-name>` metadata
+  // line don't end up as bogus card entries.
+  const parsed = parseArenaDeckList(text)
+  const cards: Record<string, number> = {}
+  const sideboard: Record<string, number> = {}
+  for (const entry of parsed.entries) {
+    cards[entry.name] = (cards[entry.name] ?? 0) + entry.count
+  }
+  for (const entry of parsed.sideboard) {
+    sideboard[entry.name] = (sideboard[entry.name] ?? 0) + entry.count
+  }
+  // Tolerate the "bare card name = 1 copy" shorthand the old parser supported,
+  // since the picker's textarea never required a leading count. The rescued line
+  // stays on whichever board it was written under.
+  for (const err of parsed.errors) {
+    if (err.reason !== 'unrecognised line format') continue
+    const name = err.raw.trim()
+    if (!name) continue
+    const board = err.section === 'side' ? sideboard : cards
+    board[name] = (board[name] ?? 0) + 1
+  }
+  return parsed.deckName !== undefined
+    ? { cards, sideboard, deckName: parsed.deckName }
+    : { cards, sideboard }
+}
+
+function formatDeckLines(cards: Record<string, number>): string {
+  return Object.entries(cards)
+    .filter(([, n]) => n > 0)
+    .map(([name, n]) => `${n} ${name}`)
+    .join('\n')
+}
+
+/**
+ * Render a deck back into the paste textarea. A sideboard is emitted under a `Sideboard`
+ * header — the same shape {@link parseDeckText} reads — so editing a saved deck that has one
+ * round-trips instead of silently dropping it.
+ */
+export function formatDeckText(cards: Record<string, number>, sideboard?: Record<string, number>): string {
+  const main = formatDeckLines(cards)
+  const side = sideboard ? formatDeckLines(sideboard) : ''
+  return side ? `${main}\n\nSideboard\n${side}` : main
+}

--- a/web-client/src/components/ui/deckPasteText.ts
+++ b/web-client/src/components/ui/deckPasteText.ts
@@ -12,7 +12,7 @@ export interface ParsedPaste {
   cards: Record<string, number>
   /**
    * The `Sideboard` / `SB:` section, card name → copies. The constructed sideboard lives
-   * "outside the game" (CR 100.4a) and is only reachable through wish effects, so it is kept
+   * "outside the game" (CR 400.11a) and is only reachable through wish effects, so it is kept
    * apart from `cards` rather than merged in — merging it would deal the sideboard into the
    * library and inflate the deck past its legal size.
    */

--- a/web-client/src/components/ui/deckPasteText.ts
+++ b/web-client/src/components/ui/deckPasteText.ts
@@ -33,12 +33,13 @@ export function parseDeckText(text: string): ParsedPaste {
   for (const entry of parsed.sideboard) {
     sideboard[entry.name] = (sideboard[entry.name] ?? 0) + entry.count
   }
-  // Tolerate the "bare card name = 1 copy" shorthand the old parser supported,
-  // since the picker's textarea never required a leading count. The rescued line
-  // stays on whichever board it was written under.
+  // Tolerate the "bare card name = 1 copy" shorthand the old parser supported, since the
+  // picker's textarea never required a leading count. Read `cleaned`, not `raw`: `raw` still
+  // carries the `SB:` prefix and any Moxfield decorations, which would become part of the card
+  // name and then fail to resolve. The rescued line stays on whichever board it was written under.
   for (const err of parsed.errors) {
     if (err.reason !== 'unrecognised line format') continue
-    const name = err.raw.trim()
+    const name = err.cleaned.trim()
     if (!name) continue
     const board = err.section === 'side' ? sideboard : cards
     board[name] = (board[name] ?? 0) + 1

--- a/web-client/src/help/topics.ts
+++ b/web-client/src/help/topics.ts
@@ -579,7 +579,7 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
         '`1 Cardname (SET) *F* *A* 42 #tag` — Moxfield bulk edit. Foil, alter and tag markers are read and discarded.',
         '`SB: 2 Counterspell` — the MTGO sideboard prefix.',
       ] },
-      { kind: 'p', text: 'Section headers are case-insensitive: `Deck` / `Mainboard` / `Main Deck` / `Maindeck`, `Sideboard` / `Side` / `SB`, `Commander` / `Commanders` / `EDH`, `Companion`, and `About`. Only the main deck and commander are imported. Blank lines and lines starting with `//` or `#` are ignored.' },
+      { kind: 'p', text: 'Section headers are case-insensitive: `Deck` / `Mainboard` / `Main Deck` / `Maindeck`, `Sideboard` / `Side` / `SB`, `Commander` / `Commanders` / `EDH`, `Companion`, and `About`. The main deck, the sideboard and the commander are all imported; `Companion` and `About` are skipped. Blank lines and lines starting with `//` or `#` are ignored.' },
       { kind: 'p', text: 'A line that looks like a card but cannot be matched is reported rather than dropped, so an import never silently loses cards. Export writes the plain `4 Lightning Bolt` shape, which every one of the above tools reads.' },
     ],
     related: ['deckbuilder', 'deck-sharing'],

--- a/web-client/src/store/slices/quickGameLobbySlice.ts
+++ b/web-client/src/store/slices/quickGameLobbySlice.ts
@@ -41,7 +41,11 @@ export interface QuickGameLobbySliceActions {
   ) => void
   joinQuickGameLobby: (lobbyId: string) => void
   leaveQuickGameLobby: () => void
-  submitQuickGameLobbyDeck: (deckList: Record<string, number>, commander?: string | null) => void
+  submitQuickGameLobbyDeck: (
+    deckList: Record<string, number>,
+    commander?: string | null,
+    sideboard?: Record<string, number>,
+  ) => void
   setQuickGameLobbyReady: (ready: boolean) => void
   setQuickGameLobbySetCode: (setCodes: readonly string[]) => void
   setQuickGameLobbyPublic: (isPublic: boolean) => void
@@ -71,8 +75,10 @@ export const createQuickGameLobbySlice: SliceCreator<QuickGameLobbySlice> = (set
     set({ quickGameLobbyState: null })
   },
 
-  submitQuickGameLobbyDeck: (deckList, commander) => {
-    getWebSocket()?.send(createSubmitQuickGameLobbyDeckMessage(deckList, commander))
+  submitQuickGameLobbyDeck: (deckList, commander, sideboard) => {
+    getWebSocket()?.send(
+      createSubmitQuickGameLobbyDeckMessage(deckList, commander, undefined, undefined, sideboard),
+    )
   },
 
   setQuickGameLobbyReady: (ready) => {

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -1004,7 +1004,11 @@ export type GameStore = {
   removeQuickGameAi: () => void
   joinQuickGameLobby: (lobbyId: string) => void
   leaveQuickGameLobby: () => void
-  submitQuickGameLobbyDeck: (deckList: Record<string, number>, commander?: string | null) => void
+  submitQuickGameLobbyDeck: (
+    deckList: Record<string, number>,
+    commander?: string | null,
+    sideboard?: Record<string, number>,
+  ) => void
   setQuickGameLobbyReady: (ready: boolean) => void
   setQuickGameLobbySetCode: (setCodes: readonly string[]) => void
   setQuickGameLobbyPublic: (isPublic: boolean) => void

--- a/web-client/src/store/useSaveDeck.ts
+++ b/web-client/src/store/useSaveDeck.ts
@@ -30,6 +30,9 @@ export function savedDeckToShared(input: SaveDeckInput): SharedDeck {
     ...(input.format ? { format: input.format } : {}),
     ...(input.commander ? { commander: input.commander } : {}),
     ...(input.commanderPrinting ? { commanderPrinting: input.commanderPrinting } : {}),
+    ...(input.sideboard && Object.keys(input.sideboard).length > 0
+      ? { sideboard: input.sideboard }
+      : {}),
   }
 }
 

--- a/web-client/src/store/useUnifiedDecks.ts
+++ b/web-client/src/store/useUnifiedDecks.ts
@@ -45,6 +45,7 @@ function detailToUnified(detail: DeckDetail): UnifiedDeck {
     ...(d.commander ? { commander: d.commander } : {}),
     ...(d.commanderPrinting ? { commanderPrinting: d.commanderPrinting } : {}),
     ...(entries ? { entries } : {}),
+    ...(d.sideboard && Object.keys(d.sideboard).length > 0 ? { sideboard: d.sideboard } : {}),
     updatedAt: Date.parse(detail.updatedAt) || 0,
   }
 }

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -3062,6 +3062,11 @@ export interface SubmitQuickGameLobbyDeckMessage {
   readonly cardEntries?: readonly DeckEntry[]
   /** Optional pinned printing for the commander. Ignored when `commander` is null. */
   readonly commanderPrinting?: PrintingRef
+  /**
+   * Constructed sideboard ("outside the game", CR 100.4a), card name → count. Omitted for a
+   * random pool, whose sideboard the server derives from the pool instead.
+   */
+  readonly sideboard?: Record<string, number>
 }
 
 export interface SetQuickGameLobbyReadyMessage {
@@ -3121,6 +3126,7 @@ export function createSubmitQuickGameLobbyDeckMessage(
   commander?: string | null,
   cardEntries?: readonly DeckEntry[],
   commanderPrinting?: PrintingRef,
+  sideboard?: Record<string, number>,
 ): SubmitQuickGameLobbyDeckMessage {
   return {
     type: 'submitQuickGameLobbyDeck',
@@ -3128,6 +3134,7 @@ export function createSubmitQuickGameLobbyDeckMessage(
     ...(commander ? { commander } : {}),
     ...(cardEntries && cardEntries.length > 0 ? { cardEntries } : {}),
     ...(commanderPrinting ? { commanderPrinting } : {}),
+    ...(sideboard && Object.keys(sideboard).length > 0 ? { sideboard } : {}),
   }
 }
 export function createSetQuickGameLobbyReadyMessage(ready: boolean): SetQuickGameLobbyReadyMessage {

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -3063,7 +3063,7 @@ export interface SubmitQuickGameLobbyDeckMessage {
   /** Optional pinned printing for the commander. Ignored when `commander` is null. */
   readonly commanderPrinting?: PrintingRef
   /**
-   * Constructed sideboard ("outside the game", CR 100.4a), card name → count. Omitted for a
+   * Constructed sideboard ("outside the game", CR 400.11a), card name → count. Omitted for a
    * random pool, whose sideboard the server derives from the pool instead.
    */
   readonly sideboard?: Record<string, number>


### PR DESCRIPTION
# Import a pasted decklist's sideboard, and carry it into the game

Pasting a full Arena/Moxfield decklist into a lobby's **Paste** tab produced a deck with an
empty sideboard, however faithfully the parser had read the list. Fixing that turned out to
need three separate things, one per commit.

## The picker was discarding it (`b03443a`)

`parseArenaDeckList` has always split a `Sideboard` section (and the per-line `SB:` prefix)
into its own list — the deckbuilder's import modal uses it. The lobby picker did not: it kept
only `parsed.entries` and hardcoded the sideboard to `{}` for every tab but Saved.

```ts
const currentSideboard = useMemo(() => {
  if (tab === 'saved') return saved?.sideboard ?? {}
  return {}          // <- a pasted Sideboard section died here
}, [...])
```

The paste box's text↔deck conversion moves into `web-client/src/components/ui/deckPasteText.ts`
so it can be tested without mounting the picker, and keeps both boards. The Paste tab feeds its
parsed sideboard into `currentSideboard`, which was *already* wired through `onDeckChange` →
`submitLobbyDeck` → the `sideboard` wire field; "Save deck" persists it; and `formatDeckText`
emits a `Sideboard` header so editing a saved deck that has one round-trips instead of silently
dropping it.

Parse errors now carry the section they were read under, so the picker's "bare card name = one
copy" shorthand rescues a line onto the board it was written under rather than always the main
deck.

Cloud saves dropped the sideboard too — the same hole in the deckbuilder, where a signed-in user
lost their sideboard on every save. `SharedDeck` gains a `sideboard`, carried in
`savedDeckToShared` and `buildSharedDeck`, read back in `detailToUnified` / `applySharedDeck`.
The account controller stores the deck body verbatim, so this needed **no server change**.

## Quick Game had no sideboard at all (`1bdd463`)

That still didn't put a sideboard in a game, because the Quick Game lobby drops it at every
layer: no `sideboard` on `SubmitQuickGameLobbyDeck`, none on the lobby seat, and the seating loop
calls `addPlayer(session, deck, commanderCardName = ...)` — leaving the `sideboard` parameter on
its `emptyMap()` default. **A Quick Game has therefore always started with an empty sideboard, for
saved decks as much as pasted ones.** The Premade Decks lobby was already wired end to end, which
is the only reason the difference between the two screens was invisible.

The field now goes through the wire message, `QuickGameLobbyPlayer`, and the seating loop (empty
for Momir Basic and for a random pool, which has no constructed sideboard — a Limited sideboard is
derived as pool − maindeck, CR 100.4b). The submit handler's resubmit no-op compares the sideboard
too, so editing only the sideboard is still a real change.

### `SideboardSanitizer` — the half that isn't optional

A submitted *deck* is validated and rejected when it names a card this engine hasn't implemented.
A sideboard is not: it reaches `GameInitializer` unchecked, where `cardRegistry.requireCard` throws
on the first unknown name, failing a game start whose decks were all perfectly legal. Pasted Arena
sideboards routinely name cards the corpus hasn't reached yet, so this became reachable the moment
the picker started delivering them — the first commit created the exposure that the second closes.

Rejecting the whole submission would be the wrong trade: one unimplemented card shouldn't lock a
player out of a game they could otherwise play. Unknown names are dropped and logged instead — a
wish simply won't find them, which is the truth of it — on the premade path as well as the new one.

## Rule citations (`d6cd32d`)

Verified against the local `MagicCompRules_20260808.txt`, which is how the mistake surfaced:

- **CR 400.11a** — "Cards in a player's sideboard are outside the game." This is the rule the
  comments wanted; every citation added on this branch originally said 100.4a, and was corrected.
- **CR 100.4a** — the fifteen-card cap, and the four-of limit applying to deck and sideboard
  *combined*. A different claim, cited nowhere in this branch's code.
- **CR 100.4b** — the Limited sideboard is the pool minus the maindeck. Pre-existing in
  `SideboardDerivation`, referenced here for the random-pool case.

The same 100.4a/400.11a mispairing predates this branch in `deckLibrary.ts`, `DeckbuilderPage.tsx`
and `messages.ts`. Those are deliberately left alone rather than swept into this change.

## No new SDK vocabulary

Nothing here is engine or SDK work. `SideboardSanitizer` is a `game-server` object, which is where
it belongs: the server is the anti-corruption layer between untrusted client input and an engine
that is entitled to assume a well-formed `Deck`. Keeping the filter out of `GameInitializer` leaves
the engine strict — it still throws on a malformed deck, which is what you want from it.

## Review fixes (`0d34bfa`)

A review pass over the branch found four defects, all fixed before opening this:

- The bare-name rescue read the *un-preprocessed* line, so `SB: Counterspell` became a card named
  `"SB: Counterspell"` — counted in the paste box's sideboard total, then silently dropped by the
  server as unknown. Introduced by this branch; two regression tests added.
- A page refresh or deep link to `/deckbuilder/<id>` rehydrated the deck without its sideboard, and
  the next Save wrote that emptiness back over the stored one. Pre-existing, but this branch is what
  made a lost sideboard matter.
- Loading an example kept the previous deck's sideboard attached.
- `GamePlayHandler`'s create/join paths handed the engine an unsanitized sideboard — the same
  `requireCard` throw the sanitizer exists to prevent, on the two call sites the first pass missed.

The full review, including one open item, is in `sideboard-paste_review.md`.

## Verification

- `just test-server` — **BUILD SUCCESSFUL, 507 passed, 0 failed**, including four new
  `SideboardSanitizerTest` cases. Re-run in full after the review fixes; an earlier targeted
  re-run (`just test-class SideboardSanitizerTest`) covered a comment-only edit, so no green here
  is claimed from a stale tree.
- `web-client` — `npx tsc --noEmit` clean; `npx vitest run` **45 files, 658 tests passed**,
  including eight new `deckPickerPaste` tests covering the paste split, the `SB:` prefix (both as a
  counted entry and as a rescued bare name), Moxfield decorations, the shorthand rescue, and the
  textarea round-trip.
- The parser was checked against the exact 20-line/11-name decklist that prompted this: it splits
  **60 main / 15 sideboard**.

**What the gates do not cover:**

- **No engine gate was run**, and none is warranted — nothing in `rules-engine` changed. A green
  `game-server` suite says nothing about engine behaviour, and isn't claimed to.
- **No e2e or integration coverage of the actual round trip.** Paste → lobby → `submitDeck` →
  `addPlayer` → `Zone.SIDEBOARD` is verified by reading the code and by unit tests at each end, not
  by exercising the path. There is no e2e harness for lobby deck submission here.
- **The cloud save/load round-trip is unverified by any test** — it relies on the account
  controller storing `SharedDeck` JSON verbatim, which is true by inspection but not asserted.

## Deliberately out of scope

- **Share links still drop the sideboard.** The v2 share code is a compact delimited format with no
  field for one; adding it needs a version bump and a decode path. Documented on the new
  `SharedDeck.sideboard` property so it doesn't read as supported.
- **A sideboard remains invisible during play.** `ClientStateTransformer` excludes it from client
  state as outside the game (CR 400.11a) and no component renders that zone, so it is observable
  only through a wish effect's search. Giving it a UI, or sideboarding between games of a match,
  would each be their own change.
- **Neither CR 100.4a limit is enforced on the paste path** — not the four-of limit across deck and
  sideboard combined, nor the fifteen-card cap. `DeckValidator` has no sideboard handling at all,
  while the deckbuilder's *manual* add path does enforce the combined cap, so the two contradict
  each other. Pre-existing, but this branch makes the lobby the shortest route to an illegal
  sideboard, so it's worth a decision — see the open item in `sideboard-paste_review.md`. Left out
  because it's a deck-legality feature and a truncate-or-reject product call, not part of making
  paste work.
