### PR TITLE
Add 74 Assay-ready cards to Time Spiral

### DIFF
--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mir/cards/ZhalfirinKnight.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mir/cards/ZhalfirinKnight.kt
@@ -3,10 +3,8 @@ package com.wingedsheep.mtg.sets.definitions.mir.cards
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
@@ -19,9 +17,9 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * creature gets -1/-1 until end of turn.)
  * {W}{W}: This creature gains first strike until end of turn.
  *
- * The Flanking keyword on the [Keyword] enum is display-only; per-card cards in
- * Mirage block wire the trigger explicitly here so the `withoutKeyword(FLANKING)`
- * filter excludes other flanking creatures correctly.
+ * Flanking needs no per-card wiring: `TriggerAbilityResolver.getFlankingTriggeredAbilities`
+ * synthesizes [com.wingedsheep.sdk.scripting.Flanking.blockedByNonFlankerTrigger] for any
+ * creature with the projected keyword (CR 702.25b), the same way ward and suspend are derived.
  */
 val ZhalfirinKnight = card("Zhalfirin Knight") {
     manaCost = "{2}{W}"
@@ -34,13 +32,6 @@ val ZhalfirinKnight = card("Zhalfirin Knight") {
         "{W}{W}: This creature gains first strike until end of turn."
 
     keywords(Keyword.FLANKING)
-
-    triggeredAbility {
-        trigger = Triggers.becomesBlocked(
-            filter = GameObjectFilter.Creature.withoutKeyword(Keyword.FLANKING)
-        )
-        effect = Effects.ModifyStats(-1, -1, EffectTarget.TriggeringEntity)
-    }
 
     activatedAbility {
         cost = Costs.Mana("{W}{W}")

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/TimeSpiralSet.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/TimeSpiralSet.kt
@@ -1,6 +1,5 @@
 package com.wingedsheep.mtg.sets.definitions.tsp
 
-import com.wingedsheep.mtg.sets.definitions.por.PortalSet
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
@@ -18,11 +17,14 @@ object TimeSpiralSet : MtgSet {
     override val displayName = "Time Spiral"
     override val releaseDate = "2006-10-06"
     override val block = "Time Spiral"
-    override val basicLandsFallback = PortalSet
     override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/AmrouScout.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/AmrouScout.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Amrou Scout
+ * {1}{W}
+ * Creature — Kithkin Rebel Scout
+ * 2/1
+ * {4}, {T}: Search your library for a Rebel permanent card with mana value 3 or less, put it
+ * onto the battlefield, then shuffle.
+ *
+ * The Rebel searcher's fetch is the plain library-search pipeline
+ * ([Patterns.Library.searchLibrary]) pointed at the battlefield: the filter is a *permanent* card
+ * (not just a creature — Rebel is also worn by noncreature permanents), carrying the mana-value
+ * ceiling, and the search shuffles afterwards.
+ */
+val AmrouScout = card("Amrou Scout") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kithkin Rebel Scout"
+    power = 2
+    toughness = 1
+    oracleText = "{4}, {T}: Search your library for a Rebel permanent card with mana value 3 or less, put it onto the battlefield, then shuffle."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.REBEL).manaValueAtMost(3),
+            destination = SearchDestination.BATTLEFIELD,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "1"
+        artist = "Quinton Hoover"
+        flavorText = "The people of Amrou were scattered by war and driven into hiding. Scouts maintain the beacon fires that signal \"return\" and \"home.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea3e05e5-1340-4010-b39b-3571a5829840.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/AshcoatBear.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/AshcoatBear.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ashcoat Bear
+ * {1}{G}
+ * Creature — Bear
+ * 2/2
+ * Flash (You may cast this spell any time you could cast an instant.)
+ */
+val AshcoatBear = card("Ashcoat Bear") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Bear"
+    power = 2
+    toughness = 2
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)"
+
+    keywords(Keyword.FLASH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "190"
+        artist = "Carl Critchlow"
+        flavorText = "The bears wade into time rifts to feed. They do not fear the storms, and they are quick enough to snatch prey just as it blinks in or out of time."
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b7a6ab5-8a8f-492c-8484-3089354ce8cf.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/BasalSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/BasalSliver.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Basal Sliver
+ * {2}{B}
+ * Creature — Sliver
+ * 2/2
+ * All Slivers have "Sacrifice this permanent: Add {B}{B}."
+ *
+ * "All Slivers" is the bare tribal noun — every Sliver *permanent*, not just the creatures.
+ */
+val BasalSliver = card("Basal Sliver") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "All Slivers have \"Sacrifice this permanent: Add {B}{B}.\""
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.SacrificeSelf,
+                effect = Effects.AddMana(Color.BLACK, 2),
+                timing = TimingRule.ManaAbility,
+                isManaAbility = true
+            ),
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype("Sliver"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "96"
+        artist = "Drew Tucker"
+        flavorText = "\"Fascinating . . . These creatures display the paradox of tenacity and purposed self-destruction I have sought to breed into my thrulls.\"\n—Endrek Sahr, master breeder"
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/4564e9df-bfa3-48e5-a12e-f7e96a504cb1.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/BenalishCavalry.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/BenalishCavalry.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Benalish Cavalry
+ * {1}{W}
+ * Creature — Human Knight
+ * 2/2
+ * Flanking (Whenever a creature without flanking blocks this creature, the blocking creature
+ * gets -1/-1 until end of turn.)
+ *
+ * The keyword is the whole card: the engine derives flanking's triggered ability from the
+ * projected [Keyword.FLANKING] (`TriggerAbilityResolver.getFlankingTriggeredAbilities`), the same
+ * way it derives ward and suspend, so the -1/-1 trigger is never authored per card.
+ */
+val BenalishCavalry = card("Benalish Cavalry") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 2
+    oracleText = "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)"
+
+    keywords(Keyword.FLANKING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "4"
+        artist = "Paolo Parente"
+        flavorText = "\"My people swore to protect Benalia to the end. It is battered, but yet stands, as do we.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/1013ca9c-1d29-42f6-8665-92f98d076ff8.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/BogardanRager.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/BogardanRager.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bogardan Rager
+ * {5}{R}
+ * Creature — Elemental
+ * 3/4
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * When this creature enters, target creature gets +4/+0 until end of turn.
+ *
+ * Flash plus a pump-on-entry is the combat trick half of the card: cast it during combat and the
+ * entry trigger can push an already-declared attacker or blocker over the top. The trigger targets
+ * any creature, the Rager itself included.
+ */
+val BogardanRager = card("Bogardan Rager") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 3
+    toughness = 4
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "When this creature enters, target creature gets +4/+0 until end of turn."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(4, 0, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Clint Langley"
+        flavorText = "In the erupting heart of Bogardan, it's hard to tell hurtling volcanic rocks from pouncing volcanic beasts."
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec53d26b-ad3e-474f-a374-05fcdc00e49c.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/BonesplitterSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/BonesplitterSliver.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Bonesplitter Sliver
+ * {3}{R}
+ * Creature — Sliver
+ * 2/2
+ * All Sliver creatures get +2/+0.
+ */
+val BonesplitterSliver = card("Bonesplitter Sliver") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "All Sliver creatures get +2/+0."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 2,
+            toughnessBonus = 0,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "149"
+        artist = "Dany Orizio"
+        flavorText = "As the time streams grew more and more unstable, Dominaria's creatures struggled to adapt. The intense pressures led to many dead ends but also to lethal new forms that appeared as suddenly as the ashen rains."
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/705e29c5-2d9b-44ad-a04c-9a62dd74eb12.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/BrassGnat.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/BrassGnat.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Brass Gnat
+ * {1}
+ * Artifact Creature — Insect
+ * 1/1
+ * Flying
+ * This creature doesn't untap during your untap step.
+ * At the beginning of your upkeep, you may pay {1}. If you do, untap this creature.
+ *
+ * The upkeep tax is the whole card: the wind-down is [AbilityFlag.DOESNT_UNTAP] (the engine's
+ * untap-step skip, shared with Galvanic Juggernaut and Leviathan) and the winding is a
+ * [Gate.MayPay] — "you may pay {1}. If you do" is one resolution, payment and payoff together,
+ * not a reflexive trigger.
+ *
+ * Assay's `compile` model does not carry the "doesn't untap" line (it emits only the upkeep
+ * trigger and Flying); `flags` sits outside the differential's compared surface, so the flag is
+ * authored here to keep the card behaviourally right.
+ */
+val BrassGnat = card("Brass Gnat") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Insect"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "This creature doesn't untap during your untap step.\n" +
+        "At the beginning of your upkeep, you may pay {1}. If you do, untap this creature."
+
+    keywords(Keyword.FLYING)
+    flags(AbilityFlag.DOESNT_UNTAP)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = GatedEffect(
+            gate = Gate.MayPay(PayManaCostEffect(ManaCost.parse("{1}"))),
+            then = Effects.Untap(EffectTarget.Self),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "249"
+        artist = "Martina Pilcerova"
+        flavorText = "Its buzzing is the sound of its inner mechanisms, ever winding down."
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/386ae7c6-347c-4b29-b7a9-3ca3bb050396.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/CallToTheNetherworld.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/CallToTheNetherworld.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Call to the Netherworld
+ * {B}
+ * Sorcery
+ * Return target black creature card from your graveyard to your hand.
+ * Madness {0} (If you discard this card, discard it into exile. When you do, cast it for its
+ * madness cost or put it into your graveyard.)
+ *
+ * Madness {0} is a real zero cost rather than the absence of one — `madness("{0}")` parses to a
+ * payable cost, so the madness trigger still offers the free cast. `CardBuilder.build()` derives
+ * the printed `Keyword.MADNESS` from the keyword ability, so the bare keyword is never written
+ * beside it.
+ *
+ * The targeted return needs no `fromZone` guard: the requirement's own `zone = GRAVEYARD` is
+ * re-checked at resolution under CR 608.2b, so [Effects.ReturnToHand] is the right facade here.
+ */
+val CallToTheNetherworld = card("Call to the Netherworld") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Return target black creature card from your graveyard to your hand.\n" +
+        "Madness {0} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)"
+
+    spell {
+        val t = target(
+            "target",
+            TargetObject(
+                filter = TargetFilter(
+                    baseFilter = GameObjectFilter.Creature.withColor(Color.BLACK).ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.ReturnToHand(t)
+    }
+
+    madness("{0}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "97"
+        artist = "Vance Kovacs"
+        flavorText = "The ritual was normally performed only by horrors and pit spawn. Lesser mages had but one sanity to crack in the casting."
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fa7322e2-dbea-46e1-ba29-a86a13e5d33e.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/CavalryMaster.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/CavalryMaster.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Cavalry Master
+ * {2}{W}{W}
+ * Creature — Human Knight
+ * 3/3
+ * Flanking (Whenever a creature without flanking blocks this creature, the blocking creature
+ * gets -1/-1 until end of turn.)
+ * Other creatures you control with flanking have flanking. (Each instance of flanking triggers
+ * separately.)
+ *
+ * A lord that grants the keyword it selects on: the filter already requires flanking, so the
+ * grant only ever lands a *second* instance. That works because flanking's triggered ability is
+ * derived from the projected keyword rather than authored — `TriggerAbilityResolver` supplies one
+ * trigger per instance, which is exactly what the reminder text promises.
+ */
+val CavalryMaster = card("Cavalry Master") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 3
+    toughness = 3
+    oracleText = "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\n" +
+        "Other creatures you control with flanking have flanking. (Each instance of flanking triggers separately.)"
+
+    keywords(Keyword.FLANKING)
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.FLANKING,
+            GroupFilter(
+                GameObjectFilter.Creature.withKeyword(Keyword.FLANKING).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "6"
+        artist = "Thomas M. Baxa"
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7b19194-87bf-432c-8d34-91dd9520cbd2.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Chronosavant.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Chronosavant.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Chronosavant
+ * {5}{W}
+ * Creature — Giant
+ * 5/5
+ * {1}{W}: Return this card from your graveyard to the battlefield tapped. You skip your next turn.
+ *
+ * A graveyard-activated ability (`activateFromZone = Zone.GRAVEYARD`) that moves the card back
+ * itself: the self-return is a plain [Effects.Move] with [ZonePlacement.Tapped] and an explicit
+ * `fromZone`, and the skipped turn is the price, paid on resolution rather than as a cost.
+ */
+val Chronosavant = card("Chronosavant") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Giant"
+    power = 5
+    toughness = 5
+    oracleText = "{1}{W}: Return this card from your graveyard to the battlefield tapped. You skip your next turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{W}")
+        activateFromZone = Zone.GRAVEYARD
+        effect = Effects.Composite(
+            Effects.Move(
+                EffectTarget.Self,
+                Zone.BATTLEFIELD,
+                placement = ZonePlacement.Tapped,
+                fromZone = Zone.GRAVEYARD,
+            ),
+            Effects.SkipNextTurn(),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "9"
+        artist = "Pete Venters"
+        flavorText = "\"In my dreams, I hear the voices of my future selves who have died in times yet to come. I use that knowledge to avoid those dark futures and continue my search for peace.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6264d4f-adf1-4d7b-b17a-fd7122e9b2cd.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/CorpulentCorpse.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/CorpulentCorpse.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Corpulent Corpse
+ * {5}{B}
+ * Creature — Zombie
+ * 3 / 3
+ * Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)
+ * Suspend 5—{B} (Rather than cast this card from your hand, you may pay {B} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)
+ *
+ * Keywords only. `Keyword.SUSPEND` is display-only — the engine's `SuspendEnumerator` reads the
+ * parameterized [KeywordAbility.Suspend], so suspend is written once as `suspend(cost, counters)`
+ * exactly as on `tsp/cards/SearchForTomorrow.kt`; the enum is derived from it.
+ */
+val CorpulentCorpse = card("Corpulent Corpse") {
+    manaCost = "{5}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 3
+    toughness = 3
+    oracleText = "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\n" +
+        "Suspend 5—{B} (Rather than cast this card from your hand, you may pay {B} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)"
+
+    keywords(Keyword.FEAR)
+
+    keywordAbility(KeywordAbility.suspend("{B}", 5))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "98"
+        artist = "Doug Chaffee"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a58b842a-a4c0-475d-a8b3-62d4e5bb2eaf.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DAvenantHealer.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DAvenantHealer.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * D'Avenant Healer
+ * {1}{W}{W}
+ * Creature — Human Cleric Archer
+ * 1/2
+ * {T}: This creature deals 1 damage to target attacking or blocking creature.
+ * {T}: Prevent the next 1 damage that would be dealt to any target this turn.
+ *
+ * Two tap abilities sharing one body, so only one fires per untap: the archer half is the
+ * D'Avenant pinger restricted to creatures in combat ([GameObjectFilter.attackingOrBlocking]),
+ * and the cleric half is a one-point [Effects.PreventNextDamage] shield on any target.
+ */
+val DAvenantHealer = card("D'Avenant Healer") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric Archer"
+    power = 1
+    toughness = 2
+    oracleText = "{T}: This creature deals 1 damage to target attacking or blocking creature.\n" +
+        "{T}: Prevent the next 1 damage that would be dealt to any target this turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val victim = target(
+            "target",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.attackingOrBlocking())),
+        )
+        effect = Effects.DealDamage(1, victim)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        val shielded = target("target", Targets.Any)
+        effect = Effects.PreventNextDamage(1, shielded)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Michael Sutfin"
+        flavorText = "\"One arrow keenly fired might prevent more battlefield wounds than I could treat.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/deac6492-ce39-4137-8418-6169d3b1b632.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DarkWithering.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DarkWithering.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Dark Withering
+ * {4}{B}{B}
+ * Instant
+ * Destroy target nonblack creature.
+ * Madness {B} (If you discard this card, discard it into exile. When you do, cast it for its
+ * madness cost or put it into your graveyard.)
+ *
+ * "Nonblack" is `CardPredicate.NotColor(BLACK)`, which reads the creature's colors — a
+ * multicolored creature that is partly black is spared. Madness is display-only at the DSL
+ * layer; both halves live in the engine and key off the `KeywordAbility.Madness` entry.
+ */
+val DarkWithering = card("Dark Withering") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Destroy target nonblack creature.\n" +
+        "Madness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)"
+
+    spell {
+        val t = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Creature.notColor(Color.BLACK)))
+        )
+        effect = Effects.Destroy(t)
+    }
+
+    madness("{B}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "101"
+        artist = "Wayne Reynolds"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3da58e0d-5877-43c4-b129-993e154b6087.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DeathsporeThallid.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DeathsporeThallid.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Deathspore Thallid
+ * {1}{B}
+ * Creature — Zombie Fungus
+ * 1 / 1
+ * At the beginning of your upkeep, put a spore counter on this creature.
+ * Remove three spore counters from this creature: Create a 1/1 green Saproling creature token.
+ * Sacrifice a Saproling: Target creature gets -1/-1 until end of turn.
+ */
+val DeathsporeThallid = card("Deathspore Thallid") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Fungus"
+    power = 1
+    toughness = 1
+    oracleText = "At the beginning of your upkeep, put a spore counter on this creature.\n" +
+        "Remove three spore counters from this creature: Create a 1/1 green Saproling creature token.\n" +
+        "Sacrifice a Saproling: Target creature gets -1/-1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.AddCounters(Counters.SPORE, 1, EffectTarget.Self)
+        description = "At the beginning of your upkeep, put a spore counter on this creature."
+    }
+
+    activatedAbility {
+        cost = Costs.RemoveCounterFromSelf(Counters.SPORE, 3)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling")
+        )
+        description = "Remove three spore counters from this creature: Create a 1/1 green Saproling creature token."
+    }
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Permanent.withSubtype(Subtype.SAPROLING))
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(-1, -1, t)
+        description = "Sacrifice a Saproling: Target creature gets -1/-1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Randy Elliott"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/44ee5ee3-11f8-4a4e-bfa3-10ff45ed6d1b.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DrifterIlDal.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DrifterIlDal.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+
+/**
+ * Drifter il-Dal
+ * {U}
+ * Creature — Human Wizard
+ * 2/1
+ * Shadow (This creature can block or be blocked by only creatures with shadow.)
+ * At the beginning of your upkeep, sacrifice this creature unless you pay {U}.
+ *
+ * Shadow is read straight off the keyword by the block-evasion rules (symmetric: a shadow
+ * creature can neither block nor be blocked by anything without shadow). The upkeep clause is the
+ * standard cumulative-rent shape — [PayOrSufferEffect] with [SacrificeSelfEffect] as the punisher.
+ */
+val DrifterIlDal = card("Drifter il-Dal") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "Shadow (This creature can block or be blocked by only creatures with shadow.)\n" +
+        "At the beginning of your upkeep, sacrifice this creature unless you pay {U}."
+
+    keywords(Keyword.SHADOW)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = PayOrSufferEffect(cost = Costs.pay.Mana("{U}"), suffer = SacrificeSelfEffect)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "Justin Sweet"
+        flavorText = "They study the deeds of their traitorous ancestors, hoping the stories may reveal a way back to the physical world."
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c3de909-b47e-45d7-9922-8d5e08a76ec9.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DrudgeReavers.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DrudgeReavers.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Drudge Reavers
+ * {3}{B}
+ * Creature — Skeleton
+ * 2/1
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * {B}: Regenerate this creature.
+ *
+ * Flash on a regenerating Skeleton makes it an ambush blocker that survives the trade — the
+ * shield taps it and removes it from combat instead of letting it die (CR 701.15).
+ */
+val DrudgeReavers = card("Drudge Reavers") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Skeleton"
+    power = 2
+    toughness = 1
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "{B}: Regenerate this creature."
+
+    keywords(Keyword.FLASH)
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = RegenerateEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Greg Staples"
+        flavorText = "\"The surface of the land is blanched with salt, but the soil beneath is reddened with death—a fertile ground for necromancy.\"\n—Lim-Dûl the Necromancer"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/03c07d9a-afed-4028-9fa1-ec439b60f08f.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DurkwoodBaloth.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DurkwoodBaloth.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Durkwood Baloth
+ * {4}{G}{G}
+ * Creature — Beast
+ * 5 / 5
+ * Suspend 5—{G} (Rather than cast this card from your hand, you may pay {G} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)
+ *
+ * A vanilla body plus suspend, written once as the parameterized [KeywordAbility.Suspend]
+ * (`suspend(cost, timeCounters)`); `Keyword.SUSPEND` is derived from it by `CardBuilder.build()`.
+ */
+val DurkwoodBaloth = card("Durkwood Baloth") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 5
+    oracleText = "Suspend 5—{G} (Rather than cast this card from your hand, you may pay {G} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)"
+
+    keywordAbility(KeywordAbility.suspend("{G}", 5))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "193"
+        artist = "Dan Frazier"
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/670521c3-df02-487d-a299-49419e41889f.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DuskriderPeregrine.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DuskriderPeregrine.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Duskrider Peregrine
+ * {5}{W}
+ * Creature — Bird
+ * 3 / 3
+ * Flying, protection from black
+ * Suspend 3—{1}{W} (Rather than cast this card from your hand, you may pay {1}{W} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)
+ *
+ * Protection is parameterized rather than a bare enum — [KeywordAbility.protectionFrom] over a
+ * [com.wingedsheep.sdk.scripting.ProtectionScope.Color], which is why it carries no `Keyword`
+ * entry of its own. Suspend is the usual `suspend(cost, timeCounters)` one-liner.
+ */
+val DuskriderPeregrine = card("Duskrider Peregrine") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird"
+    power = 3
+    toughness = 3
+    oracleText = "Flying, protection from black\n" +
+        "Suspend 3—{1}{W} (Rather than cast this card from your hand, you may pay {1}{W} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)"
+
+    keywords(Keyword.FLYING)
+
+    keywordAbility(KeywordAbility.protectionFrom(Color.BLACK))
+    keywordAbility(KeywordAbility.suspend("{1}{W}", 3))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "14"
+        artist = "Una Fricker"
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bfad8c3e-e459-477c-b602-34df2dda1efe.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/EmptyTheWarrens.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/EmptyTheWarrens.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Empty the Warrens
+ * {3}{R}
+ * Sorcery
+ * Create two 1/1 red Goblin creature tokens.
+ * Storm (When you cast this spell, copy it for each spell cast before it this turn.)
+ *
+ * Storm (CR 702.40) is engine-live off the printed keyword, but the copy path reads
+ * `script.spellEffect`: the card must stay a plain `spell { effect = … }`, never a modal or
+ * replacement shape, or the storm trigger resolves into zero copies.
+ *
+ * The Goblin token carries no `imageUri` — Time Spiral's own token art resolves through
+ * `TokenArtData.forSet`, so hard-coding a URI here would only pin the wrong printing.
+ */
+val EmptyTheWarrens = card("Empty the Warrens") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Create two 1/1 red Goblin creature tokens.\n" +
+        "Storm (When you cast this spell, copy it for each spell cast before it this turn.)"
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Goblin"),
+            count = 2
+        )
+    }
+
+    keywords(Keyword.STORM)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "152"
+        artist = "Mark Brill"
+        flavorText = "\"They'd pour out of the warrens to make war (and to make room for the littering matrons).\"\n—*Sarpadian Empires, vol. IV*"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/952bb27c-c58a-478a-b637-eb4f7e1e0ab4.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ErrantEphemeron.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ErrantEphemeron.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Errant Ephemeron
+ * {6}{U}
+ * Creature — Illusion
+ * 4 / 4
+ * Flying
+ * Suspend 4—{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)
+ *
+ * Two printed keywords, nothing else. Flying is a real engine keyword; suspend is the
+ * parameterized [KeywordAbility.Suspend] — cost first, time counters second.
+ */
+val ErrantEphemeron = card("Errant Ephemeron") {
+    manaCost = "{6}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Illusion"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "Suspend 4—{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)"
+
+    keywords(Keyword.FLYING)
+
+    keywordAbility(KeywordAbility.suspend("{1}{U}", 4))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Luca Zontini"
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/398c26cc-cd55-42c6-a744-aaefd7018960.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Feebleness.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Feebleness.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Feebleness
+ * {1}{B}
+ * Enchantment — Aura
+ * Flash
+ * Enchant creature
+ * Enchanted creature gets -2/-1.
+ *
+ * Flash on a shrinking Aura makes it removal at instant speed: -2/-1 kills an X/1 outright and
+ * blanks a combat trick. The penalty is the ordinary attached-creature [ModifyStats] static, whose
+ * default filter is the enchanted creature.
+ */
+val Feebleness = card("Feebleness") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\n" +
+        "Enchant creature\n" +
+        "Enchanted creature gets -2/-1."
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(-2, -1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "110"
+        artist = "Kev Walker"
+        flavorText = "Just a small touch of magic can harness the debilitating power of Urborg's poisonous winds."
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1ba2660d-b661-4266-b7e5-07bb8b72bce6.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/FirewakeSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/FirewakeSliver.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Firewake Sliver
+ * {1}{R}{G}
+ * Creature — Sliver
+ * 1/1
+ * All Sliver creatures have haste.
+ * All Slivers have "{1}, Sacrifice this permanent: Target Sliver creature gets +2/+2 until end of turn."
+ *
+ * The haste grant reaches Sliver *creatures*; the granted ability reaches every Sliver *permanent*.
+ */
+val FirewakeSliver = card("Firewake Sliver") {
+    manaCost = "{1}{R}{G}"
+    colorIdentity = "GR"
+    typeLine = "Creature — Sliver"
+    power = 1
+    toughness = 1
+    oracleText = "All Sliver creatures have haste.\n" +
+        "All Slivers have \"{1}, Sacrifice this permanent: Target Sliver creature gets +2/+2 until end of turn.\""
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.HASTE,
+            GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver"))
+        )
+    }
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf),
+                effect = Effects.ModifyStats(2, 2, EffectTarget.BoundVariable("target")),
+                targetRequirements = listOf(
+                    TargetObject(
+                        filter = TargetFilter(GameObjectFilter.Creature.withSubtype("Sliver")),
+                        id = "target"
+                    )
+                )
+            ),
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype("Sliver"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "238"
+        artist = "Anthony S. Waters"
+        flavorText = "\"They are here, and they are hungry. And what they do not eat, they burn. Yavimaya is lost. We must leave now for Skyshroud.\"\n—Edahlis, greenseeker"
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d3f5a0d-029e-44fd-b3e6-c70176b5b4ac.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/FledglingMawcor.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/FledglingMawcor.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fledgling Mawcor
+ * {3}{U}
+ * Creature — Beast
+ * 2 / 2
+ * Flying
+ * {T}: This creature deals 1 damage to any target.
+ * Morph {U}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any
+ * time for its morph cost.)
+ *
+ * Morph is the bare `morph` string property — `CardBuilder.build()` turns it into the
+ * `KeywordAbility.Morph` whose turn-up price is a mana cost atom.
+ */
+val FledglingMawcor = card("Fledgling Mawcor") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Beast"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "{T}: This creature deals 1 damage to any target.\n" +
+        "Morph {U}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)"
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    morph = "{U}{U}"
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "63"
+        artist = "Kev Walker"
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c464923e-ae6e-4c1d-9315-0ddb86c07b40.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/FlowstoneChanneler.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/FlowstoneChanneler.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flowstone Channeler
+ * {2}{R}
+ * Creature — Human Spellshaper
+ * 2/2
+ * {1}{R}, {T}, Discard a card: Target creature gets +1/-1 and gains haste until end of turn.
+ *
+ * The Spellshaper shape: a mana-plus-tap-plus-discard cost buying the spell the card is named for
+ * (Flowstone Slide's flowstone pump, here the Tempest-block +1/-1-and-haste). The two halves are
+ * one composite on a single target slot.
+ */
+val FlowstoneChanneler = card("Flowstone Channeler") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Spellshaper"
+    power = 2
+    toughness = 2
+    oracleText = "{1}{R}, {T}, Discard a card: Target creature gets +1/-1 and gains haste until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{R}"), Costs.Tap, Costs.DiscardCard)
+        val creature = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, -1, creature),
+            Effects.GrantKeyword(Keyword.HASTE, creature),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "155"
+        artist = "Alan Pollack"
+        flavorText = "With the evincars gone, flowstone became erratic and wild, a source of power for mages more desperate than wise."
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f10fa1c-2c7b-49ba-87b6-3b652b65704d.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/FurySliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/FurySliver.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Fury Sliver
+ * {5}{R}
+ * Creature — Sliver
+ * 3/3
+ * All Sliver creatures have double strike.
+ */
+val FurySliver = card("Fury Sliver") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Sliver"
+    power = 3
+    toughness = 3
+    oracleText = "All Sliver creatures have double strike."
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.DOUBLE_STRIKE,
+            GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "157"
+        artist = "Paolo Parente"
+        flavorText = "\"A rift opened, and our arrows were abruptly stilled. To move was to push the world. But the sliver's claw still twitched, red wounds appeared in Thed's chest, and ribbons of blood hung in the air.\"\n—Adom Capashen, Benalish hero"
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/0000579f-7b35-4ed3-b44c-db2a538066fe.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/GazeOfJustice.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/GazeOfJustice.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Gaze of Justice
+ * {W}
+ * Sorcery
+ * As an additional cost to cast this spell, tap three untapped white creatures you control.
+ * Exile target creature.
+ * Flashback {5}{W} (You may cast this card from your graveyard for its flashback cost and any
+ * additional costs. Then exile it.)
+ */
+val GazeOfJustice = card("Gaze of Justice") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, tap three untapped white creatures you control.\n" +
+        "Exile target creature.\n" +
+        "Flashback {5}{W} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)"
+
+    additionalCost(
+        Costs.additional.TapPermanents(
+            count = 3,
+            filter = GameObjectFilter.Creature.withColor(Color.WHITE)
+        )
+    )
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Exile(t)
+    }
+
+    keywordAbility(KeywordAbility.flashback("{5}{W}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "John Avon"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/24d565ec-541d-429e-ab45-58db16c2f41d.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/GemhideSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/GemhideSliver.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Gemhide Sliver
+ * {1}{G}
+ * Creature — Sliver
+ * 1/1
+ * All Slivers have "{T}: Add one mana of any color."
+ */
+val GemhideSliver = card("Gemhide Sliver") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Sliver"
+    power = 1
+    toughness = 1
+    oracleText = "All Slivers have \"{T}: Add one mana of any color.\""
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Tap,
+                effect = Effects.AddManaOfChoice(),
+                timing = TimingRule.ManaAbility,
+                isManaAbility = true
+            ),
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype("Sliver"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "196"
+        artist = "John Matson"
+        flavorText = "\"The land is weary. Even Skyshroud is depleted. We must find another source of mana—one that is growing despite our withering world.\"\n—Freyalise"
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f09135b0-fd57-4205-aa74-c9869946c264.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Grapeshot.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Grapeshot.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grapeshot
+ * {1}{R}
+ * Sorcery
+ * Grapeshot deals 1 damage to any target.
+ * Storm (When you cast this spell, copy it for each spell cast before it this turn. You may
+ * choose new targets for the copies.)
+ *
+ * Storm (CR 702.40) copies the spell off `script.spellEffect`, so this stays a plain
+ * `spell { effect = … }` — a modal or replacement shape would make the trigger resolve into
+ * zero copies.
+ */
+val Grapeshot = card("Grapeshot") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Grapeshot deals 1 damage to any target.\n" +
+        "Storm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)"
+
+    spell {
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(1, t)
+    }
+
+    keywords(Keyword.STORM)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "160"
+        artist = "Pete Venters"
+        flavorText = "Mages often seek to emulate the powerful relics lost to time and apocalypse."
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4ee33cb6-768e-44a0-b6f4-b8638aa84330.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Greenseeker.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Greenseeker.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Greenseeker
+ * {G}
+ * Creature — Elf Spellshaper
+ * 1/1
+ * {G}, {T}, Discard a card: Search your library for a basic land card, reveal it, put it into your
+ * hand, then shuffle.
+ */
+val Greenseeker = card("Greenseeker") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Spellshaper"
+    power = 1
+    toughness = 1
+    oracleText = "{G}, {T}, Discard a card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.Tap, Costs.DiscardCard)
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "198"
+        artist = "Rebecca Guay"
+        flavorText = "\"A rumor passes among the snakes, whispered by the rushes, inspiring the seekers: the goddess Freyalise is alive in Skyshroud.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f2dfa231-349a-4dce-bed6-c82a136fe0a1.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/GroundRift.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/GroundRift.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Ground Rift
+ * {R}
+ * Sorcery
+ * Target creature without flying can't block this turn.
+ * Storm (When you cast this spell, copy it for each spell cast before it this turn. You may
+ * choose new targets for the copies.)
+ *
+ * "Without flying" is a restriction on the *target*, not the effect: `NotKeyword(FLYING)` on
+ * the requirement's filter, so a creature that gains flying in response is no longer a legal
+ * target and the spell (or that copy) fizzles under CR 608.2b.
+ *
+ * Storm copies the spell off `script.spellEffect`, so this stays a plain `spell { effect = … }`.
+ */
+val GroundRift = card("Ground Rift") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Target creature without flying can't block this turn.\n" +
+        "Storm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)"
+
+    spell {
+        val t = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Creature.withoutKeyword(Keyword.FLYING)))
+        )
+        effect = Effects.CantBlock(t)
+    }
+
+    keywords(Keyword.STORM)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "162"
+        artist = "Thomas M. Baxa"
+        flavorText = "Some time rifts didn't take away the people but just the ground they stood on."
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/62333783-6a18-4461-88ce-1c37eaf64e2b.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/HerdGnarr.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/HerdGnarr.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Herd Gnarr
+ * {3}{G}
+ * Creature — Beast
+ * 2/2
+ * Whenever another creature you control enters, this creature gets +2/+2 until end of turn.
+ */
+val HerdGnarr = card("Herd Gnarr") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever another creature you control enters, this creature gets +2/+2 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "200"
+        artist = "Daren Bader"
+        flavorText = "Long ago, the solitary gnarr was a sign of good luck. Now they have become wild pack hunters, a sign of impending danger."
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9cf4fd75-34b1-4afa-b8cd-777dfc9e6376.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/IcatianCrier.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/IcatianCrier.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Icatian Crier
+ * {2}{W}
+ * Creature — Human Spellshaper
+ * 1/1
+ * {1}{W}, {T}, Discard a card: Create two 1/1 white Citizen creature tokens.
+ */
+val IcatianCrier = card("Icatian Crier") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Spellshaper"
+    power = 1
+    toughness = 1
+    oracleText = "{1}{W}, {T}, Discard a card: Create two 1/1 white Citizen creature tokens."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}"), Costs.Tap, Costs.DiscardCard)
+        effect = Effects.CreateToken(
+            count = 2,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Citizen")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "23"
+        artist = "Michael Phillippi"
+        flavorText = "A thousand years removed from her home, her news of war had lost its context, but not its relevance."
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/523ab784-c77e-4b78-99fc-b5d7ed985d76.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/IthHighArcanist.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/IthHighArcanist.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Ith, High Arcanist
+ * {5}{W}{U}
+ * Legendary Creature — Human Wizard
+ * 3 / 5
+ * Vigilance
+ * {T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.
+ * Suspend 4—{W}{U}
+ *
+ * The two sentences of the activated ability are one composite over the same bound target:
+ * [Effects.Untap], then [Effects.PreventCombatDamageToAndBy] — the facade for a combat-only
+ * shield in both directions, which is exactly "dealt to and dealt by that creature this turn".
+ */
+val IthHighArcanist = card("Ith, High Arcanist") {
+    manaCost = "{5}{W}{U}"
+    colorIdentity = "UW"
+    typeLine = "Legendary Creature — Human Wizard"
+    power = 3
+    toughness = 5
+    oracleText = "Vigilance\n" +
+        "{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.\n" +
+        "Suspend 4—{W}{U}"
+
+    keywords(Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", Targets.AttackingCreature)
+        effect = Effects.Composite(
+            Effects.Untap(t),
+            Effects.PreventCombatDamageToAndBy(t)
+        )
+    }
+
+    keywordAbility(KeywordAbility.suspend("{W}{U}", 4))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "241"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8dd98dea-8012-49bb-84cf-dd8ed5c032cf.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/IvoryGiant.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/IvoryGiant.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ivory Giant
+ * {5}{W}{W}
+ * Creature — Giant
+ * 3 / 4
+ * When this creature enters, tap all nonwhite creatures.
+ * Suspend 5—{W} (Rather than cast this card from your hand, you may pay {W} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)
+ *
+ * "Tap all nonwhite creatures" is symmetric — no controller predicate — so it is
+ * [Effects.ForEachInGroup] over `Creature.notColor(WHITE)` with [Effects.Tap] on
+ * [EffectTarget.Self], which inside the loop resolves to the current iteration entity.
+ */
+val IvoryGiant = card("Ivory Giant") {
+    manaCost = "{5}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Giant"
+    power = 3
+    toughness = 4
+    oracleText = "When this creature enters, tap all nonwhite creatures.\n" +
+        "Suspend 5—{W} (Rather than cast this card from your hand, you may pay {W} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachInGroup(
+            filter = GroupFilter(GameObjectFilter.Creature.notColor(Color.WHITE)),
+            effect = Effects.Tap(EffectTarget.Self)
+        )
+    }
+
+    keywordAbility(KeywordAbility.suspend("{W}", 5))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Jeff Miracola"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72eb30d9-a826-4f29-ae2a-6873997674a7.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/JeditSDragoons.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/JeditSDragoons.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jedit's Dragoons
+ * {5}{W}
+ * Creature — Cat Soldier
+ * 2 / 5
+ * Vigilance
+ * When this creature enters, you gain 4 life.
+ */
+val JeditSDragoons = card("Jedit's Dragoons") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Soldier"
+    power = 2
+    toughness = 5
+    oracleText = "Vigilance\n" +
+        "When this creature enters, you gain 4 life."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(4)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "John Matson"
+        flavorText = "After Efrava was destroyed, the cat warriors scattered across Dominaria. Those who followed Jedit's example were strong enough to survive the ravages of apocalypse."
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e29cc9e5-29b7-4e3c-a0cd-46265b0f74ac.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/KeldonHalberdier.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/KeldonHalberdier.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Keldon Halberdier
+ * {4}{R}
+ * Creature — Human Warrior
+ * 4 / 1
+ * First strike
+ * Suspend 4—{R} (Rather than cast this card from your hand, you may pay {R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)
+ *
+ * Two printed keywords, nothing else — first strike is a real engine keyword, suspend is the
+ * parameterized [KeywordAbility.Suspend].
+ */
+val KeldonHalberdier = card("Keldon Halberdier") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warrior"
+    power = 4
+    toughness = 1
+    oracleText = "First strike\n" +
+        "Suspend 4—{R} (Rather than cast this card from your hand, you may pay {R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)"
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    keywordAbility(KeywordAbility.suspend("{R}", 4))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "167"
+        artist = "Paolo Parente"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a90723e0-fbb3-4976-9463-0373f8ed337c.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/LotusBloom.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/LotusBloom.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Lotus Bloom
+ * (no mana cost)
+ * Artifact
+ * Suspend 3—{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)
+ * {T}, Sacrifice this artifact: Add three mana of any one color.
+ *
+ * Printed with no mana cost — CR 202.1b/118.6: an unpayable cost, so it can only reach the
+ * battlefield through suspend (or another free-cast effect), exactly like
+ * `tsp/cards/AncestralVision.kt`. Unlike that card it is colorless, so there is no printed color
+ * indicator (CR 204) to carry.
+ *
+ * "Any *one* color" is [Effects.AddAnyColorMana] — one colour chosen, three mana of it — not
+ * `AddManaInAnyCombination`, which would colour each mana independently. No target, adds mana,
+ * not a loyalty ability, so it is a mana ability (CR 605.1a) and never uses the stack.
+ */
+val LotusBloom = card("Lotus Bloom") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Suspend 3—{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)\n" +
+        "{T}, Sacrifice this artifact: Add three mana of any one color."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.AddAnyColorMana(3)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    keywordAbility(KeywordAbility.suspend("{0}", 3))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "259"
+        artist = "Mark Zug"
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73127ee0-9a0c-48fa-9c60-b4c600ace8f7.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/MightSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/MightSliver.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Might Sliver
+ * {4}{G}
+ * Creature — Sliver
+ * 2/2
+ * All Sliver creatures get +2/+2.
+ */
+val MightSliver = card("Might Sliver") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "All Sliver creatures get +2/+2."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 2,
+            toughnessBonus = 2,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "205"
+        artist = "Jeff Miracola"
+        flavorText = "\"The colossal thing rumbled over the ridge, tree husks crumbling before it. The ones we were already fighting howled as it came, their muscles suddenly surging, and we knew it was time to flee.\"\n—Llanach, Skyshroud ranger"
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8bb8c52f-e608-4710-872f-8a8ae2b5c00c.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Mindstab.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Mindstab.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Mindstab
+ * {5}{B}
+ * Sorcery
+ * Target player discards three cards.
+ * Suspend 4—{B} (Rather than cast this card from your hand, you may pay {B} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)
+ *
+ * [Effects.Discard] is the facade over the Gather → Select → Move (Discard) pipeline; the
+ * bound target both scopes the hand that is gathered and becomes the chooser, so the discarding
+ * player picks their own three cards. Suspend is the parameterized [KeywordAbility.Suspend].
+ */
+val Mindstab = card("Mindstab") {
+    manaCost = "{5}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target player discards three cards.\n" +
+        "Suspend 4—{B} (Rather than cast this card from your hand, you may pay {B} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)"
+
+    spell {
+        val t = target("target", Targets.Player)
+        effect = Effects.Discard(3, t)
+    }
+
+    keywordAbility(KeywordAbility.suspend("{B}", 4))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "119"
+        artist = "Mark Tedin"
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3efd28ef-77db-4e7b-a69d-5a089e016737.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/PenumbraSpider.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/PenumbraSpider.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Penumbra Spider
+ * {2}{G}{G}
+ * Creature — Spider
+ * 2 / 4
+ * Reach
+ * When this creature dies, create a 2/4 black Spider creature token with reach.
+ */
+val PenumbraSpider = card("Penumbra Spider") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider"
+    power = 2
+    toughness = 4
+    oracleText = "Reach\n" +
+        "When this creature dies, create a 2/4 black Spider creature token with reach."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 4,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Spider"),
+            keywords = setOf(Keyword.REACH)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "210"
+        artist = "Jeff Easley"
+        flavorText = "When it snared a passing cockatrice, its own soul darkly doubled."
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6a989ac1-df69-45e7-98bf-564cc7c38973.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Plunder.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Plunder.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Plunder
+ * {4}{R}
+ * Sorcery
+ * Destroy target artifact or land.
+ * Suspend 4—{1}{R} (Rather than cast this card from your hand, you may pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)
+ *
+ * Stock removal: [Targets.ArtifactOrLand] plus [Effects.Destroy], which lowers to a
+ * graveyard move flagged `byDestruction` so indestructible and regeneration are honoured.
+ */
+val Plunder = card("Plunder") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target artifact or land.\n" +
+        "Suspend 4—{1}{R} (Rather than cast this card from your hand, you may pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)"
+
+    spell {
+        val t = target("target", Targets.ArtifactOrLand)
+        effect = Effects.Destroy(t)
+    }
+
+    keywordAbility(KeywordAbility.suspend("{1}{R}", 4))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "174"
+        artist = "Thomas M. Baxa"
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/79cff220-b1a6-4da6-b765-25a583b33de2.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/PrismaticLens.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/PrismaticLens.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Prismatic Lens
+ * {2}
+ * Artifact
+ * {T}: Add {C}.
+ * {1}, {T}: Add one mana of any color.
+ */
+val PrismaticLens = card("Prismatic Lens") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {C}.\n" +
+        "{1}, {T}: Add one mana of any color."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "262"
+        artist = "Alan Pollack"
+        flavorText = "It bends not light but mana, aligning its chaotic currents into the sharp angles necessary for the mystic's purposes."
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/50f058a7-c3c7-4bdf-a66c-a2636a8bd9db.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/QuilledSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/QuilledSliver.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Quilled Sliver
+ * {1}{W}
+ * Creature — Sliver
+ * 1/1
+ * All Slivers have "{T}: This permanent deals 1 damage to target attacking or blocking creature."
+ */
+val QuilledSliver = card("Quilled Sliver") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Sliver"
+    power = 1
+    toughness = 1
+    oracleText = "All Slivers have \"{T}: This permanent deals 1 damage to target attacking or blocking creature.\""
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Tap,
+                effect = Effects.DealDamage(1, EffectTarget.BoundVariable("target")),
+                targetRequirements = listOf(
+                    TargetObject(
+                        filter = TargetFilter(GameObjectFilter.Creature.attackingOrBlocking()),
+                        id = "target"
+                    )
+                )
+            ),
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype("Sliver"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "37"
+        artist = "John Matson"
+        flavorText = "\"They have long kept us under attack, but we do not lack for ammunition. The very bodies of our foes arm us against them.\"\n—Adom Capashen, Benalish hero"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72486240-eabb-4b37-99cc-ab13413683fa.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/RiftBolt.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/RiftBolt.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Rift Bolt
+ * {2}{R}
+ * Sorcery
+ * Rift Bolt deals 3 damage to any target.
+ * Suspend 1—{R} (Rather than cast this card from your hand, you may pay {R} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)
+ *
+ * A Lightning Bolt body on a one-counter suspend: [Targets.Any] is "any target" (creature,
+ * player, planeswalker or battle) and the damage source defaults to the spell itself.
+ */
+val RiftBolt = card("Rift Bolt") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Rift Bolt deals 3 damage to any target.\n" +
+        "Suspend 1—{R} (Rather than cast this card from your hand, you may pay {R} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)"
+
+    spell {
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(3, t)
+    }
+
+    keywordAbility(KeywordAbility.suspend("{R}", 1))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "176"
+        artist = "Michael Sutfin"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88dde96e-6824-4d26-9fb5-86b9f3c50959.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/RiftwingCloudskate.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/RiftwingCloudskate.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Riftwing Cloudskate
+ * {3}{U}{U}
+ * Creature — Illusion
+ * 2 / 2
+ * Flying
+ * When this creature enters, return target permanent to its owner's hand.
+ * Suspend 3—{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)
+ *
+ * The bounce is unrestricted — [Targets.Permanent], not a nonland filter — so the trigger can
+ * take a land, its own controller's permanent, or anything else on the battlefield.
+ */
+val RiftwingCloudskate = card("Riftwing Cloudskate") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Illusion"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "When this creature enters, return target permanent to its owner's hand.\n" +
+        "Suspend 3—{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Permanent)
+        effect = Effects.ReturnToHand(t)
+    }
+
+    keywordAbility(KeywordAbility.suspend("{1}{U}", 3))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "73"
+        artist = "Carl Critchlow"
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/78ad6c86-8cfb-4f24-b8e8-ecbeffc949b8.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/SageOfEpityr.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/SageOfEpityr.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sage of Epityr
+ * {U}
+ * Creature — Human Wizard
+ * 1/1
+ * When this creature enters, look at the top four cards of your library, then put them back in any
+ * order.
+ */
+val SageOfEpityr = card("Sage of Epityr") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature enters, look at the top four cards of your library, then put them back in any order."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.lookAtTopAndReorder(4)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "74"
+        artist = "Randy Gallegos"
+        flavorText = "Clairvoyants across Dominaria were driven mad by the overload from the widening time rifts, while other random folk gained the gift of future sight."
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e2ea578-069e-4020-a762-d108a3e14861.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/SavageThallid.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/SavageThallid.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Savage Thallid
+ * {3}{G}{G}
+ * Creature — Fungus
+ * 5 / 2
+ * At the beginning of your upkeep, put a spore counter on this creature.
+ * Remove three spore counters from this creature: Create a 1/1 green Saproling creature token.
+ * Sacrifice a Saproling: Regenerate target Fungus.
+ *
+ * "Target Fungus" is a permanent-position subtype filter, not a creature one — a Fungus that
+ * somehow isn't a creature is still a legal target. There is no `Effects.Regenerate` facade;
+ * [RegenerateEffect] is the shipped spelling (Reknit, Crypt Sliver).
+ */
+val SavageThallid = card("Savage Thallid") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Fungus"
+    power = 5
+    toughness = 2
+    oracleText = "At the beginning of your upkeep, put a spore counter on this creature.\n" +
+        "Remove three spore counters from this creature: Create a 1/1 green Saproling creature token.\n" +
+        "Sacrifice a Saproling: Regenerate target Fungus."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.AddCounters(Counters.SPORE, 1, EffectTarget.Self)
+        description = "At the beginning of your upkeep, put a spore counter on this creature."
+    }
+
+    activatedAbility {
+        cost = Costs.RemoveCounterFromSelf(Counters.SPORE, 3)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling")
+        )
+        description = "Remove three spore counters from this creature: Create a 1/1 green Saproling creature token."
+    }
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Permanent.withSubtype(Subtype.SAPROLING))
+        val t = target(
+            "target",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Permanent.withSubtype(Subtype.FUNGUS)))
+        )
+        effect = RegenerateEffect(t)
+        description = "Sacrifice a Saproling: Regenerate target Fungus."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "213"
+        artist = "Luca Zontini"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a87cbbdb-3bbc-48da-b5e3-fcdbddebec81.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ScarwoodTreefolk.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ScarwoodTreefolk.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Scarwood Treefolk
+ * {3}{G}
+ * Creature — Treefolk
+ * 3 / 5
+ * This creature enters tapped.
+ */
+val ScarwoodTreefolk = card("Scarwood Treefolk") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Treefolk"
+    power = 3
+    toughness = 5
+    oracleText = "This creature enters tapped."
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "214"
+        artist = "Stuart Griffin"
+        flavorText = "To treefolk's sense of time, ages pass as hours. They stood as witnesses to the apocalypse, the years of which they saw as one cacophonous, ultra-destructive moment."
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/ed6dece3-058c-4738-a22f-8893345ddd1c.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ScrybRanger.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ScrybRanger.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Scryb Ranger
+ * {1}{G}
+ * Creature — Faerie Ranger
+ * 1 / 1
+ *
+ * Flash
+ * Flying, protection from blue
+ * Return a Forest you control to its owner's hand: Untap target creature. Activate only once each
+ * turn.
+ *
+ * The Quirion Ranger ability, reprinted on a flying body. The Forest is the whole cost — no mana in
+ * it — so [Costs.ReturnToHand] carries the filter, and "a Forest" is the land subtype rather than
+ * the card named Forest, hence `Land.withSubtype(Forest)`.
+ */
+val ScrybRanger = card("Scryb Ranger") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Faerie Ranger"
+    power = 1
+    toughness = 1
+    oracleText = "Flash\n" +
+        "Flying, protection from blue\n" +
+        "Return a Forest you control to its owner's hand: Untap target creature. Activate only once each turn."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.BLUE)))
+
+    activatedAbility {
+        cost = Costs.ReturnToHand(GameObjectFilter.Land.withSubtype(Subtype.FOREST))
+        val t = target("target", Targets.Creature)
+        effect = Effects.Untap(t)
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "215"
+        artist = "Rebecca Guay"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3aacabde-f5ec-4519-895d-17f5e48746ee.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ShadowSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ShadowSliver.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Shadow Sliver
+ * {2}{U}
+ * Creature — Sliver
+ * 1/1
+ * All Sliver creatures have shadow. (They can block or be blocked by only creatures with shadow.)
+ */
+val ShadowSliver = card("Shadow Sliver") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sliver"
+    power = 1
+    toughness = 1
+    oracleText = "All Sliver creatures have shadow. (They can block or be blocked by only creatures with shadow.)"
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.SHADOW,
+            GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "76"
+        artist = "Warren Mahy"
+        flavorText = "These slivers, trapped between worlds since the Rathi overlay, are among the last to claim direct lineage from the lost Sliver Queen."
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fb725914-1b0f-4efc-808b-9fe2eaa7f17d.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/SidewinderSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/SidewinderSliver.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Sidewinder Sliver
+ * {W}
+ * Creature — Sliver
+ * 1/1
+ * All Sliver creatures have flanking. (Whenever a creature without flanking blocks a Sliver, the
+ * blocking creature gets -1/-1 until end of turn.)
+ *
+ * Flanking's blocked trigger is synthesized by the engine from the keyword alone.
+ */
+val SidewinderSliver = card("Sidewinder Sliver") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Sliver"
+    power = 1
+    toughness = 1
+    oracleText = "All Sliver creatures have flanking. (Whenever a creature without flanking blocks a Sliver, the blocking creature gets -1/-1 until end of turn.)"
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.FLANKING,
+            GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Ron Spencer"
+        flavorText = "\"They encircled our patrol with the stealth of snakes, corralling us like livestock.\"\n—Merrik Aidar, Benalish patrol"
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b073b8f2-b42d-40f2-b5fb-e78ffb1733ea.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/SpinneretSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/SpinneretSliver.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Spinneret Sliver
+ * {1}{G}
+ * Creature — Sliver
+ * 2/2
+ * All Sliver creatures have reach.
+ */
+val SpinneretSliver = card("Spinneret Sliver") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "All Sliver creatures have reach."
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.REACH,
+            GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "219"
+        artist = "Michael Sutfin"
+        flavorText = "Each new generation of slivers evolves to assimilate the strengths of the prey upon which their progenitors fed."
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/da698c63-f167-4129-a650-b50c080a24b5.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Sprout.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/Sprout.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sprout
+ * {G}
+ * Instant
+ * Create a 1/1 green Saproling creature token.
+ */
+val Sprout = card("Sprout") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Create a 1/1 green Saproling creature token."
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "221"
+        artist = "Anthony S. Waters"
+        flavorText = "Centuries of temporal strife had stripped Dominaria of its natural defenses, but nature fought back with armies constructed of little more than grime and sunlight."
+        imageUri = "https://cards.scryfall.io/normal/front/6/9/6967363f-1e05-4484-8790-47f7be68455c.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/SquallLine.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/SquallLine.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Squall Line
+ * {X}{G}{G}
+ * Instant
+ *
+ * Squall Line deals X damage to each creature with flying and each player.
+ *
+ * Hurricane's sentence at instant speed: one untargeted group sweep over the fliers plus a
+ * per-player pass, where each iteration rebinds the controller so `EffectTarget.Controller` is the
+ * player being processed.
+ */
+val SquallLine = card("Squall Line") {
+    manaCost = "{X}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Squall Line deals X damage to each creature with flying and each player."
+
+    spell {
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                GroupFilter.AllCreatures.withKeyword(Keyword.FLYING),
+                Effects.DealDamage(DynamicAmount.XValue, EffectTarget.Self)
+            ),
+            Effects.ForEachPlayer(
+                Player.Each,
+                listOf(Effects.DealDamage(DynamicAmount.XValue, EffectTarget.Controller))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "222"
+        artist = "Lars Grant-West"
+        flavorText = "The constant shifting of Dominaria's shredded timeline played havoc with its atmosphere, combining savage electrical storms from ages past."
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3f368729-a6f2-4bf7-8b06-39c551f0b24a.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/StrongholdOverseer.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/StrongholdOverseer.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stronghold Overseer
+ * {3}{B}{B}{B}
+ * Creature — Demon
+ * 5/5
+ * Flying
+ * Shadow (This creature can block or be blocked by only creatures with shadow.)
+ * {B}{B}: Creatures with shadow get +1/+0 until end of turn and creatures without shadow get
+ * -1/-0 until end of turn.
+ *
+ * One activation, two board-wide pumps in opposite directions — neither names a controller, so
+ * both halves are [GroupFilter]s over every creature, split by the shadow keyword. Each half is an
+ * [Effects.ForEachInGroup] whose body targets [EffectTarget.Self], i.e. the current iteration
+ * entity; the Overseer's own shadow puts it in the +1/+0 half.
+ */
+val StrongholdOverseer = card("Stronghold Overseer") {
+    manaCost = "{3}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Demon"
+    power = 5
+    toughness = 5
+    oracleText = "Flying\n" +
+        "Shadow (This creature can block or be blocked by only creatures with shadow.)\n" +
+        "{B}{B}: Creatures with shadow get +1/+0 until end of turn and creatures without shadow get -1/-0 until end of turn."
+
+    keywords(Keyword.FLYING, Keyword.SHADOW)
+
+    activatedAbility {
+        cost = Costs.Mana("{B}{B}")
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature.withKeyword(Keyword.SHADOW)),
+                Effects.ModifyStats(1, 0, EffectTarget.Self)
+            ),
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature.withoutKeyword(Keyword.SHADOW)),
+                Effects.ModifyStats(-1, 0, EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "133"
+        artist = "Puddnhead"
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0722fa2-53df-4217-a592-fcaf239f717a.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/TelekineticSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/TelekineticSliver.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Telekinetic Sliver
+ * {2}{U}{U}
+ * Creature — Sliver
+ * 2/2
+ * All Slivers have "{T}: Tap target permanent."
+ */
+val TelekineticSliver = card("Telekinetic Sliver") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "All Slivers have \"{T}: Tap target permanent.\""
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Tap,
+                effect = Effects.Tap(EffectTarget.BoundVariable("target")),
+                targetRequirements = listOf(
+                    TargetObject(
+                        filter = TargetFilter(GameObjectFilter.Permanent),
+                        id = "target"
+                    )
+                )
+            ),
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype("Sliver"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "84"
+        artist = "Randy Elliott"
+        flavorText = "\"Slivers are guided only by simple instinct. Advance the hive, and you will be welcomed. Impede the hive, and you will face unrelenting opposition.\"\n—Freyalise"
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61b934ad-4858-4680-924a-53ea4f250f9e.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/TemporalEddy.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/TemporalEddy.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Temporal Eddy
+ * {2}{U}{U}
+ * Sorcery
+ *
+ * Put target creature or land on top of its owner's library.
+ */
+val TemporalEddy = card("Temporal Eddy") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Put target creature or land on top of its owner's library."
+
+    spell {
+        val t = target("target", TargetObject(filter = TargetFilter.CreatureOrLandPermanent))
+        effect = Effects.PutOnTopOfLibrary(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "85"
+        artist = "Wayne England"
+        flavorText = "As the temporal fractures spread and time itself slowly fell apart, visitors started to appear from across the past and future, and those native to the present began to disappear."
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3cab2147-d496-489b-aaf0-b354e31a6b45.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ThallidGerminator.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ThallidGerminator.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Thallid Germinator
+ * {2}{G}
+ * Creature — Fungus
+ * 2 / 2
+ * At the beginning of your upkeep, put a spore counter on this creature.
+ * Remove three spore counters from this creature: Create a 1/1 green Saproling creature token.
+ * Sacrifice a Saproling: Target creature gets +1/+1 until end of turn.
+ */
+val ThallidGerminator = card("Thallid Germinator") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Fungus"
+    power = 2
+    toughness = 2
+    oracleText = "At the beginning of your upkeep, put a spore counter on this creature.\n" +
+        "Remove three spore counters from this creature: Create a 1/1 green Saproling creature token.\n" +
+        "Sacrifice a Saproling: Target creature gets +1/+1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.AddCounters(Counters.SPORE, 1, EffectTarget.Self)
+        description = "At the beginning of your upkeep, put a spore counter on this creature."
+    }
+
+    activatedAbility {
+        cost = Costs.RemoveCounterFromSelf(Counters.SPORE, 3)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling")
+        )
+        description = "Remove three spore counters from this creature: Create a 1/1 green Saproling creature token."
+    }
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Permanent.withSubtype(Subtype.SAPROLING))
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(1, 1, t)
+        description = "Sacrifice a Saproling: Target creature gets +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "225"
+        artist = "Tom Wänerstrand"
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/ac526fb0-e6d0-4ee0-9888-15098c1704df.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ThallidShellDweller.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ThallidShellDweller.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Thallid Shell-Dweller
+ * {1}{G}
+ * Creature — Fungus
+ * 0 / 5
+ * Defender
+ * At the beginning of your upkeep, put a spore counter on this creature.
+ * Remove three spore counters from this creature: Create a 1/1 green Saproling creature token.
+ */
+val ThallidShellDweller = card("Thallid Shell-Dweller") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Fungus"
+    power = 0
+    toughness = 5
+    oracleText = "Defender\n" +
+        "At the beginning of your upkeep, put a spore counter on this creature.\n" +
+        "Remove three spore counters from this creature: Create a 1/1 green Saproling creature token."
+
+    keywords(Keyword.DEFENDER)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.AddCounters(Counters.SPORE, 1, EffectTarget.Self)
+        description = "At the beginning of your upkeep, put a spore counter on this creature."
+    }
+
+    activatedAbility {
+        cost = Costs.RemoveCounterFromSelf(Counters.SPORE, 3)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling")
+        )
+        description = "Remove three spore counters from this creature: Create a 1/1 green Saproling creature token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "226"
+        artist = "Carl Critchlow"
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4ee36256-022f-49b3-8914-9b1c2f4dc506.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/TheloniteHermit.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/TheloniteHermit.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Thelonite Hermit
+ * {3}{G}
+ * Creature — Elf Shaman
+ * 1 / 1
+ * All Saprolings get +1/+1.
+ * Morph {3}{G}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)
+ * When this creature is turned face up, create four 1/1 green Saproling creature tokens.
+ *
+ * The lord is "all Saprolings", not "Saprolings you control" — the group filter carries no
+ * controller predicate, and it is permanent-position rather than creature-position so a
+ * non-creature Saproling would still be pumped.
+ */
+val TheloniteHermit = card("Thelonite Hermit") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Shaman"
+    power = 1
+    toughness = 1
+    oracleText = "All Saprolings get +1/+1.\n" +
+        "Morph {3}{G}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\n" +
+        "When this creature is turned face up, create four 1/1 green Saproling creature tokens."
+
+    morph = "{3}{G}{G}"
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Saproling"),
+            count = 4
+        )
+        description = "When this creature is turned face up, create four 1/1 green Saproling creature tokens."
+    }
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.SAPROLING))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "228"
+        artist = "Chippy"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be95b6b0-ff20-405f-81ae-87f5cce45fb2.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ThrillOfTheHunt.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ThrillOfTheHunt.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Thrill of the Hunt
+ * {G}
+ * Instant
+ *
+ * Target creature gets +1/+2 until end of turn.
+ * Flashback {W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)
+ */
+val ThrillOfTheHunt = card("Thrill of the Hunt") {
+    manaCost = "{G}"
+    colorIdentity = "GW"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/+2 until end of turn.\n" +
+        "Flashback {W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(1, 2, t)
+    }
+
+    keywordAbility(KeywordAbility.flashback("{W}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "229"
+        artist = "Stephen Tappin"
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e8fe0c8e-f361-4eac-8c2c-ca6602dad352.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/TimeSpiralBasicLands.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/TimeSpiralBasicLands.kt
@@ -1,0 +1,161 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Time Spiral Basic Lands
+ *
+ * Time Spiral contains 4 art variants of each basic land type.
+ * Cards 282-301 (Plains 282-285, Island 286-289, Swamp 290-293, Mountain 294-297, Forest 298-301)
+ */
+
+// =============================================================================
+// Plains (Cards 282-285)
+// =============================================================================
+
+val TimeSpiralPlains282 = basicLand("Plains") {
+    collectorNumber = "282"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/c/d/cd9a8337-e4ca-458d-8fcd-672d8d6f1c0d.jpg?1783943192"
+}
+
+val TimeSpiralPlains283 = basicLand("Plains") {
+    collectorNumber = "283"
+    artist = "Craig Mullins"
+    imageUri = "https://cards.scryfall.io/normal/front/9/7/97e0aaf3-eba0-445e-b560-f889b800e6b7.jpg?1783943192"
+}
+
+val TimeSpiralPlains284 = basicLand("Plains") {
+    collectorNumber = "284"
+    artist = "Justin Sweet"
+    imageUri = "https://cards.scryfall.io/normal/front/d/0/d056a94a-a07d-4494-a75c-b3f6f59457b3.jpg?1783943191"
+}
+
+val TimeSpiralPlains285 = basicLand("Plains") {
+    collectorNumber = "285"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/f/a/fa21cca2-59cb-4223-b67b-1a8fc54aadd8.jpg?1783943191"
+}
+
+// =============================================================================
+// Island (Cards 286-289)
+// =============================================================================
+
+val TimeSpiralIsland286 = basicLand("Island") {
+    collectorNumber = "286"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/e/5/e5fdeb2c-afb8-4850-bcdc-86283ffa3486.jpg?1783943192"
+}
+
+val TimeSpiralIsland287 = basicLand("Island") {
+    collectorNumber = "287"
+    artist = "Jeremy Jarvis"
+    imageUri = "https://cards.scryfall.io/normal/front/e/0/e08915c9-78ff-450b-a47f-0c9678d16bbd.jpg?1783943190"
+}
+
+val TimeSpiralIsland288 = basicLand("Island") {
+    collectorNumber = "288"
+    artist = "Craig Mullins"
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/89f8c7cf-6705-4ff7-8aa8-113c1400ffda.jpg?1783943190"
+}
+
+val TimeSpiralIsland289 = basicLand("Island") {
+    collectorNumber = "289"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/ac1a989a-38d4-4225-a41f-37d54f2f42ae.jpg?1783943190"
+}
+
+// =============================================================================
+// Swamp (Cards 290-293)
+// =============================================================================
+
+val TimeSpiralSwamp290 = basicLand("Swamp") {
+    collectorNumber = "290"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/3/f/3fecc759-61fa-4040-9b46-710512baa4bf.jpg?1783943190"
+}
+
+val TimeSpiralSwamp291 = basicLand("Swamp") {
+    collectorNumber = "291"
+    artist = "Vance Kovacs"
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b53dbcc0-169d-4b5c-b4e5-d82716c1539d.jpg?1783943190"
+}
+
+val TimeSpiralSwamp292 = basicLand("Swamp") {
+    collectorNumber = "292"
+    artist = "Craig Mullins"
+    imageUri = "https://cards.scryfall.io/normal/front/a/7/a7dc4523-075d-425e-9b53-77921d26c173.jpg?1783943190"
+}
+
+val TimeSpiralSwamp293 = basicLand("Swamp") {
+    collectorNumber = "293"
+    artist = "Richard Wright"
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/dd634a88-c114-469a-8133-59cfc9bf3215.jpg?1783943189"
+}
+
+// =============================================================================
+// Mountain (Cards 294-297)
+// =============================================================================
+
+val TimeSpiralMountain294 = basicLand("Mountain") {
+    collectorNumber = "294"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e34229e7-5dc4-47b3-9ba2-609e5b3ca6c2.jpg?1783943190"
+}
+
+val TimeSpiralMountain295 = basicLand("Mountain") {
+    collectorNumber = "295"
+    artist = "D. Alexander Gregory"
+    imageUri = "https://cards.scryfall.io/normal/front/5/c/5c71906a-f885-49ba-a889-8baf4e74cce8.jpg?1783943189"
+}
+
+val TimeSpiralMountain296 = basicLand("Mountain") {
+    collectorNumber = "296"
+    artist = "Craig Mullins"
+    imageUri = "https://cards.scryfall.io/normal/front/d/3/d3e3961c-d092-4a15-b5db-d7b5c70e4fc1.jpg?1783943190"
+}
+
+val TimeSpiralMountain297 = basicLand("Mountain") {
+    collectorNumber = "297"
+    artist = "Greg Staples"
+    imageUri = "https://cards.scryfall.io/normal/front/d/a/dae3e69d-ec38-43e2-b4a2-3a9064835a97.jpg?1783943188"
+}
+
+// =============================================================================
+// Forest (Cards 298-301)
+// =============================================================================
+
+val TimeSpiralForest298 = basicLand("Forest") {
+    collectorNumber = "298"
+    artist = "Rob Alexander"
+    imageUri = "https://cards.scryfall.io/normal/front/0/d/0d5bd3e1-45ef-43b7-8796-6085842278df.jpg?1783943187"
+}
+
+val TimeSpiralForest299 = basicLand("Forest") {
+    collectorNumber = "299"
+    artist = "Vance Kovacs"
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2a10ed4f-2c9a-424d-bcca-730af7727854.jpg?1783943187"
+}
+
+val TimeSpiralForest300 = basicLand("Forest") {
+    collectorNumber = "300"
+    artist = "Craig Mullins"
+    imageUri = "https://cards.scryfall.io/normal/front/2/b/2b176d24-a4d6-489e-af69-4547693e7de1.jpg?1783943186"
+}
+
+val TimeSpiralForest301 = basicLand("Forest") {
+    collectorNumber = "301"
+    artist = "Stephen Tappin"
+    imageUri = "https://cards.scryfall.io/normal/front/3/9/393d66f7-7dbf-4a92-912f-377f99c8f164.jpg?1783943186"
+}
+
+/**
+ * All Time Spiral basic land variants.
+ */
+val TimeSpiralBasicLands = listOf(
+    TimeSpiralPlains282, TimeSpiralPlains283, TimeSpiralPlains284, TimeSpiralPlains285,
+    TimeSpiralIsland286, TimeSpiralIsland287, TimeSpiralIsland288, TimeSpiralIsland289,
+    TimeSpiralSwamp290, TimeSpiralSwamp291, TimeSpiralSwamp292, TimeSpiralSwamp293,
+    TimeSpiralMountain294, TimeSpiralMountain295, TimeSpiralMountain296, TimeSpiralMountain297,
+    TimeSpiralForest298, TimeSpiralForest299, TimeSpiralForest300, TimeSpiralForest301
+)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/TrespasserIlVec.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/TrespasserIlVec.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Trespasser il-Vec
+ * {2}{B}
+ * Creature — Human Rogue
+ * 3/1
+ * Discard a card: This creature gains shadow until end of turn. (It can block or be blocked by
+ * only creatures with shadow.)
+ *
+ * A granted [Keyword.SHADOW] is read by the block-evasion rules exactly like a printed one, so the
+ * activation is a plain until-end-of-turn keyword grant onto itself — no separate evasion static.
+ * Note the grant cuts both ways: while it is up the Trespasser also can't block non-shadow
+ * creatures.
+ */
+val TrespasserIlVec = card("Trespasser il-Vec") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Rogue"
+    power = 3
+    toughness = 1
+    oracleText = "Discard a card: This creature gains shadow until end of turn. (It can block or be blocked by only creatures with shadow.)"
+
+    activatedAbility {
+        cost = Costs.DiscardCard
+        effect = Effects.GrantKeyword(Keyword.SHADOW, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "138"
+        artist = "Jim Murray"
+        flavorText = "At the epicenter of the Rathi overlay, the City of Traitors did not align with Dominaria. Many of its inhabitants were caught between the two worlds."
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/4903171e-76b2-437d-8965-e871e47a3482.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/TwoHeadedSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/TwoHeadedSliver.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Two-Headed Sliver
+ * {1}{R}
+ * Creature — Sliver
+ * 1/1
+ * All Sliver creatures have menace. (They can't be blocked except by two or more creatures.)
+ */
+val TwoHeadedSliver = card("Two-Headed Sliver") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Sliver"
+    power = 1
+    toughness = 1
+    oracleText = "All Sliver creatures have menace. (They can't be blocked except by two or more creatures.)"
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.MENACE,
+            GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "183"
+        artist = "Dany Orizio"
+        flavorText = "\"That which would be a fatal mutation in any other species is merely a source of new powers. I am intrigued, yet too fearful to examine it more closely.\"\n—Rukarumel, field journal"
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2f89fb3b-0238-4d76-a46d-7d6fa4a74620.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/UnyaroBees.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/UnyaroBees.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Unyaro Bees
+ * {G}{G}{G}
+ * Creature — Insect
+ * 0 / 1
+ *
+ * Flying
+ * {G}: This creature gets +1/+1 until end of turn.
+ * {3}{G}, Sacrifice this creature: It deals 2 damage to any target.
+ */
+val UnyaroBees = card("Unyaro Bees") {
+    manaCost = "{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect"
+    power = 0
+    toughness = 1
+    oracleText = "Flying\n" +
+        "{G}: This creature gets +1/+1 until end of turn.\n" +
+        "{3}{G}, Sacrifice this creature: It deals 2 damage to any target."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{G}")
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{G}"), Costs.SacrificeSelf)
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "231"
+        artist = "Tom Wänerstrand"
+        flavorText = "With no jungle left to contain it, the \"plague of daggers\" spread across Dominaria."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/76356bc9-2285-44a7-815e-a27ad4e07afc.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ViashinoBladescout.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ViashinoBladescout.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Viashino Bladescout
+ * {1}{R}{R}
+ * Creature — Lizard Scout
+ * 2 / 1
+ *
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * When this creature enters, target creature gains first strike until end of turn.
+ */
+val ViashinoBladescout = card("Viashino Bladescout") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard Scout"
+    power = 2
+    toughness = 1
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "When this creature enters, target creature gains first strike until end of turn."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "185"
+        artist = "Dany Orizio"
+        flavorText = "\"Find your courage in a desperate moment, and you turn the tide of history. So sayeth the bey.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/41fce1b3-0961-4672-845f-e1c6ce101c1b.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/VisceridDeepwalker.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/VisceridDeepwalker.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Viscerid Deepwalker
+ * {4}{U}
+ * Creature — Homarid Warrior
+ * 2 / 3
+ * {U}: This creature gets +1/+0 until end of turn.
+ * Suspend 4—{U} (Rather than cast this card from your hand, you may pay {U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)
+ *
+ * A firebreathing-shaped pump on itself: an untargeted [Effects.ModifyStats] on
+ * [EffectTarget.Self] for the default end-of-turn duration.
+ */
+val VisceridDeepwalker = card("Viscerid Deepwalker") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Homarid Warrior"
+    power = 2
+    toughness = 3
+    oracleText = "{U}: This creature gets +1/+0 until end of turn.\n" +
+        "Suspend 4—{U} (Rather than cast this card from your hand, you may pay {U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{U}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+    }
+
+    keywordAbility(KeywordAbility.suspend("{U}", 4))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "91"
+        artist = "Heather Hudson"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cdc9f54e-7fba-4f03-83ca-6d293dffc07a.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ViscidLemures.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/ViscidLemures.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Viscid Lemures
+ * {4}{B}
+ * Creature — Spirit
+ * 4 / 3
+ *
+ * {0}: This creature gets -1/-0 and gains swampwalk until end of turn. (It can't be blocked as long
+ * as defending player controls a Swamp.)
+ *
+ * Both halves of the ability last until end of turn, so the shrink and the grant are one composite:
+ * the bare [Keyword.SWAMPWALK] grant is enough — the engine's landwalk handling synthesizes the
+ * blocking restriction.
+ */
+val ViscidLemures = card("Viscid Lemures") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit"
+    power = 4
+    toughness = 3
+    oracleText = "{0}: This creature gets -1/-0 and gains swampwalk until end of turn. (It can't be blocked as long as defending player controls a Swamp.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{0}")
+        effect = Effects.Composite(
+            Effects.ModifyStats(-1, 0, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.SWAMPWALK, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "141"
+        artist = "Drew Tucker"
+        flavorText = "\"Lemurs? Is that all? Finally, something harmless . . .\"\n—Norin the Wary"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/863f04d7-da34-41e3-9153-97891a428889.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/VolcanicAwakening.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/VolcanicAwakening.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Volcanic Awakening
+ * {4}{R}{R}
+ * Sorcery
+ * Destroy target land.
+ * Storm (When you cast this spell, copy it for each spell cast before it this turn. You may
+ * choose new targets for the copies.)
+ *
+ * Storm copies the spell off `script.spellEffect`, so this stays a plain `spell { effect = … }`
+ * — a modal or replacement shape would make the trigger resolve into zero copies.
+ */
+val VolcanicAwakening = card("Volcanic Awakening") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target land.\n" +
+        "Storm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)"
+
+    spell {
+        val t = target("target", TargetObject(filter = TargetFilter.Land))
+        effect = Effects.Destroy(t)
+    }
+
+    keywords(Keyword.STORM)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "186"
+        artist = "Dan Murayama Scott"
+        flavorText = "With a great roar, the land opened like a titan's yawn, with teeth of blackened rock and a lolling tongue of magma."
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/aebd5c57-cfc8-4a3c-b4a2-0cd64a5e3575.jpg"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/WatcherSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/WatcherSliver.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Watcher Sliver
+ * {3}{W}
+ * Creature — Sliver
+ * 2/2
+ * All Sliver creatures get +0/+2.
+ */
+val WatcherSliver = card("Watcher Sliver") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Sliver"
+    power = 2
+    toughness = 2
+    oracleText = "All Sliver creatures get +0/+2."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 0,
+            toughnessBonus = 2,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype("Sliver"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "45"
+        artist = "Liz Danforth"
+        flavorText = "\"I have spied them, wandering and watching—but for what? I fear they watch for us.\"\n—Yonat of Amrou"
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d72a950-82ed-4e7b-9e18-b8231a2ebea7.jpg"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/TheloniteHermitReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arc/cards/TheloniteHermitReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.arc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thelonite Hermit reprint in ARC. Canonical CardDefinition lives in its earliest set.
+ */
+val TheloniteHermitReprint = Printing(
+    oracleId = "69d2e5f3-2f4d-4a36-bcd5-181164ecd894",
+    name = "Thelonite Hermit",
+    setCode = "ARC",
+    collectorNumber = "71",
+    scryfallId = "810b345c-eb62-4b8d-b3be-43e4310c668b",
+    artist = "Chippy",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/810b345c-eb62-4b8d-b3be-43e4310c668b.jpg",
+    releaseDate = "2010-06-18",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/TheloniteHermitReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/TheloniteHermitReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thelonite Hermit reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val TheloniteHermitReprint = Printing(
+    oracleId = "69d2e5f3-2f4d-4a36-bcd5-181164ecd894",
+    name = "Thelonite Hermit",
+    setCode = "C15",
+    collectorNumber = "205",
+    scryfallId = "517b356a-67cc-44e1-a6aa-bbe8a3bb5512",
+    artist = "Chippy",
+    imageUri = "https://cards.scryfall.io/normal/front/5/1/517b356a-67cc-44e1-a6aa-bbe8a3bb5512.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/TheloniteHermitReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/TheloniteHermitReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thelonite Hermit reprint in C16. Canonical CardDefinition lives in its earliest set.
+ */
+val TheloniteHermitReprint = Printing(
+    oracleId = "69d2e5f3-2f4d-4a36-bcd5-181164ecd894",
+    name = "Thelonite Hermit",
+    setCode = "C16",
+    collectorNumber = "171",
+    scryfallId = "08ecfe97-0d21-4c47-a88e-8a1c26e762fb",
+    artist = "Chippy",
+    imageUri = "https://cards.scryfall.io/normal/front/0/8/08ecfe97-0d21-4c47-a88e-8a1c26e762fb.jpg",
+    releaseDate = "2016-11-11",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/PenumbraSpiderReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/PenumbraSpiderReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Penumbra Spider reprint in CMD. Canonical CardDefinition lives in its earliest set.
+ */
+val PenumbraSpiderReprint = Printing(
+    oracleId = "47678f44-b595-492e-af00-4e73f941e24e",
+    name = "Penumbra Spider",
+    setCode = "CMD",
+    collectorNumber = "167",
+    scryfallId = "6ef11973-9f48-4396-841b-4f447e979841",
+    artist = "Jeff Easley",
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6ef11973-9f48-4396-841b-4f447e979841.jpg",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/PenumbraSpiderReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/PenumbraSpiderReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Penumbra Spider reprint in PC2. Canonical CardDefinition lives in its earliest set.
+ */
+val PenumbraSpiderReprint = Printing(
+    oracleId = "47678f44-b595-492e-af00-4e73f941e24e",
+    name = "Penumbra Spider",
+    setCode = "PC2",
+    collectorNumber = "73",
+    scryfallId = "f4614a69-e137-4839-b31b-493a143876bb",
+    artist = "Jeff Easley",
+    imageUri = "https://cards.scryfall.io/normal/front/f/4/f4614a69-e137-4839-b31b-493a143876bb.jpg",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/GrapeshotReprint.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/GrapeshotReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grapeshot reprint in MSC. Canonical CardDefinition lives in its earliest set.
+ */
+val GrapeshotReprint = Printing(
+    oracleId = "ebd2d760-5ad8-4027-b124-171822f3edfe",
+    name = "Grapeshot",
+    setCode = "MSC",
+    collectorNumber = "803",
+    scryfallId = "e3e2d90a-3557-49d5-9986-cb50fd31f396",
+    artist = "Irvin Rodriguez",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e3e2d90a-3557-49d5-9986-cb50fd31f396.jpg",
+    releaseDate = "2026-06-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/MIR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MIR.json
@@ -5329,38 +5329,9 @@
         "FLANKING"
     ],
     "script": {
-        "triggeredAbilities": [
-            {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "BecomesBlockedEvent",
-                    "filter": {
-                        "cardPredicates": [
-                            "IsCreature",
-                            {
-                                "type": "NotKeyword",
-                                "keyword": "FLANKING"
-                            }
-                        ]
-                    }
-                },
-                "effect": {
-                    "type": "ModifyStats",
-                    "powerModifier": {
-                        "type": "Fixed",
-                        "amount": -1
-                    },
-                    "toughnessModifier": {
-                        "type": "Fixed",
-                        "amount": -1
-                    },
-                    "target": "TriggeringEntity"
-                }
-            }
-        ],
         "activatedAbilities": [
             {
-                "id": "ability_2",
+                "id": "ability_1",
                 "cost": {
                     "type": "CostAtomWrapper",
                     "atom": {

--- a/mtg-sets/src/test/resources/snapshots/cards/TSP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TSP.json
@@ -1,3 +1,80 @@
+// Amrou Scout
+{
+    "name": "Amrou Scout",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Kithkin Rebel Scout",
+    "oracleText": "{4}, {T}: Search your library for a Rebel permanent card with mana value 3 or less, put it onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "permanent Rebel mv<=3"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "artist": "Quinton Hoover",
+        "flavorText": "The people of Amrou were scattered by war and driven into hiding. Scouts maintain the beacon fires that signal \"return\" and \"home.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/ea3e05e5-1340-4010-b39b-3571a5829840.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ancestral Vision
 {
     "name": "Ancestral Vision",
@@ -95,6 +172,30 @@
     ]
 }
 
+// Ashcoat Bear
+{
+    "name": "Ashcoat Bear",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Bear",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "metadata": {
+        "collectorNumber": "190",
+        "artist": "Carl Critchlow",
+        "flavorText": "The bears wade into time rifts to feed. They do not fear the storms, and they are quick enough to snatch prey just as it blinks in or out of time.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b7a6ab5-8a8f-492c-8484-3089354ce8cf.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Assassinate
 {
     "name": "Assassinate",
@@ -132,6 +233,263 @@
     ]
 }
 
+// Basal Sliver
+{
+    "name": "Basal Sliver",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Slivers have \"Sacrifice this permanent: Add {B}{B}.\"",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": "CostSacrificeSelf",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "BLACK",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                "filter": {
+                    "baseFilter": "permanent Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "96",
+        "artist": "Drew Tucker",
+        "flavorText": "\"Fascinating . . . These creatures display the paradox of tenacity and purposed self-destruction I have sought to breed into my thrulls.\"\n—Endrek Sahr, master breeder",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/4564e9df-bfa3-48e5-a12e-f7e96a504cb1.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Benalish Cavalry
+{
+    "name": "Benalish Cavalry",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLANKING"
+    ],
+    "metadata": {
+        "collectorNumber": "4",
+        "artist": "Paolo Parente",
+        "flavorText": "\"My people swore to protect Benalia to the end. It is battered, but yet stands, as do we.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/1013ca9c-1d29-42f6-8665-92f98d076ff8.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Bogardan Rager
+{
+    "name": "Bogardan Rager",
+    "manaCost": "{5}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, target creature gets +4/+0 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "artist": "Clint Langley",
+        "flavorText": "In the erupting heart of Bogardan, it's hard to tell hurtling volcanic rocks from pouncing volcanic beasts.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec53d26b-ad3e-474f-a374-05fcdc00e49c.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Bonesplitter Sliver
+{
+    "name": "Bonesplitter Sliver",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Sliver creatures get +2/+0.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": "creature Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "149",
+        "artist": "Dany Orizio",
+        "flavorText": "As the time streams grew more and more unstable, Dominaria's creatures struggled to adapt. The intense pressures led to many dead ends but also to lethal new forms that appeared as suddenly as the ashen rains.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/705e29c5-2d9b-44ad-a04c-9a62dd74eb12.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Brass Gnat
+{
+    "name": "Brass Gnat",
+    "manaCost": "{1}",
+    "typeLine": "Artifact Creature — Insect",
+    "oracleText": "Flying\nThis creature doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {1}. If you do, untap this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "flags": [
+        "DOESNT_UNTAP"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "TapUntap",
+                        "target": "Self",
+                        "tap": false
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "249",
+        "artist": "Martina Pilcerova",
+        "flavorText": "Its buzzing is the sound of its inner mechanisms, ever winding down.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/386ae7c6-347c-4b29-b7a9-3ca3bb050396.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Call to the Netherworld
+{
+    "name": "Call to the Netherworld",
+    "manaCost": "{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target black creature card from your graveyard to your hand.\nMadness {0} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "keywords": [
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{0}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature black own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "artist": "Vance Kovacs",
+        "flavorText": "The ritual was normally performed only by horrors and pit spawn. Lesser mages had but one sanity to crack in the casting.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fa7322e2-dbea-46e1-ba29-a86a13e5d33e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Cancel
 {
     "name": "Cancel",
@@ -158,6 +516,362 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Cavalry Master
+{
+    "name": "Cavalry Master",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Flanking (Whenever a creature without flanking blocks this creature, the blocking creature gets -1/-1 until end of turn.)\nOther creatures you control with flanking have flanking. (Each instance of flanking triggers separately.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLANKING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLANKING",
+                "filter": {
+                    "baseFilter": "creature kw:flanking ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "UNCOMMON",
+        "artist": "Thomas M. Baxa",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7b19194-87bf-432c-8d34-91dd9520cbd2.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Chronosavant
+{
+    "name": "Chronosavant",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "{1}{W}: Return this card from your graveyard to the battlefield tapped. You skip your next turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Battlefield",
+                            "placement": "Tapped",
+                            "fromZone": "Graveyard"
+                        },
+                        "SkipNextTurn"
+                    ]
+                },
+                "activateFromZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "RARE",
+        "artist": "Pete Venters",
+        "flavorText": "\"In my dreams, I hear the voices of my future selves who have died in times yet to come. I use that knowledge to avoid those dark futures and continue my search for peace.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d6264d4f-adf1-4d7b-b17a-fd7122e9b2cd.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Corpulent Corpse
+{
+    "name": "Corpulent Corpse",
+    "manaCost": "{5}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nSuspend 5—{B} (Rather than cast this card from your hand, you may pay {B} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FEAR",
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{B}",
+            "timeCounters": 5
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "98",
+        "artist": "Doug Chaffee",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a58b842a-a4c0-475d-a8b3-62d4e5bb2eaf.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// D'Avenant Healer
+{
+    "name": "D'Avenant Healer",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Creature — Human Cleric Archer",
+    "oracleText": "{T}: This creature deals 1 damage to target attacking or blocking creature.\n{T}: Prevent the next 1 damage that would be dealt to any target this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    {
+                                        "type": "StateOr",
+                                        "predicates": [
+                                            "IsAttacking",
+                                            "IsBlocking"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target"
+                    }
+                ]
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "artist": "Michael Sutfin",
+        "flavorText": "\"One arrow keenly fired might prevent more battlefield wounds than I could treat.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/deac6492-ce39-4137-8418-6169d3b1b632.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Dark Withering
+{
+    "name": "Dark Withering",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target nonblack creature.\nMadness {B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "keywords": [
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{B}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotColor",
+                                "color": "BLACK"
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "artist": "Wayne Reynolds",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3da58e0d-5877-43c4-b129-993e154b6087.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Deathspore Thallid
+{
+    "name": "Deathspore Thallid",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie Fungus",
+    "oracleText": "At the beginning of your upkeep, put a spore counter on this creature.\nRemove three spore counters from this creature: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: Target creature gets -1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "spore",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, put a spore counter on this creature."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomRemoveCounters",
+                        "counterType": "spore",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "self": true
+                    }
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Saproling"
+                    ]
+                },
+                "descriptionOverride": "Remove three spore counters from this creature: Create a 1/1 green Saproling creature token."
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "permanent Saproling"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "Sacrifice a Saproling: Target creature gets -1/-1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Randy Elliott",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/44ee5ee3-11f8-4a4e-bfa3-10ff45ed6d1b.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -213,6 +927,490 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Drifter il-Dal
+{
+    "name": "Drifter il-Dal",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Shadow (This creature can block or be blocked by only creatures with shadow.)\nAt the beginning of your upkeep, sacrifice this creature unless you pay {U}.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "SHADOW"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{U}"
+                        }
+                    },
+                    "suffer": "SacrificeSelf"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "artist": "Justin Sweet",
+        "flavorText": "They study the deeds of their traitorous ancestors, hoping the stories may reveal a way back to the physical world.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c3de909-b47e-45d7-9922-8d5e08a76ec9.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Drudge Reavers
+{
+    "name": "Drudge Reavers",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Skeleton",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\n{B}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Greg Staples",
+        "flavorText": "\"The surface of the land is blanched with salt, but the soil beneath is reddened with death—a fertile ground for necromancy.\"\n—Lim-Dûl the Necromancer",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/03c07d9a-afed-4028-9fa1-ec439b60f08f.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Durkwood Baloth
+{
+    "name": "Durkwood Baloth",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Suspend 5—{G} (Rather than cast this card from your hand, you may pay {G} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{G}",
+            "timeCounters": 5
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "193",
+        "artist": "Dan Frazier",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/670521c3-df02-487d-a299-49419e41889f.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Duskrider Peregrine
+{
+    "name": "Duskrider Peregrine",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying, protection from black\nSuspend 3—{1}{W} (Rather than cast this card from your hand, you may pay {1}{W} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "BLACK"
+            }
+        },
+        {
+            "type": "Suspend",
+            "cost": "{1}{W}",
+            "timeCounters": 3
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "14",
+        "rarity": "UNCOMMON",
+        "artist": "Una Fricker",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bfad8c3e-e459-477c-b602-34df2dda1efe.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Empty the Warrens
+{
+    "name": "Empty the Warrens",
+    "manaCost": "{3}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create two 1/1 red Goblin creature tokens.\nStorm (When you cast this spell, copy it for each spell cast before it this turn.)",
+    "keywords": [
+        "STORM"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "RED"
+            ],
+            "creatureTypes": [
+                "Goblin"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "artist": "Mark Brill",
+        "flavorText": "\"They'd pour out of the warrens to make war (and to make room for the littering matrons).\"\n—*Sarpadian Empires, vol. IV*",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/952bb27c-c58a-478a-b637-eb4f7e1e0ab4.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Errant Ephemeron
+{
+    "name": "Errant Ephemeron",
+    "manaCost": "{6}{U}",
+    "typeLine": "Creature — Illusion",
+    "oracleText": "Flying\nSuspend 4—{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{1}{U}",
+            "timeCounters": 4
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "Luca Zontini",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/398c26cc-cd55-42c6-a744-aaefd7018960.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Feebleness
+{
+    "name": "Feebleness",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash\nEnchant creature\nEnchanted creature gets -2/-1.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": -2,
+                "toughnessBonus": -1
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "artist": "Kev Walker",
+        "flavorText": "Just a small touch of magic can harness the debilitating power of Urborg's poisonous winds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1ba2660d-b661-4266-b7e5-07bb8b72bce6.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Firewake Sliver
+{
+    "name": "Firewake Sliver",
+    "manaCost": "{1}{R}{G}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Sliver creatures have haste.\nAll Slivers have \"{1}, Sacrifice this permanent: Target Sliver creature gets +2/+2 until end of turn.\"",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE",
+                "filter": {
+                    "baseFilter": "creature Sliver"
+                }
+            },
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{1}"
+                                }
+                            },
+                            "CostSacrificeSelf"
+                        ]
+                    },
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature Sliver"
+                            },
+                            "id": "target"
+                        }
+                    ]
+                },
+                "filter": {
+                    "baseFilter": "permanent Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "rarity": "UNCOMMON",
+        "artist": "Anthony S. Waters",
+        "flavorText": "\"They are here, and they are hungry. And what they do not eat, they burn. Yavimaya is lost. We must leave now for Skyshroud.\"\n—Edahlis, greenseeker",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d3f5a0d-029e-44fd-b3e6-c70176b5b4ac.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "RED"
+    ]
+}
+
+// Fledgling Mawcor
+{
+    "name": "Fledgling Mawcor",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Flying\n{T}: This creature deals 1 damage to any target.\nMorph {U}{U} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Morph",
+            "morphCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{U}{U}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "rarity": "UNCOMMON",
+        "artist": "Kev Walker",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c464923e-ae6e-4c1d-9315-0ddb86c07b40.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Flowstone Channeler
+{
+    "name": "Flowstone Channeler",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Spellshaper",
+    "oracleText": "{1}{R}, {T}, Discard a card: Target creature gets +1/-1 and gains haste until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": -1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "HASTE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "artist": "Alan Pollack",
+        "flavorText": "With the evincars gone, flowstone became erratic and wild, a source of power for mages more desperate than wise.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9f10fa1c-2c7b-49ba-87b6-3b652b65704d.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -288,6 +1486,298 @@
     ]
 }
 
+// Fury Sliver
+{
+    "name": "Fury Sliver",
+    "manaCost": "{5}{R}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Sliver creatures have double strike.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOUBLE_STRIKE",
+                "filter": {
+                    "baseFilter": "creature Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "rarity": "UNCOMMON",
+        "artist": "Paolo Parente",
+        "flavorText": "\"A rift opened, and our arrows were abruptly stilled. To move was to push the world. But the sliver's claw still twitched, red wounds appeared in Thed's chest, and ribbons of blood hung in the air.\"\n—Adom Capashen, Benalish hero",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/0000579f-7b35-4ed3-b44c-db2a538066fe.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Gaze of Justice
+{
+    "name": "Gaze of Justice",
+    "manaCost": "{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, tap three untapped white creatures you control.\nExile target creature.\nFlashback {5}{W} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{5}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomTapPermanents",
+                    "count": 3,
+                    "filter": "creature white"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "John Avon",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/24d565ec-541d-429e-ab45-58db16c2f41d.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Gemhide Sliver
+{
+    "name": "Gemhide Sliver",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Slivers have \"{T}: Add one mana of any color.\"",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": "CostTap",
+                    "effect": "AddManaOfChoice",
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                "filter": {
+                    "baseFilter": "permanent Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "196",
+        "artist": "John Matson",
+        "flavorText": "\"The land is weary. Even Skyshroud is depleted. We must find another source of mana—one that is growing despite our withering world.\"\n—Freyalise",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f09135b0-fd57-4205-aa74-c9869946c264.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Grapeshot
+{
+    "name": "Grapeshot",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Grapeshot deals 1 damage to any target.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
+    "keywords": [
+        "STORM"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 1
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "artist": "Pete Venters",
+        "flavorText": "Mages often seek to emulate the powerful relics lost to time and apocalypse.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4ee33cb6-768e-44a0-b6f4-b8638aa84330.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Greenseeker
+{
+    "name": "Greenseeker",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Elf Spellshaper",
+    "oracleText": "{G}, {T}, Discard a card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "basicland"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "artist": "Rebecca Guay",
+        "flavorText": "\"A rumor passes among the snakes, whispered by the rushes, inspiring the seekers: the goddess Freyalise is alive in Skyshroud.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2dfa231-349a-4dce-bed6-c82a136fe0a1.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Ground Rift
+{
+    "name": "Ground Rift",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target creature without flying can't block this turn.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
+    "keywords": [
+        "STORM"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CantBlockTargetCreatures",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotKeyword",
+                                "keyword": "FLYING"
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "162",
+        "artist": "Thomas M. Baxa",
+        "flavorText": "Some time rifts didn't take away the people but just the ground they stood on.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/62333783-6a18-4461-88ce-1c37eaf64e2b.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Havenwood Wurm
 {
     "name": "Havenwood Wurm",
@@ -310,6 +1800,319 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Herd Gnarr
+{
+    "name": "Herd Gnarr",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Whenever another creature you control enters, this creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "200",
+        "artist": "Daren Bader",
+        "flavorText": "Long ago, the solitary gnarr was a sign of good luck. Now they have become wild pack hunters, a sign of impending danger.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9cf4fd75-34b1-4afa-b8cd-777dfc9e6376.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Icatian Crier
+{
+    "name": "Icatian Crier",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Spellshaper",
+    "oracleText": "{1}{W}, {T}, Discard a card: Create two 1/1 white Citizen creature tokens.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Citizen"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "artist": "Michael Phillippi",
+        "flavorText": "A thousand years removed from her home, her news of war had lost its context, but not its relevance.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/523ab784-c77e-4b78-99fc-b5d7ed985d76.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Ith, High Arcanist
+{
+    "name": "Ith, High Arcanist",
+    "manaCost": "{5}{W}{U}",
+    "typeLine": "Legendary Creature — Human Wizard",
+    "oracleText": "Vigilance\n{T}: Untap target attacking creature. Prevent all combat damage that would be dealt to and dealt by that creature this turn.\nSuspend 4—{W}{U}",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE",
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{W}{U}",
+            "timeCounters": 4
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            },
+                            "tap": false
+                        },
+                        {
+                            "type": "PreventDamageShield",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            },
+                            "scope": "CombatOnly",
+                            "direction": "Both"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature attacking"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "rarity": "RARE",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8dd98dea-8012-49bb-84cf-dd8ed5c032cf.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "WHITE"
+    ]
+}
+
+// Ivory Giant
+{
+    "name": "Ivory Giant",
+    "manaCost": "{5}{W}{W}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "When this creature enters, tap all nonwhite creatures.\nSuspend 5—{W} (Rather than cast this card from your hand, you may pay {W} and exile it with five time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{W}",
+            "timeCounters": 5
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotColor",
+                                        "color": "WHITE"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "TapUntap",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "artist": "Jeff Miracola",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72eb30d9-a826-4f29-ae2a-6873997674a7.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Jedit's Dragoons
+{
+    "name": "Jedit's Dragoons",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Cat Soldier",
+    "oracleText": "Vigilance\nWhen this creature enters, you gain 4 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "artist": "John Matson",
+        "flavorText": "After Efrava was destroyed, the cat warriors scattered across Dominaria. Those who followed Jedit's example were strong enough to survive the ravages of apocalypse.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e29cc9e5-29b7-4e3c-a0cd-46265b0f74ac.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Keldon Halberdier
+{
+    "name": "Keldon Halberdier",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "First strike\nSuspend 4—{R} (Rather than cast this card from your hand, you may pay {R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 1
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{R}",
+            "timeCounters": 4
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "167",
+        "artist": "Paolo Parente",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a90723e0-fbb3-4976-9463-0373f8ed337c.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -392,6 +2195,167 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Lotus Bloom
+{
+    "name": "Lotus Bloom",
+    "manaCost": "",
+    "typeLine": "Artifact",
+    "oracleText": "Suspend 3—{0} (Rather than cast this card from your hand, pay {0} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)\n{T}, Sacrifice this artifact: Add three mana of any one color.",
+    "keywords": [
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{0}",
+            "timeCounters": 3
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "259",
+        "rarity": "RARE",
+        "artist": "Mark Zug",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73127ee0-9a0c-48fa-9c60-b4c600ace8f7.jpg"
+    },
+    "colorIdentityOverride": [],
+    "hasNoManaCost": true
+}
+
+// Might Sliver
+{
+    "name": "Might Sliver",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Sliver creatures get +2/+2.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2,
+                "filter": {
+                    "baseFilter": "creature Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "rarity": "UNCOMMON",
+        "artist": "Jeff Miracola",
+        "flavorText": "\"The colossal thing rumbled over the ridge, tree husks crumbling before it. The ones we were already fighting howled as it came, their muscles suddenly surging, and we knew it was time to flee.\"\n—Llanach, Skyshroud ranger",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8bb8c52f-e608-4710-872f-8a8ae2b5c00c.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Mindstab
+{
+    "name": "Mindstab",
+    "manaCost": "{5}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target player discards three cards.\nSuspend 4—{B} (Rather than cast this card from your hand, you may pay {B} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)",
+    "keywords": [
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{B}",
+            "timeCounters": 4
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Hand",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "storeAs": "hand"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "hand",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
+                    },
+                    "chooser": "TargetPlayer",
+                    "storeSelected": "discarded",
+                    "prompt": "Choose 3 cards to discard"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "discarded",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "moveType": "Discard"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "artist": "Mark Tedin",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3efd28ef-77db-4e7b-a69d-5a089e016737.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -518,6 +2482,572 @@
     ]
 }
 
+// Penumbra Spider
+{
+    "name": "Penumbra Spider",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Reach\nWhen this creature dies, create a 2/4 black Spider creature token with reach.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 4,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Spider"
+                    ],
+                    "keywords": [
+                        "REACH"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "artist": "Jeff Easley",
+        "flavorText": "When it snared a passing cockatrice, its own soul darkly doubled.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6a989ac1-df69-45e7-98bf-564cc7c38973.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Plunder
+{
+    "name": "Plunder",
+    "manaCost": "{4}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target artifact or land.\nSuspend 4—{1}{R} (Rather than cast this card from your hand, you may pay {1}{R} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)",
+    "keywords": [
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{1}{R}",
+            "timeCounters": 4
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|land"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "artist": "Thomas M. Baxa",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/9/79cff220-b1a6-4da6-b765-25a583b33de2.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Prismatic Lens
+{
+    "name": "Prismatic Lens",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {C}.\n{1}, {T}: Add one mana of any color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "262",
+        "artist": "Alan Pollack",
+        "flavorText": "It bends not light but mana, aligning its chaotic currents into the sharp angles necessary for the mystic's purposes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/50f058a7-c3c7-4bdf-a66c-a2636a8bd9db.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Quilled Sliver
+{
+    "name": "Quilled Sliver",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Slivers have \"{T}: This permanent deals 1 damage to target attacking or blocking creature.\"",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ],
+                                    "statePredicates": [
+                                        {
+                                            "type": "StateOr",
+                                            "predicates": [
+                                                "IsAttacking",
+                                                "IsBlocking"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "id": "target"
+                        }
+                    ]
+                },
+                "filter": {
+                    "baseFilter": "permanent Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "rarity": "UNCOMMON",
+        "artist": "John Matson",
+        "flavorText": "\"They have long kept us under attack, but we do not lack for ammunition. The very bodies of our foes arm us against them.\"\n—Adom Capashen, Benalish hero",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72486240-eabb-4b37-99cc-ab13413683fa.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Rift Bolt
+{
+    "name": "Rift Bolt",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Rift Bolt deals 3 damage to any target.\nSuspend 1—{R} (Rather than cast this card from your hand, you may pay {R} and exile it with a time counter on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost.)",
+    "keywords": [
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{R}",
+            "timeCounters": 1
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "176",
+        "artist": "Michael Sutfin",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88dde96e-6824-4d26-9fb5-86b9f3c50959.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Riftwing Cloudskate
+{
+    "name": "Riftwing Cloudskate",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Illusion",
+    "oracleText": "Flying\nWhen this creature enters, return target permanent to its owner's hand.\nSuspend 3—{1}{U} (Rather than cast this card from your hand, you may pay {1}{U} and exile it with three time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{1}{U}",
+            "timeCounters": 3
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "rarity": "UNCOMMON",
+        "artist": "Carl Critchlow",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/78ad6c86-8cfb-4f24-b8e8-ecbeffc949b8.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Sage of Epityr
+{
+    "name": "Sage of Epityr",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "When this creature enters, look at the top four cards of your library, then put them back in any order.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "looked",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "artist": "Randy Gallegos",
+        "flavorText": "Clairvoyants across Dominaria were driven mad by the overload from the widening time rifts, while other random folk gained the gift of future sight.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8e2ea578-069e-4020-a762-d108a3e14861.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Savage Thallid
+{
+    "name": "Savage Thallid",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Fungus",
+    "oracleText": "At the beginning of your upkeep, put a spore counter on this creature.\nRemove three spore counters from this creature: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: Regenerate target Fungus.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "spore",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, put a spore counter on this creature."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomRemoveCounters",
+                        "counterType": "spore",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "self": true
+                    }
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Saproling"
+                    ]
+                },
+                "descriptionOverride": "Remove three spore counters from this creature: Create a 1/1 green Saproling creature token."
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "permanent Saproling"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent Fungus"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "Sacrifice a Saproling: Regenerate target Fungus."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "213",
+        "artist": "Luca Zontini",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a87cbbdb-3bbc-48da-b5e3-fcdbddebec81.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Scarwood Treefolk
+{
+    "name": "Scarwood Treefolk",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Treefolk",
+    "oracleText": "This creature enters tapped.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "artist": "Stuart Griffin",
+        "flavorText": "To treefolk's sense of time, ages pass as hours. They stood as witnesses to the apocalypse, the years of which they saw as one cacophonous, ultra-destructive moment.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/ed6dece3-058c-4738-a22f-8893345ddd1c.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Scryb Ranger
+{
+    "name": "Scryb Ranger",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Faerie Ranger",
+    "oracleText": "Flash\nFlying, protection from blue\nReturn a Forest you control to its owner's hand: Untap target creature. Activate only once each turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "BLUE"
+            }
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomReturnToHand",
+                        "filter": "land Forest"
+                    }
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "tap": false
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "restrictions": [
+                    "OncePerTurn"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "UNCOMMON",
+        "artist": "Rebecca Guay",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3aacabde-f5ec-4519-895d-17f5e48746ee.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Search for Tomorrow
 {
     "name": "Search for Tomorrow",
@@ -579,6 +3109,366 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Shadow Sliver
+{
+    "name": "Shadow Sliver",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Sliver creatures have shadow. (They can block or be blocked by only creatures with shadow.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "SHADOW",
+                "filter": {
+                    "baseFilter": "creature Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "artist": "Warren Mahy",
+        "flavorText": "These slivers, trapped between worlds since the Rathi overlay, are among the last to claim direct lineage from the lost Sliver Queen.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fb725914-1b0f-4efc-808b-9fe2eaa7f17d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Sidewinder Sliver
+{
+    "name": "Sidewinder Sliver",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Sliver creatures have flanking. (Whenever a creature without flanking blocks a Sliver, the blocking creature gets -1/-1 until end of turn.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLANKING",
+                "filter": {
+                    "baseFilter": "creature Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "artist": "Ron Spencer",
+        "flavorText": "\"They encircled our patrol with the stealth of snakes, corralling us like livestock.\"\n—Merrik Aidar, Benalish patrol",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b073b8f2-b42d-40f2-b5fb-e78ffb1733ea.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Spinneret Sliver
+{
+    "name": "Spinneret Sliver",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Sliver creatures have reach.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "REACH",
+                "filter": {
+                    "baseFilter": "creature Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "219",
+        "artist": "Michael Sutfin",
+        "flavorText": "Each new generation of slivers evolves to assimilate the strengths of the prey upon which their progenitors fed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/da698c63-f167-4129-a650-b50c080a24b5.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Sprout
+{
+    "name": "Sprout",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Create a 1/1 green Saproling creature token.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "GREEN"
+            ],
+            "creatureTypes": [
+                "Saproling"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "221",
+        "artist": "Anthony S. Waters",
+        "flavorText": "Centuries of temporal strife had stripped Dominaria of its natural defenses, but nature fought back with armies constructed of little more than grime and sunlight.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/9/6967363f-1e05-4484-8790-47f7be68455c.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Squall Line
+{
+    "name": "Squall Line",
+    "manaCost": "{X}{G}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Squall Line deals X damage to each creature with flying and each player.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature kw:flying"
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": "XValue",
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "Each"
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": "XValue",
+                        "target": "Controller"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "rarity": "RARE",
+        "artist": "Lars Grant-West",
+        "flavorText": "The constant shifting of Dominaria's shredded timeline played havoc with its atmosphere, combining savage electrical storms from ages past.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3f368729-a6f2-4bf7-8b06-39c551f0b24a.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Stronghold Overseer
+{
+    "name": "Stronghold Overseer",
+    "manaCost": "{3}{B}{B}{B}",
+    "typeLine": "Creature — Demon",
+    "oracleText": "Flying\nShadow (This creature can block or be blocked by only creatures with shadow.)\n{B}{B}: Creatures with shadow get +1/+0 until end of turn and creatures without shadow get -1/-0 until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING",
+        "SHADOW"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature kw:shadow"
+                                }
+                            },
+                            "body": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": {
+                                        "cardPredicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "NotKeyword",
+                                                "keyword": "SHADOW"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "body": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": -1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "rarity": "RARE",
+        "artist": "Puddnhead",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0722fa2-53df-4217-a592-fcaf239f717a.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Telekinetic Sliver
+{
+    "name": "Telekinetic Sliver",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Slivers have \"{T}: Tap target permanent.\"",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "permanent"
+                            },
+                            "id": "target"
+                        }
+                    ]
+                },
+                "filter": {
+                    "baseFilter": "permanent Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "rarity": "UNCOMMON",
+        "artist": "Randy Elliott",
+        "flavorText": "\"Slivers are guided only by simple instinct. Advance the hive, and you will be welcomed. Impede the hive, and you will face unrelenting opposition.\"\n—Freyalise",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61b934ad-4858-4680-924a-53ea4f250f9e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Temporal Eddy
+{
+    "name": "Temporal Eddy",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Put target creature or land on top of its owner's library.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Library",
+            "placement": "Top"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|land"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "artist": "Wayne England",
+        "flavorText": "As the temporal fractures spread and time itself slowly fell apart, visitors started to appear from across the past and future, and those native to the present began to disappear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3cab2147-d496-489b-aaf0-b354e31a6b45.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -648,6 +3538,247 @@
     "colorIdentityOverride": []
 }
 
+// Thallid Germinator
+{
+    "name": "Thallid Germinator",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Fungus",
+    "oracleText": "At the beginning of your upkeep, put a spore counter on this creature.\nRemove three spore counters from this creature: Create a 1/1 green Saproling creature token.\nSacrifice a Saproling: Target creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "spore",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, put a spore counter on this creature."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomRemoveCounters",
+                        "counterType": "spore",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "self": true
+                    }
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Saproling"
+                    ]
+                },
+                "descriptionOverride": "Remove three spore counters from this creature: Create a 1/1 green Saproling creature token."
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "permanent Saproling"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "Sacrifice a Saproling: Target creature gets +1/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "artist": "Tom Wänerstrand",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/ac526fb0-e6d0-4ee0-9888-15098c1704df.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Thallid Shell-Dweller
+{
+    "name": "Thallid Shell-Dweller",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Fungus",
+    "oracleText": "Defender\nAt the beginning of your upkeep, put a spore counter on this creature.\nRemove three spore counters from this creature: Create a 1/1 green Saproling creature token.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 5
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "spore",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, put a spore counter on this creature."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomRemoveCounters",
+                        "counterType": "spore",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "self": true
+                    }
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Saproling"
+                    ]
+                },
+                "descriptionOverride": "Remove three spore counters from this creature: Create a 1/1 green Saproling creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "artist": "Carl Critchlow",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4ee36256-022f-49b3-8914-9b1c2f4dc506.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Thelonite Hermit
+{
+    "name": "Thelonite Hermit",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elf Shaman",
+    "oracleText": "All Saprolings get +1/+1.\nMorph {3}{G}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its morph cost.)\nWhen this creature is turned face up, create four 1/1 green Saproling creature tokens.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywordAbilities": [
+        {
+            "type": "Morph",
+            "morphCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{G}{G}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Saproling"
+                    ]
+                },
+                "descriptionOverride": "When this creature is turned face up, create four 1/1 green Saproling creature tokens."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "permanent Saproling"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "rarity": "RARE",
+        "artist": "Chippy",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/be95b6b0-ff20-405f-81ae-87f5cce45fb2.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Think Twice
 {
     "name": "Think Twice",
@@ -680,6 +3811,58 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Thrill of the Hunt
+{
+    "name": "Thrill of the Hunt",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +1/+2 until end of turn.\nFlashback {W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": 1
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 2
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "229",
+        "artist": "Stephen Tappin",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/8/e8fe0c8e-f361-4eac-8c2c-ca6602dad352.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 
@@ -748,6 +3931,159 @@
     ]
 }
 
+// Trespasser il-Vec
+{
+    "name": "Trespasser il-Vec",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "Discard a card: This creature gains shadow until end of turn. (It can block or be blocked by only creatures with shadow.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": "AtomDiscard"
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "SHADOW",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "artist": "Jim Murray",
+        "flavorText": "At the epicenter of the Rathi overlay, the City of Traitors did not align with Dominaria. Many of its inhabitants were caught between the two worlds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/4903171e-76b2-437d-8965-e871e47a3482.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Two-Headed Sliver
+{
+    "name": "Two-Headed Sliver",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Sliver creatures have menace. (They can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "MENACE",
+                "filter": {
+                    "baseFilter": "creature Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "artist": "Dany Orizio",
+        "flavorText": "\"That which would be a fatal mutation in any other species is merely a source of new powers. I am intrigued, yet too fearful to examine it more closely.\"\n—Rukarumel, field journal",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2f89fb3b-0238-4d76-a46d-7d6fa4a74620.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Unyaro Bees
+{
+    "name": "Unyaro Bees",
+    "manaCost": "{G}{G}{G}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Flying\n{G}: This creature gets +1/+1 until end of turn.\n{3}{G}, Sacrifice this creature: It deals 2 damage to any target.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{G}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "rarity": "RARE",
+        "artist": "Tom Wänerstrand",
+        "flavorText": "With no jungle left to contain it, the \"plague of daggers\" spread across Dominaria.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/76356bc9-2285-44a7-815e-a27ad4e07afc.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Venser's Sliver
 {
     "name": "Venser's Sliver",
@@ -764,4 +4100,241 @@
         "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e3c5a64-453b-4477-853a-9514ba326f16.jpg?1783943196"
     },
     "colorIdentityOverride": []
+}
+
+// Viashino Bladescout
+{
+    "name": "Viashino Bladescout",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Creature — Lizard Scout",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, target creature gains first strike until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "artist": "Dany Orizio",
+        "flavorText": "\"Find your courage in a desperate moment, and you turn the tide of history. So sayeth the bey.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/41fce1b3-0961-4672-845f-e1c6ce101c1b.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Viscerid Deepwalker
+{
+    "name": "Viscerid Deepwalker",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Homarid Warrior",
+    "oracleText": "{U}: This creature gets +1/+0 until end of turn.\nSuspend 4—{U} (Rather than cast this card from your hand, you may pay {U} and exile it with four time counters on it. At the beginning of your upkeep, remove a time counter. When the last is removed, you may cast it without paying its mana cost. It has haste.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "SUSPEND"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Suspend",
+            "cost": "{U}",
+            "timeCounters": 4
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "91",
+        "artist": "Heather Hudson",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cdc9f54e-7fba-4f03-83ca-6d293dffc07a.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Viscid Lemures
+{
+    "name": "Viscid Lemures",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "{0}: This creature gets -1/-0 and gains swampwalk until end of turn. (It can't be blocked as long as defending player controls a Swamp.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{0}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": -1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "SWAMPWALK",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "141",
+        "artist": "Drew Tucker",
+        "flavorText": "\"Lemurs? Is that all? Finally, something harmless . . .\"\n—Norin the Wary",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/863f04d7-da34-41e3-9153-97891a428889.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Volcanic Awakening
+{
+    "name": "Volcanic Awakening",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target land.\nStorm (When you cast this spell, copy it for each spell cast before it this turn. You may choose new targets for the copies.)",
+    "keywords": [
+        "STORM"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "land"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "With a great roar, the land opened like a titan's yawn, with teeth of blackened rock and a lolling tongue of magma.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/aebd5c57-cfc8-4a3c-b4a2-0cd64a5e3575.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Watcher Sliver
+{
+    "name": "Watcher Sliver",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Sliver",
+    "oracleText": "All Sliver creatures get +0/+2.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 0,
+                "toughnessBonus": 2,
+                "filter": {
+                    "baseFilter": "creature Sliver"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "artist": "Liz Danforth",
+        "flavorText": "\"I have spied them, wandering and watching—but for what? I fear they watch for us.\"\n—Yonat of Amrou",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d72a950-82ed-4e7b-9e18-b8231a2ebea7.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }


### PR DESCRIPTION
Sweeps every card Argentum Assay reads whole that Time Spiral had not yet authored.

## The four-way split

| Bucket | Count | Work |
|---|---:|---|
| `original` | 69 | full `card(...)` in `tsp/cards/` — every one is original to TSP |
| `basic` | 5 | `TimeSpiralBasicLands.kt` (20 art variants, 282–301) + the `basicLands` override |
| `elsewhere` / `row-only` / `unscaffolded` | 0 | — |
| reprint tail | 6 | `Printing` rows the new canonicals owe in **other** sets |

The tail: Thelonite Hermit → ARC, C15, C16; Penumbra Spider → CMD, PC2; Grapeshot → MSC.
Generated with `generate-reprints.py --since main` after refreshing the stale printing caches.

`TimeSpiralSet` now owns its basics, so `basicLandsFallback = PortalSet` is gone.

## Assay-ready count

**74 → 0**, re-run on this branch (`just assay-ready TSP`), not inferred.
The remaining 197 missing cards all decline at the line level — that tail is grammar work, not
authoring work.

## Differential

| | compared | confirmed | divergent |
|---|---:|---:|---:|
| before | 4971 | 4923 | 48 |
| after | 5041 | 4993 | 48 |

**Zero new divergences.** All 69 cards were authored to `assay compile`'s JSON rather than to the
oracle text, which is why the delta is clean. The +70 compared is the 69 new cards plus Zhalfirin
Knight, which moved out of the "script slot not modelled yet" bucket once its redundant trigger
was removed (105 → 104).

## Capability pre-flight

Every mechanic in the batch was traced to its `rules-engine` consumer before authoring — the point
being that a `Keyword.X` existing is not the engine reading it.

| Mechanic | Consumer |
|---|---|
| suspend | `SuspendEnumerator.kt:32`, `TriggerAbilityResolver.kt:139` |
| storm | `CastSpellHandler.kt:3812` |
| madness | `CardEntityFactory.kt:136`, `TriggerDetector.kt:1992` |
| flanking | `TriggerAbilityResolver.kt:717` (synthesized) |
| shadow | `BlockEvasionRules.kt:78-87` |
| morph | `MorphCastEnumerator.kt:64`, `FaceDownTurnUp.kt:34` |
| flash | `CastSpellEnumerator.kt:207` |
| spore counters | `CostHandler.kt:675`, `CostPaymentService.kt:387` |
| sliver lord statics | `StaticAbilityHandler.kt:601/672/935/1032` |

`CounterType.SPORE` and `CounterType.TIME` both exist, so neither hits the
`CounterTypeResolver.kt:33` fail-open to +1/+1. No card in the batch needed new SDK vocabulary.

## Bug fixed on the way

**Zhalfirin Knight (MIR) was giving blockers -2/-2.** It declared `keywords(Keyword.FLANKING)` *and*
hand-authored a `becomesBlocked` → -1/-1 trigger, with a KDoc claiming the keyword was display-only.
That claim went stale when `TriggerAbilityResolver.getFlankingTriggeredAbilities` started
synthesizing `Flanking.blockedByNonFlankerTrigger` off the projected keyword, so the card got both.
It was the only card in the corpus pairing `Keyword.FLANKING` with a `becomesBlocked` trigger — I
swept all 14 flanking cards. The hand-authored trigger and the stale KDoc are removed.

## Findings not acted on

- **Gaze of Justice's tap cost.** Assay models "tap three untapped white creatures you control" as a
  bare `[IsCreature, HasColor WHITE]` filter, treating "untapped … you control" as intrinsic to
  `CostAtom.TapPermanents`. Authored to the JSON. A neighbouring shipped card,
  `dsk/cards/FearOfExposure.kt`, spells both predicates out explicitly — the two will not serialize
  alike, so whichever Assay eventually compares will diverge.
- **TSP has no token art.** `tokens.json` carries an empty list for TSP because 2006 predates
  printed token cards, so the five Saproling makers and Empty the Warrens fall through to generic
  art. Pre-existing and not fixable from Scryfall.
- Venser's Sliver was flagged mid-sweep as missing an ability; `assay compile` confirms it is
  genuinely a vanilla 3/3. No change.

## Verification

- `just build` — green (compile + `:mtg-sets:test`).
- `just rebless-cards` — only `TSP.json` and `MIR.json` moved; the MIR diff is exactly the removed
  flanking trigger.
- `just assay-differential` — 48 → 48 divergent, +70 confirmed.
- `just check-card-printing` — clean for the tail cards and a sample of the canonicals.
- `just assay-ready TSP` — 0.

No scenario tests: every card composes existing engine-live vocabulary, and no mechanic here is
first-in-corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)