### PR TITLE
Add the five NEO channel lands and Divide by Zero

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3767,6 +3767,10 @@ Each side carries its own optional `GameObjectFilter`, and either may be left nu
 | `permanentFilter` | the battlefield half | `GameObjectFilter.Creature` → "target spell or creature" (Swat Away) |
 | `spellFilter` | the stack half | `GameObjectFilter.Any.manaValueAtLeast(1)` → the stack half of Divide by Zero |
 
+`descriptionOverride` supplies the printed wording when the generated one reads badly — the same
+escape hatch `TargetPermanentOrPlayer` carries. A restriction covering *both* halves is printed once
+but has to be passed to each filter separately, so the generated text otherwise repeats it per side.
+
 Most printed cards in this shape restrict neither side or only the permanent one. A card whose
 single restriction applies to *both* halves spells it by passing the same filter to each:
 
@@ -3776,7 +3780,8 @@ val t = target(
     "target spell or permanent with mana value 1 or greater",
     TargetSpellOrPermanent(
         permanentFilter = GameObjectFilter.Permanent.manaValueAtLeast(1),
-        spellFilter = GameObjectFilter.Any.manaValueAtLeast(1)
+        spellFilter = GameObjectFilter.Any.manaValueAtLeast(1),
+        descriptionOverride = "target spell or permanent with mana value 1 or greater"
     )
 )
 effect = Effects.ReturnSpellOrPermanentToOwnersHand(t) then Patterns.Mechanic.learn()
@@ -4110,6 +4115,10 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   the land base (`GameObjectFilter.Land.nonbasic()`), or use the named constant `GameObjectFilter.NonbasicLand`
   / `TargetFilter.NonbasicLand` (Rocket Volley, Shivan Harvest, Encroaching Wastes). `TargetFilter.Land.nonbasic()`
   is the target-side passthrough.
+- `GameObjectFilter.LandWithBasicLandType` — a land with one of the five basic land types
+  (CR 205.3i): "a land card with a basic land type" (Boseiju, Who Endures). Deliberately *not*
+  `GameObjectFilter.BasicLand` — a shockland (`Land — Forest Island`) or Dryad Arbor qualifies, and a
+  basic is only the common case.
 - `.withChosenColor()` — `CardPredicate.HasChosenColor`: matches the color chosen during the current
   effect's resolution (read from `EffectContext.chosenColor`, set by `Effects.ChooseColorThen`). Use with
   `AggregateBattlefield(Player.Each, …)` for "for each permanent of that color" (Coalition Dragon cycle).
@@ -10549,6 +10558,16 @@ both spellings, and the ability its bare-noun line grants says "Regenerate this 
   as a `ForEachInGroup` over `Creature.youControl().powerGreaterThanBase()` reading the amount off
   `EntityReference.IterationEntity`. Not projected — always the printed base.
 - `CardNumericProperty(card, property)` — generic numeric property accessor.
+
+### Board-count shortcuts (`DynamicAmounts.*` facades)
+
+`DynamicAmounts.creaturesYouControl()`, `.landsYouControl()`, `.otherCreaturesYouControl()`,
+`.attackingCreaturesYouControl()`, `.equipmentYouControl()` — each a named `battlefield(…).count()`.
+
+`DynamicAmounts.legendaryCreaturesYouControl()` is the same shape over
+`GameObjectFilter.Creature.legendary()`: the Kamigawa channel lands' "costs {1} less to activate for
+each legendary creature you control", fed to `ActivatedAbility.genericCostReduction`. Counts creatures
+only — a legendary land or artifact does not qualify.
 
 ### Triggering-entity shortcuts (`DynamicAmounts.*` facades)
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2351,7 +2351,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `ReselectTargetRandomlyEffect(spell)` — re-choose targets at random.
 - `Effects.ChangeTriggeringObjectTargets(chooser = RetargetChooser.Controller)` — the player named by `chooser` may change the target or targets of the triggering spell/ability (`context.triggeringEntityId`); the player-chosen, multi-target counterpart of `ReselectTargetRandomly`. `RetargetChooser.Controller` = the effect's controller; `RetargetChooser.OwnerOfStored(name)` = the owner of the single card in pipeline collection `name` (≠1 card → no chooser → no-op). Reselection is offered slot-by-slot among the original object's legal targets (legality judged from *its* controller, current target kept as a "keep" option, no target chosen twice). **Psychic Battle** composes from atoms: `Composite(GatherCards(TopOfLibrary(1, Player.Each), revealed=true, storeAs="revealed"), FilterCollection("revealed", GreatestManaValue, storeMatching="w"), ChangeTriggeringObjectTargets(RetargetChooser.OwnerOfStored("w")))` — a tie keeps several greatest cards so `OwnerOfStored` finds no unique owner and the targets stay put.
 - `ReturnSpellToOwnersHandEffect` / `Effects.ReturnSpellToOwnersHand()` — return the targeted spell (`ContextTarget`) from the stack to its owner's hand. Not a counter (CR 701.27 / 701.5b), so "can't be countered" doesn't block it. Pair with `Targets.Spell` (Reprieve, Hullbreaker Horror).
-- `Effects.ReturnSpellOrPermanentToOwnersHand(target = ContextTarget(0))` (`ReturnSpellOrPermanentToOwnersHandEffect`) — bounce one target to its owner's hand, dispatching on what it resolves to: a **spell on the stack** is removed from the stack to hand (does not resolve; not a counter), a **permanent** is bounced normally (delegates to the standard `MoveToZone(HAND)` path with its full leave-the-battlefield cleanup). The bounce counterpart of `PutOnLibraryPositionOfChoiceEffect`. Pair with `TargetSpellOrPermanent` for "return target spell or nonland permanent…" cards (Press the Enemy). To cap a follow-up free-cast at the bounced object's mana value, capture it first with `Effects.StoreNumber("mv", DynamicAmount.EntityProperty(EntityReference.Target(0), EntityNumericProperty.ManaValue))` before bouncing, then read it via `DynamicAmount.VariableReference("mv")`.
+- `Effects.ReturnSpellOrPermanentToOwnersHand(target = ContextTarget(0))` (`ReturnSpellOrPermanentToOwnersHandEffect`) — bounce one target to its owner's hand, dispatching on what it resolves to: a **spell on the stack** is removed from the stack to hand (does not resolve; not a counter), a **permanent** is bounced normally (delegates to the standard `MoveToZone(HAND)` path with its full leave-the-battlefield cleanup). The bounce counterpart of `PutOnLibraryPositionOfChoiceEffect`. Pair with `TargetSpellOrPermanent` for "return target spell or nonland permanent…" cards (Press the Enemy); that requirement filters its two halves independently via `permanentFilter` / `spellFilter` (see *Spell-or-permanent targets*). To cap a follow-up free-cast at the bounced object's mana value, capture it first with `Effects.StoreNumber("mv", DynamicAmount.EntityProperty(EntityReference.Target(0), EntityNumericProperty.ManaValue))` before bouncing, then read it via `DynamicAmount.VariableReference("mv")`.
 
 ### Combat-shape & misc
 
@@ -3751,6 +3751,41 @@ effect = Effects.Composite(Effects.ReturnToHand(t), Effects.AddMana(Color.RED))
 `Keyword.FLASHBACK` to the card's base keywords, so the predicate matches even on a card sitting in
 exile (no projection needed). The client routes a union to its cross-zone card picker, grouping the
 valid targets into per-(owner, zone) tabs — "Your Graveyard", "Your Exile", etc.
+
+### Spell-or-permanent targets (`TargetSpellOrPermanent`)
+
+One target that may be either a spell on the stack **or** a permanent on the battlefield —
+"target spell or permanent" (Artificial Evolution, the lace effects, Venser, Shaper Savant).
+Distinct from the cross-zone union above: this is a fixed two-sided union the engine dispatches
+on directly, not a list of `TargetFilter` clauses.
+
+Each side carries its own optional `GameObjectFilter`, and either may be left null to mean
+"anything of that kind":
+
+| Field | Restricts | Example |
+|---|---|---|
+| `permanentFilter` | the battlefield half | `GameObjectFilter.Creature` → "target spell or creature" (Swat Away) |
+| `spellFilter` | the stack half | `GameObjectFilter.Any.manaValueAtLeast(1)` → the stack half of Divide by Zero |
+
+Most printed cards in this shape restrict neither side or only the permanent one. A card whose
+single restriction applies to *both* halves spells it by passing the same filter to each:
+
+```kotlin
+// Divide by Zero — "target spell or permanent with mana value 1 or greater"
+val t = target(
+    "target spell or permanent with mana value 1 or greater",
+    TargetSpellOrPermanent(
+        permanentFilter = GameObjectFilter.Permanent.manaValueAtLeast(1),
+        spellFilter = GameObjectFilter.Any.manaValueAtLeast(1)
+    )
+)
+effect = Effects.ReturnSpellOrPermanentToOwnersHand(t) then Patterns.Mechanic.learn()
+```
+
+A filter is matched against a stack spell the same way it is against a permanent, through the
+predicate evaluator. Stack entities have no projection entry, so the matchers fall back to the
+base card characteristics on their own — which also means a spell's mana value reads off the card
+rather than off a chosen `{X}` (CR 202.3b).
 
 ### Named multi-target binding
 

--- a/manual-scenarios/cards/b/boseiju-who-endures.json
+++ b/manual-scenarios/cards/b/boseiju-who-endures.json
@@ -32,5 +32,6 @@
   "player1StopAtSteps": [],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
 }

