### PR TITLE
Check state-based actions after a land is played

### DIFF
--- a/manual-scenarios/bugs/legend-rule-land-drop.json
+++ b/manual-scenarios/bugs/legend-rule-land-drop.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Eiganjo Castle", "Plains"],
+    "battlefield": [
+      {"name": "Eiganjo Castle"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Mirri, Cat Warrior"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Grizzly Bears", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Eiganjo Castle"},
+      {"name": "Centaur Courser"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Hill Giant", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_ATTACKERS", "DECLARE_BLOCKERS"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -172,6 +172,11 @@ class PlayLandHandler(
         val played = executePlay(state, action)
         if (!played.isSuccess) return played
 
+        // Ordering: the land's own ETB triggers (landfall) are already detected and on the stack
+        // by this point — `executePlay` does that before returning — which is the order CR 603.10
+        // wants and the one PassPriorityHandler arranges explicitly for the resolution path. Moving
+        // this check earlier would drop a landfall trigger whose permanent the legend rule then
+        // removes, and no test here would notice.
         val sbaResult = sbaChecker.checkAndApply(played.state)
         // An SBA that needs input (the legend rule's "which one do you keep?") pauses the action;
         // the land is already on the battlefield, so the decision resolves against the real board.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.engine.core.EngineServices
 import com.wingedsheep.engine.handlers.actions.ActionHandler
 import com.wingedsheep.engine.handlers.effects.permanent.types.setDfcFace
 import com.wingedsheep.engine.handlers.effects.permanent.types.stampDoubleFacedFrontFace
+import com.wingedsheep.engine.mechanics.StateBasedActionChecker
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
@@ -57,6 +58,7 @@ class PlayLandHandler(
                                  com.wingedsheep.sdk.scripting.effects.Effect,
                                  com.wingedsheep.engine.handlers.EffectContext) ->
         com.wingedsheep.engine.core.EffectResult,
+    private val sbaChecker: StateBasedActionChecker,
 ) : ActionHandler<PlayLand> {
     override val actionType: KClass<PlayLand> = PlayLand::class
 
@@ -154,7 +156,39 @@ class PlayLandHandler(
         else execute(state, action)
     }
 
+    /**
+     * Playing a land is a special action (CR 116.2a) — it uses no stack and the player keeps
+     * priority afterwards. State-based actions are still checked before that player receives
+     * priority again (CR 704.3), and this is the only path onto the battlefield that doesn't go
+     * through spell resolution, so the check has to happen here or not at all.
+     *
+     * Without it a second copy of a legendary land simply stayed on the battlefield: the legend
+     * rule (CR 704.5j) is a state-based action, so playing the land was correctly legal, but
+     * nothing ever culled the duplicate. Casting a second legendary *spell* was unaffected, since
+     * PassPriorityHandler checks SBAs after resolution — which is why LegendRuleTest passed
+     * throughout.
+     */
     override fun execute(state: GameState, action: PlayLand): ExecutionResult {
+        val played = executePlay(state, action)
+        if (!played.isSuccess) return played
+
+        val sbaResult = sbaChecker.checkAndApply(played.state)
+        // An SBA that needs input (the legend rule's "which one do you keep?") pauses the action;
+        // the land is already on the battlefield, so the decision resolves against the real board.
+        if (sbaResult.isPaused) {
+            return ExecutionResult.paused(
+                sbaResult.state,
+                sbaResult.pendingDecision!!,
+                played.events + sbaResult.events,
+            )
+        }
+        return ExecutionResult.success(
+            sbaResult.state,
+            played.events + sbaResult.events,
+        ).copy(triggersAlreadyProcessed = played.triggersAlreadyProcessed)
+    }
+
+    private fun executePlay(state: GameState, action: PlayLand): ExecutionResult {
         val container = state.getEntity(action.cardId)
             ?: return ExecutionResult.error(state, "Card not found")
 
@@ -822,6 +856,7 @@ class PlayLandHandler(
                 services.triggerProcessor,
                 services.conditionEvaluator,
                 services.effectExecutorRegistry::execute,
+                services.sbaChecker,
             )
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LegendRuleLandDropTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LegendRuleLandDropTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * The legend rule (CR 704.5j) on the **land-drop** path.
+ *
+ * Regression. Playing a land is a special action (CR 116.2a): it uses no stack, so it is the one
+ * way onto the battlefield that never passes through spell resolution. `PlayLandHandler` ran no
+ * state-based-action check, and none of the other SBA call sites covered it — so a player could
+ * play a second copy of a legendary land they already controlled and simply keep both, for as
+ * long as the game lasted.
+ *
+ * Playing the second copy is *correct*; the legend rule is a state-based action, not a play
+ * restriction. What was missing is the cull that follows.
+ *
+ * The cast path was never affected — `PassPriorityHandler` checks SBAs after resolution — which is
+ * why [LegendRuleTest] passed the whole time. The fixture here is Eiganjo Castle (CHK), one of the
+ * 22 legendary lands already in the corpus.
+ */
+class LegendRuleLandDropTest : ScenarioTestBase() {
+
+    init {
+        test("playing a second copy of a legendary land culls one to the graveyard") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Eiganjo Castle")
+                .withCardOnBattlefield(1, "Eiganjo Castle")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val handCard = game.findCardsInHand(1, "Eiganjo Castle").first()
+
+            withClue("The legend rule is a state-based action, not a play restriction (CR 704.5j)") {
+                game.execute(PlayLand(game.player1Id, handCard)).error shouldBe null
+            }
+
+            withClue("Both copies are briefly on the battlefield, so the choice is a real one") {
+                game.hasPendingDecision() shouldBe true
+            }
+            val decision = game.getPendingDecision()
+            decision.shouldNotBeNull()
+            decision.shouldBeInstanceOf<SelectCardsDecision>()
+            decision.options.size shouldBe 2
+
+            // Keep the copy that was already in play.
+            game.selectCards(listOf(decision.options.first()))
+
+            withClue("Exactly one Eiganjo Castle survives") {
+                game.findPermanents("Eiganjo Castle").size shouldBe 1
+            }
+            withClue("…and the other is in its owner's graveyard") {
+                game.isInGraveyard(1, "Eiganjo Castle") shouldBe true
+            }
+        }
+
+        test("a nonlegendary duplicate land raises no legend-rule prompt") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Forest")
+                .withLandsOnBattlefield(1, "Forest", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val handCard = game.findCardsInHand(1, "Forest").first()
+            game.execute(PlayLand(game.player1Id, handCard)).error shouldBe null
+
+            withClue("The SBA check must not disturb the ordinary land drop") {
+                game.hasPendingDecision() shouldBe false
+                game.findPermanents("Forest").size shouldBe 2
+            }
+        }
+
+        test("a legendary land is untouched when its controller has no duplicate") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Eiganjo Castle")
+                .withCardOnBattlefield(2, "Eiganjo Castle")   // the *opponent* controls the other
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val handCard = game.findCardsInHand(1, "Eiganjo Castle").first()
+            game.execute(PlayLand(game.player1Id, handCard)).error shouldBe null
+
+            withClue("The legend rule is per-player — two players may each control one") {
+                game.hasPendingDecision() shouldBe false
+                game.findPermanents("Eiganjo Castle").size shouldBe 2
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Check state-based actions after a land is played

Playing a second copy of a legendary land you already control left **both** copies on the
battlefield, permanently. No prompt, nothing put into the graveyard, and no self-correction on any
later priority pass.

## What was wrong

Playing a land is a special action (CR 116.2a): it uses no stack, so it is the one route onto the
battlefield that never passes through spell resolution. `PlayLandHandler` ran no state-based-action
check, and none of the other five SBA call sites cover a land drop — `TurnManager`,
`StepActionHelper`, `ConcedeHandler`, `SubmitDecisionHandler`, `PassPriorityHandler`.

The visible consequence was the legend rule. Note the half that was already correct: **playing the
second copy is legal.** CR 704.5j is a state-based action, not a play restriction —

> **704.5j** If two or more legendary permanents with the same name are controlled by the same
> player, that player chooses one of them, and the rest are put into their owners' graveyards. This
> is called the "legend rule."

— so the land enters and the game *then* makes you choose. What was missing is that second half.

Casting a second legendary **spell** was never affected, because `PassPriorityHandler` checks SBAs
after resolution. That is why `LegendRuleTest` passed the whole time and why this went unnoticed: the
existing coverage exercises the cast path exclusively.

## Scope

Not specific to any recent card. **22 legendary lands already in the corpus** had this — Tolarian
Academy, Gaea's Cradle, Eiganjo Castle, Shizo, Okina, Phyrexian Tower and the rest of the Kamigawa
and Urza's cycles.

## The change

`PlayLandHandler.execute` had several success return paths, so rather than patching each, the
existing body becomes `executePlay` and `execute` wraps it: on success, run
`sbaChecker.checkAndApply`, propagating a pause so the legend rule's "which one do you keep?"
decision resolves against the real board with both copies on it. Nothing else about the action
changes, and no new SDK vocabulary is introduced.

## Rules cited

Verified against the local `MagicCompRules_20260808.txt` (effective 2026-08-07):

- **CR 704.5j** — the legend rule, quoted above, and a state-based action rather than a restriction.
- **CR 704.3** — state-based actions are checked whenever a player would receive priority.
- **CR 116.2a** — playing a land is a special action that doesn't use the stack.

## Verification

`scripts/gradle-locked` run **serially, one module per invocation** — `just test` fans the per-era
test modules out in parallel and starves them into `TestHangGuard` timeouts on this box. All 14
modules green:

```
sdk · rules-engine · mtg-sets · game-server · ai
era-1993-1999 · 2000-2002 · 2003-2007 · 2008-2016 · 2017-2022 · 2023 · 2024 · 2025 · 2026
```

The full suite matters more than usual here: every land drop in the codebase now runs an SBA check,
so the blast radius is wide even though the diff is 35 lines.

`LegendRuleLandDropTest` adds three cases — the cull itself, a duplicate *nonlegendary* land raising
no prompt (the check must not make ordinary land drops noisier), and two players each controlling one
copy (the rule is per-player). Mutation-checked: short-circuiting the new call reddens only the
legend-rule case and leaves both controls green. The four pre-existing `LegendRuleTest` cases and
`GhaltaStampedeTyrantLegendRuleTest` still pass.

The fixture is Eiganjo Castle (CHK), deliberately an existing corpus card, so this branch is
independent of any in-flight card work.

**What this does not cover.** No TypeScript or web-client tooling was run — the client side is
unverified by any tool. `manual-scenarios/bugs/legend-rule-land-drop.json` is validated only as JSON
with its card names resolved against the registry; it was not booted against a running server.