--- a/manual-scenarios/cards/b/boseiju-who-endures.json
+++ b/manual-scenarios/cards/b/boseiju-who-endures.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Boseiju, Who Endures"],
+    "battlefield": [
+      {"name": "Boseiju, Who Endures"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Grizzly Bears", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Secluded Courtyard"},
+      {"name": "Sol Ring"},
+      {"name": "Glorious Anthem"},
+      {"name": "Island"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Forest", "Hill Giant", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/d/divide-by-zero.json
+++ b/manual-scenarios/cards/d/divide-by-zero.json
@@ -15,7 +15,7 @@
   },
   "player2": {
     "lifeTotal": 20,
-    "hand": ["Grizzly Bears", "Memnite"],
+    "hand": ["Ornithopter", "Memnite"],
     "battlefield": [
       {"name": "Centaur Courser"},
       {"name": "Ornithopter"},
@@ -30,6 +30,7 @@
   "priorityPlayer": 2,
   "player1StopAtSteps": [],
   "player2StopAtSteps": [],
-  "player1OpponentStopAtSteps": ["PRECOMBAT_MAIN"],
-  "player2OpponentStopAtSteps": []
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
 }

--- a/manual-scenarios/cards/d/divide-by-zero.json
+++ b/manual-scenarios/cards/d/divide-by-zero.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Divide by Zero", "Hill Giant"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "sideboard": ["Boomerang Basics", "Hill Giant"],
+    "library": ["Island", "Grizzly Bears", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Grizzly Bears", "Memnite"],
+    "battlefield": [
+      {"name": "Centaur Courser"},
+      {"name": "Ornithopter"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Hill Giant", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 2,
+  "priorityPlayer": 2,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": ["PRECOMBAT_MAIN"],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/e/eiganjo-seat-of-the-empire.json
+++ b/manual-scenarios/cards/e/eiganjo-seat-of-the-empire.json
@@ -33,6 +33,7 @@
   "priorityPlayer": 2,
   "player1StopAtSteps": [],
   "player2StopAtSteps": [],
-  "player1OpponentStopAtSteps": ["DECLARE_ATTACKERS", "DECLARE_BLOCKERS"],
-  "player2OpponentStopAtSteps": []
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
 }

--- a/manual-scenarios/cards/e/eiganjo-seat-of-the-empire.json
+++ b/manual-scenarios/cards/e/eiganjo-seat-of-the-empire.json
@@ -1,0 +1,38 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Eiganjo, Seat of the Empire"],
+    "battlefield": [
+      {"name": "Eiganjo, Seat of the Empire"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Mirri, Cat Warrior"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Grizzly Bears", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Centaur Courser"},
+      {"name": "Hill Giant"},
+      {"name": "Grizzly Bears"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Hill Giant", "Forest"]
+  },
+  "phase": "COMBAT",
+  "step": "DECLARE_ATTACKERS",
+  "activePlayer": 2,
+  "priorityPlayer": 2,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": ["DECLARE_ATTACKERS", "DECLARE_BLOCKERS"],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/o/otawara-soaring-city.json
+++ b/manual-scenarios/cards/o/otawara-soaring-city.json
@@ -1,0 +1,37 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Otawara, Soaring City"],
+    "battlefield": [
+      {"name": "Otawara, Soaring City"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Mirri, Cat Warrior"},
+      {"name": "Squee, Goblin Nabob"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Grizzly Bears", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Centaur Courser"},
+      {"name": "Sol Ring"},
+      {"name": "Glorious Anthem"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Hill Giant", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/o/otawara-soaring-city.json
+++ b/manual-scenarios/cards/o/otawara-soaring-city.json
@@ -33,5 +33,6 @@
   "player1StopAtSteps": [],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
 }

--- a/manual-scenarios/cards/s/sokenzan-crucible-of-defiance.json
+++ b/manual-scenarios/cards/s/sokenzan-crucible-of-defiance.json
@@ -28,8 +28,9 @@
   "phase": "PRECOMBAT_MAIN",
   "activePlayer": 1,
   "priorityPlayer": 1,
-  "player1StopAtSteps": ["DECLARE_ATTACKERS", "DECLARE_BLOCKERS"],
+  "player1StopAtSteps": [],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
 }

--- a/manual-scenarios/cards/s/sokenzan-crucible-of-defiance.json
+++ b/manual-scenarios/cards/s/sokenzan-crucible-of-defiance.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Sokenzan, Crucible of Defiance"],
+    "battlefield": [
+      {"name": "Sokenzan, Crucible of Defiance"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Squee, Goblin Nabob"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Grizzly Bears", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Hill Giant", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["DECLARE_ATTACKERS", "DECLARE_BLOCKERS"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/t/takenuma-abandoned-mire.json
+++ b/manual-scenarios/cards/t/takenuma-abandoned-mire.json
@@ -1,0 +1,34 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Takenuma, Abandoned Mire"],
+    "battlefield": [
+      {"name": "Takenuma, Abandoned Mire"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Squee, Goblin Nabob"}
+    ],
+    "graveyard": ["Grizzly Bears", "Sol Ring"],
+    "library": ["Hill Giant", "Centaur Courser", "Llanowar Elves", "Swamp", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Hill Giant", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/t/takenuma-abandoned-mire.json
+++ b/manual-scenarios/cards/t/takenuma-abandoned-mire.json
@@ -30,5 +30,6 @@
   "player1StopAtSteps": [],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -175,6 +175,14 @@ object DynamicAmounts {
     fun creaturesYouControl(): DynamicAmount =
         battlefield(Player.You, GameObjectFilter.Creature).count()
 
+    /**
+     * Legendary creatures you control — the Kamigawa channel lands' "costs {1} less to activate
+     * for each legendary creature you control", and the same count the legendary-matters payoffs
+     * read. Counts creatures only: a legendary land or artifact does not qualify.
+     */
+    fun legendaryCreaturesYouControl(): DynamicAmount =
+        battlefield(Player.You, GameObjectFilter.Creature.legendary()).count()
+
     fun allCreatures(): DynamicAmount =
         battlefield(Player.Each, GameObjectFilter.Creature).count()
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -124,6 +124,25 @@ data class GameObjectFilter(
         val NonbasicLand = GameObjectFilter(
             cardPredicates = listOf(CardPredicate.IsLand, CardPredicate.Not(CardPredicate.IsBasicLand))
         )
+        /**
+         * A land with one of the five basic land types (CR 205.3i) — Boseiju, Who Endures' "a
+         * land card with a basic land type". Deliberately *not* [BasicLand]: a shockland
+         * (`Land — Forest Island`) or Dryad Arbor qualifies, and a basic is only the common case.
+         */
+        val LandWithBasicLandType = GameObjectFilter(
+            cardPredicates = listOf(
+                CardPredicate.IsLand,
+                CardPredicate.Or(
+                    listOf(
+                        CardPredicate.HasBasicLandType(Subtype.PLAINS.value),
+                        CardPredicate.HasBasicLandType(Subtype.ISLAND.value),
+                        CardPredicate.HasBasicLandType(Subtype.SWAMP.value),
+                        CardPredicate.HasBasicLandType(Subtype.MOUNTAIN.value),
+                        CardPredicate.HasBasicLandType(Subtype.FOREST.value),
+                    )
+                )
+            )
+        )
         val Artifact = GameObjectFilter(cardPredicates = listOf(CardPredicate.IsArtifact))
         val Enchantment = GameObjectFilter(cardPredicates = listOf(CardPredicate.IsEnchantment))
         val Planeswalker = GameObjectFilter(cardPredicates = listOf(CardPredicate.IsPlaneswalker))

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
@@ -373,9 +373,19 @@ data class TargetCreatureOrPlaneswalker(
  * Used by text-changing effects like Artificial Evolution and bounce-to-library
  * effects like Swat Away ("target spell or creature").
  *
- * The [permanentFilter] restricts which permanents are valid. When null, any
- * permanent may be targeted. For "target spell or creature", pass
- * [GameObjectFilter.Creature].
+ * The two halves are filtered independently, and either may be left null to mean
+ * "anything of that kind":
+ *  - [permanentFilter] restricts the battlefield half. For "target spell or creature",
+ *    pass [GameObjectFilter.Creature].
+ *  - [spellFilter] restricts the stack half. Most printed cards in this shape don't
+ *    restrict it (the lace effects, Artificial Evolution, Venser, Shaper Savant), but
+ *    some do: Divide by Zero's "target spell or permanent with mana value 1 or greater"
+ *    and Aether Gust's "target spell or permanent that's red or green" apply one
+ *    restriction to *both* halves, which is spelled here by passing the same filter twice.
+ *
+ * A filter is matched against a spell on the stack the same way it is against a permanent,
+ * via the predicate evaluator; stack entities have no projection entry, so the matchers fall
+ * back to the base card characteristics on their own.
  */
 @SerialName("TargetSpellOrPermanent")
 @Serializable
@@ -383,16 +393,21 @@ data class TargetSpellOrPermanent(
     override val count: Int = 1,
     override val optional: Boolean = false,
     override val id: String? = null,
-    val permanentFilter: GameObjectFilter? = null
+    val permanentFilter: GameObjectFilter? = null,
+    val spellFilter: GameObjectFilter? = null
 ) : TargetRequirement {
     override val description: String = run {
         val permanentNoun = permanentFilter?.description ?: "permanent"
-        if (count == 1) "target spell or $permanentNoun"
-        else "$count target spells or ${permanentNoun}s"
+        val spellNoun = spellFilter?.let { "${it.description} spell" } ?: "spell"
+        if (count == 1) "target $spellNoun or $permanentNoun"
+        else "$count target ${spellNoun}s or ${permanentNoun}s"
     }
     override fun applyTextReplacement(replacer: TextReplacer): TargetRequirement {
-        val newFilter = permanentFilter?.applyTextReplacement(replacer)
-        return if (newFilter !== permanentFilter) copy(permanentFilter = newFilter) else this
+        val newPermanentFilter = permanentFilter?.applyTextReplacement(replacer)
+        val newSpellFilter = spellFilter?.applyTextReplacement(replacer)
+        return if (newPermanentFilter !== permanentFilter || newSpellFilter !== spellFilter) {
+            copy(permanentFilter = newPermanentFilter, spellFilter = newSpellFilter)
+        } else this
     }
 }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
@@ -394,11 +394,18 @@ data class TargetSpellOrPermanent(
     override val optional: Boolean = false,
     override val id: String? = null,
     val permanentFilter: GameObjectFilter? = null,
-    val spellFilter: GameObjectFilter? = null
+    val spellFilter: GameObjectFilter? = null,
+    /**
+     * Printed wording, when the generated one reads badly. A restriction that applies to
+     * *both* halves is printed once ("target spell or permanent with mana value 1 or greater")
+     * but has to be passed to each filter separately, and the generated text then repeats it on
+     * both sides. Same escape hatch [TargetPermanentOrPlayer] carries, for the same reason.
+     */
+    private val descriptionOverride: String? = null
 ) : TargetRequirement {
-    override val description: String = run {
+    override val description: String = descriptionOverride ?: run {
         val permanentNoun = permanentFilter?.description ?: "permanent"
-        val spellNoun = spellFilter?.let { "${it.description} spell" } ?: "spell"
+        val spellNoun = spellFilter?.let { "spell ${it.description}" } ?: "spell"
         if (count == 1) "target $spellNoun or $permanentNoun"
         else "$count target ${spellNoun}s or ${permanentNoun}s"
     }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/BoseijuWhoEndures.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/BoseijuWhoEndures.kt
@@ -13,7 +13,6 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.effects.SearchDestination
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
-import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.TargetPermanent
 
@@ -38,7 +37,7 @@ import com.wingedsheep.sdk.scripting.targets.TargetPermanent
  *
  * "A land card **with a basic land type**" is deliberately not "a basic land card" — a shockland
  * (`Land — Forest Island`) or Dryad Arbor qualifies and a basic is merely the common case. Hence
- * the explicit [CardPredicate.HasBasicLandType] union rather than [GameObjectFilter.BasicLand].
+ * [GameObjectFilter.LandWithBasicLandType] rather than [GameObjectFilter.BasicLand].
  */
 val BoseijuWhoEndures = card("Boseiju, Who Endures") {
     typeLine = "Legendary Land"
@@ -59,8 +58,7 @@ val BoseijuWhoEndures = card("Boseiju, Who Endures") {
     activatedAbility {
         cost = Costs.Composite(Costs.Mana("{1}{G}"), Costs.DiscardSelf)
         activateFromZone = Zone.HAND
-        genericCostReduction =
-            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.legendary()).count()
+        genericCostReduction = DynamicAmounts.legendaryCreaturesYouControl()
         val t = target(
             "target artifact, enchantment, or nonbasic land an opponent controls",
             TargetPermanent(
@@ -77,20 +75,7 @@ val BoseijuWhoEndures = card("Boseiju, Who Endures") {
                 listOf(
                     MayEffect(
                         Patterns.Library.searchLibrary(
-                            filter = GameObjectFilter(
-                                cardPredicates = listOf(
-                                    CardPredicate.IsLand,
-                                    CardPredicate.Or(
-                                        listOf(
-                                            CardPredicate.HasBasicLandType("Plains"),
-                                            CardPredicate.HasBasicLandType("Island"),
-                                            CardPredicate.HasBasicLandType("Swamp"),
-                                            CardPredicate.HasBasicLandType("Mountain"),
-                                            CardPredicate.HasBasicLandType("Forest")
-                                        )
-                                    )
-                                )
-                            ),
+                            filter = GameObjectFilter.LandWithBasicLandType,
                             count = 1,
                             destination = SearchDestination.BATTLEFIELD
                         )

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/BoseijuWhoEndures.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/BoseijuWhoEndures.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.mtg.sets.definitions.neo.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Boseiju, Who Endures — Kamigawa: Neon Dynasty #266 (canonical printing)
+ * Legendary Land · Rare
+ *
+ * {T}: Add {G}.
+ * Channel — {1}{G}, Discard this card: Destroy target artifact, enchantment, or nonbasic land an
+ * opponent controls. That player may search their library for a land card with a basic land type,
+ * put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each
+ * legendary creature you control.
+ *
+ * One of the five NEO channel lands; see [OtawaraSoaringCity] for the shape they share.
+ *
+ * The consolation fetch is the Assassin's Trophy shape: it belongs to the *destroyed permanent's*
+ * controller, not to you, so it runs under [Effects.ForEachPlayer] with [Player.ControllerOf] —
+ * that rebinds `Player.You` inside the search to that player, which is what makes
+ * [Patterns.Library.searchLibrary] (hard-wired to `Player.You`) read the right library. Two
+ * consequences fall out of the ordering rather than needing a gate: an indestructible target
+ * still hands its controller the land, and declining the search skips the shuffle with it.
+ *
+ * "A land card **with a basic land type**" is deliberately not "a basic land card" — a shockland
+ * (`Land — Forest Island`) or Dryad Arbor qualifies and a basic is merely the common case. Hence
+ * the explicit [CardPredicate.HasBasicLandType] union rather than [GameObjectFilter.BasicLand].
+ */
+val BoseijuWhoEndures = card("Boseiju, Who Endures") {
+    typeLine = "Legendary Land"
+    colorIdentity = "G"
+    oracleText = "{T}: Add {G}.\n" +
+        "Channel — {1}{G}, Discard this card: Destroy target artifact, enchantment, or nonbasic " +
+        "land an opponent controls. That player may search their library for a land card with a " +
+        "basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less " +
+        "to activate for each legendary creature you control."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+    }
+
+    // Channel — {1}{G}, Discard this card (from hand): Naya-style destroy + consolation fetch.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{G}"), Costs.DiscardSelf)
+        activateFromZone = Zone.HAND
+        genericCostReduction =
+            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.legendary()).count()
+        val t = target(
+            "target artifact, enchantment, or nonbasic land an opponent controls",
+            TargetPermanent(
+                filter = TargetFilter(
+                    (GameObjectFilter.Artifact or
+                        GameObjectFilter.Enchantment or
+                        GameObjectFilter.NonbasicLand).opponentControls()
+                )
+            )
+        )
+        effect = Effects.Destroy(t) then
+            Effects.ForEachPlayer(
+                Player.ControllerOf("the destroyed permanent"),
+                listOf(
+                    MayEffect(
+                        Patterns.Library.searchLibrary(
+                            filter = GameObjectFilter(
+                                cardPredicates = listOf(
+                                    CardPredicate.IsLand,
+                                    CardPredicate.Or(
+                                        listOf(
+                                            CardPredicate.HasBasicLandType("Plains"),
+                                            CardPredicate.HasBasicLandType("Island"),
+                                            CardPredicate.HasBasicLandType("Swamp"),
+                                            CardPredicate.HasBasicLandType("Mountain"),
+                                            CardPredicate.HasBasicLandType("Forest")
+                                        )
+                                    )
+                                )
+                            ),
+                            count = 1,
+                            destination = SearchDestination.BATTLEFIELD
+                        )
+                    )
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "266"
+        artist = "Chris Ostrowski"
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/2135ac5a-187b-4dc9-8f82-34e8d1603416.jpg?1783923818"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/EiganjoSeatOfTheEmpire.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/EiganjoSeatOfTheEmpire.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.neo.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Eiganjo, Seat of the Empire — Kamigawa: Neon Dynasty #268 (canonical printing)
+ * Legendary Land · Rare
+ *
+ * {T}: Add {W}.
+ * Channel — {2}{W}, Discard this card: It deals 4 damage to target attacking or blocking
+ * creature. This ability costs {1} less to activate for each legendary creature you control.
+ *
+ * One of the five NEO channel lands; see [OtawaraSoaringCity] for the shape they share.
+ *
+ * "It deals 4 damage" — the *land card* is the source, not a permanent: the ability is activated
+ * from hand and the card is in the graveyard by the time it resolves. `Effects.DealDamage` with
+ * the ability's own source is exactly that.
+ */
+val EiganjoSeatOfTheEmpire = card("Eiganjo, Seat of the Empire") {
+    typeLine = "Legendary Land"
+    colorIdentity = "W"
+    oracleText = "{T}: Add {W}.\n" +
+        "Channel — {2}{W}, Discard this card: It deals 4 damage to target attacking or blocking " +
+        "creature. This ability costs {1} less to activate for each legendary creature you control."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+    }
+
+    // Channel — {2}{W}, Discard this card (from hand): 4 damage to an attacking/blocking creature.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{W}"), Costs.DiscardSelf)
+        activateFromZone = Zone.HAND
+        genericCostReduction =
+            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.legendary()).count()
+        val t = target(
+            "target attacking or blocking creature",
+            TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature)
+        )
+        effect = Effects.DealDamage(4, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "268"
+        artist = "Julian Kok Joon Wen"
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c375a022-5b57-496d-a802-e4ea8376e9e4.jpg?1783923818"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/EiganjoSeatOfTheEmpire.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/EiganjoSeatOfTheEmpire.kt
@@ -44,8 +44,7 @@ val EiganjoSeatOfTheEmpire = card("Eiganjo, Seat of the Empire") {
     activatedAbility {
         cost = Costs.Composite(Costs.Mana("{2}{W}"), Costs.DiscardSelf)
         activateFromZone = Zone.HAND
-        genericCostReduction =
-            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.legendary()).count()
+        genericCostReduction = DynamicAmounts.legendaryCreaturesYouControl()
         val t = target(
             "target attacking or blocking creature",
             TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/OtawaraSoaringCity.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/OtawaraSoaringCity.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.neo.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Otawara, Soaring City — Kamigawa: Neon Dynasty #271 (canonical printing)
+ * Legendary Land · Rare
+ *
+ * {T}: Add {U}.
+ * Channel — {3}{U}, Discard this card: Return target artifact, creature, enchantment, or
+ * planeswalker to its owner's hand. This ability costs {1} less to activate for each legendary
+ * creature you control.
+ *
+ * The reference implementation of the five NEO channel lands (Boseiju, Eiganjo, Otawara,
+ * Sokenzan, Takenuma). All five share one shape:
+ *
+ *  - **Channel is an ability *word*** (CR 207.2c) — italic flavour with no rules meaning and no
+ *    entry of its own in the rules. So it is not modelled as a keyword: it lives in [oracleText]
+ *    and nowhere else, exactly as Landfall and Magecraft do on their cards. The ability itself is
+ *    an ordinary activated ability.
+ *  - **Activated from hand**, paid for by discarding itself: `activateFromZone = Zone.HAND` plus
+ *    [Costs.DiscardSelf] (the Steel Wrecking Ball shape).
+ *  - **"Costs {1} less to activate for each legendary creature you control"** is
+ *    [com.wingedsheep.sdk.scripting.ActivatedAbility.genericCostReduction], which shaves only the
+ *    generic pips — so the coloured pip always survives and {3}{U} floors at {U}.
+ *
+ * Note the target is *any* artifact, creature, enchantment, or planeswalker — Otawara can bounce
+ * your own permanent, unlike Boseiju, which is restricted to what an opponent controls.
+ */
+val OtawaraSoaringCity = card("Otawara, Soaring City") {
+    typeLine = "Legendary Land"
+    colorIdentity = "U"
+    oracleText = "{T}: Add {U}.\n" +
+        "Channel — {3}{U}, Discard this card: Return target artifact, creature, enchantment, or " +
+        "planeswalker to its owner's hand. This ability costs {1} less to activate for each " +
+        "legendary creature you control."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+    }
+
+    // Channel — {3}{U}, Discard this card (from hand): bounce an artifact/creature/enchantment/PW.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{U}"), Costs.DiscardSelf)
+        activateFromZone = Zone.HAND
+        genericCostReduction =
+            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.legendary()).count()
+        val t = target(
+            "target artifact, creature, enchantment, or planeswalker",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.Artifact or
+                        GameObjectFilter.Creature or
+                        GameObjectFilter.Enchantment or
+                        GameObjectFilter.Planeswalker
+                )
+            )
+        )
+        effect = Effects.ReturnToHand(t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "271"
+        artist = "Alayna Danner"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/486d7edc-d983-41f0-8b78-c99aecd72996.jpg?1783923816"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/OtawaraSoaringCity.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/OtawaraSoaringCity.kt
@@ -56,8 +56,7 @@ val OtawaraSoaringCity = card("Otawara, Soaring City") {
     activatedAbility {
         cost = Costs.Composite(Costs.Mana("{3}{U}"), Costs.DiscardSelf)
         activateFromZone = Zone.HAND
-        genericCostReduction =
-            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.legendary()).count()
+        genericCostReduction = DynamicAmounts.legendaryCreaturesYouControl()
         val t = target(
             "target artifact, creature, enchantment, or planeswalker",
             TargetPermanent(

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/SokenzanCrucibleOfDefiance.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/SokenzanCrucibleOfDefiance.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.neo.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sokenzan, Crucible of Defiance — Kamigawa: Neon Dynasty #276 (canonical printing)
+ * Legendary Land · Rare
+ *
+ * {T}: Add {R}.
+ * Channel — {3}{R}, Discard this card: Create two 1/1 colorless Spirit creature tokens. They
+ * gain haste until end of turn. This ability costs {1} less to activate for each legendary
+ * creature you control.
+ *
+ * One of the five NEO channel lands; see [OtawaraSoaringCity] for the shape they share.
+ *
+ * "They gain haste until end of turn" iterates the [CREATED_TOKENS] pipeline collection the
+ * create-token executor publishes, so the grant lands on exactly the two tokens this activation
+ * made — and only until end of turn (the [Effects.GrantKeyword] default). Baking haste into the
+ * token itself would be the easy approximation and the wrong one: printed haste would still be
+ * there on a later turn, which matters the moment the token changes control.
+ */
+val SokenzanCrucibleOfDefiance = card("Sokenzan, Crucible of Defiance") {
+    typeLine = "Legendary Land"
+    colorIdentity = "R"
+    oracleText = "{T}: Add {R}.\n" +
+        "Channel — {3}{R}, Discard this card: Create two 1/1 colorless Spirit creature tokens. " +
+        "They gain haste until end of turn. This ability costs {1} less to activate for each " +
+        "legendary creature you control."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+    }
+
+    // Channel — {3}{R}, Discard this card (from hand): two 1/1 Spirits with haste until EOT.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{R}"), Costs.DiscardSelf)
+        activateFromZone = Zone.HAND
+        genericCostReduction =
+            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.legendary()).count()
+        effect = Effects.Composite(
+            listOf(
+                Effects.CreateToken(
+                    count = 2,
+                    power = 1,
+                    toughness = 1,
+                    colors = emptySet(),
+                    creatureTypes = setOf("Spirit"),
+                    imageUri = "https://cards.scryfall.io/normal/front/c/a/ca20548f-6324-4858-adbe-87303ff1ca52.jpg?1783923715"
+                ),
+                ForEachInCollectionEffect(
+                    CREATED_TOKENS,
+                    Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "276"
+        artist = "Lucas Staniec"
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aa548dcd-c1dd-492d-a69f-c65dfeef0633.jpg?1783923814"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/SokenzanCrucibleOfDefiance.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/SokenzanCrucibleOfDefiance.kt
@@ -50,8 +50,7 @@ val SokenzanCrucibleOfDefiance = card("Sokenzan, Crucible of Defiance") {
     activatedAbility {
         cost = Costs.Composite(Costs.Mana("{3}{R}"), Costs.DiscardSelf)
         activateFromZone = Zone.HAND
-        genericCostReduction =
-            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.legendary()).count()
+        genericCostReduction = DynamicAmounts.legendaryCreaturesYouControl()
         effect = Effects.Composite(
             listOf(
                 Effects.CreateToken(

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/TakenumaAbandonedMire.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/TakenumaAbandonedMire.kt
@@ -59,8 +59,7 @@ val TakenumaAbandonedMire = card("Takenuma, Abandoned Mire") {
     activatedAbility {
         cost = Costs.Composite(Costs.Mana("{3}{B}"), Costs.DiscardSelf)
         activateFromZone = Zone.HAND
-        genericCostReduction =
-            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.legendary()).count()
+        genericCostReduction = DynamicAmounts.legendaryCreaturesYouControl()
         effect = Effects.Composite(
             listOf(
                 Patterns.Library.mill(3),

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/TakenumaAbandonedMire.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/TakenumaAbandonedMire.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.mtg.sets.definitions.neo.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Takenuma, Abandoned Mire — Kamigawa: Neon Dynasty #278 (canonical printing)
+ * Legendary Land · Rare
+ *
+ * {T}: Add {B}.
+ * Channel — {3}{B}, Discard this card: Mill three cards, then return a creature or planeswalker
+ * card from your graveyard to your hand. This ability costs {1} less to activate for each
+ * legendary creature you control.
+ *
+ * One of the five NEO channel lands; see [OtawaraSoaringCity] for the shape they share.
+ *
+ * The return is **not targeted** — it is a choice made on resolution, and it is mandatory rather
+ * than a "may", so it is the Gather → Select → Move pipeline with
+ * [SelectionMode.ChooseExactly]. That mode clamps to what is actually there, which is the right
+ * reading here: with no creature or planeswalker card in the graveyard after the mill, nothing
+ * is returned and the ability simply finishes.
+ *
+ * Printed order matters and is preserved: the mill happens *first*, so a creature card milled by
+ * this very ability is already in the graveyard and is a legal choice to return.
+ */
+val TakenumaAbandonedMire = card("Takenuma, Abandoned Mire") {
+    typeLine = "Legendary Land"
+    colorIdentity = "B"
+    oracleText = "{T}: Add {B}.\n" +
+        "Channel — {3}{B}, Discard this card: Mill three cards, then return a creature or " +
+        "planeswalker card from your graveyard to your hand. This ability costs {1} less to " +
+        "activate for each legendary creature you control."
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+    }
+
+    // Channel — {3}{B}, Discard this card (from hand): mill 3, then return a creature/PW card.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{B}"), Costs.DiscardSelf)
+        activateFromZone = Zone.HAND
+        genericCostReduction =
+            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.legendary()).count()
+        effect = Effects.Composite(
+            listOf(
+                Patterns.Library.mill(3),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.GRAVEYARD,
+                        player = Player.You,
+                        filter = GameObjectFilter.CreatureOrPlaneswalker
+                    ),
+                    storeAs = "takenumaGraveyard"
+                ),
+                SelectFromCollectionEffect(
+                    from = "takenumaGraveyard",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    storeSelected = "takenumaReturned",
+                    prompt = "Choose a creature or planeswalker card to return to your hand",
+                    showAllCards = true
+                ),
+                MoveCollectionEffect(
+                    from = "takenumaReturned",
+                    destination = CardDestination.ToZone(Zone.HAND, Player.You),
+                    moveType = MoveType.Default
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "278"
+        artist = "Sam Burley"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/499037cc-a577-41cb-8ca2-5e117945634f.jpg?1783923812"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/DivideByZero.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/DivideByZero.kt
@@ -41,7 +41,9 @@ val DivideByZero = card("Divide by Zero") {
             "target spell or permanent with mana value 1 or greater",
             TargetSpellOrPermanent(
                 permanentFilter = GameObjectFilter.Permanent.manaValueAtLeast(1),
-                spellFilter = GameObjectFilter.Any.manaValueAtLeast(1)
+                spellFilter = GameObjectFilter.Any.manaValueAtLeast(1),
+                // One restriction, printed once — the generated text would repeat it per half.
+                descriptionOverride = "target spell or permanent with mana value 1 or greater"
             )
         )
         effect = Effects.ReturnSpellOrPermanentToOwnersHand(t) then Patterns.Mechanic.learn()

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/DivideByZero.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/DivideByZero.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.TargetSpellOrPermanent
+
+/**
+ * Divide by Zero — Strixhaven: School of Mages #41 (canonical printing)
+ * {2}{U} · Instant
+ *
+ * Return target spell or permanent with mana value 1 or greater to its owner's hand.
+ * Learn.
+ *
+ * The one printed restriction applies to *both* halves of the target, so it is passed to both
+ * filters of [TargetSpellOrPermanent]: a {0} spell on the stack (Memnite, a Mox) is no more a
+ * legal target than a land on the battlefield is. Before this card the stack half of that
+ * requirement carried no filter at all — see the SDK field's docs.
+ *
+ * `Learn` is [Patterns.Mechanic.learn] (CR 701.48), and it runs *after* the bounce in printed
+ * order — so a card returned to your own hand is already there to be pitched to the Learn's
+ * discard.
+ *
+ * Known limitation, narrow enough to be worth naming: mana value is read off the card, so a
+ * spell on the stack whose cost is purely `{X}` reads as MV 0 rather than the value chosen for X
+ * (CR 202.3b). That makes such a spell wrongly untargetable; every other `{X}` spell has a
+ * non-X pip and so clears "1 or greater" either way.
+ */
+val DivideByZero = card("Divide by Zero") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return target spell or permanent with mana value 1 or greater to its owner's hand.\n" +
+        "Learn. (You may reveal a Lesson card you own from outside the game and put it into your " +
+        "hand, or discard a card to draw a card.)"
+
+    spell {
+        val t = target(
+            "target spell or permanent with mana value 1 or greater",
+            TargetSpellOrPermanent(
+                permanentFilter = GameObjectFilter.Permanent.manaValueAtLeast(1),
+                spellFilter = GameObjectFilter.Any.manaValueAtLeast(1)
+            )
+        )
+        effect = Effects.ReturnSpellOrPermanentToOwnersHand(t) then Patterns.Mechanic.learn()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "41"
+        artist = "Liiga Smilshkalne"
+        flavorText = "\"Misery. Inadequacy. Failure. The common denominator is you.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/1958d96e-ec44-48ab-80b1-5b01a24ac7b8.jpg?1783927380"
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BoseijuWhoEnduresScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BoseijuWhoEnduresScenarioTest.kt
@@ -1,0 +1,148 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.support.ScenarioTestBase.TestGame
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Boseiju, Who Endures (NEO #266) — Legendary Land.
+ *
+ *   {T}: Add {G}.
+ *   Channel — {1}{G}, Discard this card: Destroy target artifact, enchantment, or nonbasic land
+ *   an opponent controls. That player may search their library for a land card with a basic land
+ *   type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for
+ *   each legendary creature you control.
+ *
+ * See OtawaraSoaringCityScenarioTest for the shared channel shape. Boseiju's own points are the
+ * "an opponent controls" restriction — unlike Otawara, it can't be pointed at your own board —
+ * and that a *basic* land is not a legal target while a nonbasic one is.
+ */
+class BoseijuWhoEnduresScenarioTest : ScenarioTestBase() {
+
+    private fun channelAbilityId() = cardRegistry.getCard("Boseiju, Who Endures")!!
+        .activatedAbilities.first { it.activateFromZone == Zone.HAND }.id
+
+    private fun activate(game: TestGame, target: EntityId) =
+        game.execute(
+            ActivateAbility(
+                playerId = game.player1Id,
+                sourceId = game.findCardsInHand(1, "Boseiju, Who Endures").first(),
+                abilityId = channelAbilityId(),
+                targets = listOf(ChosenTarget.Permanent(target))
+            )
+        )
+
+
+    /**
+     * Clear whatever prompts an activation raises, without assuming their shape or count.
+     * Bounded, because an unbounded `while (hasPendingDecision())` spins forever the moment a
+     * decision arrives that the chosen responder can't answer — `skipSelection` is a no-op
+     * against a yes/no prompt, which is exactly what the consolation search raises.
+     */
+    private fun declineAllPrompts(game: TestGame, max: Int = 8) {
+        var guard = 0
+        while (game.hasPendingDecision() && guard++ < max) {
+            when (game.getPendingDecision()) {
+                is YesNoDecision -> game.answerYesNo(false)
+                else -> game.skipSelection()
+            }
+        }
+        withClue("prompts should settle well inside the guard") {
+            game.hasPendingDecision() shouldBe false
+        }
+    }
+
+    init {
+        context("Boseiju, Who Endures") {
+
+            test("destroys an opponent's nonbasic land") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Boseiju, Who Endures")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(2, "Secluded Courtyard")   // a nonbasic land
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courtyard = game.findPermanent("Secluded Courtyard")!!
+
+                withClue("{1}{G} from two Forests") {
+                    activate(game, courtyard).error shouldBe null
+                }
+                game.resolveStack()
+                // The consolation search belongs to the opponent and is a "may" — decline it.
+                declineAllPrompts(game)
+
+                withClue("The nonbasic land is destroyed") {
+                    game.isOnBattlefield("Secluded Courtyard") shouldBe false
+                    game.isInGraveyard(2, "Secluded Courtyard") shouldBe true
+                }
+                withClue("Boseiju discarded itself to pay") {
+                    game.isInGraveyard(1, "Boseiju, Who Endures") shouldBe true
+                }
+            }
+
+            test("destroys an opponent's artifact") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Boseiju, Who Endures")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(2, "Sol Ring")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val solRing = game.findPermanent("Sol Ring")!!
+                activate(game, solRing).error shouldBe null
+                game.resolveStack()
+                declineAllPrompts(game)
+
+                game.isInGraveyard(2, "Sol Ring") shouldBe true
+            }
+
+            test("a basic land is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Boseiju, Who Endures")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(2, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val island = game.findPermanent("Island")!!
+
+                withClue("'nonbasic land' excludes an Island") {
+                    activate(game, island).error shouldNotBe null
+                }
+            }
+
+            test("your own nonbasic land is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Boseiju, Who Endures")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(1, "Secluded Courtyard")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ownCourtyard = game.findPermanent("Secluded Courtyard")!!
+
+                withClue("'an opponent controls' — Boseiju can't eat your own land") {
+                    activate(game, ownCourtyard).error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DivideByZeroScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DivideByZeroScenarioTest.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Divide by Zero (STX #41) — "Return target spell or permanent with mana value 1 or greater to
+ * its owner's hand. Learn."
+ *
+ * The interesting half is the target: one restriction ("mana value 1 or greater") applied to
+ * *both* sides of a spell-or-permanent choice. The permanent side was always filterable; the
+ * stack side was not, and every spell on the stack used to be a legal target regardless of what
+ * the card said. So the two "{0} is not a legal target" tests below are the regression, and the
+ * Memnite one is the case that had no way of being expressed at all before this card.
+ *
+ * Learn (CR 701.48) is [com.wingedsheep.sdk.dsl.Patterns.Mechanic.learn] and is exercised in
+ * depth by AcademicDisputeScenarioTest; here it is only checked to fire in the right order,
+ * after the bounce.
+ */
+class DivideByZeroScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("the permanent half") {
+
+            test("bounces a permanent with mana value 1 or greater") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Divide by Zero")
+                    .withCardInHand(1, "Hill Giant")             // something for Learn to offer
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardOnBattlefield(2, "Grizzly Bears")   // {1}{G} — mana value 2
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Divide by Zero", bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears is back in its owner's hand") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInHand(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("Learn follows the bounce — with a card in hand it offers the discard") {
+                    game.hasPendingDecision() shouldBe true
+                }
+            }
+
+            test("a land is not a legal target — every land has mana value 0") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Divide by Zero")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forest = game.findPermanent("Forest")!!
+
+                withClue("A {0} permanent fails the 'mana value 1 or greater' clause") {
+                    game.castSpell(1, "Divide by Zero", forest).error shouldNotBe null
+                }
+            }
+
+            test("a {0} artifact creature is not a legal target either") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Divide by Zero")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardOnBattlefield(2, "Ornithopter")   // {0} — mana value 0
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val thopter = game.findPermanent("Ornithopter")!!
+
+                withClue("Ornithopter is a nonland permanent, but its mana value is still 0") {
+                    game.castSpell(1, "Divide by Zero", thopter).error shouldNotBe null
+                }
+            }
+        }
+
+        context("the spell half") {
+
+            test("bounces a spell off the stack — it never resolves") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Divide by Zero")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.execute(PassPriority(game.player2Id))
+
+                val result = game.castSpellTargetingStackSpell(1, "Divide by Zero", "Grizzly Bears")
+                withClue("A {1}{G} spell on the stack clears 'mana value 1 or greater': ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The bounced spell goes to hand, not the battlefield and not the graveyard") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInHand(2, "Grizzly Bears") shouldBe true
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("a {0} spell on the stack is NOT a legal target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Divide by Zero")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInHand(2, "Memnite")   // {0} creature spell
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Memnite").error shouldBe null
+                game.execute(PassPriority(game.player2Id))
+
+                withClue("This is the case the stack half had no way to reject before") {
+                    game.castSpellTargetingStackSpell(1, "Divide by Zero", "Memnite")
+                        .error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EiganjoSeatOfTheEmpireScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EiganjoSeatOfTheEmpireScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Eiganjo, Seat of the Empire (NEO #268) — Legendary Land.
+ *
+ *   {T}: Add {W}.
+ *   Channel — {2}{W}, Discard this card: It deals 4 damage to target attacking or blocking
+ *   creature. This ability costs {1} less to activate for each legendary creature you control.
+ *
+ * See OtawaraSoaringCityScenarioTest for the channel shape these five lands share; this test
+ * covers Eiganjo's own restriction — the target must be *attacking or blocking*, which is what
+ * makes it a combat trick rather than generic removal.
+ */
+class EiganjoSeatOfTheEmpireScenarioTest : ScenarioTestBase() {
+
+    private fun channelAbilityId() = cardRegistry.getCard("Eiganjo, Seat of the Empire")!!
+        .activatedAbilities.first { it.activateFromZone == Zone.HAND }.id
+
+    init {
+        context("Eiganjo, Seat of the Empire") {
+
+            test("4 damage kills an attacking 3/3") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Eiganjo, Seat of the Empire")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardOnBattlefield(2, "Centaur Courser")   // 3/3
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Centaur Courser" to 1)).error shouldBe null
+                // The attacking player holds priority first in the declare-attackers step.
+                game.execute(PassPriority(game.player2Id))
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                val handCard = game.findCardsInHand(1, "Eiganjo, Seat of the Empire").first()
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = handCard,
+                        abilityId = channelAbilityId(),
+                        targets = listOf(ChosenTarget.Permanent(courser))
+                    )
+                )
+                withClue("{2}{W} from three Plains, targeting an attacker: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("4 damage kills the 3/3") {
+                    game.isOnBattlefield("Centaur Courser") shouldBe false
+                }
+                withClue("The land discarded itself to pay") {
+                    game.isInGraveyard(1, "Eiganjo, Seat of the Empire") shouldBe true
+                }
+            }
+
+            test("a creature that is neither attacking nor blocking is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Eiganjo, Seat of the Empire")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                val handCard = game.findCardsInHand(1, "Eiganjo, Seat of the Empire").first()
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = handCard,
+                        abilityId = channelAbilityId(),
+                        targets = listOf(ChosenTarget.Permanent(courser))
+                    )
+                )
+                withClue("Outside combat there is nothing Eiganjo may point at") {
+                    result.error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/OtawaraSoaringCityScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/OtawaraSoaringCityScenarioTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Otawara, Soaring City (NEO #271) — Legendary Land.
+ *
+ *   {T}: Add {U}.
+ *   Channel — {3}{U}, Discard this card: Return target artifact, creature, enchantment, or
+ *   planeswalker to its owner's hand. This ability costs {1} less to activate for each legendary
+ *   creature you control.
+ *
+ * The reference test for the five NEO channel lands: it covers the from-hand activation, the
+ * per-legendary cost reduction, and the target restriction. The other four lands' tests lean on
+ * this one for the shared shape and focus on their own effects.
+ *
+ * The reduction is also covered from the enumeration side by
+ * ZoneAbilityCostReductionEnumerationTest, which is where the "was the ability even *offered*"
+ * regression lives; here we prove the handler charges the reduced cost and the effect works.
+ */
+class OtawaraSoaringCityScenarioTest : ScenarioTestBase() {
+
+    private fun channelAbilityId() = cardRegistry.getCard("Otawara, Soaring City")!!
+        .activatedAbilities.first { it.activateFromZone == Zone.HAND }.id
+
+    init {
+        context("Otawara, Soaring City") {
+
+            test("{T}: Add {U} — it is still just a land") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Otawara, Soaring City")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val otawara = game.findPermanent("Otawara, Soaring City")!!
+                val manaAbility = cardRegistry.getCard("Otawara, Soaring City")!!
+                    .activatedAbilities.first { it.isManaAbility }
+
+                val result = game.execute(
+                    ActivateAbility(game.player1Id, otawara, manaAbility.id)
+                )
+                withClue("tapping for {U} should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+            }
+
+            test("Channel from hand at full price bounces a creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Otawara, Soaring City")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val handCard = game.findCardsInHand(1, "Otawara, Soaring City").first()
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = handCard,
+                        abilityId = channelAbilityId(),
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                )
+                withClue("{3}{U} with four Islands should be payable: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears is bounced") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInHand(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("The land paid for itself by being discarded") {
+                    game.isInGraveyard(1, "Otawara, Soaring City") shouldBe true
+                }
+            }
+
+            test("two legendary creatures make it cost {1}{U} — two lands are enough") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Otawara, Soaring City")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    // Two *differently named* legendary creatures, so the legend rule keeps both.
+                    .withCardOnBattlefield(1, "Ghalta, Primal Hunger")
+                    .withCardOnBattlefield(1, "Squee, Goblin Nabob")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val handCard = game.findCardsInHand(1, "Otawara, Soaring City").first()
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = handCard,
+                        abilityId = channelAbilityId(),
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                )
+                withClue("{3}{U} reduced by two legends is {1}{U}: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+                game.isInHand(2, "Grizzly Bears") shouldBe true
+            }
+
+            test("a land is not a legal target — artifact/creature/enchantment/planeswalker only") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Otawara, Soaring City")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forest = game.findPermanent("Forest")!!
+                val handCard = game.findCardsInHand(1, "Otawara, Soaring City").first()
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = handCard,
+                        abilityId = channelAbilityId(),
+                        targets = listOf(ChosenTarget.Permanent(forest))
+                    )
+                )
+                withClue("Otawara can't bounce a land — Boseiju is the one that touches lands") {
+                    result.error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SokenzanCrucibleOfDefianceScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SokenzanCrucibleOfDefianceScenarioTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Sokenzan, Crucible of Defiance (NEO #276) — Legendary Land.
+ *
+ *   {T}: Add {R}.
+ *   Channel — {3}{R}, Discard this card: Create two 1/1 colorless Spirit creature tokens. They
+ *   gain haste until end of turn. This ability costs {1} less to activate for each legendary
+ *   creature you control.
+ *
+ * See OtawaraSoaringCityScenarioTest for the shared channel shape. What matters here is that
+ * "they" means *these two tokens* — the grant iterates the created-tokens collection rather than
+ * baking haste onto the token, which would leave printed haste behind on later turns.
+ */
+class SokenzanCrucibleOfDefianceScenarioTest : ScenarioTestBase() {
+
+    private fun channelAbilityId() = cardRegistry.getCard("Sokenzan, Crucible of Defiance")!!
+        .activatedAbilities.first { it.activateFromZone == Zone.HAND }.id
+
+    init {
+        context("Sokenzan, Crucible of Defiance") {
+
+            test("creates two 1/1 Spirits, and both have haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sokenzan, Crucible of Defiance")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handCard = game.findCardsInHand(1, "Sokenzan, Crucible of Defiance").first()
+                val result = game.execute(
+                    ActivateAbility(game.player1Id, handCard, channelAbilityId())
+                )
+                withClue("{3}{R} from four Mountains: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                val spirits = game.findPermanents("Spirit Token")
+
+                withClue("Exactly two Spirit tokens") {
+                    spirits.size shouldBe 2
+                }
+                withClue("Both gained haste — 'they' is the pair this activation made") {
+                    spirits.all {
+                        game.state.projectedState.hasKeyword(it, Keyword.HASTE)
+                    } shouldBe true
+                }
+                withClue("The land discarded itself to pay") {
+                    game.isInGraveyard(1, "Sokenzan, Crucible of Defiance") shouldBe true
+                }
+            }
+
+            test("the hasty Spirits can attack the turn they are made") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sokenzan, Crucible of Defiance")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handCard = game.findCardsInHand(1, "Sokenzan, Crucible of Defiance").first()
+                game.execute(ActivateAbility(game.player1Id, handCard, channelAbilityId()))
+                game.resolveStack()
+
+                val spirits = game.findPermanents("Spirit Token")
+                spirits.size shouldBe 2
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Spirit Token" to 2)).error shouldBe null
+
+                // `declareAttackers` drops names it can't resolve, so a green call proves nothing
+                // on its own — assert the token is actually marked as attacking.
+                withClue("Haste is the whole point of the token half") {
+                    game.state.getEntity(spirits.first())?.has<AttackingComponent>() shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TakenumaAbandonedMireScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TakenumaAbandonedMireScenarioTest.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.support.ScenarioTestBase.TestGame
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Takenuma, Abandoned Mire (NEO #278) — Legendary Land.
+ *
+ *   {T}: Add {B}.
+ *   Channel — {3}{B}, Discard this card: Mill three cards, then return a creature or planeswalker
+ *   card from your graveyard to your hand. This ability costs {1} less to activate for each
+ *   legendary creature you control.
+ *
+ * See OtawaraSoaringCityScenarioTest for the shared channel shape. Takenuma's own points are the
+ * printed order — the mill happens first, so a creature it mills is itself a legal choice — and
+ * that the return is a mandatory *choice on resolution*, not a target, and not a "may".
+ */
+class TakenumaAbandonedMireScenarioTest : ScenarioTestBase() {
+
+    private fun channelAbilityId() = cardRegistry.getCard("Takenuma, Abandoned Mire")!!
+        .activatedAbilities.first { it.activateFromZone == Zone.HAND }.id
+
+
+    /**
+     * Clear whatever prompts an activation raises, without assuming their shape or count.
+     * Bounded, because an unbounded `while (hasPendingDecision())` spins forever the moment a
+     * decision arrives that the chosen responder can't answer — `skipSelection` is a no-op
+     * against a yes/no prompt, which is exactly what the consolation search raises.
+     */
+    private fun declineAllPrompts(game: TestGame, max: Int = 8) {
+        var guard = 0
+        while (game.hasPendingDecision() && guard++ < max) {
+            when (game.getPendingDecision()) {
+                is YesNoDecision -> game.answerYesNo(false)
+                else -> game.skipSelection()
+            }
+        }
+        withClue("prompts should settle well inside the guard") {
+            game.hasPendingDecision() shouldBe false
+        }
+    }
+
+    init {
+        context("Takenuma, Abandoned Mire") {
+
+            test("mills three, then returns a creature card already in the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Takenuma, Abandoned Mire")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    // The scenario library starts empty — give the mill something to eat.
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handCard = game.findCardsInHand(1, "Takenuma, Abandoned Mire").first()
+                val librarySizeBefore = game.state.getZone(game.player1Id, Zone.LIBRARY).size
+
+                val result = game.execute(
+                    ActivateAbility(game.player1Id, handCard, channelAbilityId())
+                )
+                withClue("{3}{B} from four Swamps: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Three cards were milled") {
+                    game.state.getZone(game.player1Id, Zone.LIBRARY).size shouldBe
+                        librarySizeBefore - 3
+                }
+
+                withClue("The return is a choice made on resolution") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val choice = game.getPendingDecision() as? SelectCardsDecision
+                choice.shouldNotBeNull()
+                val bears = choice.cardInfo!!.entries
+                    .first { it.value.name == "Grizzly Bears" }.key
+                game.selectCards(listOf(bears))
+
+                withClue("Grizzly Bears is back in hand") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("with no creature or planeswalker card to return, the mill still happens") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Takenuma, Abandoned Mire")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    // Library is all lands, so the mill can never turn up a returnable card.
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInGraveyard(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handCard = game.findCardsInHand(1, "Takenuma, Abandoned Mire").first()
+                val librarySizeBefore = game.state.getZone(game.player1Id, Zone.LIBRARY).size
+
+                game.execute(ActivateAbility(game.player1Id, handCard, channelAbilityId()))
+                    .error shouldBe null
+                game.resolveStack()
+                // Whatever the mill turned up may or may not be returnable; clear any prompt.
+                declineAllPrompts(game)
+
+                withClue("The mill is not conditional on the return finding anything") {
+                    game.state.getZone(game.player1Id, Zone.LIBRARY).size shouldBe
+                        librarySizeBefore - 3
+                }
+                withClue("Lightning Bolt is not a creature or planeswalker — it stays put") {
+                    game.isInGraveyard(1, "Lightning Bolt") shouldBe true
+                    game.isInHand(1, "Lightning Bolt") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/NEO.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/NEO.json
@@ -1,3 +1,189 @@
+// Boseiju, Who Endures
+{
+    "name": "Boseiju, Who Endures",
+    "manaCost": "",
+    "typeLine": "Legendary Land",
+    "oracleText": "{T}: Add {G}.\nChannel — {1}{G}, Discard this card: Destroy target artifact, enchantment, or nonbasic land an opponent controls. That player may search their library for a land card with a basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each legendary creature you control.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
+                        },
+                        "CostDiscardSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target artifact, enchantment, or nonbasic land an opponent controls"
+                            },
+                            "destination": "Graveyard",
+                            "byDestruction": true
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": {
+                                    "type": "ControllerOf",
+                                    "targetDescription": "the destroyed permanent"
+                                }
+                            },
+                            "body": {
+                                "type": "Gated",
+                                "gate": "Gate.MayDecide",
+                                "then": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Library",
+                                                "filter": {
+                                                    "cardPredicates": [
+                                                        "IsLand",
+                                                        {
+                                                            "type": "Or",
+                                                            "predicates": [
+                                                                {
+                                                                    "type": "HasBasicLandType",
+                                                                    "landType": "Plains"
+                                                                },
+                                                                {
+                                                                    "type": "HasBasicLandType",
+                                                                    "landType": "Island"
+                                                                },
+                                                                {
+                                                                    "type": "HasBasicLandType",
+                                                                    "landType": "Swamp"
+                                                                },
+                                                                {
+                                                                    "type": "HasBasicLandType",
+                                                                    "landType": "Mountain"
+                                                                },
+                                                                {
+                                                                    "type": "HasBasicLandType",
+                                                                    "landType": "Forest"
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "storeAs": "searchable"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "searchable",
+                                            "selection": {
+                                                "type": "ChooseUpTo",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "found"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "found",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Battlefield"
+                                            }
+                                        },
+                                        "ShuffleLibrary",
+                                        "EmitLibrarySearchedEvent"
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    {
+                                        "type": "Or",
+                                        "predicates": [
+                                            {
+                                                "type": "Or",
+                                                "predicates": [
+                                                    "IsArtifact",
+                                                    "IsEnchantment"
+                                                ]
+                                            },
+                                            {
+                                                "type": "And",
+                                                "predicates": [
+                                                    "IsLand",
+                                                    {
+                                                        "type": "Not",
+                                                        "predicate": "IsBasicLand"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "controllerPredicate": "ControlledByOpponent"
+                            }
+                        },
+                        "id": "target artifact, enchantment, or nonbasic land an opponent controls"
+                    }
+                ],
+                "activateFromZone": "Hand",
+                "genericCostReduction": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "IsLegendary"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "266",
+        "rarity": "RARE",
+        "artist": "Chris Ostrowski",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/2135ac5a-187b-4dc9-8f82-34e8d1603416.jpg?1783923818"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Circuit Mender
 {
     "name": "Circuit Mender",
@@ -50,6 +236,97 @@
         "imageUri": "https://cards.scryfall.io/normal/front/d/e/defaeb68-3f8a-4740-b13f-8c71c7e9c8b4.jpg?1783923827"
     },
     "colorIdentityOverride": []
+}
+
+// Eiganjo, Seat of the Empire
+{
+    "name": "Eiganjo, Seat of the Empire",
+    "manaCost": "",
+    "typeLine": "Legendary Land",
+    "oracleText": "{T}: Add {W}.\nChannel — {2}{W}, Discard this card: It deals 4 damage to target attacking or blocking creature. This ability costs {1} less to activate for each legendary creature you control.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
+                        },
+                        "CostDiscardSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking or blocking creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    {
+                                        "type": "StateOr",
+                                        "predicates": [
+                                            "IsAttacking",
+                                            "IsBlocking"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target attacking or blocking creature"
+                    }
+                ],
+                "activateFromZone": "Hand",
+                "genericCostReduction": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "IsLegendary"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "268",
+        "rarity": "RARE",
+        "artist": "Julian Kok Joon Wen",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c375a022-5b57-496d-a802-e4ea8376e9e4.jpg?1783923818"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Experimental Synthesizer
@@ -178,6 +455,81 @@
     ]
 }
 
+// Otawara, Soaring City
+{
+    "name": "Otawara, Soaring City",
+    "manaCost": "",
+    "typeLine": "Legendary Land",
+    "oracleText": "{T}: Add {U}.\nChannel — {3}{U}, Discard this card: Return target artifact, creature, enchantment, or planeswalker to its owner's hand. This ability costs {1} less to activate for each legendary creature you control.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{U}"
+                            }
+                        },
+                        "CostDiscardSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact, creature, enchantment, or planeswalker"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact|creature|enchantment|planeswalker"
+                        },
+                        "id": "target artifact, creature, enchantment, or planeswalker"
+                    }
+                ],
+                "activateFromZone": "Hand",
+                "genericCostReduction": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "IsLegendary"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "271",
+        "rarity": "RARE",
+        "artist": "Alayna Danner",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/486d7edc-d983-41f0-8b78-c99aecd72996.jpg?1783923816"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Secluded Courtyard
 {
     "name": "Secluded Courtyard",
@@ -223,6 +575,95 @@
     "colorIdentityOverride": []
 }
 
+// Sokenzan, Crucible of Defiance
+{
+    "name": "Sokenzan, Crucible of Defiance",
+    "manaCost": "",
+    "typeLine": "Legendary Land",
+    "oracleText": "{T}: Add {R}.\nChannel — {3}{R}, Discard this card: Create two 1/1 colorless Spirit creature tokens. They gain haste until end of turn. This ability costs {1} less to activate for each legendary creature you control.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{R}"
+                            }
+                        },
+                        "CostDiscardSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Spirit"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/c/a/ca20548f-6324-4858-adbe-87303ff1ca52.jpg?1783923715"
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Collection",
+                                "collection": "createdTokens"
+                            },
+                            "body": {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "activateFromZone": "Hand",
+                "genericCostReduction": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "IsLegendary"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "276",
+        "rarity": "RARE",
+        "artist": "Lucas Staniec",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aa548dcd-c1dd-492d-a69f-c65dfeef0633.jpg?1783923814"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Spirited Companion
 {
     "name": "Spirited Companion",
@@ -259,6 +700,125 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Takenuma, Abandoned Mire
+{
+    "name": "Takenuma, Abandoned Mire",
+    "manaCost": "",
+    "typeLine": "Legendary Land",
+    "oracleText": "{T}: Add {B}.\nChannel — {3}{B}, Discard this card: Mill three cards, then return a creature or planeswalker card from your graveyard to your hand. This ability costs {1} less to activate for each legendary creature you control.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{B}"
+                            }
+                        },
+                        "CostDiscardSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 3
+                                        },
+                                        "isMill": true
+                                    },
+                                    "storeAs": "milled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "milled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "filter": "creature|planeswalker"
+                            },
+                            "storeAs": "takenumaGraveyard"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "takenumaGraveyard",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "takenumaReturned",
+                            "prompt": "Choose a creature or planeswalker card to return to your hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "takenumaReturned",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                },
+                "activateFromZone": "Hand",
+                "genericCostReduction": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "IsLegendary"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "278",
+        "rarity": "RARE",
+        "artist": "Sam Burley",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/499037cc-a577-41cb-8ca2-5e117945634f.jpg?1783923812"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/STX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STX.json
@@ -796,7 +796,8 @@
                             "min": 1
                         }
                     ]
-                }
+                },
+                "descriptionOverride": "target spell or permanent with mana value 1 or greater"
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/STX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STX.json
@@ -675,6 +675,143 @@
     ]
 }
 
+// Divide by Zero
+{
+    "name": "Divide by Zero",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return target spell or permanent with mana value 1 or greater to its owner's hand.\nLearn. (You may reveal a Lesson card you own from outside the game and put it into your hand, or discard a card to draw a card.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ReturnSpellOrPermanentToOwnersHand",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target spell or permanent with mana value 1 or greater"
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "learn_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "learn_hand",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "learn_discarded",
+                            "prompt": "Learn — you may discard a card to draw a card"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "learn_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "learn_discarded",
+                            "ifNotEmpty": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Sideboard",
+                                            "filter": "Lesson"
+                                        },
+                                        "storeAs": "learn_lessons"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "learn_lessons",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "learn_lessonsFound"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "learn_lessonsFound",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Learn"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetSpellOrPermanent",
+                "id": "target spell or permanent with mana value 1 or greater",
+                "permanentFilter": {
+                    "cardPredicates": [
+                        "IsPermanent",
+                        {
+                            "type": "ManaValueAtLeast",
+                            "min": 1
+                        }
+                    ]
+                },
+                "spellFilter": {
+                    "cardPredicates": [
+                        {
+                            "type": "ManaValueAtLeast",
+                            "min": 1
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "rarity": "UNCOMMON",
+        "artist": "Liiga Smilshkalne",
+        "flavorText": "\"Misery. Inadequacy. Failure. The common denominator is you.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/1958d96e-ec44-48ab-80b1-5b01a24ac7b8.jpg?1783927380"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dream Strix
 {
     "name": "Dream Strix",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
@@ -573,7 +573,16 @@ class TargetFinder(
 
         // Add all spells on the stack — only actual spells (CR 112.1), never abilities
         // on the stack (CR 113.3b/c, 113.7a), consistent with findSpellTargets above.
-        targets.addAll(state.stack.filter { spellId -> state.isSpellOnStack(spellId) })
+        // The stack half carries its own filter (Divide by Zero: "with mana value 1 or
+        // greater"), independent of the battlefield half's.
+        val spellFilter = requirement.spellFilter
+        targets.addAll(
+            state.stack.filter { spellId ->
+                state.isSpellOnStack(spellId) &&
+                    (spellFilter == null ||
+                        predicateEvaluator.matches(state, projected, spellId, spellFilter, predicateContext))
+            }
+        )
 
         return targets
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.handlers.effects.permanent.counters.resolveCounter
 import com.wingedsheep.engine.mechanics.SummoningSicknessRules
 import com.wingedsheep.engine.mechanics.mana.TapForGeneric
 import com.wingedsheep.engine.legalactions.*
+import com.wingedsheep.engine.legalactions.utils.AbilityCostReduction
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.*
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -174,7 +175,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                     context.castPermissionUtils.applyFreeFirstEquipDiscount(
                         context.castPermissionUtils.applyEquipCostReduction(
                             context.castPermissionUtils.applyActivatedAbilityCostReduction(
-                                applyAbilityGenericCostReduction(costWithDefinedX, ability, state, entityId, playerId, context),
+                                AbilityCostReduction.apply(costWithDefinedX, ability, state, entityId, playerId, context.targetUtils),
                                 state, entityId, ability.isExhaust, ability.isPowerUp
                             ),
                             ability, state, playerId, abilitySourceId = entityId
@@ -1456,74 +1457,6 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
     }
 
     /**
-     * Apply [ActivatedAbility.genericCostReduction] to the mana portion of [cost].
-     * The reduction is evaluated against the activating entity (e.g., the equipped creature
-     * for The Dominion Bracelet, where X = the creature's power).
-     *
-     * When the ability requires a target, the player hasn't chosen one yet at enumeration time,
-     * so a reduction that reads the chosen target (e.g. Dragonfire Blade — "costs {1} less to
-     * activate for each color of the creature it targets") can't resolve a specific target here.
-     * We gate affordability on the *cheapest* reachable cost — the largest reduction over the
-     * currently-legal targets — so the ability is offered (and its displayed cost shown) whenever
-     * it's payable for at least one target. The handler re-derives the exact reduction from the
-     * target the player actually chose (ActivateAbilityHandler.applyGenericCostReduction), and in
-     * auto-tap mode pays that exact per-target cost. The reduction only ever lowers the cost, so a
-     * best-case preview never causes the client to under-tap for the chosen target in auto-tap mode.
-     */
-    private fun applyAbilityGenericCostReduction(
-        cost: AbilityCost,
-        ability: ActivatedAbility,
-        state: com.wingedsheep.engine.state.GameState,
-        sourceId: EntityId,
-        controllerId: EntityId,
-        enumerationContext: EnumerationContext
-    ): AbilityCost {
-        val reduction = ability.genericCostReduction ?: return cost
-        val evaluator = com.wingedsheep.engine.handlers.DynamicAmountEvaluator()
-        val baseContext = com.wingedsheep.engine.handlers.EffectContext(
-            sourceId = sourceId,
-            controllerId = controllerId,
-        )
-        val amount = if (ability.targetRequirements.isNotEmpty()) {
-            maxReductionOverLegalTargets(reduction, ability, state, sourceId, controllerId, enumerationContext, evaluator)
-        } else {
-            evaluator.evaluate(state, reduction, baseContext)
-        }
-        if (amount <= 0) return cost
-        return reduceGenericInAbilityCost(cost, amount)
-    }
-
-    /**
-     * Largest [reduction] achievable across the ability's currently-legal first-requirement
-     * targets. Evaluates the reduction once per legal target (as if that target were chosen) and
-     * keeps the maximum. For a reduction that doesn't read the target this collapses to a constant,
-     * so it stays correct for non-target-dependent reductions on targeted abilities too. Returns 0
-     * when there are no legal targets (the ability won't be offered anyway).
-     */
-    private fun maxReductionOverLegalTargets(
-        reduction: com.wingedsheep.sdk.scripting.values.DynamicAmount,
-        ability: ActivatedAbility,
-        state: com.wingedsheep.engine.state.GameState,
-        sourceId: EntityId,
-        controllerId: EntityId,
-        enumerationContext: EnumerationContext,
-        evaluator: com.wingedsheep.engine.handlers.DynamicAmountEvaluator
-    ): Int {
-        val validTargets = enumerationContext.targetUtils
-            .buildTargetInfos(state, controllerId, ability.targetRequirements, sourceId = sourceId)
-            .firstOrNull()?.validTargets ?: emptyList()
-        if (validTargets.isEmpty()) return 0
-        return validTargets.maxOf { targetId ->
-            val targetContext = com.wingedsheep.engine.handlers.EffectContext(
-                sourceId = sourceId,
-                controllerId = controllerId,
-                targets = listOf(ChosenTarget.Permanent(targetId))
-            )
-            evaluator.evaluate(state, reduction, targetContext)
-        }
-    }
-
-    /**
      * Is [granterId] a permanent that is on the battlefield and untapped? The payability gate for
      * [AbilityCost.TapGrantingPermanent]; an unresolved granter (null) is treated as unpayable,
      * since the cost names a specific permanent that must still be there to tap (CR 201.5a).
@@ -1535,19 +1468,4 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
         return !granter.has<TappedComponent>()
     }
 
-    private fun reduceGenericInAbilityCost(cost: AbilityCost, amount: Int): AbilityCost = when (cost) {
-        is AbilityCost.Atom -> cost.manaCostOrNull
-            ?.let { AbilityCost.Atom(CostAtom.Mana(it.reduceGeneric(amount))) } ?: cost
-        is AbilityCost.Composite -> {
-            var applied = false
-            AbilityCost.Composite(cost.costs.map { sub ->
-                val subMana = sub.manaCostOrNull
-                if (!applied && subMana != null) {
-                    applied = true
-                    AbilityCost.Atom(CostAtom.Mana(subMana.reduceGeneric(amount)))
-                } else sub
-            })
-        }
-        else -> cost
-    }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -191,14 +191,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 // prefix from [effectiveCost] so the menu reflects what the player will actually pay.
                 // Cards with an explicit descriptionOverride keep it (we can't safely splice a cost
                 // into custom text).
-                val displayDescription =
-                    if (effectiveCost != rawCost && ability.descriptionOverride == null) {
-                        // Rebuild from the effective cost, preserving any keyword-action prefixes
-                        // ("Exhaust — ", "Waterbend ") and rendering a fully-discounted cost as "{0}".
-                        ability.describeWithCost(effectiveCost)
-                    } else {
-                        ability.description
-                    }
+                val displayDescription = AbilityCostReduction.describe(ability, effectiveCost, rawCost)
 
                 // Ability payment context — lets the solver consider restricted mana that's
                 // only spendable on this kind of activation (e.g., Steelswarm Operator's mana

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ZoneActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ZoneActivatedAbilityEnumerator.kt
@@ -97,16 +97,7 @@ class ZoneActivatedAbilityEnumerator(private val zone: Zone) : ActionEnumerator 
                         .applyDefinedXValue(ability.cost, ability, state, entityId, playerId),
                     ability, state, entityId, playerId, context.targetUtils
                 )
-                // Description shown to the player. Mirrors ActivatedAbilityEnumerator: rebuild the
-                // label from [effectiveCost] only when it differs from the printed cost, and never
-                // when the ability carries an explicit descriptionOverride — a custom label such as
-                // Renew's "Renew — …" has no safe place to splice a cost into.
-                val displayDescription =
-                    if (effectiveCost != ability.cost && ability.descriptionOverride == null) {
-                        ability.describeWithCost(effectiveCost)
-                    } else {
-                        ability.description
-                    }
+                val displayDescription = AbilityCostReduction.describe(ability, effectiveCost)
 
                 var costCanBePaid = true
                 val handCards = state.getZone(playerId, Zone.HAND)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ZoneActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ZoneActivatedAbilityEnumerator.kt
@@ -97,6 +97,17 @@ class ZoneActivatedAbilityEnumerator(private val zone: Zone) : ActionEnumerator 
                         .applyDefinedXValue(ability.cost, ability, state, entityId, playerId),
                     ability, state, entityId, playerId, context.targetUtils
                 )
+                // Description shown to the player. Mirrors ActivatedAbilityEnumerator: rebuild the
+                // label from [effectiveCost] only when it differs from the printed cost, and never
+                // when the ability carries an explicit descriptionOverride — a custom label such as
+                // Renew's "Renew — …" has no safe place to splice a cost into.
+                val displayDescription =
+                    if (effectiveCost != ability.cost && ability.descriptionOverride == null) {
+                        ability.describeWithCost(effectiveCost)
+                    } else {
+                        ability.description
+                    }
+
                 var costCanBePaid = true
                 val handCards = state.getZone(playerId, Zone.HAND)
                 var hasDiscardCost = false
@@ -235,7 +246,7 @@ class ZoneActivatedAbilityEnumerator(private val zone: Zone) : ActionEnumerator 
                         result.add(
                             LegalAction(
                                 actionType = "ActivateAbility",
-                                description = ability.describeWithCost(effectiveCost),
+                                description = displayDescription,
                                 action = ActivateAbility(
                                     playerId, entityId, ability.id,
                                     targets = listOf(autoSelectedTarget)
@@ -251,7 +262,7 @@ class ZoneActivatedAbilityEnumerator(private val zone: Zone) : ActionEnumerator 
                         result.add(
                             LegalAction(
                                 actionType = "ActivateAbility",
-                                description = ability.describeWithCost(effectiveCost),
+                                description = displayDescription,
                                 action = ActivateAbility(playerId, entityId, ability.id),
                                 validTargets = firstInfo.validTargets,
                                 requiresTargets = true,
@@ -271,7 +282,7 @@ class ZoneActivatedAbilityEnumerator(private val zone: Zone) : ActionEnumerator 
                     result.add(
                         LegalAction(
                             actionType = "ActivateAbility",
-                            description = ability.describeWithCost(effectiveCost),
+                            description = displayDescription,
                             action = ActivateAbility(playerId, entityId, ability.id),
                             additionalCostInfo = costInfo,
                             hasXCost = abilityHasXCost,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ZoneActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ZoneActivatedAbilityEnumerator.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.legalactions.ActionEnumerator
 import com.wingedsheep.engine.legalactions.AdditionalCostData
 import com.wingedsheep.engine.legalactions.EnumerationContext
 import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.legalactions.utils.AbilityCostReduction
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.sdk.core.Zone
@@ -83,12 +84,19 @@ class ZoneActivatedAbilityEnumerator(private val zone: Zone) : ActionEnumerator 
                 }
                 if (!restrictionsMet) continue
 
-                // Check cost requirements and build cost info. A *defined* {X} (CR 107.3c) is
-                // resolved here for the same reason the battlefield enumerator resolves it: the
-                // affordability check below and the cost shown in the menu both have to be the
-                // number the handler will charge, not an unresolved `{X}`.
-                val effectiveCost = context.castPermissionUtils
-                    .applyDefinedXValue(ability.cost, ability, state, entityId, playerId)
+                // Check cost requirements and build cost info. A *defined* {X} (CR 107.3c) and
+                // the ability's generic cost reduction are both resolved here for the same reason
+                // the battlefield enumerator resolves them: the affordability check below and the
+                // cost shown in the menu have to be the number the handler will charge, not an
+                // unresolved `{X}` or an unreduced cost. Without the reduction, a channel land
+                // ("costs {1} less to activate for each legendary creature you control", activated
+                // by discarding it from hand) is hidden from the menu whenever the player can
+                // afford only the reduced price.
+                val effectiveCost = AbilityCostReduction.apply(
+                    context.castPermissionUtils
+                        .applyDefinedXValue(ability.cost, ability, state, entityId, playerId),
+                    ability, state, entityId, playerId, context.targetUtils
+                )
                 var costCanBePaid = true
                 val handCards = state.getZone(playerId, Zone.HAND)
                 var hasDiscardCost = false
@@ -193,7 +201,7 @@ class ZoneActivatedAbilityEnumerator(private val zone: Zone) : ActionEnumerator 
                 } else null
 
                 // Calculate X cost info
-                val abilityManaCost = when (val c = ability.cost) {
+                val abilityManaCost = when (val c = effectiveCost) {
                     is AbilityCost.Atom -> c.manaCostOrNull
                     is AbilityCost.Composite -> c.costs.firstNotNullOfOrNull { it.manaCostOrNull }
                     else -> null
@@ -227,7 +235,7 @@ class ZoneActivatedAbilityEnumerator(private val zone: Zone) : ActionEnumerator 
                         result.add(
                             LegalAction(
                                 actionType = "ActivateAbility",
-                                description = ability.description,
+                                description = ability.describeWithCost(effectiveCost),
                                 action = ActivateAbility(
                                     playerId, entityId, ability.id,
                                     targets = listOf(autoSelectedTarget)
@@ -243,7 +251,7 @@ class ZoneActivatedAbilityEnumerator(private val zone: Zone) : ActionEnumerator 
                         result.add(
                             LegalAction(
                                 actionType = "ActivateAbility",
-                                description = ability.description,
+                                description = ability.describeWithCost(effectiveCost),
                                 action = ActivateAbility(playerId, entityId, ability.id),
                                 validTargets = firstInfo.validTargets,
                                 requiresTargets = true,
@@ -263,7 +271,7 @@ class ZoneActivatedAbilityEnumerator(private val zone: Zone) : ActionEnumerator 
                     result.add(
                         LegalAction(
                             actionType = "ActivateAbility",
-                            description = ability.description,
+                            description = ability.describeWithCost(effectiveCost),
                             action = ActivateAbility(playerId, entityId, ability.id),
                             additionalCostInfo = costInfo,
                             hasXCost = abilityHasXCost,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/AbilityCostReduction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/AbilityCostReduction.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.legalactions.utils
+
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.costs.manaCostOrNull
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * [ActivatedAbility.genericCostReduction] applied to the mana portion of an ability cost, for the
+ * *enumeration* side — the affordability gate, the cost string the client shows, and the auto-tap
+ * preview. [com.wingedsheep.engine.handlers.actions.ability.ActivateAbilityHandler] runs its own
+ * copy at payment time against the target the player actually chose.
+ *
+ * Shared because the reduction is a property of the ability, not of the zone it is activated from:
+ * [com.wingedsheep.engine.legalactions.enumerators.ActivatedAbilityEnumerator] applies it to
+ * battlefield abilities and
+ * [com.wingedsheep.engine.legalactions.enumerators.ZoneActivatedAbilityEnumerator] to the hand and
+ * graveyard ones (the Kamigawa channel lands — "costs {1} less to activate for each legendary
+ * creature you control" — are activated by discarding them *from hand*). Before this was shared,
+ * the zone enumerator gated affordability on the unreduced cost and so hid a channel ability the
+ * handler would have been happy to charge the reduced price for.
+ */
+object AbilityCostReduction {
+
+    /**
+     * [cost] with [ActivatedAbility.genericCostReduction] applied to its generic mana, evaluated
+     * against the activating entity (e.g. the equipped creature for The Dominion Bracelet, where
+     * X = the creature's power).
+     *
+     * When the ability requires a target, the player hasn't chosen one yet at enumeration time, so
+     * a reduction that reads the chosen target (e.g. Dragonfire Blade — "costs {1} less to activate
+     * for each color of the creature it targets") can't resolve a specific target here. We gate
+     * affordability on the *cheapest* reachable cost — the largest reduction over the currently
+     * legal targets — so the ability is offered whenever it's payable for at least one target. The
+     * handler re-derives the exact reduction from the chosen target, and in auto-tap mode pays that
+     * exact per-target cost. The reduction only ever lowers the cost, so a best-case preview never
+     * causes the client to under-tap for the chosen target.
+     */
+    fun apply(
+        cost: AbilityCost,
+        ability: ActivatedAbility,
+        state: GameState,
+        sourceId: EntityId,
+        controllerId: EntityId,
+        targetUtils: TargetEnumerationUtils
+    ): AbilityCost {
+        val reduction = ability.genericCostReduction ?: return cost
+        val evaluator = DynamicAmountEvaluator()
+        val amount = if (ability.targetRequirements.isNotEmpty()) {
+            maxReductionOverLegalTargets(reduction, ability, state, sourceId, controllerId, targetUtils, evaluator)
+        } else {
+            evaluator.evaluate(state, reduction, EffectContext(sourceId = sourceId, controllerId = controllerId))
+        }
+        if (amount <= 0) return cost
+        return reduceGeneric(cost, amount)
+    }
+
+    /**
+     * Largest [reduction] achievable across the ability's currently-legal first-requirement
+     * targets. Evaluates the reduction once per legal target (as if that target were chosen) and
+     * keeps the maximum. For a reduction that doesn't read the target this collapses to a constant,
+     * so it stays correct for non-target-dependent reductions on targeted abilities too — which is
+     * the channel lands' case, where the count is of legendary creatures you control. Returns 0
+     * when there are no legal targets (the ability won't be offered anyway).
+     */
+    private fun maxReductionOverLegalTargets(
+        reduction: DynamicAmount,
+        ability: ActivatedAbility,
+        state: GameState,
+        sourceId: EntityId,
+        controllerId: EntityId,
+        targetUtils: TargetEnumerationUtils,
+        evaluator: DynamicAmountEvaluator
+    ): Int {
+        val validTargets = targetUtils
+            .buildTargetInfos(state, controllerId, ability.targetRequirements, sourceId = sourceId)
+            .firstOrNull()?.validTargets ?: emptyList()
+        if (validTargets.isEmpty()) return 0
+        return validTargets.maxOf { targetId ->
+            evaluator.evaluate(
+                state,
+                reduction,
+                EffectContext(
+                    sourceId = sourceId,
+                    controllerId = controllerId,
+                    targets = listOf(ChosenTarget.Permanent(targetId))
+                )
+            )
+        }
+    }
+
+    /** [cost] with [amount] shaved off the generic part of its first mana component. */
+    private fun reduceGeneric(cost: AbilityCost, amount: Int): AbilityCost = when (cost) {
+        is AbilityCost.Atom -> cost.manaCostOrNull
+            ?.let { AbilityCost.Atom(CostAtom.Mana(it.reduceGeneric(amount))) } ?: cost
+        is AbilityCost.Composite -> {
+            var applied = false
+            AbilityCost.Composite(cost.costs.map { sub ->
+                val subMana = sub.manaCostOrNull
+                if (!applied && subMana != null) {
+                    applied = true
+                    AbilityCost.Atom(CostAtom.Mana(subMana.reduceGeneric(amount)))
+                } else sub
+            })
+        }
+        else -> cost
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/AbilityCostReduction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/AbilityCostReduction.kt
@@ -95,6 +95,30 @@ object AbilityCostReduction {
         }
     }
 
+    /**
+     * The menu label for [ability] given the [effectiveCost] it will actually be charged.
+     *
+     * Rebuilt from the effective cost only when that differs from [baselineCost] — otherwise the
+     * printed label is already right — and never when the ability carries an explicit
+     * `descriptionOverride`, since a custom label such as Renew's "Renew — …" has no safe place to
+     * splice a cost into. Both enumerators render the label the same way, so the rule lives here
+     * rather than in each of them.
+     *
+     * [baselineCost] defaults to the printed cost. The battlefield enumerator passes its
+     * text-replaced cost instead ("Sacrifice a Goblin" → "Sacrifice a Bird"), so that a replacement
+     * alone — which does not change what the player pays — doesn't count as a cost change.
+     */
+    fun describe(
+        ability: ActivatedAbility,
+        effectiveCost: AbilityCost,
+        baselineCost: AbilityCost = ability.cost,
+    ): String =
+        if (effectiveCost != baselineCost && ability.descriptionOverride == null) {
+            ability.describeWithCost(effectiveCost)
+        } else {
+            ability.description
+        }
+
     /** [cost] with [amount] shaved off the generic part of its first mana component. */
     private fun reduceGeneric(cost: AbilityCost, amount: Int): AbilityCost = when (cost) {
         is AbilityCost.Atom -> cost.manaCostOrNull

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
@@ -104,7 +104,13 @@ class TargetEnumerationUtils(
                         predicateEvaluator.matches(state, projected, entityId, permanentFilter, context)
                     }
                 }
-                val spells = findValidSpellTargets(state, playerId, TargetFilter.SpellOnStack)
+                val spellFilter = requirement.spellFilter
+                val allSpells = findValidSpellTargets(state, playerId, TargetFilter.SpellOnStack)
+                val spells = if (spellFilter == null) allSpells else {
+                    val projected = state.projectedState
+                    val context = PredicateContext(controllerId = playerId, sourceId = sourceId)
+                    allSpells.filter { predicateEvaluator.matches(state, projected, it, spellFilter, context) }
+                }
                 permanents + spells
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -995,8 +995,11 @@ class TargetValidator {
     /**
      * Validate a target for TargetSpellOrPermanent.
      * Accepts either a spell on the stack or a permanent on the battlefield.
-     * If [requirement.permanentFilter] is set, permanent targets must also match it
-     * (e.g., "target spell or creature" restricts the permanent side to creatures).
+     * Each half carries its own optional filter, and a target must match the one for its
+     * side: [requirement.permanentFilter] for battlefield targets (e.g. "target spell or
+     * creature" restricts the permanent side to creatures) and [requirement.spellFilter]
+     * for stack targets (Divide by Zero's "with mana value 1 or greater" restricts both,
+     * so it passes the same filter to each).
      */
     private fun validateSpellOrPermanentTarget(
         state: GameState,
@@ -1026,6 +1029,14 @@ class TargetValidator {
             is ChosenTarget.Spell -> {
                 if (target.spellEntityId !in state.stack) {
                     return "Target spell not on the stack"
+                }
+                val spellFilter = requirement.spellFilter
+                if (spellFilter != null) {
+                    val projected = state.projectedState
+                    val context = PredicateContext(controllerId = casterId, sourceId = sourceId, xValue = xValue)
+                    if (!predicateEvaluator.matches(state, projected, target.spellEntityId, spellFilter, context)) {
+                        return "Target does not match ${spellFilter.description}"
+                    }
                 }
                 null
             }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/ZoneAbilityCostReductionEnumerationTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/ZoneAbilityCostReductionEnumerationTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.legalactions
+
+import com.wingedsheep.engine.legalactions.support.EnumerationTestDriver
+import com.wingedsheep.engine.legalactions.support.setupP1
+import com.wingedsheep.engine.legalactions.support.shouldContainActivatedAbilityOn
+import com.wingedsheep.engine.legalactions.support.shouldNotContainActivatedAbilityOn
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Supertype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [enumerators.ZoneActivatedAbilityEnumerator] and
+ * [com.wingedsheep.sdk.scripting.ActivatedAbility.genericCostReduction] together — a cost
+ * reduction on an ability activated from a *non-battlefield* zone.
+ *
+ * Regression. The reduction used to be applied in only two places: the battlefield enumerator
+ * and [com.wingedsheep.engine.handlers.actions.ability.ActivateAbilityHandler]. The zone
+ * enumerator gated affordability on the *unreduced* cost, so a from-hand ability that the
+ * handler would have been happy to charge the reduced price for was never offered as a legal
+ * action — unreachable in a real game. Both now route through
+ * [com.wingedsheep.engine.legalactions.utils.AbilityCostReduction].
+ *
+ * The fixture is Otawara, Soaring City, whose channel ability is activated by discarding it from
+ * hand and "costs {1} less to activate for each legendary creature you control". The other four
+ * NEO channel lands share the shape; each has its own scenario test alongside its card.
+ */
+class ZoneAbilityCostReductionEnumerationTest : FunSpec({
+
+    /** Distinct legendary creatures, so the legend rule never eats the count being tested. */
+    fun legend(name: String): CardDefinition = CardDefinition.creature(
+        name = name,
+        manaCost = ManaCost.parse("{1}"),
+        subtypes = setOf(Subtype("Spirit")),
+        power = 1,
+        toughness = 1,
+        supertypes = setOf(Supertype.LEGENDARY)
+    )
+
+    val legends = listOf("Test Legend Alpha", "Test Legend Beta", "Test Legend Gamma")
+    val legendCards = legends.map { legend(it) }
+
+    fun handId(driver: EnumerationTestDriver, name: String): EntityId {
+        val state = driver.game.state
+        return state.getZone(driver.player1, Zone.HAND).first { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+    }
+
+    fun otawaraCost(driver: EnumerationTestDriver): String? {
+        val id = handId(driver, "Otawara, Soaring City")
+        return driver.enumerateFor(driver.player1)
+            .activatedAbilityActionsFor(id).single().manaCostString
+    }
+
+    context("Otawara, Soaring City — Channel {3}{U}, costs {1} less per legendary creature") {
+
+        test("no legendary creatures — full {3}{U}, and four lands pay it") {
+            val driver = setupP1(
+                hand = listOf("Otawara, Soaring City"),
+                // Four Islands for the unreduced cost, plus a nonlegendary creature to target.
+                battlefield = listOf("Island", "Island", "Island", "Island", "Grizzly Bears"),
+                atStep = Step.PRECOMBAT_MAIN
+            )
+            val otawara = handId(driver, "Otawara, Soaring City")
+
+            driver.enumerateFor(driver.player1) shouldContainActivatedAbilityOn otawara
+            otawaraCost(driver) shouldBe "{3}{U}"
+        }
+
+        test("two legendary creatures — reduced to {1}{U}, and two lands are enough") {
+            val driver = setupP1(
+                hand = listOf("Otawara, Soaring City"),
+                // Only two Islands: {3}{U} is unpayable, {1}{U} is payable.
+                battlefield = listOf("Island", "Island", legends[0], legends[1]),
+                extraSetCards = legendCards,
+                atStep = Step.PRECOMBAT_MAIN
+            )
+            val otawara = handId(driver, "Otawara, Soaring City")
+
+            withClue("Before the shared reduction, affordability was gated on the full {3}{U}") {
+                driver.enumerateFor(driver.player1) shouldContainActivatedAbilityOn otawara
+            }
+            withClue("…and the menu must show what the handler will actually charge") {
+                otawaraCost(driver) shouldBe "{1}{U}"
+            }
+        }
+
+        test("three legendary creatures — the coloured pip survives, floor is {U}") {
+            val driver = setupP1(
+                hand = listOf("Otawara, Soaring City"),
+                battlefield = listOf("Island", legends[0], legends[1], legends[2]),
+                extraSetCards = legendCards,
+                atStep = Step.PRECOMBAT_MAIN
+            )
+            val otawara = handId(driver, "Otawara, Soaring City")
+
+            driver.enumerateFor(driver.player1) shouldContainActivatedAbilityOn otawara
+            withClue("Reduction is generic-only — three legends can't eat the {U}") {
+                otawaraCost(driver) shouldBe "{U}"
+            }
+        }
+
+        test("two legendary creatures but no blue source — still not offered") {
+            val driver = setupP1(
+                hand = listOf("Otawara, Soaring City"),
+                // Forests can pay the generic remainder but never the {U}.
+                battlefield = listOf("Forest", "Forest", legends[0], legends[1]),
+                extraSetCards = legendCards,
+                atStep = Step.PRECOMBAT_MAIN
+            )
+            val otawara = handId(driver, "Otawara, Soaring City")
+
+            withClue("The reduction lowers the cost; it does not make it colourless") {
+                driver.enumerateFor(driver.player1) shouldNotContainActivatedAbilityOn otawara
+            }
+        }
+    }
+})


### PR DESCRIPTION
# Add the five NEO channel lands and Divide by Zero

Six cards, plus the two engine gaps that were blocking them. Both gaps are the same shape:
a modifier that existed on one code path but was never wired into the parallel one.

## The cards

**The Kamigawa: Neon Dynasty channel land cycle** — Boseiju, Who Endures; Eiganjo, Seat of the
Empire; Otawara, Soaring City; Sokenzan, Crucible of Defiance; Takenuma, Abandoned Mire. All five
are rare legendary lands sharing one shape: tap for their colour, plus an ability activated by
discarding the land *from hand*, costing {1} less per legendary creature you control. NEO is the
earliest real printing for all five.

**Divide by Zero** (STX #41) — `{2}{U}` instant, bounce a spell or permanent with mana value 1 or
greater, then Learn. STX is the earliest real printing.

Channel is an **ability word** (CR 207.2c: ability words "have no special rules meaning and no
individual entries in the Comprehensive Rules"), so it is not modelled as a keyword. It lives in
`oracleText` and nowhere else, exactly as Landfall and Magecraft do on their cards — the repo has no
ability-word mechanism and this change doesn't add one. Each channel ability is an ordinary
`activatedAbility` with `activateFromZone = Zone.HAND` and `Costs.DiscardSelf`, the shape Steel
Wrecking Ball already uses.

Everything else composes existing primitives: `Effects.DealDamage`, `Effects.ReturnToHand`,
`Patterns.Library.mill` plus the Gather → Select → Move pipeline, `Effects.CreateToken` with the
haste grant iterating `CREATED_TOKENS`, and the Assassin's Trophy shape (`ForEachPlayer` +
`Player.ControllerOf`) for Boseiju's consolation fetch.

## Engine gap 1 — cost reduction never reached zone-activated abilities

`ActivatedAbility.genericCostReduction` was honoured in exactly two places: the battlefield
enumerator and `ActivateAbilityHandler`. `ZoneActivatedAbilityEnumerator` — the one that surfaces
abilities activated from hand and graveyard — gated affordability on the **unreduced** cost. With two
legendary creatures out and `{1}{U}` available, Otawara's channel was never offered as a legal
action, even though the handler would have charged the reduced price. Unreachable in a real game.

The battlefield enumerator's three private helpers are extracted into a shared
`AbilityCostReduction` and both enumerators route through it. The zone enumerator also built its
displayed cost and auto-tap preview from the printed `ability.cost`, ignoring `effectiveCost`
entirely; both now describe what the player will actually pay.

## Engine gap 2 — `TargetSpellOrPermanent` couldn't filter its stack half

The requirement carried only a `permanentFilter`; every spell on the stack was a legal target
regardless of what the card said. That is right for the 22 printed cards in this shape that don't
restrict the stack side (the lace effects, Artificial Evolution, Venser, Shaper Savant), and wrong
for the two that do — Divide by Zero, and Aether Gust ("target spell or permanent that's red or
green"), each applying one restriction to both halves.

A `spellFilter` is added alongside, honoured in the three places the requirement is read for
legality: `TargetValidator`, `TargetFinder`, `TargetEnumerationUtils`. Null keeps today's behaviour,
so no existing card's snapshot moved.

## New SDK vocabulary

Four additions, each a named recipe over existing primitives rather than a new type:

- `TargetSpellOrPermanent.spellFilter` — genuinely new capability; the stack half had no filter at
  all, so composition couldn't express it.
- `TargetSpellOrPermanent.descriptionOverride` — the escape hatch `TargetPermanentOrPlayer` already
  carries. A both-halves restriction is printed once but passed to each filter separately, so the
  generated text otherwise repeats it per side.
- `DynamicAmounts.legendaryCreaturesYouControl()` — `battlefield(You, Creature.legendary()).count()`,
  named because five cards in this PR alone wanted it. Sits beside `creaturesYouControl()`.
- `GameObjectFilter.LandWithBasicLandType` — the five-way basic-type union, named because "a land
  card with a basic land type" is not the same set as `BasicLand` (a shockland qualifies).

`docs/card-sdk-language-reference.md` is updated for all four.

## Rules cited

Verified against the local `MagicCompRules_20260808.txt` (effective 2026-08-07):

- **CR 207.2c** — ability words, listing `channel` among them, with no rules meaning.
- **CR 202.3b** — a spell's mana value on the stack uses the chosen value for `{X}`. See below.

## Verification

`scripts/gradle-locked` run **serially, one module per invocation** — `just test` fans the per-era
test modules out in parallel and starves them into `TestHangGuard` timeouts on this box. All 14
modules green on the final tree, after the review fixes:

```
sdk · rules-engine · mtg-sets · game-server · ai
era-1993-1999 · 2000-2002 · 2003-2007 · 2008-2016 · 2017-2022 · 2023 · 2024 · 2025 · 2026
```

Also run: `just rebless-cards` (only NEO and STX moved, pure additions plus the one
`descriptionOverride` line — no existing card shifted); `just check-card-printing` green for all six;
`just assay-differential --set STX` 0 divergent, `--set NEO` 1 divergent which is the pre-existing
Experimental Synthesizer, not from this branch.

Both engine fixes were mutation-checked: reverting each reddens exactly its own test and leaves the
controls green.

**What this does not cover.** No TypeScript or web-client tooling was run — `node_modules` is absent
and the network is firewalled here, so the client side of this change is unverified by any tool. The
client reasoning (the ability's menu label comes from `action.description`, which now carries the
reduced cost) is from reading `ActionMenu.tsx`, not from running it. No scenario was booted against a
running game server; the six dev scenarios under `manual-scenarios/` are validated only as JSON with
every card name resolved against the registry.

## Deliberately left out

- **`{X}` spells read mana value 0 on the stack.** `CardPredicate.ManaValueAtLeast` reads the card's
  mana value, not the value chosen for `{X}` (CR 202.3b), so a spell whose cost is purely `{X}` is
  wrongly untargetable by Divide by Zero. Every other `{X}` spell has a non-X pip and clears "1 or
  greater" either way. Documented in the card's KDoc; fixing it means threading the stack object's
  chosen X into the predicate evaluator, which is its own change.
- **`ReselectTargetRandomlyExecutor`** still ignores both filters on this requirement. It already
  ignored `permanentFilter` before this branch; narrowing only the new half would be inconsistent.
- **Aether Gust** is now expressible but not implemented — it belongs in its own card PR.
- **Otawara's scenario has no planeswalker** on the opposing board, so it exercises three of the four
  target types.
